### PR TITLE
fix(newspack-plugin): keep admin list-table Title from collapsing

### DIFF
--- a/plugins/newspack-plugin/includes/class-admin-list-table-layout.php
+++ b/plugins/newspack-plugin/includes/class-admin-list-table-layout.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Admin list-table layout legibility.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Keeps Newspack's admin list-table screens legible when many plugins add
+ * columns and over-subscribe the fixed-layout table (collapsing Title to 0).
+ * Switches those screens to `table-layout: auto` and floors the primary column.
+ *
+ * See plans/2026-07-07-admin-column-widths-autolayout-design.md.
+ */
+class Admin_List_Table_Layout {
+
+	/**
+	 * Screens treated by default. Each entry is a post_type, taxonomy, or screen id.
+	 * Overridable (add or remove) via the `newspack_admin_autolayout_screens` filter.
+	 *
+	 * @var string[]
+	 */
+	const DEFAULT_SCREENS = [ 'post', 'page' ];
+
+	/**
+	 * Default primary-column min-width floor. `35ch` ≈ 300px at the default admin
+	 * font and scales with it. Overridable via `newspack_admin_primary_column_min_width`.
+	 */
+	const DEFAULT_MIN_WIDTH = '35ch';
+
+	/**
+	 * Allowed min-width syntax: a positive integer plus a length unit. Percentage
+	 * is intentionally excluded — it is ignored on table cells.
+	 */
+	const MIN_WIDTH_PATTERN = '/^\d+(?:px|ch|rem)$/';
+
+	/**
+	 * Extra screens registered on top of DEFAULT_SCREENS.
+	 *
+	 * @var string[]
+	 */
+	private static $registered = [];
+
+	/**
+	 * Register an additional screen for the auto-layout treatment.
+	 *
+	 * @param string $key A post_type, taxonomy, or screen id.
+	 */
+	public static function register_screen( $key ) {
+		if ( is_string( $key ) && '' !== $key ) {
+			self::$registered[] = $key;
+		}
+	}
+
+	/**
+	 * The full set of treated screen keys: defaults + registered, then filtered.
+	 *
+	 * @return string[]
+	 */
+	public static function get_screens() {
+		$screens = array_merge( self::DEFAULT_SCREENS, self::$registered );
+
+		/**
+		 * Filters the admin list-table screens that receive the auto-layout
+		 * treatment. May add or remove entries, including the `post`/`page`
+		 * defaults.
+		 *
+		 * @param string[] $screens Screen keys (post_type, taxonomy, or screen id).
+		 */
+		$screens = apply_filters( 'newspack_admin_autolayout_screens', array_values( array_unique( $screens ) ) );
+
+		return array_values( array_filter( (array) $screens ) );
+	}
+
+	/**
+	 * Whether a screen is treated. Base-gated: a `post` key matches the Posts
+	 * list (`edit.php`, base `edit`) but never the Categories/Tags term screens
+	 * (`edit-tags.php`, base `edit-tags`) which also carry `post_type=post`.
+	 *
+	 * @param \WP_Screen $screen Screen to test.
+	 * @return bool
+	 */
+	public static function screen_matches( $screen ) {
+		if ( ! $screen instanceof \WP_Screen ) {
+			return false;
+		}
+		$keys = self::get_screens();
+		if ( empty( $keys ) ) {
+			return false;
+		}
+		$candidates = [ isset( $screen->id ) ? $screen->id : '' ];
+		if ( 'edit' === $screen->base ) {
+			$candidates[] = isset( $screen->post_type ) ? $screen->post_type : '';
+		} elseif ( 'edit-tags' === $screen->base ) {
+			$candidates[] = isset( $screen->taxonomy ) ? $screen->taxonomy : '';
+		}
+		$candidates = array_filter( $candidates );
+		return (bool) array_intersect( $keys, $candidates );
+	}
+}

--- a/plugins/newspack-plugin/includes/class-admin-list-table-layout.php
+++ b/plugins/newspack-plugin/includes/class-admin-list-table-layout.php
@@ -13,8 +13,6 @@ defined( 'ABSPATH' ) || exit;
  * Keeps Newspack's admin list-table screens legible when many plugins add
  * columns and over-subscribe the fixed-layout table (collapsing Title to 0).
  * Switches those screens to `table-layout: auto` and floors the primary column.
- *
- * See plans/2026-07-07-admin-column-widths-autolayout-design.md.
  */
 class Admin_List_Table_Layout {
 
@@ -31,11 +29,12 @@ class Admin_List_Table_Layout {
 	const DEFAULT_MIN_WIDTH = '35ch';
 
 	/**
-	 * Allowed min-width syntax: a positive integer plus a length unit. Percentage
-	 * is intentionally excluded (ignored on table cells); the `D` flag anchors the
+	 * Allowed min-width syntax: a positive, non-zero integer plus a length unit.
+	 * Zero is excluded so a `0px`/`0ch` filter value can't defeat the floor;
+	 * percentage is excluded (ignored on table cells); the `D` flag anchors the
 	 * end so a trailing newline is rejected too.
 	 */
-	const MIN_WIDTH_PATTERN = '/^\d+(?:px|ch|rem)$/D';
+	const MIN_WIDTH_PATTERN = '/^[1-9]\d*(?:px|ch|rem)$/D';
 
 	/**
 	 * Extra screens registered on top of DEFAULT_SCREENS.

--- a/plugins/newspack-plugin/includes/class-admin-list-table-layout.php
+++ b/plugins/newspack-plugin/includes/class-admin-list-table-layout.php
@@ -101,4 +101,53 @@ class Admin_List_Table_Layout {
 		$candidates = array_filter( $candidates );
 		return (bool) array_intersect( $keys, $candidates );
 	}
+
+	/**
+	 * Resolve the validated primary-column min-width floor.
+	 *
+	 * @return string A valid CSS length (px|ch|rem); the default on invalid input.
+	 */
+	public static function get_min_width() {
+		/**
+		 * Filters the primary (Title) column min-width floor on treated screens.
+		 *
+		 * @param string $min_width A CSS length: px, ch, or rem (default '35ch').
+		 */
+		$min_width = apply_filters( 'newspack_admin_primary_column_min_width', self::DEFAULT_MIN_WIDTH );
+		return preg_match( self::MIN_WIDTH_PATTERN, (string) $min_width ) ? (string) $min_width : self::DEFAULT_MIN_WIDTH;
+	}
+
+	/**
+	 * Build the CSS for a screen. Empty string unless the screen is treated.
+	 *
+	 * @param \WP_Screen $screen Screen to build CSS for.
+	 * @return string CSS block (no <style> wrapper); '' when not treated.
+	 */
+	public static function get_styles_for_screen( $screen ) {
+		if ( ! self::screen_matches( $screen ) ) {
+			return '';
+		}
+		$min_width = self::get_min_width();
+		return "@media screen and (min-width: 783px) {\n"
+			. "\t.wp-list-table.fixed { table-layout: auto; }\n"
+			. "\t.wp-list-table th.column-primary,\n"
+			. "\t.wp-list-table td.column-primary { min-width: " . $min_width . "; }\n"
+			. '}';
+	}
+
+	/**
+	 * Echo the scoped <style> block for the current screen.
+	 */
+	public static function render_styles() {
+		$screen = get_current_screen();
+		if ( ! $screen ) {
+			return;
+		}
+		$styles = self::get_styles_for_screen( $screen );
+		if ( '' === $styles ) {
+			return;
+		}
+		// Fixed literal CSS plus an allowlist-validated length (get_min_width) — safe.
+		echo "<style id=\"newspack-admin-list-table-layout\">\n" . $styles . "\n</style>\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
 }

--- a/plugins/newspack-plugin/includes/class-admin-list-table-layout.php
+++ b/plugins/newspack-plugin/includes/class-admin-list-table-layout.php
@@ -21,8 +21,6 @@ class Admin_List_Table_Layout {
 	/**
 	 * Screens treated by default. Each entry is a post_type, taxonomy, or screen id.
 	 * Overridable (add or remove) via the `newspack_admin_autolayout_screens` filter.
-	 *
-	 * @var string[]
 	 */
 	const DEFAULT_SCREENS = [ 'post', 'page' ];
 
@@ -34,9 +32,10 @@ class Admin_List_Table_Layout {
 
 	/**
 	 * Allowed min-width syntax: a positive integer plus a length unit. Percentage
-	 * is intentionally excluded — it is ignored on table cells.
+	 * is intentionally excluded (ignored on table cells); the `D` flag anchors the
+	 * end so a trailing newline is rejected too.
 	 */
-	const MIN_WIDTH_PATTERN = '/^\d+(?:px|ch|rem)$/';
+	const MIN_WIDTH_PATTERN = '/^\d+(?:px|ch|rem)$/D';
 
 	/**
 	 * Extra screens registered on top of DEFAULT_SCREENS.

--- a/plugins/newspack-plugin/includes/class-admin-list-table-layout.php
+++ b/plugins/newspack-plugin/includes/class-admin-list-table-layout.php
@@ -46,6 +46,14 @@ class Admin_List_Table_Layout {
 	private static $registered = [];
 
 	/**
+	 * Hook style output onto list-table screens.
+	 */
+	public static function init() {
+		add_action( 'admin_head-edit.php', [ __CLASS__, 'render_styles' ] );
+		add_action( 'admin_head-edit-tags.php', [ __CLASS__, 'render_styles' ] );
+	}
+
+	/**
 	 * Register an additional screen for the auto-layout treatment.
 	 *
 	 * @param string $key A post_type, taxonomy, or screen id.
@@ -151,3 +159,4 @@ class Admin_List_Table_Layout {
 		echo "<style id=\"newspack-admin-list-table-layout\">\n" . $styles . "\n</style>\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }
+Admin_List_Table_Layout::init();

--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -97,6 +97,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-plugin-manager.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-theme-manager.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-admin-plugins-screen.php';
+		include_once NEWSPACK_ABSPATH . 'includes/class-admin-list-table-layout.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/class-reader-activation.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/class-reader-registration.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/class-reader-activation-emails.php';

--- a/plugins/newspack-plugin/tests/unit-tests/test-admin-list-table-layout.php
+++ b/plugins/newspack-plugin/tests/unit-tests/test-admin-list-table-layout.php
@@ -103,4 +103,15 @@ class Test_Admin_List_Table_Layout extends \WP_UnitTestCase {
 			remove_all_filters( 'newspack_admin_primary_column_min_width' );
 		}
 	}
+
+	public function test_init_registers_admin_head_hooks(): void {
+		// The class self-calls init() on require (set_up_before_class), so the
+		// hooks should already be registered.
+		$this->assertNotFalse(
+			has_action( 'admin_head-edit.php', [ Admin_List_Table_Layout::class, 'render_styles' ] )
+		);
+		$this->assertNotFalse(
+			has_action( 'admin_head-edit-tags.php', [ Admin_List_Table_Layout::class, 'render_styles' ] )
+		);
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/test-admin-list-table-layout.php
+++ b/plugins/newspack-plugin/tests/unit-tests/test-admin-list-table-layout.php
@@ -10,47 +10,84 @@ namespace Newspack\Tests;
 use Newspack\Admin_List_Table_Layout;
 
 /**
+ * Tests for the Admin_List_Table_Layout helper.
+ *
  * @group admin-list-table-layout
  */
 class Test_Admin_List_Table_Layout extends \WP_UnitTestCase {
 
+	/**
+	 * Load the class under test once for the whole test case.
+	 */
 	public static function set_up_before_class(): void {
 		parent::set_up_before_class();
 		require_once NEWSPACK_ABSPATH . 'includes/class-admin-list-table-layout.php';
 	}
 
-	/** Pin the screen set so tests are independent of register_screen() bleed. */
+	/**
+	 * Reset the static registry so register_screen() calls can't bleed across tests.
+	 */
+	public function tear_down(): void {
+		$registered = new \ReflectionProperty( Admin_List_Table_Layout::class, 'registered' );
+		$registered->setAccessible( true );
+		$registered->setValue( null, [] );
+		parent::tear_down();
+	}
+
+	/**
+	 * Pin the screen set so tests are independent of register_screen() bleed.
+	 *
+	 * @param string[] $screens Screen keys to force as the treated set.
+	 */
 	private function pin_screens( array $screens ): void {
 		add_filter( 'newspack_admin_autolayout_screens', fn() => $screens );
 	}
 
+	/**
+	 * The default treated set includes the post and page list screens.
+	 */
 	public function test_defaults_include_post_and_page(): void {
 		$screens = Admin_List_Table_Layout::get_screens();
 		$this->assertContains( 'post', $screens );
 		$this->assertContains( 'page', $screens );
 	}
 
+	/**
+	 * Registering a screen adds its key to the treated set.
+	 */
 	public function test_register_screen_adds_key(): void {
 		Admin_List_Table_Layout::register_screen( 'my_cpt' );
 		$this->assertContains( 'my_cpt', Admin_List_Table_Layout::get_screens() );
 	}
 
+	/**
+	 * The Posts list screen (edit.php, base edit) matches the 'post' key.
+	 */
 	public function test_matches_post_list_screen(): void {
 		$this->pin_screens( [ 'post', 'page' ] );
 		$this->assertTrue( Admin_List_Table_Layout::screen_matches( \WP_Screen::get( 'edit-post' ) ) );
 	}
 
+	/**
+	 * The Categories term screen must not match despite carrying post_type=post.
+	 */
 	public function test_leak_guard_category_term_screen_does_not_match(): void {
 		$this->pin_screens( [ 'post', 'page' ] );
 		// edit-category carries post_type=post but base=edit-tags — must NOT match.
 		$this->assertFalse( Admin_List_Table_Layout::screen_matches( \WP_Screen::get( 'edit-category' ) ) );
 	}
 
+	/**
+	 * The Tags term screen must not match despite carrying post_type=post.
+	 */
 	public function test_leak_guard_tag_term_screen_does_not_match(): void {
 		$this->pin_screens( [ 'post', 'page' ] );
 		$this->assertFalse( Admin_List_Table_Layout::screen_matches( \WP_Screen::get( 'edit-post_tag' ) ) );
 	}
 
+	/**
+	 * A post type that is not in the treated set does not match.
+	 */
 	public function test_unregistered_post_type_does_not_match(): void {
 		register_post_type( 'np_test_cpt', [ 'public' => true ] );
 		$this->pin_screens( [ 'post', 'page' ] );
@@ -58,11 +95,17 @@ class Test_Admin_List_Table_Layout extends \WP_UnitTestCase {
 		unregister_post_type( 'np_test_cpt' );
 	}
 
+	/**
+	 * The filter can remove a default screen from the treated set.
+	 */
 	public function test_filter_can_remove_a_default(): void {
-		$this->pin_screens( [ 'page' ] ); // 'post' removed
+		$this->pin_screens( [ 'page' ] ); // 'post' removed.
 		$this->assertFalse( Admin_List_Table_Layout::screen_matches( \WP_Screen::get( 'edit-post' ) ) );
 	}
 
+	/**
+	 * Untreated screens emit no CSS.
+	 */
 	public function test_no_emission_for_untreated_screen(): void {
 		register_post_type( 'np_test_cpt', [ 'public' => true ] );
 		$this->pin_screens( [ 'post', 'page' ] );
@@ -70,11 +113,17 @@ class Test_Admin_List_Table_Layout extends \WP_UnitTestCase {
 		unregister_post_type( 'np_test_cpt' );
 	}
 
+	/**
+	 * Term screens emit no CSS (leak guard at the emission layer).
+	 */
 	public function test_leak_guard_emits_nothing_on_term_screen(): void {
 		$this->pin_screens( [ 'post', 'page' ] );
 		$this->assertSame( '', Admin_List_Table_Layout::get_styles_for_screen( \WP_Screen::get( 'edit-category' ) ) );
 	}
 
+	/**
+	 * A treated screen emits the desktop-scoped auto-layout CSS with the floor.
+	 */
 	public function test_emits_auto_layout_for_post_list(): void {
 		$this->pin_screens( [ 'post', 'page' ] );
 		$css = Admin_List_Table_Layout::get_styles_for_screen( \WP_Screen::get( 'edit-post' ) );
@@ -84,10 +133,16 @@ class Test_Admin_List_Table_Layout extends \WP_UnitTestCase {
 		$this->assertStringContainsString( 'min-width: 35ch;', $css );
 	}
 
+	/**
+	 * The min-width floor defaults to 35ch.
+	 */
 	public function test_min_width_default(): void {
 		$this->assertSame( '35ch', Admin_List_Table_Layout::get_min_width() );
 	}
 
+	/**
+	 * The min-width filter accepts px, ch, and rem length values.
+	 */
 	public function test_min_width_accepts_px_and_ch_and_rem(): void {
 		foreach ( [ '280px', '40ch', '20rem' ] as $value ) {
 			add_filter( 'newspack_admin_primary_column_min_width', fn() => $value );
@@ -96,17 +151,21 @@ class Test_Admin_List_Table_Layout extends \WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * The min-width filter rejects junk, percentages, and trailing newlines.
+	 */
 	public function test_min_width_rejects_junk_and_percentage(): void {
-		foreach ( [ '30%', '100', 'red;}', 'expression(alert(1))', '35 ch' ] as $junk ) {
+		foreach ( [ '30%', '100', 'red;}', 'expression(alert(1))', '35 ch', "35ch\n" ] as $junk ) {
 			add_filter( 'newspack_admin_primary_column_min_width', fn() => $junk );
 			$this->assertSame( '35ch', Admin_List_Table_Layout::get_min_width(), "rejected: $junk" );
 			remove_all_filters( 'newspack_admin_primary_column_min_width' );
 		}
 	}
 
+	/**
+	 * The init() self-call registers the admin_head hooks on require.
+	 */
 	public function test_init_registers_admin_head_hooks(): void {
-		// The class self-calls init() on require (set_up_before_class), so the
-		// hooks should already be registered.
 		$this->assertNotFalse(
 			has_action( 'admin_head-edit.php', [ Admin_List_Table_Layout::class, 'render_styles' ] )
 		);

--- a/plugins/newspack-plugin/tests/unit-tests/test-admin-list-table-layout.php
+++ b/plugins/newspack-plugin/tests/unit-tests/test-admin-list-table-layout.php
@@ -25,9 +25,11 @@ class Test_Admin_List_Table_Layout extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Reset the static registry so register_screen() calls can't bleed across tests.
+	 * Reset shared state so filters and register_screen() calls can't bleed across tests.
 	 */
 	public function tear_down(): void {
+		remove_all_filters( 'newspack_admin_autolayout_screens' );
+		remove_all_filters( 'newspack_admin_primary_column_min_width' );
 		$registered = new \ReflectionProperty( Admin_List_Table_Layout::class, 'registered' );
 		$registered->setAccessible( true );
 		$registered->setValue( null, [] );
@@ -152,10 +154,10 @@ class Test_Admin_List_Table_Layout extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * The min-width filter rejects junk, percentages, and trailing newlines.
+	 * The min-width filter rejects junk, percentages, zero, and trailing newlines.
 	 */
 	public function test_min_width_rejects_junk_and_percentage(): void {
-		foreach ( [ '30%', '100', 'red;}', 'expression(alert(1))', '35 ch', "35ch\n" ] as $junk ) {
+		foreach ( [ '30%', '100', 'red;}', 'expression(alert(1))', '35 ch', "35ch\n", '0px', '0ch' ] as $junk ) {
 			add_filter( 'newspack_admin_primary_column_min_width', fn() => $junk );
 			$this->assertSame( '35ch', Admin_List_Table_Layout::get_min_width(), "rejected: $junk" );
 			remove_all_filters( 'newspack_admin_primary_column_min_width' );

--- a/plugins/newspack-plugin/tests/unit-tests/test-admin-list-table-layout.php
+++ b/plugins/newspack-plugin/tests/unit-tests/test-admin-list-table-layout.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Tests for admin list-table auto-layout.
+ *
+ * @package Newspack\Tests
+ */
+
+namespace Newspack\Tests;
+
+use Newspack\Admin_List_Table_Layout;
+
+/**
+ * @group admin-list-table-layout
+ */
+class Test_Admin_List_Table_Layout extends \WP_UnitTestCase {
+
+	public static function set_up_before_class(): void {
+		parent::set_up_before_class();
+		require_once NEWSPACK_ABSPATH . 'includes/class-admin-list-table-layout.php';
+	}
+
+	/** Pin the screen set so tests are independent of register_screen() bleed. */
+	private function pin_screens( array $screens ): void {
+		add_filter( 'newspack_admin_autolayout_screens', fn() => $screens );
+	}
+
+	public function test_defaults_include_post_and_page(): void {
+		$screens = Admin_List_Table_Layout::get_screens();
+		$this->assertContains( 'post', $screens );
+		$this->assertContains( 'page', $screens );
+	}
+
+	public function test_register_screen_adds_key(): void {
+		Admin_List_Table_Layout::register_screen( 'my_cpt' );
+		$this->assertContains( 'my_cpt', Admin_List_Table_Layout::get_screens() );
+	}
+
+	public function test_matches_post_list_screen(): void {
+		$this->pin_screens( [ 'post', 'page' ] );
+		$this->assertTrue( Admin_List_Table_Layout::screen_matches( \WP_Screen::get( 'edit-post' ) ) );
+	}
+
+	public function test_leak_guard_category_term_screen_does_not_match(): void {
+		$this->pin_screens( [ 'post', 'page' ] );
+		// edit-category carries post_type=post but base=edit-tags — must NOT match.
+		$this->assertFalse( Admin_List_Table_Layout::screen_matches( \WP_Screen::get( 'edit-category' ) ) );
+	}
+
+	public function test_leak_guard_tag_term_screen_does_not_match(): void {
+		$this->pin_screens( [ 'post', 'page' ] );
+		$this->assertFalse( Admin_List_Table_Layout::screen_matches( \WP_Screen::get( 'edit-post_tag' ) ) );
+	}
+
+	public function test_unregistered_post_type_does_not_match(): void {
+		register_post_type( 'np_test_cpt', [ 'public' => true ] );
+		$this->pin_screens( [ 'post', 'page' ] );
+		$this->assertFalse( Admin_List_Table_Layout::screen_matches( \WP_Screen::get( 'edit-np_test_cpt' ) ) );
+		unregister_post_type( 'np_test_cpt' );
+	}
+
+	public function test_filter_can_remove_a_default(): void {
+		$this->pin_screens( [ 'page' ] ); // 'post' removed
+		$this->assertFalse( Admin_List_Table_Layout::screen_matches( \WP_Screen::get( 'edit-post' ) ) );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/test-admin-list-table-layout.php
+++ b/plugins/newspack-plugin/tests/unit-tests/test-admin-list-table-layout.php
@@ -62,4 +62,45 @@ class Test_Admin_List_Table_Layout extends \WP_UnitTestCase {
 		$this->pin_screens( [ 'page' ] ); // 'post' removed
 		$this->assertFalse( Admin_List_Table_Layout::screen_matches( \WP_Screen::get( 'edit-post' ) ) );
 	}
+
+	public function test_no_emission_for_untreated_screen(): void {
+		register_post_type( 'np_test_cpt', [ 'public' => true ] );
+		$this->pin_screens( [ 'post', 'page' ] );
+		$this->assertSame( '', Admin_List_Table_Layout::get_styles_for_screen( \WP_Screen::get( 'edit-np_test_cpt' ) ) );
+		unregister_post_type( 'np_test_cpt' );
+	}
+
+	public function test_leak_guard_emits_nothing_on_term_screen(): void {
+		$this->pin_screens( [ 'post', 'page' ] );
+		$this->assertSame( '', Admin_List_Table_Layout::get_styles_for_screen( \WP_Screen::get( 'edit-category' ) ) );
+	}
+
+	public function test_emits_auto_layout_for_post_list(): void {
+		$this->pin_screens( [ 'post', 'page' ] );
+		$css = Admin_List_Table_Layout::get_styles_for_screen( \WP_Screen::get( 'edit-post' ) );
+		$this->assertStringContainsString( '@media screen and (min-width: 783px)', $css );
+		$this->assertStringContainsString( '.wp-list-table.fixed { table-layout: auto; }', $css );
+		$this->assertStringContainsString( 'column-primary', $css );
+		$this->assertStringContainsString( 'min-width: 35ch;', $css );
+	}
+
+	public function test_min_width_default(): void {
+		$this->assertSame( '35ch', Admin_List_Table_Layout::get_min_width() );
+	}
+
+	public function test_min_width_accepts_px_and_ch_and_rem(): void {
+		foreach ( [ '280px', '40ch', '20rem' ] as $value ) {
+			add_filter( 'newspack_admin_primary_column_min_width', fn() => $value );
+			$this->assertSame( $value, Admin_List_Table_Layout::get_min_width() );
+			remove_all_filters( 'newspack_admin_primary_column_min_width' );
+		}
+	}
+
+	public function test_min_width_rejects_junk_and_percentage(): void {
+		foreach ( [ '30%', '100', 'red;}', 'expression(alert(1))', '35 ch' ] as $junk ) {
+			add_filter( 'newspack_admin_primary_column_min_width', fn() => $junk );
+			$this->assertSame( '35ch', Admin_List_Table_Layout::get_min_width(), "rejected: $junk" );
+			remove_all_filters( 'newspack_admin_primary_column_min_width' );
+		}
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go](https://docs.wpvip.com/technical-references/code-review/) coding standards? _(phpcs clean against the root ruleset)_
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Automattic/newspack-workspace/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Admin list-table screens (Posts/Pages) render the **Title** column as an unreadable sliver — text stacking one character per line — once enough columns are visible.

**Cause:** WP admin list tables use `table-layout: fixed`, so when many plugins add columns and the declared widths over-subscribe 100%, the width-less Title column is squeezed toward 0px. The width hogs are typically third-party (SEO score/readability, analytics views, consent scan, multi-author) rather than Newspack's own columns — so the fix must be agnostic to which columns trigger it.

This adds `Newspack\Admin_List_Table_Layout`, which switches Newspack's list-table screens (`post`/`page` by default, plus a `register_screen()` / `newspack_admin_autolayout_screens` filter surface) to `table-layout: auto` with a `min-width: 35ch` floor on the primary column, desktop-scoped (`min-width: 783px`). Under `auto`, no column can be starved to 0 regardless of which plugin added it. Screen matching is base-gated (`edit` vs `edit-tags`) so the Categories/Tags term screens are untouched.

Closes NPPM-2989

### How to test the changes in this Pull Request:

1. On a Posts list with several columns enabled — e.g. an SEO plugin's score/readability columns, an analytics "views" column, a consent "scan" column — open **Posts** at desktop width (≥783px) and note the Title column collapsing / text stacking vertically.
2. With this change active, reload: the table switches to content-based layout — Title (and every column) stays legible; on extremely crowded screens the table scrolls horizontally instead of collapsing.
3. Confirm the **Categories** and **Tags** term screens are unaffected (no layout change).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? _(14 unit tests: screen matching incl. the term-screen leak guard, emission, min-width validation)_
* [x] Have you successfully run tests with your changes locally? _(14/14 passing; phpcs clean against the root ruleset)_

UI-only / non-functional change on a shared admin surface. Verified via multi-model review (design + code) and a live-env A/B (fix on → legible + horizontal scroll on extreme loads; fix off → Title collapses to ~32px). Cross-repo impact review: clean (self-contained to `newspack-plugin`). Cross-browser: verified in Chromium; Firefox/Safari spot-check pending. Trade-offs: horizontal scroll on extremely crowded screens (strictly better than collapse, and bounded by the Screen Options mitigation support already recommends); mild column-width variation on sparse tables.
