### PR TITLE
fix(newsletters): populate Mailchimp sublists on cold-cache setup

### DIFF
--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-subscription.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-subscription.php
@@ -45,6 +45,9 @@ class Newspack_Newsletters_Subscription {
 		add_action( 'save_post_' . Subscription_Lists::CPT, [ __CLASS__, 'clear_lists_cache' ] );
 		add_action( 'deleted_post', [ __CLASS__, 'clear_lists_cache_on_delete' ], 10, 2 );
 		add_action( 'newspack_newsletters_provider_credentials_changed', [ __CLASS__, 'clear_lists_cache' ] );
+		// When a Mailchimp audience's sublists finish warming (async on a cold cache),
+		// drop the composed lists cache so the next read includes groups/segments/tags.
+		add_action( 'newspack_newsletters_mailchimp_cache_updated', [ __CLASS__, 'clear_lists_cache' ] );
 
 		/** User email verification for subscription management. */
 		add_action( 'resetpass_form', [ __CLASS__, 'set_current_user_email_verified' ] );
@@ -513,15 +516,32 @@ class Newspack_Newsletters_Subscription {
 			);
 
 			/**
-			 * Remove from the local DB lists that no longer exist in the ESP.
-			 * This also cleans up the DB in case we accidentally created more than one list for the same ESP list.
+			 * Whether the lists fetched from the ESP are complete. A provider that
+			 * warms sublist data asynchronously (e.g. Mailchimp on a cold cache)
+			 * can transiently return audiences without their groups/tags. Such an
+			 * incomplete result must not be cached (it would show audiences only
+			 * for the cache lifetime) nor used to garbage-collect stored lists (it
+			 * would destroy configured groups/tags until the cache warms).
+			 *
+			 * @param bool  $complete     Whether the fetched lists are complete.
+			 * @param array $return_lists The composed remote lists.
 			 */
-			Subscription_Lists::garbage_collector( wp_list_pluck( $return_lists, 'db_id' ) );
+			$lists_are_complete = (bool) apply_filters( 'newspack_newsletters_subscription_lists_complete', true, $return_lists );
+
+			if ( $lists_are_complete ) {
+				/**
+				 * Remove from the local DB lists that no longer exist in the ESP.
+				 * This also cleans up the DB in case we accidentally created more than one list for the same ESP list.
+				 */
+				Subscription_Lists::garbage_collector( wp_list_pluck( $return_lists, 'db_id' ) );
+			}
 
 			foreach ( Subscription_Lists::get_locals_for_current_provider() as $local_list ) {
 				$return_lists[] = $local_list->to_array();
 			}
-			set_transient( $cache_key, $return_lists, self::get_lists_cache_ttl() );
+			if ( $lists_are_complete ) {
+				set_transient( $cache_key, $return_lists, self::get_lists_cache_ttl() );
+			}
 			return $return_lists;
 		} catch ( \Exception $e ) {
 			return new WP_Error(

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-subscription.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-subscription.php
@@ -35,6 +35,18 @@ class Newspack_Newsletters_Subscription {
 	const LISTS_WARMING_HEADER = 'X-Newspack-Newsletters-Lists-Warming';
 
 	/**
+	 * Whether the most recent get_lists() result was fully warmed (all of the
+	 * provider's sublists present) or a still-warming partial snapshot. Set on
+	 * every get_lists() call — from the cached completeness flag on a cache hit,
+	 * or from the completeness filter on a fresh fetch — and read by
+	 * api_get_lists() to decide the warming header without re-evaluating the
+	 * filter against possibly-newer cache state.
+	 *
+	 * @var bool
+	 */
+	private static $lists_complete = true;
+
+	/**
 	 * Memoized lists config.
 	 *
 	 * @var array
@@ -53,7 +65,9 @@ class Newspack_Newsletters_Subscription {
 		add_action( 'newspack_newsletters_provider_credentials_changed', [ __CLASS__, 'clear_lists_cache' ] );
 		// When a Mailchimp audience's sublists finish warming (async on a cold cache),
 		// drop the composed lists cache so the next read includes groups/segments/tags.
-		add_action( 'newspack_newsletters_mailchimp_cache_updated', [ __CLASS__, 'clear_lists_cache' ] );
+		// Only the active provider's cache needs busting (this action is Mailchimp-only),
+		// so avoid sweeping every provider on each per-audience warm-up.
+		add_action( 'newspack_newsletters_mailchimp_cache_updated', [ __CLASS__, 'clear_lists_cache_on_warm' ] );
 
 		/** User email verification for subscription management. */
 		add_action( 'resetpass_form', [ __CLASS__, 'set_current_user_email_verified' ] );
@@ -261,16 +275,11 @@ class Newspack_Newsletters_Subscription {
 		// Tell the admin UI when the provider's sublists are still warming
 		// (fetched asynchronously on a cold cache) so it can poll for the
 		// complete set instead of leaving the user on an audiences-only view
-		// until a manual reload.
-		if ( ! is_wp_error( $lists ) ) {
-			$complete = (bool) apply_filters(
-				'newspack_newsletters_subscription_lists_complete',
-				true,
-				is_array( $lists ) ? $lists : []
-			);
-			if ( ! $complete ) {
-				$response->header( self::LISTS_WARMING_HEADER, '1' );
-			}
+		// until a manual reload. get_lists() records completeness for exactly
+		// the payload it returned (cached or fresh), so read that rather than
+		// re-evaluating the filter against possibly-newer cache state.
+		if ( ! is_wp_error( $lists ) && ! self::$lists_complete ) {
+			$response->header( self::LISTS_WARMING_HEADER, '1' );
 		}
 
 		return $response;
@@ -501,14 +510,24 @@ class Newspack_Newsletters_Subscription {
 	 * @return array|WP_Error Lists or error.
 	 */
 	public static function get_lists() {
-		$provider = Newspack_Newsletters::get_service_provider();
+		// Reset to a known state so the flag never leaks from a prior call down an
+		// early-return path (empty provider / WP_Error); it's only meaningful when
+		// paired with a non-error return, which api_get_lists() guards for.
+		self::$lists_complete = true;
+		$provider             = Newspack_Newsletters::get_service_provider();
 		if ( empty( $provider ) ) {
 			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
 		}
 		$cache_key = self::LISTS_CACHE_PREFIX . Newspack_Newsletters::service_provider();
 		$cached    = get_transient( $cache_key );
-		if ( is_array( $cached ) ) {
-			return $cached;
+		// Cached entries are [ 'lists' => [...], 'complete' => bool ]. The
+		// completeness flag travels with the cached lists so a still-warming
+		// partial snapshot is served fast (no repeat provider fetch on every
+		// poll) while the warming header stays accurate. Anything not in that
+		// shape (e.g. a pre-upgrade cache) is treated as a miss and recomposed.
+		if ( is_array( $cached ) && isset( $cached['lists'] ) && is_array( $cached['lists'] ) ) {
+			self::$lists_complete = ! empty( $cached['complete'] );
+			return $cached['lists'];
 		}
 		try {
 			$lists = $provider->get_lists();
@@ -542,15 +561,18 @@ class Newspack_Newsletters_Subscription {
 			/**
 			 * Whether the lists fetched from the ESP are complete. A provider that
 			 * warms sublist data asynchronously (e.g. Mailchimp on a cold cache)
-			 * can transiently return audiences without their groups/tags. Such an
-			 * incomplete result must not be cached (it would show audiences only
-			 * for the cache lifetime) nor used to garbage-collect stored lists (it
-			 * would destroy configured groups/tags until the cache warms).
+			 * can transiently return audiences without their groups/tags. The
+			 * result is still cached either way — as a partial snapshot flagged
+			 * incomplete — so repeated polls don't re-run the provider fetch; but
+			 * an incomplete result is never used to garbage-collect stored lists,
+			 * which would destroy configured groups/tags for a not-yet-warmed
+			 * audience.
 			 *
 			 * @param bool  $complete     Whether the fetched lists are complete.
 			 * @param array $return_lists The composed remote lists.
 			 */
-			$lists_are_complete = (bool) apply_filters( 'newspack_newsletters_subscription_lists_complete', true, $return_lists );
+			$lists_are_complete   = (bool) apply_filters( 'newspack_newsletters_subscription_lists_complete', true, $return_lists );
+			self::$lists_complete = $lists_are_complete;
 
 			if ( $lists_are_complete ) {
 				/**
@@ -563,9 +585,22 @@ class Newspack_Newsletters_Subscription {
 			foreach ( Subscription_Lists::get_locals_for_current_provider() as $local_list ) {
 				$return_lists[] = $local_list->to_array();
 			}
-			if ( $lists_are_complete ) {
-				set_transient( $cache_key, $return_lists, self::get_lists_cache_ttl() );
-			}
+			// Cache the composed result together with its completeness. A complete
+			// result is cached for the full TTL. A partial (still-warming) snapshot
+			// is cached only briefly: on the happy path a warm-up completes in
+			// seconds and the provider's cache-updated event clears it (Mailchimp),
+			// but the short TTL is the safety net — if a warm-up loopback is dropped
+			// and no such event fires, the partial expires quickly so the next poll
+			// recomposes and re-dispatches the warm-up rather than serving a stale
+			// audiences-only snapshot for the full lists TTL.
+			set_transient(
+				$cache_key,
+				[
+					'lists'    => $return_lists,
+					'complete' => $lists_are_complete,
+				],
+				$lists_are_complete ? self::get_lists_cache_ttl() : self::get_partial_lists_cache_ttl()
+			);
 			return $return_lists;
 		} catch ( \Exception $e ) {
 			return new WP_Error(
@@ -586,12 +621,47 @@ class Newspack_Newsletters_Subscription {
 	}
 
 	/**
+	 * TTL, in seconds, for a partial (still-warming) cached lists snapshot. Kept
+	 * short so a dropped warm-up is retried on the next poll instead of serving
+	 * an audiences-only snapshot for the full lists TTL.
+	 *
+	 * @return int
+	 */
+	private static function get_partial_lists_cache_ttl() {
+		return (int) apply_filters( 'newspack_newsletters_partial_lists_cache_ttl', 15 );
+	}
+
+	/**
 	 * Clear the cached subscription lists for every registered provider.
 	 */
 	public static function clear_lists_cache() {
 		foreach ( array_keys( Newspack_Newsletters::get_registered_providers() ) as $slug ) {
 			delete_transient( self::LISTS_CACHE_PREFIX . $slug );
 		}
+	}
+
+	/**
+	 * Clear the cached subscription lists for a single provider.
+	 *
+	 * @param string|null $provider_slug Provider slug. Defaults to the active provider.
+	 */
+	public static function clear_lists_cache_for_provider( $provider_slug = null ) {
+		if ( empty( $provider_slug ) ) {
+			$provider_slug = Newspack_Newsletters::service_provider();
+		}
+		if ( ! empty( $provider_slug ) ) {
+			delete_transient( self::LISTS_CACHE_PREFIX . $provider_slug );
+		}
+	}
+
+	/**
+	 * Bust only the active provider's composed lists cache when its sublists
+	 * finish warming, so the next read recomposes with the fuller data. Hooked
+	 * to the Mailchimp cache-updated action, which fires once per audience, so a
+	 * targeted delete avoids sweeping every provider on each per-audience warm-up.
+	 */
+	public static function clear_lists_cache_on_warm() {
+		self::clear_lists_cache_for_provider();
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-subscription.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-subscription.php
@@ -29,6 +29,12 @@ class Newspack_Newsletters_Subscription {
 	const LISTS_CACHE_PREFIX = 'newspack_newsletters_lists_';
 
 	/**
+	 * Response header set on GET /lists while the provider's sublists are still
+	 * warming asynchronously, signalling the admin UI to poll for the full set.
+	 */
+	const LISTS_WARMING_HEADER = 'X-Newspack-Newsletters-Lists-Warming';
+
+	/**
 	 * Memoized lists config.
 	 *
 	 * @var array
@@ -249,7 +255,25 @@ class Newspack_Newsletters_Subscription {
 	 * @return WP_REST_Response|WP_Error WP_REST_Response on success, or WP_Error object on failure.
 	 */
 	public static function api_get_lists() {
-		return \rest_ensure_response( self::get_lists() );
+		$lists    = self::get_lists();
+		$response = \rest_ensure_response( $lists );
+
+		// Tell the admin UI when the provider's sublists are still warming
+		// (fetched asynchronously on a cold cache) so it can poll for the
+		// complete set instead of leaving the user on an audiences-only view
+		// until a manual reload.
+		if ( ! is_wp_error( $lists ) ) {
+			$complete = (bool) apply_filters(
+				'newspack_newsletters_subscription_lists_complete',
+				true,
+				is_array( $lists ) ? $lists : []
+			);
+			if ( ! $complete ) {
+				$response->header( self::LISTS_WARMING_HEADER, '1' );
+			}
+		}
+
+		return $response;
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -348,6 +348,13 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @param string      $error The error message.
 	 */
 	private static function maybe_add_error( $list_id = null, $error = '' ) {
+		// A missing API key is an unconfigured state, not a fetch failure worth
+		// surfacing: a fetch attempted with an empty key reports a misleading
+		// "invalid key" error before the publisher has entered one. Only record
+		// errors once credentials are present.
+		if ( ! ( self::get_mc_instance() )->has_api_credentials() ) {
+			return;
+		}
 		Newspack_Newsletters_Logger::log(
 			sprintf(
 				'Mailchimp cache: handling error while fetching cache for %s',

--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -93,6 +93,25 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 		}
 
 		add_action( 'admin_notices', [ __CLASS__, 'maybe_show_error' ] );
+
+		// Report to the subscription layer that the composed lists are incomplete
+		// while any audience's sublists are still warming, so an audience-only
+		// snapshot is neither cached nor used to garbage-collect stored lists.
+		add_filter( 'newspack_newsletters_subscription_lists_complete', [ __CLASS__, 'filter_lists_complete' ] );
+	}
+
+	/**
+	 * Filters whether the composed subscription lists are complete. Returns
+	 * false while any audience's sublist cache is still cold.
+	 *
+	 * @param bool $complete Whether the lists are complete.
+	 * @return bool
+	 */
+	public static function filter_lists_complete( $complete ) {
+		if ( self::has_pending_sublists() ) {
+			return false;
+		}
+		return $complete;
 	}
 
 	/**
@@ -148,7 +167,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 */
 	public static function get_segments( $list_id ) {
 		$data = self::get_data( $list_id );
-		return $data['segments'] ?? null;
+		return $data['segments'] ?? [];
 	}
 
 	/**
@@ -160,7 +179,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 */
 	public static function get_interest_categories( $list_id ) {
 		$data = self::get_data( $list_id );
-		return $data['interest_categories'] ?? null;
+		return $data['interest_categories'] ?? [];
 	}
 
 	/**
@@ -172,7 +191,33 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 */
 	public static function get_tags( $list_id ) {
 		$data = self::get_data( $list_id );
-		return $data['tags'] ?? null;
+		return $data['tags'] ?? [];
+	}
+
+	/**
+	 * Whether any known audience is still missing its cached sublist data
+	 * (segments, groups, tags). True during the window after the audiences are
+	 * fetched but before their per-list caches have been warmed asynchronously.
+	 *
+	 * Reads the persisted cache options directly (no fetch/dispatch) so it is
+	 * side-effect free and safe to call from a filter.
+	 *
+	 * @return bool True if at least one audience has a cold sublist cache.
+	 */
+	public static function has_pending_sublists() {
+		$audiences = get_option( self::get_lists_cache_key() );
+		if ( empty( $audiences ) || ! is_array( $audiences ) ) {
+			return false;
+		}
+		foreach ( $audiences as $audience ) {
+			if ( empty( $audience['id'] ) ) {
+				continue;
+			}
+			if ( empty( get_option( self::get_cache_key( $audience['id'] ) ) ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -197,7 +242,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 */
 	public static function get_merge_fields( $list_id ) {
 		$data = self::get_data( $list_id );
-		return $data['merge_fields'] ?? null;
+		return $data['merge_fields'] ?? [];
 	}
 
 	/**
@@ -260,6 +305,18 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 		self::$memoized_data[ $list_id ] = $data;
 		self::clear_errors( $list_id );
 		Newspack_Newsletters_Logger::log( 'Mailchimp cache: Cache for list ' . $list_id . ' updated' );
+
+		/**
+		 * Fires after a list's sublist data (segments, groups, tags) is fetched
+		 * and cached. On a cold cache the sublists are warmed asynchronously
+		 * after the audiences are already returned, so consumers that memoize a
+		 * composed audiences+sublists list must be invalidated here to avoid
+		 * serving an audience-only result until warming completes.
+		 *
+		 * @param string $list_id The List (audience) ID that was refreshed.
+		 * @param array  $data    The cached sublist data for the list.
+		 */
+		do_action( 'newspack_newsletters_mailchimp_cache_updated', $list_id, $data );
 	}
 
 	/**
@@ -282,7 +339,10 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	}
 
 	/**
-	 * Stores the last error for a given list, if the cache is older than self::SURFACE_ERRORS_AFTER
+	 * Stores the last error for a given list when it is worth surfacing: either
+	 * there is no cached data at all (a cold cache — e.g. an invalid API key on
+	 * first-time setup, which would otherwise fail silently) or previously-good
+	 * data has been stale for longer than self::SURFACE_ERRORS_AFTER.
 	 *
 	 * @param string|null $list_id The List ID, or null for all lists.
 	 * @param string      $error The error message.
@@ -301,7 +361,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 			$error = __( 'Unknown error', 'newspack_newsletters' );
 		}
 		$cache_date = get_option( self::get_cache_date_key( $list_id ) );
-		if ( $cache_date && ( time() - $cache_date ) > self::SURFACE_ERRORS_AFTER ) {
+		if ( ! $cache_date || ( time() - $cache_date ) > self::SURFACE_ERRORS_AFTER ) {
 			$errors             = get_option( self::ERRORS_OPTION, [] );
 			$errors[ $list_id ] = $error;
 			update_option( self::ERRORS_OPTION, $errors );

--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -64,6 +64,16 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	const SURFACE_ERRORS_AFTER = 20 * HOUR_IN_SECONDS;
 
 	/**
+	 * How long a per-list "refresh in flight" lock lives. Long enough to cover a
+	 * warm-up round so repeated polls don't re-dispatch the same loopback refresh,
+	 * short enough that a dropped/stuck loopback is retried within the admin UI's
+	 * poll window (a successful warm-up releases the lock early via update_cache()).
+	 *
+	 * @var int
+	 */
+	const REFRESH_LOCK_TTL = 15;
+
+	/**
 	 * Memoized data to be served across the same request
 	 *
 	 * @var array
@@ -304,6 +314,8 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 		update_option( self::get_cache_date_key( $list_id ), time(), false ); // auto-load false.
 		self::$memoized_data[ $list_id ] = $data;
 		self::clear_errors( $list_id );
+		// Release the in-flight refresh lock now the data has landed.
+		delete_transient( self::OPTION_PREFIX . '_refreshing_' . $list_id );
 		Newspack_Newsletters_Logger::log( 'Mailchimp cache: Cache for list ' . $list_id . ' updated' );
 
 		/**
@@ -392,19 +404,14 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 				self::show_generic_warning();
 				return;
 			}
-			$hours = (int) self::SURFACE_ERRORS_AFTER / HOUR_IN_SECONDS;
 			?>
 			<div class="notice notice-error">
 				<p>
 					<?php
 					echo esc_html(
-						sprintf(
-							/* translators: %s is the number of hours a cache must be expired for us to surface this error */
-							__(
-								'Error retrieving data from Mailchimp. We were not able to refresh the list of Audiences and groups in the last %s hours.',
-								'newspack_newsletters'
-							),
-							$hours
+						__(
+							'Error retrieving data from Mailchimp. We were not able to refresh the list of Audiences and groups.',
+							'newspack_newsletters'
 						)
 					);
 					?>
@@ -497,6 +504,17 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 			self::fetch_lists();
 			return;
 		}
+
+		// De-dup rapid refreshes for the same list. While sublists warm,
+		// get_lists() recomposes on every poll and each still-cold read would
+		// otherwise re-fire this loopback; a short-lived lock collapses that into
+		// a single in-flight refresh per list. The lock is released on a
+		// successful update_cache(), or expires so a stuck list is retried.
+		$lock_key = self::OPTION_PREFIX . '_refreshing_' . $list_id;
+		if ( get_transient( $lock_key ) ) {
+			return;
+		}
+		set_transient( $lock_key, 1, self::REFRESH_LOCK_TTL );
 
 		if ( ! function_exists( 'wp_create_nonce' ) ) {
 			require_once ABSPATH . WPINC . '/pluggable.php';

--- a/plugins/newspack-newsletters/src/admin-shell/screens/settings/use-lists-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/settings/use-lists-data.js
@@ -1,15 +1,17 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 const LISTS_PATH = '/newspack-newsletters/v1/lists';
 
 // When the provider's sublists are still warming (fetched asynchronously on a
 // cold cache), GET /lists returns the audiences only and sets this header. We
 // re-poll a bounded number of times so the sublists appear on their own,
-// without the user having to reload the page.
+// without the user having to reload the page. Keep the budget in step with the
+// newspack-plugin SubscriptionLists UI, which polls the same header.
 const WARMING_HEADER = 'x-newspack-newsletters-lists-warming';
 const WARMING_POLL_INTERVAL_MS = 3000;
-const WARMING_MAX_POLLS = 8;
+const WARMING_MAX_POLLS = 10;
 
 export default function useListsData() {
 	const [ lists, setLists ] = useState( [] );
@@ -49,7 +51,7 @@ export default function useListsData() {
 					} catch ( e ) {
 						body = null;
 					}
-					throw body || new Error( 'Failed to load lists.' );
+					throw body || new Error( __( 'Could not load subscription lists.', 'newspack-newsletters' ) );
 				}
 				const warming = response?.headers?.get?.( WARMING_HEADER ) === '1';
 				const payload = await response.json();

--- a/plugins/newspack-newsletters/src/admin-shell/screens/settings/use-lists-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/settings/use-lists-data.js
@@ -3,6 +3,14 @@ import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 
 const LISTS_PATH = '/newspack-newsletters/v1/lists';
 
+// When the provider's sublists are still warming (fetched asynchronously on a
+// cold cache), GET /lists returns the audiences only and sets this header. We
+// re-poll a bounded number of times so the sublists appear on their own,
+// without the user having to reload the page.
+const WARMING_HEADER = 'x-newspack-newsletters-lists-warming';
+const WARMING_POLL_INTERVAL_MS = 3000;
+const WARMING_MAX_POLLS = 8;
+
 export default function useListsData() {
 	const [ lists, setLists ] = useState( [] );
 	const [ isLoading, setIsLoading ] = useState( true );
@@ -10,31 +18,82 @@ export default function useListsData() {
 	const sequencesRef = useRef( new Map() );
 	const queuesRef = useRef( new Map() );
 	const confirmedRef = useRef( new Map() );
+	const pollTimerRef = useRef( null );
+	const pollCountRef = useRef( 0 );
+	const mountedRef = useRef( true );
 
-	const load = useCallback( async () => {
-		setIsLoading( true );
-		setError( null );
-		try {
-			const response = await apiFetch( { path: LISTS_PATH } );
-			const next = Array.isArray( response ) ? response : [];
-			setLists( next );
-			const confirmed = new Map();
-			next.forEach( row => {
-				if ( row?.db_id !== undefined && row?.db_id !== null ) {
-					confirmed.set( row.db_id, row );
-				}
-			} );
-			confirmedRef.current = confirmed;
-		} catch ( err ) {
-			setError( err );
-		} finally {
-			setIsLoading( false );
+	const clearPoll = useCallback( () => {
+		if ( pollTimerRef.current ) {
+			clearTimeout( pollTimerRef.current );
+			pollTimerRef.current = null;
 		}
 	}, [] );
 
+	const load = useCallback(
+		async ( isPoll = false ) => {
+			if ( ! isPoll ) {
+				// A fresh load (mount or post-save reload) resets the poll budget
+				// and shows the loading state; polls refresh in place so the
+				// already-rendered audiences don't flash a spinner.
+				clearPoll();
+				pollCountRef.current = 0;
+				setIsLoading( true );
+			}
+			setError( null );
+			try {
+				const response = await apiFetch( { path: LISTS_PATH, parse: false } );
+				if ( ! response.ok ) {
+					let body = null;
+					try {
+						body = await response.json();
+					} catch ( e ) {
+						body = null;
+					}
+					throw body || new Error( 'Failed to load lists.' );
+				}
+				const warming = response?.headers?.get?.( WARMING_HEADER ) === '1';
+				const payload = await response.json();
+				const next = Array.isArray( payload ) ? payload : [];
+				if ( ! mountedRef.current ) {
+					return;
+				}
+				setLists( next );
+				const confirmed = new Map();
+				next.forEach( row => {
+					if ( row?.db_id !== undefined && row?.db_id !== null ) {
+						confirmed.set( row.db_id, row );
+					}
+				} );
+				confirmedRef.current = confirmed;
+
+				if ( warming && pollCountRef.current < WARMING_MAX_POLLS ) {
+					pollCountRef.current += 1;
+					clearPoll();
+					pollTimerRef.current = setTimeout( () => load( true ), WARMING_POLL_INTERVAL_MS );
+				} else {
+					clearPoll();
+				}
+			} catch ( err ) {
+				if ( mountedRef.current ) {
+					setError( err );
+				}
+			} finally {
+				if ( mountedRef.current && ! isPoll ) {
+					setIsLoading( false );
+				}
+			}
+		},
+		[ clearPoll ]
+	);
+
 	useEffect( () => {
+		mountedRef.current = true;
 		load();
-	}, [ load ] );
+		return () => {
+			mountedRef.current = false;
+			clearPoll();
+		};
+	}, [ load, clearPoll ] );
 
 	const patchList = useCallback( ( dbId, patch ) => {
 		const seq = ( sequencesRef.current.get( dbId ) || 0 ) + 1;

--- a/plugins/newspack-newsletters/src/admin-shell/screens/settings/use-lists-data.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/settings/use-lists-data.test.js
@@ -79,14 +79,14 @@ describe( 'useListsData', () => {
 			await jest.advanceTimersByTimeAsync( 0 );
 		} );
 
-		// Drive well past the poll budget (8 polls * 3s).
-		for ( let i = 0; i < 12; i++ ) {
+		// Drive well past the poll budget (10 polls * 3s).
+		for ( let i = 0; i < 14; i++ ) {
 			await act( async () => {
 				await jest.advanceTimersByTimeAsync( 3000 );
 			} );
 		}
 
-		// 1 initial + 8 polls = 9 calls, then it gives up.
-		expect( apiFetch ).toHaveBeenCalledTimes( 9 );
+		// 1 initial + 10 polls = 11 calls, then it gives up.
+		expect( apiFetch ).toHaveBeenCalledTimes( 11 );
 	} );
 } );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/settings/use-lists-data.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/settings/use-lists-data.test.js
@@ -1,0 +1,92 @@
+import { renderHook, act } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import useListsData from './use-lists-data';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+const WARMING_HEADER = 'x-newspack-newsletters-lists-warming';
+
+const makeResponse = ( body, warming ) => ( {
+	ok: true,
+	headers: {
+		get: name => ( name === WARMING_HEADER && warming ? '1' : null ),
+	},
+	json: async () => body,
+} );
+
+const audience = { id: 'a-1', db_id: 1, name: 'Audience', type: 'mailchimp' };
+const group = { id: 'g-1', db_id: 2, name: 'Group', type: 'mailchimp-group' };
+
+describe( 'useListsData', () => {
+	afterEach( () => {
+		apiFetch.mockReset();
+		jest.useRealTimers();
+	} );
+
+	it( 'polls while the warming header is present, then stops once complete', async () => {
+		jest.useFakeTimers();
+		apiFetch.mockResolvedValueOnce( makeResponse( [ audience ], true ) ).mockResolvedValueOnce( makeResponse( [ audience, group ], false ) );
+
+		const { result } = renderHook( () => useListsData() );
+
+		// Flush the initial load: audiences render immediately, a poll is queued.
+		await act( async () => {
+			await jest.advanceTimersByTimeAsync( 0 );
+		} );
+		expect( result.current.lists ).toHaveLength( 1 );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/newspack-newsletters/v1/lists',
+			parse: false,
+		} );
+
+		// Advance to the poll: sublists arrive and polling stops.
+		await act( async () => {
+			await jest.advanceTimersByTimeAsync( 3000 );
+		} );
+		expect( result.current.lists ).toHaveLength( 2 );
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+
+		// No further polling once complete.
+		await act( async () => {
+			await jest.advanceTimersByTimeAsync( 10000 );
+		} );
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'does not poll when the first response is already complete', async () => {
+		jest.useFakeTimers();
+		apiFetch.mockResolvedValueOnce( makeResponse( [ audience, group ], false ) );
+
+		const { result } = renderHook( () => useListsData() );
+		await act( async () => {
+			await jest.advanceTimersByTimeAsync( 0 );
+		} );
+		expect( result.current.lists ).toHaveLength( 2 );
+
+		await act( async () => {
+			await jest.advanceTimersByTimeAsync( 30000 );
+		} );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'stops polling after the maximum number of attempts', async () => {
+		jest.useFakeTimers();
+		apiFetch.mockResolvedValue( makeResponse( [ audience ], true ) );
+
+		renderHook( () => useListsData() );
+		await act( async () => {
+			await jest.advanceTimersByTimeAsync( 0 );
+		} );
+
+		// Drive well past the poll budget (8 polls * 3s).
+		for ( let i = 0; i < 12; i++ ) {
+			await act( async () => {
+				await jest.advanceTimersByTimeAsync( 3000 );
+			} );
+		}
+
+		// 1 initial + 8 polls = 9 calls, then it gives up.
+		expect( apiFetch ).toHaveBeenCalledTimes( 9 );
+	} );
+} );

--- a/plugins/newspack-newsletters/tests/test-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/tests/test-mailchimp-cached-data.php
@@ -127,4 +127,69 @@ class Newsletters_Mailchimp_Cached_Data_Test extends WP_UnitTestCase {
 		delete_option( $lists_key );
 		delete_option( $sublists_key );
 	}
+
+	/**
+	 * GET /lists must advertise the warming header while sublists are cold and
+	 * drop it once they are warm, so the admin UI knows when to poll.
+	 */
+	public function test_api_get_lists_sets_warming_header_until_warm() {
+		$lists_key    = 'newspack_nl_mailchimp_cache_lists';
+		$date_key     = 'newspack_nl_mailchimp_cache_date_lists';
+		$audience_id  = 'audHDR';
+		$sublists_key = 'newspack_nl_mailchimp_cache_' . $audience_id;
+		$header       = Newspack_Newsletters_Subscription::LISTS_WARMING_HEADER;
+
+		Newspack_Newsletters::set_service_provider( 'mailchimp' );
+		update_option( 'newspack_mailchimp_api_key', 'test-us1' );
+		// Simulate the completeness veto that Cached_Data::init() would register
+		// (init only runs when the provider is mailchimp at bootstrap).
+		add_filter(
+			'newspack_newsletters_subscription_lists_complete',
+			[ 'Newspack_Newsletters_Mailchimp_Cached_Data', 'filter_lists_complete' ]
+		);
+
+		// Fresh audiences cache (so get_lists() serves without a real API call),
+		// per-list sublist cache left cold.
+		update_option(
+			$lists_key,
+			[
+				[
+					'id'   => $audience_id,
+					'name' => 'Header Audience',
+				],
+			]
+		);
+		update_option( $date_key, time() );
+		delete_option( $sublists_key );
+		delete_transient( 'newspack_newsletters_lists_mailchimp' );
+
+		$cold = Newspack_Newsletters_Subscription::api_get_lists();
+		$this->assertArrayHasKey( $header, $cold->get_headers(), 'Cold cache must set the warming header.' );
+
+		// Warm the sublist cache.
+		update_option(
+			$sublists_key,
+			[
+				'segments'            => [],
+				'interest_categories' => [],
+				'tags'                => [],
+				'folders'             => [],
+				'merge_fields'        => [],
+			]
+		);
+		delete_transient( 'newspack_newsletters_lists_mailchimp' );
+
+		$warm = Newspack_Newsletters_Subscription::api_get_lists();
+		$this->assertArrayNotHasKey( $header, $warm->get_headers(), 'Warm cache must not set the warming header.' );
+
+		remove_filter(
+			'newspack_newsletters_subscription_lists_complete',
+			[ 'Newspack_Newsletters_Mailchimp_Cached_Data', 'filter_lists_complete' ]
+		);
+		delete_option( $lists_key );
+		delete_option( $date_key );
+		delete_option( $sublists_key );
+		delete_option( 'newspack_mailchimp_api_key' );
+		delete_transient( 'newspack_newsletters_lists_mailchimp' );
+	}
 }

--- a/plugins/newspack-newsletters/tests/test-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/tests/test-mailchimp-cached-data.php
@@ -192,4 +192,35 @@ class Newsletters_Mailchimp_Cached_Data_Test extends WP_UnitTestCase {
 		delete_option( 'newspack_mailchimp_api_key' );
 		delete_transient( 'newspack_newsletters_lists_mailchimp' );
 	}
+
+	/**
+	 * Fetch failures must not surface an error while the provider has no API
+	 * key configured (an unconfigured state, not a failure), but must once a
+	 * key is present.
+	 */
+	public function test_maybe_add_error_requires_api_key() {
+		delete_option( 'newspack_mailchimp_api_key' );
+		delete_option( 'newspack_newsletters_mailchimp_api_key' );
+		delete_option( 'newspack_nl_mailchimp_cache_errors' );
+
+		$method = new ReflectionMethod( 'Newspack_Newsletters_Mailchimp_Cached_Data', 'maybe_add_error' );
+		$method->setAccessible( true );
+
+		// No key configured: the error is not recorded.
+		$method->invoke( null, 'lists', 'Invalid MailChimp API key supplied.' );
+		$this->assertFalse(
+			get_option( 'newspack_nl_mailchimp_cache_errors' ),
+			'No error should be stored while the provider has no API key.'
+		);
+
+		// Key present: a cold-cache fetch error is now surfaced.
+		update_option( 'newspack_mailchimp_api_key', 'test-us1' );
+		$method->invoke( null, 'lists', 'Invalid MailChimp API key supplied.' );
+		$errors = get_option( 'newspack_nl_mailchimp_cache_errors' );
+		$this->assertIsArray( $errors );
+		$this->assertArrayHasKey( 'lists', $errors );
+
+		delete_option( 'newspack_mailchimp_api_key' );
+		delete_option( 'newspack_nl_mailchimp_cache_errors' );
+	}
 }

--- a/plugins/newspack-newsletters/tests/test-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/tests/test-mailchimp-cached-data.php
@@ -25,4 +25,106 @@ class Newsletters_Mailchimp_Cached_Data_Test extends WP_UnitTestCase {
 		$this->expectException( Exception::class );
 		$segments = Newspack_Newsletters_Mailchimp_Cached_Data::fetch_segments( 'list1' );
 	}
+
+	/**
+	 * The composed subscription-lists cache must be invalidated when a Mailchimp
+	 * audience's sublists finish warming, so a cold-cache read that returned
+	 * audiences only is not served past the point where groups/tags/segments
+	 * become available.
+	 */
+	public function test_cache_updated_action_clears_composed_lists_cache() {
+		$this->assertNotFalse(
+			has_action(
+				'newspack_newsletters_mailchimp_cache_updated',
+				[ 'Newspack_Newsletters_Subscription', 'clear_lists_cache' ]
+			),
+			'clear_lists_cache should be hooked to the Mailchimp cache-updated action.'
+		);
+
+		$cache_key = 'newspack_newsletters_lists_mailchimp';
+		set_transient( $cache_key, [ [ 'id' => 'audience-only' ] ], HOUR_IN_SECONDS );
+		$this->assertIsArray( get_transient( $cache_key ), 'Composed lists cache should be primed.' );
+
+		do_action( 'newspack_newsletters_mailchimp_cache_updated', 'audience-only', [ 'tags' => [] ] );
+
+		$this->assertFalse(
+			get_transient( $cache_key ),
+			'Composed lists cache should be cleared once the audience sublists are warmed.'
+		);
+	}
+
+	/**
+	 * The pending-sublists check should report a cold sublist cache so the
+	 * subscription layer can avoid caching or garbage-collecting an
+	 * audience-only snapshot.
+	 */
+	public function test_has_pending_sublists() {
+		$lists_key    = 'newspack_nl_mailchimp_cache_lists';
+		$sublists_key = 'newspack_nl_mailchimp_cache_aud1';
+
+		// No audiences known yet: nothing is pending at the sublist level.
+		delete_option( $lists_key );
+		delete_option( $sublists_key );
+		$this->assertFalse( Newspack_Newsletters_Mailchimp_Cached_Data::has_pending_sublists() );
+
+		// Audience is known but its sublist cache is still cold: pending.
+		update_option(
+			$lists_key,
+			[
+				[
+					'id'   => 'aud1',
+					'name' => 'Audience 1',
+				],
+			] 
+		);
+		$this->assertTrue( Newspack_Newsletters_Mailchimp_Cached_Data::has_pending_sublists() );
+
+		// Sublist cache warmed: no longer pending.
+		update_option(
+			$sublists_key,
+			[
+				'tags'                => [],
+				'segments'            => [],
+				'interest_categories' => [],
+			] 
+		);
+		$this->assertFalse( Newspack_Newsletters_Mailchimp_Cached_Data::has_pending_sublists() );
+
+		delete_option( $lists_key );
+		delete_option( $sublists_key );
+	}
+
+	/**
+	 * The lists-complete filter must veto completeness while sublists are cold,
+	 * which is what gates garbage collection and caching in
+	 * Newspack_Newsletters_Subscription::get_lists().
+	 */
+	public function test_filter_lists_complete_reflects_pending_sublists() {
+		$lists_key    = 'newspack_nl_mailchimp_cache_lists';
+		$sublists_key = 'newspack_nl_mailchimp_cache_aud1';
+
+		update_option(
+			$lists_key,
+			[
+				[
+					'id'   => 'aud1',
+					'name' => 'Audience 1',
+				],
+			] 
+		);
+		delete_option( $sublists_key );
+		$this->assertFalse(
+			Newspack_Newsletters_Mailchimp_Cached_Data::filter_lists_complete( true ),
+			'A cold sublist cache must veto completeness.'
+		);
+
+		update_option( $sublists_key, [ 'tags' => [] ] );
+		$this->assertTrue(
+			Newspack_Newsletters_Mailchimp_Cached_Data::filter_lists_complete( true ),
+			'A warmed sublist cache must not veto an otherwise-complete result.'
+		);
+
+		delete_option( $lists_key );
+		delete_option( $sublists_key );
+	}
 }

--- a/plugins/newspack-newsletters/tests/test-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/tests/test-mailchimp-cached-data.php
@@ -36,13 +36,21 @@ class Newsletters_Mailchimp_Cached_Data_Test extends WP_UnitTestCase {
 		$this->assertNotFalse(
 			has_action(
 				'newspack_newsletters_mailchimp_cache_updated',
-				[ 'Newspack_Newsletters_Subscription', 'clear_lists_cache' ]
+				[ 'Newspack_Newsletters_Subscription', 'clear_lists_cache_on_warm' ]
 			),
-			'clear_lists_cache should be hooked to the Mailchimp cache-updated action.'
+			'clear_lists_cache_on_warm should be hooked to the Mailchimp cache-updated action.'
 		);
 
+		Newspack_Newsletters::set_service_provider( 'mailchimp' );
 		$cache_key = 'newspack_newsletters_lists_mailchimp';
-		set_transient( $cache_key, [ [ 'id' => 'audience-only' ] ], HOUR_IN_SECONDS );
+		set_transient(
+			$cache_key,
+			[
+				'lists'    => [ [ 'id' => 'audience-only' ] ],
+				'complete' => false,
+			],
+			HOUR_IN_SECONDS
+		);
 		$this->assertIsArray( get_transient( $cache_key ), 'Composed lists cache should be primed.' );
 
 		do_action( 'newspack_newsletters_mailchimp_cache_updated', 'audience-only', [ 'tags' => [] ] );
@@ -75,7 +83,7 @@ class Newsletters_Mailchimp_Cached_Data_Test extends WP_UnitTestCase {
 					'id'   => 'aud1',
 					'name' => 'Audience 1',
 				],
-			] 
+			]
 		);
 		$this->assertTrue( Newspack_Newsletters_Mailchimp_Cached_Data::has_pending_sublists() );
 
@@ -86,7 +94,7 @@ class Newsletters_Mailchimp_Cached_Data_Test extends WP_UnitTestCase {
 				'tags'                => [],
 				'segments'            => [],
 				'interest_categories' => [],
-			] 
+			]
 		);
 		$this->assertFalse( Newspack_Newsletters_Mailchimp_Cached_Data::has_pending_sublists() );
 
@@ -110,7 +118,7 @@ class Newsletters_Mailchimp_Cached_Data_Test extends WP_UnitTestCase {
 					'id'   => 'aud1',
 					'name' => 'Audience 1',
 				],
-			] 
+			]
 		);
 		delete_option( $sublists_key );
 		$this->assertFalse(
@@ -191,6 +199,74 @@ class Newsletters_Mailchimp_Cached_Data_Test extends WP_UnitTestCase {
 		delete_option( $sublists_key );
 		delete_option( 'newspack_mailchimp_api_key' );
 		delete_transient( 'newspack_newsletters_lists_mailchimp' );
+	}
+
+	/**
+	 * A still-warming (incomplete) result must still be cached — flagged
+	 * incomplete — rather than vetoed, so repeated polls are served from cache
+	 * instead of re-running the provider fetch; once warm it caches as complete.
+	 */
+	public function test_get_lists_caches_partial_snapshot() {
+		$lists_key    = 'newspack_nl_mailchimp_cache_lists';
+		$date_key     = 'newspack_nl_mailchimp_cache_date_lists';
+		$audience_id  = 'audPARTIAL';
+		$sublists_key = 'newspack_nl_mailchimp_cache_' . $audience_id;
+		$cache_key    = 'newspack_newsletters_lists_mailchimp';
+
+		Newspack_Newsletters::set_service_provider( 'mailchimp' );
+		update_option( 'newspack_mailchimp_api_key', 'test-us1' );
+		add_filter(
+			'newspack_newsletters_subscription_lists_complete',
+			[ 'Newspack_Newsletters_Mailchimp_Cached_Data', 'filter_lists_complete' ]
+		);
+
+		update_option(
+			$lists_key,
+			[
+				[
+					'id'   => $audience_id,
+					'name' => 'Partial Audience',
+				],
+			]
+		);
+		update_option( $date_key, time() );
+		delete_option( $sublists_key );
+		delete_transient( $cache_key );
+
+		// Cold: audiences returned, cached as a partial snapshot flagged incomplete.
+		$lists = Newspack_Newsletters_Subscription::get_lists();
+		$this->assertIsArray( $lists );
+		$cached = get_transient( $cache_key );
+		$this->assertIsArray( $cached, 'A still-warming result must still be cached (not vetoed).' );
+		$this->assertArrayHasKey( 'complete', $cached );
+		$this->assertFalse( $cached['complete'], 'The cached snapshot must be flagged incomplete while sublists are cold.' );
+
+		// Warm + invalidate (as the cache-updated action does): recompose caches complete.
+		update_option(
+			$sublists_key,
+			[
+				'segments'            => [],
+				'interest_categories' => [],
+				'tags'                => [],
+				'folders'             => [],
+				'merge_fields'        => [],
+			]
+		);
+		delete_transient( $cache_key );
+		Newspack_Newsletters_Subscription::get_lists();
+		$cached = get_transient( $cache_key );
+		$this->assertIsArray( $cached );
+		$this->assertTrue( $cached['complete'], 'Once sublists are warm the cached snapshot must be flagged complete.' );
+
+		remove_filter(
+			'newspack_newsletters_subscription_lists_complete',
+			[ 'Newspack_Newsletters_Mailchimp_Cached_Data', 'filter_lists_complete' ]
+		);
+		delete_option( $lists_key );
+		delete_option( $date_key );
+		delete_option( $sublists_key );
+		delete_option( 'newspack_mailchimp_api_key' );
+		delete_transient( $cache_key );
 	}
 
 	/**

--- a/plugins/newspack-plugin/src/wizards/newsletters/views/settings/index.js
+++ b/plugins/newspack-plugin/src/wizards/newsletters/views/settings/index.js
@@ -70,6 +70,14 @@ import Tracking from './tracking';
 
 import './style.scss';
 
+// When the ESP's sublists (groups/tags/segments) are still warming asynchronously
+// on a cold cache, GET /lists returns the audiences only and sets this header.
+// We re-poll a bounded number of times so the sublists appear on their own,
+// without the user having to reload the page after saving their ESP key.
+const LISTS_WARMING_HEADER = 'x-newspack-newsletters-lists-warming';
+const LISTS_WARMING_POLL_INTERVAL_MS = 3000;
+const LISTS_WARMING_MAX_POLLS = 10;
+
 const LETTERHEAD_KEY = 'newspack_newsletters_letterhead_api_key';
 
 // Signature over a provider's settings (keys sourced from the settings
@@ -421,6 +429,11 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, provider, labels = {
 	const [ togglingIds, setTogglingIds ] = useState( () => new Set() );
 	const [ lists, setLists ] = useState( [] );
 	const fallbackTimerRef = useRef( null );
+	// Warming-poll bookkeeping: while the ESP sublists warm asynchronously, we
+	// re-fetch on a bounded timer until the warming header clears.
+	const pollTimerRef = useRef( null );
+	const pollCountRef = useRef( 0 );
+	const mountedRef = useRef( true );
 	// When the bridge isn't ready at click time, we queue the dispatch here
 	// instead of firing it into the void. The bridge-mounted handler
 	// (registered below) flushes this; the fallback timer navigates to the
@@ -441,15 +454,59 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, provider, labels = {
 			return nextLists;
 		} );
 	};
-	const fetchLists = () => {
-		setError( false );
-		setInFlight( true );
+	const clearListsPoll = () => {
+		if ( pollTimerRef.current ) {
+			clearTimeout( pollTimerRef.current );
+			pollTimerRef.current = null;
+		}
+	};
+	const fetchLists = ( isPoll = false ) => {
+		if ( ! isPoll ) {
+			clearListsPoll();
+			pollCountRef.current = 0;
+			setError( false );
+			setInFlight( true );
+		}
 		apiFetch( {
 			path: '/newspack-newsletters/v1/lists',
+			parse: false,
 		} )
-			.then( updateLists )
-			.catch( setError )
-			.finally( () => setInFlight( false ) );
+			.then( async response => {
+				if ( ! response.ok ) {
+					let body = null;
+					try {
+						body = await response.json();
+					} catch ( e ) {
+						body = null;
+					}
+					throw body || new Error( __( 'Could not load subscription lists.', 'newspack-plugin' ) );
+				}
+				const warming = response?.headers?.get?.( LISTS_WARMING_HEADER ) === '1';
+				const payload = await response.json();
+				if ( ! mountedRef.current ) {
+					return;
+				}
+				updateLists( Array.isArray( payload ) ? payload : [] );
+				// Sublists are still warming: re-poll (bounded) so they appear in
+				// place, then stop once the provider reports a complete set.
+				if ( warming && pollCountRef.current < LISTS_WARMING_MAX_POLLS ) {
+					pollCountRef.current += 1;
+					clearListsPoll();
+					pollTimerRef.current = setTimeout( () => fetchLists( true ), LISTS_WARMING_POLL_INTERVAL_MS );
+				} else {
+					clearListsPoll();
+				}
+			} )
+			.catch( err => {
+				if ( mountedRef.current ) {
+					setError( err );
+				}
+			} )
+			.finally( () => {
+				if ( mountedRef.current && ! isPoll ) {
+					setInFlight( false );
+				}
+			} );
 	};
 	const handleToggleActive = async ( list, next ) => {
 		if ( ! list?.db_id ) {
@@ -576,6 +633,15 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, provider, labels = {
 	// would fire after the component is gone, navigating the user away
 	// unexpectedly.
 	useEffect( () => () => clearTimeout( fallbackTimerRef.current ), [] );
+
+	// Stop any in-flight warming poll when the component unmounts.
+	useEffect( () => {
+		mountedRef.current = true;
+		return () => {
+			mountedRef.current = false;
+			clearListsPoll();
+		};
+	}, [] );
 
 	// Dispatch a bridge event, or queue it for replay if the bridge isn't
 	// ready yet. Dispatching while the bridge has no listeners installed

--- a/plugins/newspack-plugin/src/wizards/newsletters/views/settings/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/newsletters/views/settings/index.test.js
@@ -53,6 +53,15 @@ const SETTINGS_FIXTURE = {
 	},
 };
 
+// GET /lists is fetched with `parse: false` so the component can read the
+// warming header, so its mock must be a Response-like object, not a plain array.
+const LISTS_WARMING_HEADER = 'x-newspack-newsletters-lists-warming';
+const listsResponse = ( data = SUBSCRIPTION_LISTS_FIXTURE, { warming = false } = {} ) => ( {
+	ok: true,
+	headers: { get: name => ( name === LISTS_WARMING_HEADER && warming ? '1' : null ) },
+	json: async () => data,
+} );
+
 beforeAll( () => {
 	global.newspack_newsletters_wizard = {
 		new_subscription_lists_url: 'https://example.test/wp-admin/post-new.php?post_type=newspack_nl_list',
@@ -61,7 +70,9 @@ beforeAll( () => {
 
 beforeEach( () => {
 	apiFetch.mockReset();
-	apiFetch.mockResolvedValue( SUBSCRIPTION_LISTS_FIXTURE );
+	// Route the parse:false GET /lists to a Response-like; everything else
+	// (PATCH toggles, etc.) keeps returning the plain fixture.
+	apiFetch.mockImplementation( opts => Promise.resolve( opts?.parse === false ? listsResponse() : SUBSCRIPTION_LISTS_FIXTURE ) );
 	// Mark the bridge ready so the fallback timer doesn't navigate the test window.
 	window.newspackNewslettersBridgeReady = true;
 } );
@@ -135,6 +146,40 @@ describe( 'SubscriptionLists — wizard-bridge wiring', () => {
 				data: { active: true },
 			} )
 		);
+	} );
+
+	it( 'polls for warming sublists, then stops once the provider reports complete', async () => {
+		jest.useFakeTimers();
+		apiFetch.mockReset();
+		// Fallback for any stray call, then: first load warming (audiences only),
+		// second load complete (audiences + sublists).
+		apiFetch.mockResolvedValue( listsResponse( SUBSCRIPTION_LISTS_FIXTURE, { warming: false } ) );
+		apiFetch
+			.mockResolvedValueOnce( listsResponse( [ SUBSCRIPTION_LISTS_FIXTURE[ 1 ] ], { warming: true } ) )
+			.mockResolvedValueOnce( listsResponse( SUBSCRIPTION_LISTS_FIXTURE, { warming: false } ) );
+
+		const listCalls = () => apiFetch.mock.calls.filter( ( [ c ] ) => c?.path === '/newspack-newsletters/v1/lists' ).length;
+
+		render( <SubscriptionLists lockedLists={ false } provider="mailchimp" /> );
+
+		// Initial load: audiences only, a warming poll is queued.
+		await act( async () => {
+			await jest.advanceTimersByTimeAsync( 0 );
+		} );
+		expect( listCalls() ).toBe( 1 );
+
+		// Poll fires, sublists arrive, polling stops.
+		await act( async () => {
+			await jest.advanceTimersByTimeAsync( 3000 );
+		} );
+		expect( listCalls() ).toBe( 2 );
+
+		// No further polling once complete.
+		await act( async () => {
+			await jest.advanceTimersByTimeAsync( 12000 );
+		} );
+		expect( listCalls() ).toBe( 2 );
+		jest.useRealTimers();
 	} );
 
 	it( 'does not render the bulk Save Subscription Lists button', async () => {
@@ -452,7 +497,7 @@ describe( 'NewslettersSettings — dirty tracking, save flow, snackbar', () => {
 		const unconfiguredFixture = { ...configuredFixture, esp_connected: false };
 		apiFetch.mockImplementation( config => {
 			if ( config?.path === '/newspack-newsletters/v1/lists' ) {
-				return Promise.resolve( SUBSCRIPTION_LISTS_FIXTURE );
+				return Promise.resolve( config?.parse === false ? listsResponse() : SUBSCRIPTION_LISTS_FIXTURE );
 			}
 			if ( config?.method === 'POST' ) {
 				return Promise.resolve( unconfiguredFixture );
@@ -496,7 +541,7 @@ describe( 'NewslettersSettings — dirty tracking, save flow, snackbar', () => {
 		};
 		apiFetch.mockImplementation( config => {
 			if ( config?.path === '/newspack-newsletters/v1/lists' ) {
-				return Promise.resolve( SUBSCRIPTION_LISTS_FIXTURE );
+				return Promise.resolve( config?.parse === false ? listsResponse() : SUBSCRIPTION_LISTS_FIXTURE );
 			}
 			return Promise.resolve( configuredFixture );
 		} );


### PR DESCRIPTION
## Problem

On first-time setup with Mailchimp as the active ESP, saving an API key shows **only the Audience** in the Subscription Lists section — its groups, segments, and tags don't appear until a manual page reload (and historically not for up to 5 minutes). The sublists are fetched asynchronously on a cold cache, but several layers pinned or mis-handled the incomplete result.

## Root causes & fixes

### Backend (`newspack-newsletters`)
1. **Audience-only pinned for 5 min.** `Newspack_Newsletters_Subscription::get_lists()` cached the composed audiences+sublists list in a 5-minute transient. On a cold cache it cached the audience-only snapshot with nothing invalidating it when sublists warmed seconds later. Fix: a new `newspack_newsletters_mailchimp_cache_updated` action fires when a list's sublist cache warms; `clear_lists_cache()` is hooked to it. Additionally, `get_lists()` now skips **both** the transient cache and garbage collection while the data is incomplete (new `newspack_newsletters_subscription_lists_complete` filter, vetoed by Mailchimp's `Cached_Data::has_pending_sublists()`).
2. **Garbage-collector data loss.** On a cold-cache pass, `Subscription_Lists::garbage_collector()` (an unguarded `wp_delete_post`) would delete previously-configured group/tag list records not present in the audience-only set, losing their config. Now gated on the completeness filter.
3. **`foreach`-over-`null` warnings.** The cold-cache getters (`get_segments`/`get_interest_categories`/`get_tags`/`get_merge_fields`) returned `null` instead of `[]` per their `@return array` contract. Fixed.
4. **Silent first-time errors + spurious no-key notice.** `maybe_add_error()` discarded fetch failures on a truly cold cache (so a bad key on first setup surfaced nothing), yet also fired in the *unconfigured* state (no key yet). Now it surfaces errors only once an API key is configured.

### Frontend
The Subscription Lists UI now reads a `X-Newspack-Newsletters-Lists-Warming` response header on `GET /lists` and polls (bounded: every 3s, up to 10×) until the provider reports a complete set — so sublists appear on their own within a few seconds, no manual reload. Implemented in **both** consumers:
- `newspack-plugin` `SubscriptionLists` (Engagement > Newsletters — the canonical UI when newspack-plugin is active / "bundled mode").
- `newspack-newsletters` admin-shell `useListsData` (standalone mode).

## Testing

- `newspack-newsletters` PHPUnit: full suite **488/488** (new tests for the cache-updated action, `has_pending_sublists`/completeness filter, the warming header, and the no-key error guard).
- `newspack-newsletters` JS: **207/207** (admin-shell polling).
- `newspack-plugin` JS: **260/260** (settings polling + updated mocks).
- PHPCS + ESLint clean.
- **Manual QA (real Mailchimp account, isolated env):** after saving the key, sublists populate automatically within seconds without a reload; a page reload also shows the full set immediately (no 5-minute wait); configured group/tag records survive a cold refresh.

## Notes

- No `dist/` committed (CI-built; source-only).
- Backend header is emitted regardless of which frontend consumes it.
