### PR TITLE
feat(popups): move A/B variant selection into the view engine

### DIFF
--- a/plugins/newspack-popups/includes/class-newspack-popups-ab-tests.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-ab-tests.php
@@ -74,6 +74,16 @@ final class Newspack_Popups_AB_Tests {
 				[
 					'type'              => 'string',
 					'sanitize_callback' => [ __CLASS__, 'sanitize_variant' ],
+					// The enum makes an invalid REST write fail with a 400 the editor
+					// can surface, instead of the sanitize callback silently coercing
+					// it to '' (which would detach the prompt from its test on a 200).
+					// The empty string stays valid: it is the "not part of a test" state.
+					'show_in_rest'      => [
+						'schema' => [
+							'type' => 'string',
+							'enum' => array_merge( [ '' ], self::VALID_VARIANTS ),
+						],
+					],
 				]
 			)
 		);
@@ -98,6 +108,20 @@ final class Newspack_Popups_AB_Tests {
 				[
 					'type'              => 'integer',
 					'sanitize_callback' => [ __CLASS__, 'sanitize_control_share' ],
+					// The explicit default keeps REST reads of an unset share at the
+					// same 50 the display path assumes. Without it, the schema default
+					// 0 would round-trip through an editor and clamp to 20 — silently
+					// changing the live split and re-bucketing anonymous readers
+					// mid-test (see get_tests_config()).
+					'default'           => self::DEFAULT_CONTROL_SHARE,
+					'show_in_rest'      => [
+						'schema' => [
+							'type'    => 'integer',
+							'minimum' => 20,
+							'maximum' => 80,
+							'default' => self::DEFAULT_CONTROL_SHARE,
+						],
+					],
 				]
 			)
 		);
@@ -181,6 +205,13 @@ final class Newspack_Popups_AB_Tests {
 			]
 		);
 
+		// 'fields' => 'ids' skips meta-cache priming, so without this each
+		// get_post_meta() below would issue its own query — an N+1 on the
+		// always-enqueued front-end path. One batched load instead.
+		if ( ! empty( $prompt_ids ) ) {
+			update_meta_cache( 'post', $prompt_ids );
+		}
+
 		$config = [];
 		foreach ( $prompt_ids as $prompt_id ) {
 			$fields = self::get_popup_ab_fields( $prompt_id );
@@ -231,6 +262,12 @@ final class Newspack_Popups_AB_Tests {
 	 * hash in src/view/utils/ab.js. Server and client MUST use the same hash on
 	 * the same identity (the client ID cookie) or a reader can land in different
 	 * arms anonymous vs. logged-in. Parity is pinned by tests on both sides.
+	 *
+	 * ASCII-ONLY PRECONDITION: this hashes UTF-8 *bytes* (strlen/ord) while the
+	 * client hashes UTF-16 *code units* (charCodeAt) — the two agree only while
+	 * every hashed input (client ID, test ID) is ASCII. That holds today by
+	 * construction (generated cookie IDs; sanitize_title output). If either
+	 * input's charset ever widens, normalize both implementations together.
 	 *
 	 * @param string $str String to hash.
 	 * @return int Unsigned 32-bit hash.

--- a/plugins/newspack-popups/includes/class-newspack-popups-ab-tests.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-ab-tests.php
@@ -18,12 +18,12 @@ defined( 'ABSPATH' ) || exit;
  */
 final class Newspack_Popups_AB_Tests {
 
-	const META_TEST_ID       = 'newspack_ab_test_id';
-	const META_VARIANT       = 'newspack_ab_variant';
-	const META_GOAL          = 'newspack_ab_test_goal';
-	const META_CONTROL_SHARE = 'newspack_ab_control_share';
+	const META_TEST_ID       = 'newspack_popups_ab_test_id';
+	const META_VARIANT       = 'newspack_popups_ab_variant';
+	const META_GOAL          = 'newspack_popups_ab_test_goal';
+	const META_CONTROL_SHARE = 'newspack_popups_ab_control_share';
 
-	const USER_META_BUCKET_PREFIX = 'np_ab_bucket_';
+	const USER_META_BUCKET_PREFIX = 'newspack_popups_ab_bucket_';
 
 	const VALID_VARIANTS = [ 'a', 'b', 'c', 'd' ];
 

--- a/plugins/newspack-popups/includes/class-newspack-popups-ab-tests.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-ab-tests.php
@@ -257,7 +257,7 @@ final class Newspack_Popups_AB_Tests {
 				// The prompts CPT is inherently small (tens of posts) and this is
 				// further narrowed by the meta filter; a bound here would silently
 				// truncate the config and drop whole tests (fail-open, uncounted).
-				'posts_per_page' => -1, // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Prompts CPT; config-scale.
 				'fields'         => 'ids',
 				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					[

--- a/plugins/newspack-popups/includes/class-newspack-popups-ab-tests.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-ab-tests.php
@@ -1,0 +1,300 @@
+<?php
+/**
+ * Newspack Popups A/B Tests
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * A/B testing for prompts: meta registration, test configuration, and
+ * reader bucket assignment.
+ *
+ * Two prompts (or more, post-v1) sharing a `newspack_ab_test_id` form a test.
+ * Variant selection happens client-side in the view engine (src/view/utils/ab.js)
+ * using the config this class localizes; logged-in readers get a server-computed
+ * bucket persisted in user meta so assignment is stable across devices.
+ */
+final class Newspack_Popups_AB_Tests {
+
+	const META_TEST_ID       = 'newspack_ab_test_id';
+	const META_VARIANT       = 'newspack_ab_variant';
+	const META_GOAL          = 'newspack_ab_test_goal';
+	const META_CONTROL_SHARE = 'newspack_ab_control_share';
+
+	const USER_META_BUCKET_PREFIX = 'np_ab_bucket_';
+
+	const VALID_VARIANTS = [ 'a', 'b', 'c', 'd' ];
+
+	const DEFAULT_CONTROL_SHARE = 50;
+
+	/**
+	 * Memoized tests config.
+	 *
+	 * @var array|null
+	 */
+	private static $tests_config = null;
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_meta' ] );
+	}
+
+	/**
+	 * Register A/B test meta fields on the prompts CPT.
+	 */
+	public static function register_meta() {
+		$base = [
+			'object_subtype' => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+			'show_in_rest'   => true,
+			'single'         => true,
+			'auth_callback'  => '__return_true',
+		];
+
+		\register_meta(
+			'post',
+			self::META_TEST_ID,
+			array_merge(
+				$base,
+				[
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_title',
+				]
+			)
+		);
+
+		\register_meta(
+			'post',
+			self::META_VARIANT,
+			array_merge(
+				$base,
+				[
+					'type'              => 'string',
+					'sanitize_callback' => [ __CLASS__, 'sanitize_variant' ],
+				]
+			)
+		);
+
+		\register_meta(
+			'post',
+			self::META_GOAL,
+			array_merge(
+				$base,
+				[
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_key',
+				]
+			)
+		);
+
+		\register_meta(
+			'post',
+			self::META_CONTROL_SHARE,
+			array_merge(
+				$base,
+				[
+					'type'              => 'integer',
+					'sanitize_callback' => [ __CLASS__, 'sanitize_control_share' ],
+				]
+			)
+		);
+	}
+
+	/**
+	 * Sanitize a variant key.
+	 *
+	 * @param string $value Raw value.
+	 * @return string Valid variant key, or empty string.
+	 */
+	public static function sanitize_variant( $value ) {
+		return in_array( $value, self::VALID_VARIANTS, true ) ? $value : '';
+	}
+
+	/**
+	 * Sanitize a control share percentage, clamped to 20–80.
+	 *
+	 * @param int $value Raw value.
+	 * @return int Clamped value.
+	 */
+	public static function sanitize_control_share( $value ) {
+		return max( 20, min( 80, absint( $value ) ) );
+	}
+
+	/**
+	 * Get the A/B fields for a single prompt.
+	 *
+	 * @param int $popup_id Prompt post ID.
+	 * @return array|null Array with test_id and variant, or null if not part of a test.
+	 */
+	public static function get_popup_ab_fields( $popup_id ) {
+		$test_id = get_post_meta( $popup_id, self::META_TEST_ID, true );
+		$variant = get_post_meta( $popup_id, self::META_VARIANT, true );
+		if ( ! $test_id || ! in_array( $variant, self::VALID_VARIANTS, true ) ) {
+			return null;
+		}
+		return [
+			'test_id' => $test_id,
+			'variant' => $variant,
+		];
+	}
+
+	/**
+	 * Build the config for all valid A/B tests: tests with a published control
+	 * and at least one published challenger.
+	 *
+	 * The full variant set is derived from published prompts regardless of which
+	 * prompts render on a given page, so client-side hash ranges stay stable.
+	 *
+	 * @return array Config keyed by test ID: [ 'variants' => [ 'a', 'b' ], 'control_share' => 60 ].
+	 */
+	public static function get_tests_config() {
+		if ( null !== self::$tests_config ) {
+			return self::$tests_config;
+		}
+
+		$prompt_ids = get_posts(
+			[
+				'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+				'post_status'    => 'publish',
+				'posts_per_page' => 100,
+				'fields'         => 'ids',
+				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					[
+						'key'     => self::META_TEST_ID,
+						'compare' => '!=',
+						'value'   => '',
+					],
+				],
+			]
+		);
+
+		$config = [];
+		foreach ( $prompt_ids as $prompt_id ) {
+			$fields = self::get_popup_ab_fields( $prompt_id );
+			if ( ! $fields ) {
+				continue;
+			}
+			$test_id = $fields['test_id'];
+			$variant = $fields['variant'];
+			if ( ! isset( $config[ $test_id ] ) ) {
+				$config[ $test_id ] = [
+					'variants'      => [],
+					'control_share' => self::DEFAULT_CONTROL_SHARE,
+				];
+			}
+			if ( ! in_array( $variant, $config[ $test_id ]['variants'], true ) ) {
+				$config[ $test_id ]['variants'][] = $variant;
+			}
+			if ( 'a' === $variant ) {
+				$control_share = get_post_meta( $prompt_id, self::META_CONTROL_SHARE, true );
+				if ( $control_share ) {
+					$config[ $test_id ]['control_share'] = absint( $control_share );
+				}
+			}
+		}
+
+		// Only tests with a control and at least one challenger are valid.
+		$config = array_filter(
+			$config,
+			function ( $test ) {
+				return in_array( 'a', $test['variants'], true ) && count( $test['variants'] ) >= 2;
+			}
+		);
+
+		// Normalize variant order for stable client-side range math.
+		foreach ( $config as $test_id => $test ) {
+			sort( $config[ $test_id ]['variants'] );
+		}
+
+		self::$tests_config = $config;
+		return $config;
+	}
+
+	/**
+	 * Compute a stable bucket for a reader key using weighted ranges.
+	 *
+	 * Uses crc32, matching the POC's server-side assignment, so buckets computed
+	 * before the core integration carry over for logged-in readers.
+	 *
+	 * @param string $reader_key Stable reader identifier (e.g. user ID).
+	 * @param string $test_id    Test ID.
+	 * @param array  $config     Test config with variants and control_share.
+	 * @return string Variant key.
+	 */
+	public static function compute_bucket( $reader_key, $test_id, $config ) {
+		$variants    = $config['variants'];
+		$challengers = array_values(
+			array_filter(
+				$variants,
+				function ( $variant ) {
+					return 'a' !== $variant;
+				}
+			)
+		);
+
+		if ( empty( $challengers ) ) {
+			return 'a';
+		}
+
+		$control_share    = ( $config['control_share'] ?? self::DEFAULT_CONTROL_SHARE ) / 100;
+		$challenger_share = ( 1 - $control_share ) / count( $challengers );
+
+		$ranges = [ [ 'a', $control_share ] ];
+		$cursor = $control_share;
+		foreach ( $challengers as $variant ) {
+			$cursor  += $challenger_share;
+			$ranges[] = [ $variant, $cursor ];
+		}
+
+		$hash       = abs( crc32( $reader_key . '|' . $test_id ) );
+		$normalized = $hash / 4294967295;
+
+		foreach ( $ranges as $range ) {
+			if ( $normalized <= $range[1] ) {
+				return $range[0];
+			}
+		}
+		return end( $ranges )[0];
+	}
+
+	/**
+	 * Get (computing and persisting on first encounter) the current logged-in
+	 * user's buckets for the given tests.
+	 *
+	 * The persisted value always wins, so mid-test control-share edits never
+	 * re-bucket a reader who has already been assigned.
+	 *
+	 * @param array $tests_config Config from get_tests_config().
+	 * @return array Buckets keyed by test ID.
+	 */
+	public static function get_logged_in_buckets( $tests_config ) {
+		$user_id = get_current_user_id();
+		if ( ! $user_id ) {
+			return [];
+		}
+
+		$buckets = [];
+		foreach ( $tests_config as $test_id => $config ) {
+			$meta_key = self::USER_META_BUCKET_PREFIX . $test_id;
+			$bucket   = get_user_meta( $user_id, $meta_key, true );
+			if ( ! in_array( $bucket, $config['variants'], true ) ) {
+				$bucket = self::compute_bucket( (string) $user_id, $test_id, $config );
+				update_user_meta( $user_id, $meta_key, $bucket );
+			}
+			$buckets[ $test_id ] = $bucket;
+		}
+		return $buckets;
+	}
+
+	/**
+	 * Reset the memoized config (for tests).
+	 */
+	public static function reset_config_cache() {
+		self::$tests_config = null;
+	}
+}
+
+Newspack_Popups_AB_Tests::init();

--- a/plugins/newspack-popups/includes/class-newspack-popups-ab-tests.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-ab-tests.php
@@ -25,6 +25,16 @@ final class Newspack_Popups_AB_Tests {
 
 	const USER_META_BUCKET_PREFIX = 'newspack_popups_ab_bucket_';
 
+	/**
+	 * Autoloaded flag recording whether any valid test exists.
+	 *
+	 * Three states, and the distinction matters: '1' and absent both fall through to
+	 * the discovery query, only '0' short-circuits. Invalidation therefore deletes
+	 * the option rather than writing '0', so a missed invalidation degrades to an
+	 * extra query rather than to tests silently not running.
+	 */
+	const OPTION_HAS_TESTS = 'newspack_popups_ab_has_tests';
+
 	const VALID_VARIANTS = [ 'a', 'b', 'c', 'd' ];
 
 	const DEFAULT_CONTROL_SHARE = 50;
@@ -41,6 +51,51 @@ final class Newspack_Popups_AB_Tests {
 	 */
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
+
+		// Anything that can add or remove a test invalidates the flag. Scoped to the
+		// prompts CPT and to the test-id meta key: a news site saves posts constantly,
+		// and invalidating on those would reinstate the per-request query this exists
+		// to avoid. Meta hooks are covered separately because update_post_meta() can
+		// set a test id without firing save_post.
+		add_action( 'save_post_' . Newspack_Popups::NEWSPACK_POPUPS_CPT, [ __CLASS__, 'invalidate_has_tests' ] );
+		foreach ( [ 'deleted_post', 'trashed_post', 'untrashed_post' ] as $hook ) {
+			add_action( $hook, [ __CLASS__, 'invalidate_has_tests_for_post' ] );
+		}
+		foreach ( [ 'added_post_meta', 'updated_post_meta', 'deleted_post_meta' ] as $hook ) {
+			add_action( $hook, [ __CLASS__, 'invalidate_has_tests_for_meta' ], 10, 3 );
+		}
+	}
+
+	/**
+	 * Drop the has-tests flag.
+	 */
+	public static function invalidate_has_tests() {
+		delete_option( self::OPTION_HAS_TESTS );
+		self::$tests_config = null;
+	}
+
+	/**
+	 * Drop the flag when a prompt is deleted, trashed or restored.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public static function invalidate_has_tests_for_post( $post_id ) {
+		if ( Newspack_Popups::NEWSPACK_POPUPS_CPT === get_post_type( $post_id ) ) {
+			self::invalidate_has_tests();
+		}
+	}
+
+	/**
+	 * Drop the flag when a prompt's test-id meta changes.
+	 *
+	 * @param int    $meta_id   Meta ID.
+	 * @param int    $object_id Post ID.
+	 * @param string $meta_key  Meta key.
+	 */
+	public static function invalidate_has_tests_for_meta( $meta_id, $object_id, $meta_key ) {
+		if ( self::META_TEST_ID === $meta_key ) {
+			self::invalidate_has_tests_for_post( $object_id );
+		}
 	}
 
 	/**
@@ -186,6 +241,15 @@ final class Newspack_Popups_AB_Tests {
 			return self::$tests_config;
 		}
 
+		// Every non-AMP front-end request reaches this, on every site. WP's query cache
+		// absorbs the repeat cost only until the next post save, which on a news site
+		// is continuous -- so without this a site with zero tests pays a postmeta-join
+		// query more or less per request, forever.
+		if ( '0' === get_option( self::OPTION_HAS_TESTS, '' ) ) {
+			self::$tests_config = [];
+			return self::$tests_config;
+		}
+
 		$prompt_ids = get_posts(
 			[
 				'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
@@ -252,6 +316,10 @@ final class Newspack_Popups_AB_Tests {
 		foreach ( $config as $test_id => $test ) {
 			sort( $config[ $test_id ]['variants'] );
 		}
+
+		// update_option() is a no-op when the stored value already matches, so this
+		// does not write on every request.
+		update_option( self::OPTION_HAS_TESTS, empty( $config ) ? '0' : '1', true );
 
 		self::$tests_config = $config;
 		return $config;
@@ -375,6 +443,7 @@ final class Newspack_Popups_AB_Tests {
 	 */
 	public static function reset_config_cache() {
 		self::$tests_config = null;
+		delete_option( self::OPTION_HAS_TESTS );
 	}
 }
 

--- a/plugins/newspack-popups/includes/class-newspack-popups-ab-tests.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-ab-tests.php
@@ -411,8 +411,16 @@ final class Newspack_Popups_AB_Tests {
 	 * identity and hash the anonymous client-side assignment uses — so a reader
 	 * who registers mid-test stays in the arm they were already seeing. The user
 	 * ID is the fallback key when no client ID is available. The persisted value
-	 * always wins thereafter, so mid-test control-share edits never re-bucket a
-	 * reader, and assignment is stable across devices once logged in.
+	 * wins thereafter for as long as it names a published variant, so mid-test
+	 * control-share edits never re-bucket a reader, and assignment is stable across
+	 * devices once logged in.
+	 *
+	 * The exception is a stored variant that leaves the published set: the guard
+	 * below recomputes and overwrites it. In a two-arm test that cannot happen --
+	 * unpublishing the only challenger ends the test -- but with three or more arms,
+	 * briefly drafting one variant permanently reassigns every reader holding it, and
+	 * republishing does not bring them back. Tracked separately; the fix is to keep
+	 * any stored VALID_VARIANTS value and fall back only for display.
 	 *
 	 * @param array $tests_config Config from get_tests_config().
 	 * @return array Buckets keyed by test ID.

--- a/plugins/newspack-popups/includes/class-newspack-popups-ab-tests.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-ab-tests.php
@@ -126,13 +126,20 @@ final class Newspack_Popups_AB_Tests {
 	/**
 	 * Get the A/B fields for a single prompt.
 	 *
-	 * @param int $popup_id Prompt post ID.
+	 * @param int  $popup_id Prompt post ID.
+	 * @param bool $validate If true, only return fields when the prompt's test is
+	 *                       valid (published control + at least one published
+	 *                       challenger) — an invalid test must not present itself
+	 *                       as a live experiment in markup or analytics params.
 	 * @return array|null Array with test_id and variant, or null if not part of a test.
 	 */
-	public static function get_popup_ab_fields( $popup_id ) {
+	public static function get_popup_ab_fields( $popup_id, $validate = false ) {
 		$test_id = get_post_meta( $popup_id, self::META_TEST_ID, true );
 		$variant = get_post_meta( $popup_id, self::META_VARIANT, true );
 		if ( ! $test_id || ! in_array( $variant, self::VALID_VARIANTS, true ) ) {
+			return null;
+		}
+		if ( $validate && ! isset( self::get_tests_config()[ $test_id ] ) ) {
 			return null;
 		}
 		return [
@@ -159,7 +166,10 @@ final class Newspack_Popups_AB_Tests {
 			[
 				'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 				'post_status'    => 'publish',
-				'posts_per_page' => 100,
+				// The prompts CPT is inherently small (tens of posts) and this is
+				// further narrowed by the meta filter; a bound here would silently
+				// truncate the config and drop whole tests (fail-open, uncounted).
+				'posts_per_page' => -1, // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
 				'fields'         => 'ids',
 				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					[
@@ -191,7 +201,10 @@ final class Newspack_Popups_AB_Tests {
 			if ( 'a' === $variant ) {
 				$control_share = get_post_meta( $prompt_id, self::META_CONTROL_SHARE, true );
 				if ( $control_share ) {
-					$config[ $test_id ]['control_share'] = absint( $control_share );
+					// Clamp at read time too: direct meta writes (importers, CLI)
+					// bypass the sanitize callback, and an out-of-range share would
+					// skew the client-side range math.
+					$config[ $test_id ]['control_share'] = self::sanitize_control_share( $control_share );
 				}
 			}
 		}
@@ -214,12 +227,27 @@ final class Newspack_Popups_AB_Tests {
 	}
 
 	/**
+	 * The djb2 (xor variant) string hash, bit-for-bit identical to the client-side
+	 * hash in src/view/utils/ab.js. Server and client MUST use the same hash on
+	 * the same identity (the client ID cookie) or a reader can land in different
+	 * arms anonymous vs. logged-in. Parity is pinned by tests on both sides.
+	 *
+	 * @param string $str String to hash.
+	 * @return int Unsigned 32-bit hash.
+	 */
+	public static function hash_djb2( $str ) {
+		$hash = 5381;
+		$len  = strlen( $str );
+		for ( $i = 0; $i < $len; $i++ ) {
+			$hash = ( ( ( $hash << 5 ) + $hash ) ^ ord( $str[ $i ] ) ) & 0xFFFFFFFF;
+		}
+		return $hash;
+	}
+
+	/**
 	 * Compute a stable bucket for a reader key using weighted ranges.
 	 *
-	 * Uses crc32, matching the POC's server-side assignment, so buckets computed
-	 * before the core integration carry over for logged-in readers.
-	 *
-	 * @param string $reader_key Stable reader identifier (e.g. user ID).
+	 * @param string $reader_key Stable reader identifier (client ID cookie, or user ID as fallback).
 	 * @param string $test_id    Test ID.
 	 * @param array  $config     Test config with variants and control_share.
 	 * @return string Variant key.
@@ -249,7 +277,7 @@ final class Newspack_Popups_AB_Tests {
 			$ranges[] = [ $variant, $cursor ];
 		}
 
-		$hash       = abs( crc32( $reader_key . '|' . $test_id ) );
+		$hash       = self::hash_djb2( $reader_key . '|' . $test_id );
 		$normalized = $hash / 4294967295;
 
 		foreach ( $ranges as $range ) {
@@ -261,11 +289,25 @@ final class Newspack_Popups_AB_Tests {
 	}
 
 	/**
+	 * Get the reader's client ID from the Reader Activation cookie, if present.
+	 *
+	 * @return string Client ID, or empty string.
+	 */
+	public static function get_client_id() {
+		$cookie_name = defined( 'NEWSPACK_CLIENT_ID_COOKIE_NAME' ) ? NEWSPACK_CLIENT_ID_COOKIE_NAME : 'newspack-cid';
+		return isset( $_COOKIE[ $cookie_name ] ) ? sanitize_text_field( wp_unslash( $_COOKIE[ $cookie_name ] ) ) : ''; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+	}
+
+	/**
 	 * Get (computing and persisting on first encounter) the current logged-in
 	 * user's buckets for the given tests.
 	 *
-	 * The persisted value always wins, so mid-test control-share edits never
-	 * re-bucket a reader who has already been assigned.
+	 * First assignment prefers the client ID cookie as the hash key — the same
+	 * identity and hash the anonymous client-side assignment uses — so a reader
+	 * who registers mid-test stays in the arm they were already seeing. The user
+	 * ID is the fallback key when no client ID is available. The persisted value
+	 * always wins thereafter, so mid-test control-share edits never re-bucket a
+	 * reader, and assignment is stable across devices once logged in.
 	 *
 	 * @param array $tests_config Config from get_tests_config().
 	 * @return array Buckets keyed by test ID.
@@ -276,12 +318,14 @@ final class Newspack_Popups_AB_Tests {
 			return [];
 		}
 
-		$buckets = [];
+		$client_id = self::get_client_id();
+		$buckets   = [];
 		foreach ( $tests_config as $test_id => $config ) {
 			$meta_key = self::USER_META_BUCKET_PREFIX . $test_id;
 			$bucket   = get_user_meta( $user_id, $meta_key, true );
 			if ( ! in_array( $bucket, $config['variants'], true ) ) {
-				$bucket = self::compute_bucket( (string) $user_id, $test_id, $config );
+				$reader_key = $client_id ? $client_id : (string) $user_id;
+				$bucket     = self::compute_bucket( $reader_key, $test_id, $config );
 				update_user_meta( $user_id, $meta_key, $bucket );
 			}
 			$buckets[ $test_id ] = $bucket;

--- a/plugins/newspack-popups/includes/class-newspack-popups-data-api.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-data-api.php
@@ -113,6 +113,13 @@ final class Newspack_Popups_Data_Api {
 			$data['prompt_placement'] = $popup['options']['placement'] ?? '';
 		}
 
+		// A/B test params: a displayed prompt's variant is the reader's assigned
+		// bucket, so static per-prompt params are sufficient for GA analysis.
+		if ( ! empty( $popup['ab_test_id'] ) ) {
+			$data['ab_test_id'] = $popup['ab_test_id'];
+			$data['ab_variant'] = $popup['ab_variant'];
+		}
+
 		$watched_blocks = [
 			'registration'             => 'newspack/reader-registration',
 			'donation'                 => 'newspack-blocks/donate',

--- a/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
@@ -1088,6 +1088,11 @@ final class Newspack_Popups_Inserter {
 				$script_data['donor_landing_page'] = $donor_landing_page;
 			}
 
+			// Variant suppression is entirely client-side, and this whole block sits
+			// inside the non-AMP branch, so AMP requests get no A/B config at all.
+			// That is correct only because AMP prompt display is currently disabled:
+			// if it is ever restored, every arm of a test would render un-suppressed
+			// unless suppression is reimplemented for that path.
 			$ab_tests = Newspack_Popups_AB_Tests::get_tests_config();
 			if ( ! empty( $ab_tests ) ) {
 				$script_data['ab_tests']   = $ab_tests;

--- a/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
@@ -1088,6 +1088,16 @@ final class Newspack_Popups_Inserter {
 				$script_data['donor_landing_page'] = $donor_landing_page;
 			}
 
+			$ab_tests = Newspack_Popups_AB_Tests::get_tests_config();
+			if ( ! empty( $ab_tests ) ) {
+				$script_data['ab_tests']   = $ab_tests;
+				$script_data['cid_cookie'] = defined( 'NEWSPACK_CLIENT_ID_COOKIE_NAME' ) ? NEWSPACK_CLIENT_ID_COOKIE_NAME : 'newspack-cid';
+				$ab_buckets                = Newspack_Popups_AB_Tests::get_logged_in_buckets( $ab_tests );
+				if ( ! empty( $ab_buckets ) ) {
+					$script_data['ab_buckets'] = $ab_buckets;
+				}
+			}
+
 			\wp_localize_script( $script_handle, 'newspack_popups_view', $script_data );
 			\wp_enqueue_script( $script_handle );
 		}

--- a/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
@@ -1096,6 +1096,13 @@ final class Newspack_Popups_Inserter {
 				if ( ! empty( $ab_buckets ) ) {
 					$script_data['ab_buckets'] = $ab_buckets;
 				}
+				// Variant preview (view_as=ab_variant:x) is echoed server-side via the
+				// admin-gated View_As spec rather than parsed from the URL in JS, so a
+				// non-privileged visitor cannot self-select an arm (and pollute GA).
+				$view_as_spec = Newspack_Popups_View_As::parse_view_as();
+				if ( ! empty( $view_as_spec['ab_variant'] ) && in_array( $view_as_spec['ab_variant'], Newspack_Popups_AB_Tests::VALID_VARIANTS, true ) ) {
+					$script_data['ab_view_as'] = $view_as_spec['ab_variant'];
+				}
 			}
 
 			\wp_localize_script( $script_handle, 'newspack_popups_view', $script_data );

--- a/plugins/newspack-popups/includes/class-newspack-popups-model.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-model.php
@@ -708,6 +708,13 @@ final class Newspack_Popups_Model {
 			$popup['duplicate_of'] = $duplicate_of;
 		}
 
+		$ab_fields = Newspack_Popups_AB_Tests::get_popup_ab_fields( $id );
+
+		if ( $ab_fields ) {
+			$popup['ab_test_id'] = $ab_fields['test_id'];
+			$popup['ab_variant'] = $ab_fields['variant'];
+		}
+
 		if ( self::is_inline( $popup ) ) {
 			switch ( $popup['options']['trigger_type'] ) {
 				case 'blocks_count':
@@ -1072,6 +1079,10 @@ final class Newspack_Popups_Model {
 				<?php if ( ! empty( $utm_suppression ) ) : ?>
 					data-suppression="<?php echo esc_attr( $utm_suppression ); ?>"
 				<?php endif; ?>
+				<?php if ( ! empty( $popup['ab_test_id'] ) ) : ?>
+					data-ab-test-id="<?php echo esc_attr( $popup['ab_test_id'] ); ?>"
+					data-ab-variant="<?php echo esc_attr( $popup['ab_variant'] ); ?>"
+				<?php endif; ?>
 			>
 				<?php echo do_shortcode( $body ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</div>
@@ -1229,6 +1240,10 @@ final class Newspack_Popups_Model {
 			data-frequency="<?php echo esc_attr( $frequency_config ); ?>"
 			<?php if ( ! empty( $utm_suppression ) ) : ?>
 				data-suppression="<?php echo esc_attr( $utm_suppression ); ?>"
+			<?php endif; ?>
+			<?php if ( ! empty( $popup['ab_test_id'] ) ) : ?>
+				data-ab-test-id="<?php echo esc_attr( $popup['ab_test_id'] ); ?>"
+				data-ab-variant="<?php echo esc_attr( $popup['ab_variant'] ); ?>"
 			<?php endif; ?>
 
 			<?php if ( $is_scroll_triggered ) : ?>

--- a/plugins/newspack-popups/includes/class-newspack-popups-model.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-model.php
@@ -708,7 +708,7 @@ final class Newspack_Popups_Model {
 			$popup['duplicate_of'] = $duplicate_of;
 		}
 
-		$ab_fields = Newspack_Popups_AB_Tests::get_popup_ab_fields( $id );
+		$ab_fields = Newspack_Popups_AB_Tests::get_popup_ab_fields( $id, true );
 
 		if ( $ab_fields ) {
 			$popup['ab_test_id'] = $ab_fields['test_id'];

--- a/plugins/newspack-popups/includes/class-newspack-popups.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups.php
@@ -111,6 +111,7 @@ final class Newspack_Popups {
 		include_once __DIR__ . '/class-newspack-popups-custom-placements.php';
 		include_once __DIR__ . '/class-newspack-popups-view-as.php';
 		include_once __DIR__ . '/class-newspack-popups-data-api.php';
+		include_once __DIR__ . '/class-newspack-popups-ab-tests.php';
 		include_once __DIR__ . '/class-newspack-popups-criteria.php';
 		include_once __DIR__ . '/class-newspack-popups-expiry.php';
 		include_once __DIR__ . '/merge-tags/class-merge-tag.php';

--- a/plugins/newspack-popups/src/view/segmentation.js
+++ b/plugins/newspack-popups/src/view/segmentation.js
@@ -3,6 +3,7 @@
 import {
 	debug,
 	closeOverlay,
+	getAbOverride,
 	getBestPrioritySegment,
 	getIntersectionObserver,
 	getRawId,
@@ -35,7 +36,11 @@ export const handleSegmentation = prompts => {
 		prompts.forEach( prompt => {
 			const promptId = prompt.getAttribute( 'id' );
 			const isOverlay = prompt.classList.contains( 'newspack-lightbox' );
-			const override = getOverride( getRawId( promptId ), isOverlay, overlayDisplayed );
+			// A/B variant selection composes with the standard override: a test
+			// variant the reader is not assigned to is suppressed before it can
+			// claim the single-overlay slot; the assigned variant goes through
+			// the normal frequency/segmentation checks.
+			const override = getOverride( getRawId( promptId ), isOverlay, overlayDisplayed ) ?? getAbOverride( prompt );
 
 			// Attach event listeners to overlay close buttons.
 			const closeButtons = [ ...prompt.querySelectorAll( '.newspack-lightbox__close, button.newspack-lightbox-overlay' ) ];

--- a/plugins/newspack-popups/src/view/segmentation.test.js
+++ b/plugins/newspack-popups/src/view/segmentation.test.js
@@ -1,0 +1,100 @@
+/**
+ * Direct coverage of the A/B + override composition in handleSegmentation.
+ *
+ * The POC bug this feature replaces was positional: a variant the reader is not
+ * assigned to still claimed the single-overlay slot, so a later legitimate overlay
+ * never showed. getAbOverride() unit tests cannot catch that -- they prove the
+ * override value, not what handleSegmentation does with it -- so this exercises
+ * `getOverride( ... ) ?? getAbOverride( prompt )` through the real loop.
+ */
+
+// Real getOverride / getAbOverride / getRawId: they are the composition under test.
+// Everything else is stubbed so display turns only on the override.
+jest.mock( './utils', () => {
+	const actual = jest.requireActual( './utils' );
+	return {
+		...actual,
+		debug: () => {},
+		closeOverlay: () => {},
+		handleSeen: () => {},
+		getIntersectionObserver: () => ( { observe: () => {} } ),
+		getBestPrioritySegment: () => null,
+		shouldPromptBeDisplayed: ( prompt, segment, ras, override ) => override ?? true,
+	};
+} );
+
+import { handleSegmentation } from './segmentation';
+import { computeBucket } from './utils';
+
+const READER_ID = 'reader-fixture-1';
+const TEST_ID = 'slot-test';
+const CONFIG = { variants: [ 'a', 'b' ], control_share: 50 };
+
+const makePrompt = ( { overlay = false, variant = null } = {} ) => {
+	const prompt = document.createElement( 'div' );
+	prompt.setAttribute( 'id', `id_${ Math.floor( Math.random() * 1e6 ) }` );
+	prompt.classList.add( 'hidden' );
+	if ( overlay ) {
+		prompt.classList.add( 'newspack-lightbox' );
+	}
+	if ( variant ) {
+		prompt.setAttribute( 'data-ab-test-id', TEST_ID );
+		prompt.setAttribute( 'data-ab-variant', variant );
+	}
+	return prompt;
+};
+
+const isVisible = prompt => ! prompt.classList.contains( 'hidden' );
+
+describe( 'handleSegmentation A/B composition', () => {
+	let assigned;
+	let unassigned;
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+		global.newspack_popups_view = { ab_tests: { [ TEST_ID ]: CONFIG }, cid_cookie: 'newspack-cid' };
+		document.cookie = `newspack-cid=${ READER_ID }`;
+		document.body.className = '';
+		// Derive the arm from the real hash rather than hard-coding it, so the test
+		// keeps testing suppression if the bucketing math is ever retuned.
+		assigned = computeBucket( READER_ID, TEST_ID, CONFIG );
+		unassigned = 'a' === assigned ? 'b' : 'a';
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'does not let a suppressed overlay variant claim the single-overlay slot', () => {
+		const suppressed = makePrompt( { overlay: true, variant: unassigned } );
+		const legitimate = makePrompt( { overlay: true } );
+
+		handleSegmentation( [ suppressed, legitimate ] );
+		jest.runAllTimers();
+
+		expect( isVisible( suppressed ) ).toBe( false );
+		expect( isVisible( legitimate ) ).toBe( true );
+	} );
+
+	it( 'displays only the assigned arm when both inline variants are present', () => {
+		const armA = makePrompt( { variant: assigned } );
+		const armB = makePrompt( { variant: unassigned } );
+
+		handleSegmentation( [ armA, armB ] );
+		jest.runAllTimers();
+
+		expect( isVisible( armA ) ).toBe( true );
+		expect( isVisible( armB ) ).toBe( false );
+	} );
+
+	it( 'still enforces one overlay at a time among assigned prompts', () => {
+		const first = makePrompt( { overlay: true, variant: assigned } );
+		const second = makePrompt( { overlay: true } );
+
+		handleSegmentation( [ first, second ] );
+		jest.runAllTimers();
+
+		expect( isVisible( first ) ).toBe( true );
+		expect( isVisible( second ) ).toBe( false );
+	} );
+} );

--- a/plugins/newspack-popups/src/view/utils/ab.js
+++ b/plugins/newspack-popups/src/view/utils/ab.js
@@ -12,7 +12,13 @@ const getViewData = () => ( typeof newspack_popups_view !== 'undefined' ? newspa
 
 /**
  * djb2 (xor variant) string hash. Matches the POC's client-side hash so
- * anonymous assignments made by the POC carry over.
+ * anonymous assignments made by the POC carry over, and is bit-for-bit
+ * identical to the server-side Newspack_Popups_AB_Tests::hash_djb2().
+ *
+ * ASCII-ONLY PRECONDITION: this hashes UTF-16 code units (charCodeAt) while
+ * the server hashes UTF-8 bytes — the two agree only while every hashed input
+ * (client ID, test ID) is ASCII, which holds today by construction. If either
+ * input's charset ever widens, normalize both implementations together.
  *
  * @param {string} str String to hash.
  * @return {number} Unsigned 32-bit hash.

--- a/plugins/newspack-popups/src/view/utils/ab.js
+++ b/plugins/newspack-popups/src/view/utils/ab.js
@@ -1,7 +1,5 @@
 /* globals newspack_popups_view */
 
-import { parseViewAs } from './segments';
-
 const DEFAULT_CID_COOKIE = 'newspack-cid';
 const DEFAULT_CONTROL_SHARE = 50;
 
@@ -80,23 +78,25 @@ export const computeBucket = ( readerId, testId, config ) => {
 /**
  * Get the reader's assigned bucket for a test.
  *
- * Precedence: view_as=ab_variant:x preview > server-computed bucket (logged-in
- * readers) > client-side hash of the reader's client ID. Returns null when no
- * stable identity is available (fail open: no A/B suppression).
+ * Precedence: server-echoed variant preview (view_as=ab_variant:x, admin-gated
+ * in PHP) > server-computed bucket (logged-in readers) > client-side hash of
+ * the reader's client ID > control. The control fallback keeps the one-variant
+ * invariant for readers with no stable identity (e.g. cookies blocked) — an
+ * inline test must not render both arms.
  *
  * @param {string}      testId       Test ID.
  * @param {Object}      config       Test config with variants and control_share.
- * @param {string|null} viewAsString Optional, for testing. A query string with view_as params.
  * @param {string|null} cookieString Optional, for testing. A cookie string to parse.
- * @return {string|null} Variant key, or null.
+ * @return {string} Variant key.
  */
-export const getAssignedBucket = ( testId, config, viewAsString = null, cookieString = null ) => {
+export const getAssignedBucket = ( testId, config, cookieString = null ) => {
 	const variants = config.variants || [];
 
-	// Variant preview for editors: ?view_as=ab_variant:b.
-	const viewAs = parseViewAs( viewAsString );
-	if ( viewAs?.ab_variant && -1 < variants.indexOf( viewAs.ab_variant ) ) {
-		return viewAs.ab_variant;
+	// Variant preview for editors, echoed by the server through the admin-gated
+	// View_As spec — never parsed from the URL here.
+	const viewAsVariant = getViewData().ab_view_as;
+	if ( viewAsVariant && -1 < variants.indexOf( viewAsVariant ) ) {
+		return viewAsVariant;
 	}
 
 	// Server-computed bucket for logged-in readers.
@@ -107,7 +107,8 @@ export const getAssignedBucket = ( testId, config, viewAsString = null, cookieSt
 
 	const readerId = getReaderId( cookieString );
 	if ( ! readerId ) {
-		return null;
+		// No stable identity: fail to control.
+		return 'a';
 	}
 	return computeBucket( readerId, testId, config );
 };
@@ -120,11 +121,10 @@ export const getAssignedBucket = ( testId, config, viewAsString = null, cookieSt
  *   assigned variant must still pass the normal display checks.
  *
  * @param {HTMLElement} prompt       HTML element of the prompt being checked.
- * @param {string|null} viewAsString Optional, for testing. A query string with view_as params.
  * @param {string|null} cookieString Optional, for testing. A cookie string to parse.
  * @return {boolean|null} The override value to pass to the shouldPromptBeDisplayed function.
  */
-export const getAbOverride = ( prompt, viewAsString = null, cookieString = null ) => {
+export const getAbOverride = ( prompt, cookieString = null ) => {
 	const testId = prompt.getAttribute( 'data-ab-test-id' );
 	if ( ! testId ) {
 		return null;
@@ -134,9 +134,6 @@ export const getAbOverride = ( prompt, viewAsString = null, cookieString = null 
 		// Unknown or invalid test (e.g. missing challenger): fail open.
 		return null;
 	}
-	const bucket = getAssignedBucket( testId, config, viewAsString, cookieString );
-	if ( ! bucket ) {
-		return null;
-	}
+	const bucket = getAssignedBucket( testId, config, cookieString );
 	return bucket === prompt.getAttribute( 'data-ab-variant' ) ? null : false;
 };

--- a/plugins/newspack-popups/src/view/utils/ab.js
+++ b/plugins/newspack-popups/src/view/utils/ab.js
@@ -1,0 +1,142 @@
+/* globals newspack_popups_view */
+
+import { parseViewAs } from './segments';
+
+const DEFAULT_CID_COOKIE = 'newspack-cid';
+const DEFAULT_CONTROL_SHARE = 50;
+
+/**
+ * Get the localized view data, guarded for test environments.
+ *
+ * @return {Object} View data.
+ */
+const getViewData = () => ( typeof newspack_popups_view !== 'undefined' ? newspack_popups_view : {} );
+
+/**
+ * djb2 (xor variant) string hash. Matches the POC's client-side hash so
+ * anonymous assignments made by the POC carry over.
+ *
+ * @param {string} str String to hash.
+ * @return {number} Unsigned 32-bit hash.
+ */
+export const hashString = str => {
+	let hash = 5381;
+	for ( let i = 0; i < str.length; i++ ) {
+		hash = ( ( hash << 5 ) + hash ) ^ str.charCodeAt( i ); // eslint-disable-line no-bitwise
+	}
+	return hash >>> 0; // eslint-disable-line no-bitwise
+};
+
+/**
+ * Get the reader's client ID from the Reader Activation cookie.
+ *
+ * @param {string|null} cookieString Optional, for testing. A cookie string to parse.
+ * @return {string|null} Client ID, or null if unavailable.
+ */
+export const getReaderId = ( cookieString = null ) => {
+	const cookieName = getViewData().cid_cookie || DEFAULT_CID_COOKIE;
+	const cookies = null === cookieString ? document.cookie || '' : cookieString;
+	const match = cookies.match( new RegExp( '(?:^|;\\s*)' + cookieName + '=([^;]+)' ) );
+	return match ? decodeURIComponent( match[ 1 ] ) : null;
+};
+
+/**
+ * Assign a reader to a bucket using weighted ranges.
+ *
+ * Example — control_share=60, variants a/b:
+ *   A: 0.00 – 0.60 (60%)
+ *   B: 0.60 – 1.00 (40%)
+ *
+ * @param {string} readerId Stable reader identifier.
+ * @param {string} testId   Test ID.
+ * @param {Object} config   Test config with variants and control_share.
+ * @return {string} Variant key.
+ */
+export const computeBucket = ( readerId, testId, config ) => {
+	const challengers = ( config.variants || [] ).filter( variant => 'a' !== variant );
+	if ( ! challengers.length ) {
+		return 'a';
+	}
+	const controlShare = ( config.control_share || DEFAULT_CONTROL_SHARE ) / 100;
+	const challengerShare = ( 1 - controlShare ) / challengers.length;
+
+	const ranges = [ [ 'a', controlShare ] ];
+	let cursor = controlShare;
+	for ( const variant of challengers ) {
+		cursor += challengerShare;
+		ranges.push( [ variant, cursor ] );
+	}
+
+	const normalized = hashString( readerId + '|' + testId ) / 0xffffffff;
+
+	for ( const [ variant, end ] of ranges ) {
+		if ( normalized <= end ) {
+			return variant;
+		}
+	}
+	return ranges[ ranges.length - 1 ][ 0 ];
+};
+
+/**
+ * Get the reader's assigned bucket for a test.
+ *
+ * Precedence: view_as=ab_variant:x preview > server-computed bucket (logged-in
+ * readers) > client-side hash of the reader's client ID. Returns null when no
+ * stable identity is available (fail open: no A/B suppression).
+ *
+ * @param {string}      testId       Test ID.
+ * @param {Object}      config       Test config with variants and control_share.
+ * @param {string|null} viewAsString Optional, for testing. A query string with view_as params.
+ * @param {string|null} cookieString Optional, for testing. A cookie string to parse.
+ * @return {string|null} Variant key, or null.
+ */
+export const getAssignedBucket = ( testId, config, viewAsString = null, cookieString = null ) => {
+	const variants = config.variants || [];
+
+	// Variant preview for editors: ?view_as=ab_variant:b.
+	const viewAs = parseViewAs( viewAsString );
+	if ( viewAs?.ab_variant && -1 < variants.indexOf( viewAs.ab_variant ) ) {
+		return viewAs.ab_variant;
+	}
+
+	// Server-computed bucket for logged-in readers.
+	const serverBucket = getViewData().ab_buckets?.[ testId ];
+	if ( serverBucket && -1 < variants.indexOf( serverBucket ) ) {
+		return serverBucket;
+	}
+
+	const readerId = getReaderId( cookieString );
+	if ( ! readerId ) {
+		return null;
+	}
+	return computeBucket( readerId, testId, config );
+};
+
+/**
+ * Get an A/B override value for a prompt, to compose with getOverride():
+ * - false - The prompt is a test variant the reader is not assigned to; suppress it.
+ * - null (default) - Not part of a valid test, or the reader's assigned variant;
+ *   let segmentation and frequency controls decide. Never returns true — the
+ *   assigned variant must still pass the normal display checks.
+ *
+ * @param {HTMLElement} prompt       HTML element of the prompt being checked.
+ * @param {string|null} viewAsString Optional, for testing. A query string with view_as params.
+ * @param {string|null} cookieString Optional, for testing. A cookie string to parse.
+ * @return {boolean|null} The override value to pass to the shouldPromptBeDisplayed function.
+ */
+export const getAbOverride = ( prompt, viewAsString = null, cookieString = null ) => {
+	const testId = prompt.getAttribute( 'data-ab-test-id' );
+	if ( ! testId ) {
+		return null;
+	}
+	const config = getViewData().ab_tests?.[ testId ];
+	if ( ! config ) {
+		// Unknown or invalid test (e.g. missing challenger): fail open.
+		return null;
+	}
+	const bucket = getAssignedBucket( testId, config, viewAsString, cookieString );
+	if ( ! bucket ) {
+		return null;
+	}
+	return bucket === prompt.getAttribute( 'data-ab-variant' ) ? null : false;
+};

--- a/plugins/newspack-popups/src/view/utils/ab.js
+++ b/plugins/newspack-popups/src/view/utils/ab.js
@@ -41,7 +41,22 @@ export const getReaderId = ( cookieString = null ) => {
 	const cookieName = getViewData().cid_cookie || DEFAULT_CID_COOKIE;
 	const cookies = null === cookieString ? document.cookie || '' : cookieString;
 	const match = cookies.match( new RegExp( '(?:^|;\\s*)' + cookieName + '=([^;]+)' ) );
-	return match ? decodeURIComponent( match[ 1 ] ) : null;
+	if ( ! match ) {
+		return null;
+	}
+	try {
+		// A cookie value the reader set by hand can contain a stray percent, which
+		// throws URIError here. Uncaught, that aborts prompt processing for the whole
+		// page, so an unreadable id degrades to "no id" rather than to no prompts.
+		//
+		// The server reads this same cookie with sanitize_text_field(), which does not
+		// URL-decode. The two agree for Newspack-generated client IDs; a value needing
+		// decoding is a second way the pair can diverge, beyond the ASCII-only
+		// precondition documented on computeBucket().
+		return decodeURIComponent( match[ 1 ] );
+	} catch ( e ) {
+		return null;
+	}
 };
 
 /**

--- a/plugins/newspack-popups/src/view/utils/ab.test.js
+++ b/plugins/newspack-popups/src/view/utils/ab.test.js
@@ -1,0 +1,120 @@
+import { computeBucket, getAbOverride, getAssignedBucket, getReaderId, hashString } from './index.js';
+
+const makePrompt = ( testId = null, variant = null ) => {
+	const prompt = document.createElement( 'div' );
+	prompt.setAttribute( 'id', 'id_123' );
+	if ( testId ) {
+		prompt.setAttribute( 'data-ab-test-id', testId );
+		prompt.setAttribute( 'data-ab-variant', variant );
+	}
+	return prompt;
+};
+
+const AB_CONFIG = {
+	variants: [ 'a', 'b' ],
+	control_share: 50,
+};
+
+describe( 'hashString', () => {
+	it( 'is deterministic and unsigned', () => {
+		expect( hashString( 'reader|test' ) ).toBe( hashString( 'reader|test' ) );
+		expect( hashString( 'reader|test' ) ).toBeGreaterThanOrEqual( 0 );
+		expect( hashString( 'reader-a|test' ) ).not.toBe( hashString( 'reader-b|test' ) );
+	} );
+} );
+
+describe( 'getReaderId', () => {
+	beforeEach( () => {
+		global.newspack_popups_view = {};
+	} );
+	it( 'reads the default client ID cookie', () => {
+		expect( getReaderId( 'foo=bar; newspack-cid=abc123' ) ).toBe( 'abc123' );
+	} );
+	it( 'uses the localized cookie name when provided', () => {
+		global.newspack_popups_view = { cid_cookie: 'custom-cid' };
+		expect( getReaderId( 'custom-cid=xyz; newspack-cid=abc123' ) ).toBe( 'xyz' );
+	} );
+	it( 'returns null when the cookie is absent', () => {
+		expect( getReaderId( 'foo=bar' ) ).toBeNull();
+		expect( getReaderId( '' ) ).toBeNull();
+	} );
+} );
+
+describe( 'computeBucket', () => {
+	it( 'is deterministic', () => {
+		expect( computeBucket( 'reader-1', 'test-x', AB_CONFIG ) ).toBe( computeBucket( 'reader-1', 'test-x', AB_CONFIG ) );
+	} );
+	it( 'respects the control share weighting', () => {
+		const config = { variants: [ 'a', 'b' ], control_share: 80 };
+		let aCount = 0;
+		for ( let i = 0; i < 500; i++ ) {
+			if ( 'a' === computeBucket( `reader-${ i }`, 'test-x', config ) ) {
+				aCount++;
+			}
+		}
+		expect( aCount ).toBeGreaterThan( 350 );
+		expect( aCount ).toBeLessThan( 470 );
+	} );
+	it( 'assigns different variants across readers', () => {
+		const buckets = new Set();
+		for ( let i = 0; i < 50; i++ ) {
+			buckets.add( computeBucket( `reader-${ i }`, 'test-x', AB_CONFIG ) );
+		}
+		expect( buckets.has( 'a' ) ).toBe( true );
+		expect( buckets.has( 'b' ) ).toBe( true );
+	} );
+	it( 'falls back to control for a degenerate config', () => {
+		expect( computeBucket( 'reader-1', 'test-x', { variants: [ 'a' ], control_share: 50 } ) ).toBe( 'a' );
+	} );
+} );
+
+describe( 'getAssignedBucket', () => {
+	beforeEach( () => {
+		global.newspack_popups_view = {};
+	} );
+	it( 'prefers the view_as variant preview', () => {
+		global.newspack_popups_view = { ab_buckets: { 'test-x': 'a' } };
+		expect( getAssignedBucket( 'test-x', AB_CONFIG, '?view_as=ab_variant:b', 'newspack-cid=abc' ) ).toBe( 'b' );
+	} );
+	it( 'ignores a view_as variant that is not part of the test', () => {
+		expect( getAssignedBucket( 'test-x', AB_CONFIG, '?view_as=ab_variant:d', 'newspack-cid=abc' ) ).toBe(
+			computeBucket( 'abc', 'test-x', AB_CONFIG )
+		);
+	} );
+	it( 'prefers the server-computed bucket over the client hash', () => {
+		global.newspack_popups_view = { ab_buckets: { 'test-x': 'b' } };
+		expect( getAssignedBucket( 'test-x', AB_CONFIG, '?', 'newspack-cid=abc' ) ).toBe( 'b' );
+	} );
+	it( 'hashes the client ID when no server bucket exists', () => {
+		expect( getAssignedBucket( 'test-x', AB_CONFIG, '?', 'newspack-cid=abc' ) ).toBe( computeBucket( 'abc', 'test-x', AB_CONFIG ) );
+	} );
+	it( 'returns null without a stable identity', () => {
+		expect( getAssignedBucket( 'test-x', AB_CONFIG, '?', '' ) ).toBeNull();
+	} );
+} );
+
+describe( 'getAbOverride', () => {
+	beforeEach( () => {
+		global.newspack_popups_view = { ab_tests: { 'test-x': AB_CONFIG } };
+	} );
+	it( 'returns null for prompts that are not part of a test', () => {
+		expect( getAbOverride( makePrompt(), '?', 'newspack-cid=abc' ) ).toBeNull();
+	} );
+	it( 'returns null when the test is not in the localized config', () => {
+		expect( getAbOverride( makePrompt( 'unknown-test', 'a' ), '?', 'newspack-cid=abc' ) ).toBeNull();
+	} );
+	it( 'suppresses the non-assigned variant and passes the assigned one through', () => {
+		const bucket = computeBucket( 'abc', 'test-x', AB_CONFIG );
+		const loser = 'a' === bucket ? 'b' : 'a';
+		expect( getAbOverride( makePrompt( 'test-x', loser ), '?', 'newspack-cid=abc' ) ).toBe( false );
+		// Never true: the assigned variant must still pass frequency/segmentation.
+		expect( getAbOverride( makePrompt( 'test-x', bucket ), '?', 'newspack-cid=abc' ) ).toBeNull();
+	} );
+	it( 'respects a view_as variant preview', () => {
+		expect( getAbOverride( makePrompt( 'test-x', 'b' ), '?view_as=ab_variant:b', 'newspack-cid=abc' ) ).toBeNull();
+		expect( getAbOverride( makePrompt( 'test-x', 'a' ), '?view_as=ab_variant:b', 'newspack-cid=abc' ) ).toBe( false );
+	} );
+	it( 'fails open without a stable identity', () => {
+		expect( getAbOverride( makePrompt( 'test-x', 'b' ), '?', '' ) ).toBeNull();
+	} );
+} );

--- a/plugins/newspack-popups/src/view/utils/ab.test.js
+++ b/plugins/newspack-popups/src/view/utils/ab.test.js
@@ -21,6 +21,12 @@ describe( 'hashString', () => {
 		expect( hashString( 'reader|test' ) ).toBeGreaterThanOrEqual( 0 );
 		expect( hashString( 'reader-a|test' ) ).not.toBe( hashString( 'reader-b|test' ) );
 	} );
+	it( 'matches the server-side hash bit for bit', () => {
+		// Vector pinned in tests/test-ab-tests.php (Newspack_Popups_AB_Tests::hash_djb2)
+		// — if either implementation changes, both parity tests fail together.
+		expect( hashString( 'abc|test-x' ) ).toBe( 809016026 );
+		expect( computeBucket( 'abc', 'test-x', AB_CONFIG ) ).toBe( 'a' );
+	} );
 } );
 
 describe( 'getReaderId', () => {
@@ -72,24 +78,23 @@ describe( 'getAssignedBucket', () => {
 	beforeEach( () => {
 		global.newspack_popups_view = {};
 	} );
-	it( 'prefers the view_as variant preview', () => {
-		global.newspack_popups_view = { ab_buckets: { 'test-x': 'a' } };
-		expect( getAssignedBucket( 'test-x', AB_CONFIG, '?view_as=ab_variant:b', 'newspack-cid=abc' ) ).toBe( 'b' );
+	it( 'prefers the server-echoed variant preview', () => {
+		global.newspack_popups_view = { ab_view_as: 'b', ab_buckets: { 'test-x': 'a' } };
+		expect( getAssignedBucket( 'test-x', AB_CONFIG, 'newspack-cid=abc' ) ).toBe( 'b' );
 	} );
-	it( 'ignores a view_as variant that is not part of the test', () => {
-		expect( getAssignedBucket( 'test-x', AB_CONFIG, '?view_as=ab_variant:d', 'newspack-cid=abc' ) ).toBe(
-			computeBucket( 'abc', 'test-x', AB_CONFIG )
-		);
+	it( 'ignores a previewed variant that is not part of the test', () => {
+		global.newspack_popups_view = { ab_view_as: 'd' };
+		expect( getAssignedBucket( 'test-x', AB_CONFIG, 'newspack-cid=abc' ) ).toBe( computeBucket( 'abc', 'test-x', AB_CONFIG ) );
 	} );
 	it( 'prefers the server-computed bucket over the client hash', () => {
 		global.newspack_popups_view = { ab_buckets: { 'test-x': 'b' } };
-		expect( getAssignedBucket( 'test-x', AB_CONFIG, '?', 'newspack-cid=abc' ) ).toBe( 'b' );
+		expect( getAssignedBucket( 'test-x', AB_CONFIG, 'newspack-cid=abc' ) ).toBe( 'b' );
 	} );
 	it( 'hashes the client ID when no server bucket exists', () => {
-		expect( getAssignedBucket( 'test-x', AB_CONFIG, '?', 'newspack-cid=abc' ) ).toBe( computeBucket( 'abc', 'test-x', AB_CONFIG ) );
+		expect( getAssignedBucket( 'test-x', AB_CONFIG, 'newspack-cid=abc' ) ).toBe( computeBucket( 'abc', 'test-x', AB_CONFIG ) );
 	} );
-	it( 'returns null without a stable identity', () => {
-		expect( getAssignedBucket( 'test-x', AB_CONFIG, '?', '' ) ).toBeNull();
+	it( 'falls back to control without a stable identity', () => {
+		expect( getAssignedBucket( 'test-x', AB_CONFIG, '' ) ).toBe( 'a' );
 	} );
 } );
 
@@ -98,23 +103,25 @@ describe( 'getAbOverride', () => {
 		global.newspack_popups_view = { ab_tests: { 'test-x': AB_CONFIG } };
 	} );
 	it( 'returns null for prompts that are not part of a test', () => {
-		expect( getAbOverride( makePrompt(), '?', 'newspack-cid=abc' ) ).toBeNull();
+		expect( getAbOverride( makePrompt(), 'newspack-cid=abc' ) ).toBeNull();
 	} );
 	it( 'returns null when the test is not in the localized config', () => {
-		expect( getAbOverride( makePrompt( 'unknown-test', 'a' ), '?', 'newspack-cid=abc' ) ).toBeNull();
+		expect( getAbOverride( makePrompt( 'unknown-test', 'a' ), 'newspack-cid=abc' ) ).toBeNull();
 	} );
 	it( 'suppresses the non-assigned variant and passes the assigned one through', () => {
 		const bucket = computeBucket( 'abc', 'test-x', AB_CONFIG );
 		const loser = 'a' === bucket ? 'b' : 'a';
-		expect( getAbOverride( makePrompt( 'test-x', loser ), '?', 'newspack-cid=abc' ) ).toBe( false );
+		expect( getAbOverride( makePrompt( 'test-x', loser ), 'newspack-cid=abc' ) ).toBe( false );
 		// Never true: the assigned variant must still pass frequency/segmentation.
-		expect( getAbOverride( makePrompt( 'test-x', bucket ), '?', 'newspack-cid=abc' ) ).toBeNull();
+		expect( getAbOverride( makePrompt( 'test-x', bucket ), 'newspack-cid=abc' ) ).toBeNull();
 	} );
-	it( 'respects a view_as variant preview', () => {
-		expect( getAbOverride( makePrompt( 'test-x', 'b' ), '?view_as=ab_variant:b', 'newspack-cid=abc' ) ).toBeNull();
-		expect( getAbOverride( makePrompt( 'test-x', 'a' ), '?view_as=ab_variant:b', 'newspack-cid=abc' ) ).toBe( false );
+	it( 'respects a server-echoed variant preview', () => {
+		global.newspack_popups_view.ab_view_as = 'b';
+		expect( getAbOverride( makePrompt( 'test-x', 'b' ), 'newspack-cid=abc' ) ).toBeNull();
+		expect( getAbOverride( makePrompt( 'test-x', 'a' ), 'newspack-cid=abc' ) ).toBe( false );
 	} );
-	it( 'fails open without a stable identity', () => {
-		expect( getAbOverride( makePrompt( 'test-x', 'b' ), '?', '' ) ).toBeNull();
+	it( 'fails to control without a stable identity (one-variant invariant)', () => {
+		expect( getAbOverride( makePrompt( 'test-x', 'a' ), '' ) ).toBeNull();
+		expect( getAbOverride( makePrompt( 'test-x', 'b' ), '' ) ).toBe( false );
 	} );
 } );

--- a/plugins/newspack-popups/src/view/utils/ab.test.js
+++ b/plugins/newspack-popups/src/view/utils/ab.test.js
@@ -44,6 +44,13 @@ describe( 'getReaderId', () => {
 		expect( getReaderId( 'foo=bar' ) ).toBeNull();
 		expect( getReaderId( '' ) ).toBeNull();
 	} );
+	it( 'returns null instead of throwing on an undecodable cookie value', () => {
+		// A stray percent makes decodeURIComponent throw URIError. Uncaught, that
+		// propagates out of prompt processing and no prompts render on the page, so
+		// the failure has to degrade to "no reader id", not to "no prompts".
+		expect( () => getReaderId( 'newspack-cid=100%' ) ).not.toThrow();
+		expect( getReaderId( 'newspack-cid=100%' ) ).toBeNull();
+	} );
 } );
 
 describe( 'computeBucket', () => {

--- a/plugins/newspack-popups/src/view/utils/index.js
+++ b/plugins/newspack-popups/src/view/utils/index.js
@@ -1,5 +1,6 @@
 /* globals newspack_popups_view */
 
+export * from './ab';
 export * from './analytics';
 export * from './prompts';
 export * from './segments';

--- a/plugins/newspack-popups/src/view/utils/segments.js
+++ b/plugins/newspack-popups/src/view/utils/segments.js
@@ -15,7 +15,7 @@ export const periods = {
  *
  * @return {Object|null} View_as object or null.
  */
-export const parseViewAs = ( queryString = null ) => {
+const parseViewAs = ( queryString = null ) => {
 	if ( ! queryString ) {
 		queryString = window.location.search;
 	}

--- a/plugins/newspack-popups/src/view/utils/segments.js
+++ b/plugins/newspack-popups/src/view/utils/segments.js
@@ -15,7 +15,7 @@ export const periods = {
  *
  * @return {Object|null} View_as object or null.
  */
-const parseViewAs = ( queryString = null ) => {
+export const parseViewAs = ( queryString = null ) => {
 	if ( ! queryString ) {
 		queryString = window.location.search;
 	}

--- a/plugins/newspack-popups/tests/test-ab-tests.php
+++ b/plugins/newspack-popups/tests/test-ab-tests.php
@@ -212,10 +212,10 @@ class ABTestsTest extends WP_UnitTestCase_PageWithPopups {
 		self::assertArrayHasKey( 'sticky-test', $buckets );
 		$assigned = $buckets['sticky-test'];
 		self::assertContains( $assigned, [ 'a', 'b' ] );
-		self::assertSame( $assigned, get_user_meta( $user_id, 'np_ab_bucket_sticky-test', true ) );
+		self::assertSame( $assigned, get_user_meta( $user_id, 'newspack_popups_ab_bucket_sticky-test', true ) );
 
 		// A changed control share must not re-bucket an already-assigned reader.
-		update_user_meta( $user_id, 'np_ab_bucket_sticky-test', 'b' );
+		update_user_meta( $user_id, 'newspack_popups_ab_bucket_sticky-test', 'b' );
 		$buckets = Newspack_Popups_AB_Tests::get_logged_in_buckets( Newspack_Popups_AB_Tests::get_tests_config() );
 		self::assertSame( 'b', $buckets['sticky-test'] );
 

--- a/plugins/newspack-popups/tests/test-ab-tests.php
+++ b/plugins/newspack-popups/tests/test-ab-tests.php
@@ -50,8 +50,20 @@ class ABTestsTest extends WP_UnitTestCase_PageWithPopups {
 			Newspack_Popups_AB_Tests::META_CONTROL_SHARE,
 		] as $key ) {
 			self::assertArrayHasKey( $key, $registered, "Meta key $key should be registered." );
-			self::assertTrue( $registered[ $key ]['show_in_rest'], "Meta key $key should be exposed in REST." );
+			self::assertNotEmpty( $registered[ $key ]['show_in_rest'], "Meta key $key should be exposed in REST." );
 		}
+
+		// The variant REST schema rejects invalid values with a 400 instead of a
+		// silent coercion; the empty string (no test) stays writable.
+		$variant_enum = $registered[ Newspack_Popups_AB_Tests::META_VARIANT ]['show_in_rest']['schema']['enum'];
+		self::assertContains( '', $variant_enum );
+		self::assertContains( 'a', $variant_enum );
+
+		// An unset control share must read back as the same 50 the display path
+		// assumes — never the integer schema default 0 (which would clamp to 20
+		// on a round-trip and silently re-bucket anonymous readers mid-test).
+		self::assertSame( 50, $registered[ Newspack_Popups_AB_Tests::META_CONTROL_SHARE ]['default'] );
+		self::assertSame( 50, get_post_meta( self::$popup_id, Newspack_Popups_AB_Tests::META_CONTROL_SHARE, true ) );
 	}
 
 	/**
@@ -228,6 +240,48 @@ class ABTestsTest extends WP_UnitTestCase_PageWithPopups {
 		self::assertSame( $expected, $buckets['continuity-test'], 'The persisted bucket should derive from the client ID, matching the anonymous assignment.' );
 
 		unset( $_COOKIE['newspack-cid'] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Without a client ID cookie, the logged-in bucket hashes the user ID.
+	 */
+	public function test_logged_in_bucket_user_id_fallback() {
+		$this->create_test_variant( 'fallback-test', 'a', null, [], 50 );
+		$this->create_test_variant( 'fallback-test', 'b' );
+
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+		unset( $_COOKIE['newspack-cid'] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+
+		$config   = Newspack_Popups_AB_Tests::get_tests_config();
+		$buckets  = Newspack_Popups_AB_Tests::get_logged_in_buckets( $config );
+		$expected = Newspack_Popups_AB_Tests::compute_bucket( (string) $user_id, 'fallback-test', $config['fallback-test'] );
+		self::assertSame( $expected, $buckets['fallback-test'], 'With no client ID cookie, the bucket should derive from the user ID.' );
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * The view_as spec (which feeds ab_view_as into script data) is admin-gated:
+	 * a non-privileged request must not be able to force a variant preview.
+	 */
+	public function test_view_as_parsing_is_admin_gated() {
+		$_GET['view_as'] = 'ab_variant:b';
+
+		$subscriber_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+		self::assertEmpty( Newspack_Popups_View_As::parse_view_as(), 'A non-privileged user must not resolve a view_as spec.' );
+
+		wp_set_current_user( 0 );
+		self::assertEmpty( Newspack_Popups_View_As::parse_view_as(), 'An anonymous request must not resolve a view_as spec.' );
+
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+		$parsed = Newspack_Popups_View_As::parse_view_as();
+		self::assertSame( 'b', $parsed['ab_variant'], 'An admin request should resolve the previewed variant.' );
+
+		unset( $_GET['view_as'] );
 		wp_set_current_user( 0 );
 	}
 

--- a/plugins/newspack-popups/tests/test-ab-tests.php
+++ b/plugins/newspack-popups/tests/test-ab-tests.php
@@ -38,6 +38,73 @@ class ABTestsTest extends WP_UnitTestCase_PageWithPopups {
 	}
 
 	/**
+	 * A site with no tests records the flag, so later requests skip the query.
+	 */
+	public function test_zero_test_site_records_the_has_tests_flag() {
+		self::assertSame( [], Newspack_Popups_AB_Tests::get_tests_config() );
+		self::assertSame( '0', get_option( Newspack_Popups_AB_Tests::OPTION_HAS_TESTS ) );
+	}
+
+	/**
+	 * A recorded "no tests" must not survive a test being created.
+	 *
+	 * This is the failure the flag can cause: a stale '0' short-circuits the config
+	 * builder, and every live test silently stops running with nothing in the logs.
+	 * Creating a variant has to invalidate it through the meta hook.
+	 */
+	public function test_creating_a_test_invalidates_a_stale_flag() {
+		update_option( Newspack_Popups_AB_Tests::OPTION_HAS_TESTS, '0' );
+
+		$this->create_test_variant( 'flag-test', 'a' );
+		$this->create_test_variant( 'flag-test', 'b' );
+
+		$config = Newspack_Popups_AB_Tests::get_tests_config();
+		self::assertArrayHasKey( 'flag-test', $config, 'A stale flag must not hide a newly created test.' );
+	}
+
+	/**
+	 * Adding test meta to an existing prompt invalidates the flag.
+	 *
+	 * Distinct from the case above: creating a prompt fires save_post, which
+	 * invalidates on its own, so that path exercises the post hook and never the
+	 * meta hook. update_post_meta() on an already-saved prompt fires neither
+	 * save_post nor any post-lifecycle hook, so only the meta hook can catch it --
+	 * and a test id set this way is how a test can appear with no post save at all.
+	 */
+	public function test_setting_test_meta_on_an_existing_prompt_invalidates_the_flag() {
+		$control    = $this->createPopup();
+		$challenger = $this->createPopup();
+
+		// Record "no tests" the way a real request would.
+		self::assertSame( [], Newspack_Popups_AB_Tests::get_tests_config() );
+		self::assertSame( '0', get_option( Newspack_Popups_AB_Tests::OPTION_HAS_TESTS ) );
+
+		update_post_meta( $control, Newspack_Popups_AB_Tests::META_TEST_ID, 'meta-only-test' );
+		update_post_meta( $control, Newspack_Popups_AB_Tests::META_VARIANT, 'a' );
+		update_post_meta( $challenger, Newspack_Popups_AB_Tests::META_TEST_ID, 'meta-only-test' );
+		update_post_meta( $challenger, Newspack_Popups_AB_Tests::META_VARIANT, 'b' );
+
+		$config = Newspack_Popups_AB_Tests::get_tests_config();
+		self::assertArrayHasKey( 'meta-only-test', $config, 'A test id set via meta must invalidate the flag.' );
+	}
+
+	/**
+	 * Deleting the last prompt of a test invalidates the flag.
+	 */
+	public function test_deleting_a_prompt_invalidates_the_flag() {
+		$control    = $this->create_test_variant( 'gone-test', 'a' );
+		$challenger = $this->create_test_variant( 'gone-test', 'b' );
+		self::assertArrayHasKey( 'gone-test', Newspack_Popups_AB_Tests::get_tests_config() );
+		self::assertSame( '1', get_option( Newspack_Popups_AB_Tests::OPTION_HAS_TESTS ) );
+
+		wp_delete_post( $control, true );
+		wp_delete_post( $challenger, true );
+
+		self::assertFalse( get_option( Newspack_Popups_AB_Tests::OPTION_HAS_TESTS ), 'Deleting a prompt must drop the flag.' );
+		self::assertSame( [], Newspack_Popups_AB_Tests::get_tests_config() );
+	}
+
+	/**
 	 * A/B meta keys are registered on the prompts CPT with REST support.
 	 */
 	public function test_ab_meta_registered() {

--- a/plugins/newspack-popups/tests/test-ab-tests.php
+++ b/plugins/newspack-popups/tests/test-ab-tests.php
@@ -1,0 +1,196 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Class ABTests Test
+ *
+ * @package Newspack_Popups
+ */
+
+/**
+ * A/B tests display-integration test case.
+ *
+ * @group ab-tests
+ */
+class ABTestsTest extends WP_UnitTestCase_PageWithPopups {
+
+	public function set_up() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		parent::set_up();
+		Newspack_Popups_AB_Tests::reset_config_cache();
+	}
+
+	/**
+	 * Create a prompt participating in an A/B test.
+	 *
+	 * @param string $test_id Test ID.
+	 * @param string $variant Variant key.
+	 * @param array  $options Popup options.
+	 * @param array  $post_options Post options (e.g. post_status).
+	 * @param int    $control_share Control share, stored on variant A only.
+	 * @return int Popup ID.
+	 */
+	private function create_test_variant( $test_id, $variant, $options = null, $post_options = [], $control_share = 0 ) {
+		$popup_id = $this->createPopup( null, $options, $post_options );
+		update_post_meta( $popup_id, Newspack_Popups_AB_Tests::META_TEST_ID, $test_id );
+		update_post_meta( $popup_id, Newspack_Popups_AB_Tests::META_VARIANT, $variant );
+		if ( $control_share ) {
+			update_post_meta( $popup_id, Newspack_Popups_AB_Tests::META_CONTROL_SHARE, $control_share );
+		}
+		return $popup_id;
+	}
+
+	/**
+	 * A/B meta keys are registered on the prompts CPT with REST support.
+	 */
+	public function test_ab_meta_registered() {
+		do_action( 'init' );
+		$registered = get_registered_meta_keys( 'post', Newspack_Popups::NEWSPACK_POPUPS_CPT );
+		foreach ( [
+			Newspack_Popups_AB_Tests::META_TEST_ID,
+			Newspack_Popups_AB_Tests::META_VARIANT,
+			Newspack_Popups_AB_Tests::META_GOAL,
+			Newspack_Popups_AB_Tests::META_CONTROL_SHARE,
+		] as $key ) {
+			self::assertArrayHasKey( $key, $registered, "Meta key $key should be registered." );
+			self::assertTrue( $registered[ $key ]['show_in_rest'], "Meta key $key should be exposed in REST." );
+		}
+	}
+
+	/**
+	 * The popup object carries A/B fields when the prompt is part of a test.
+	 */
+	public function test_popup_object_has_ab_fields() {
+		$popup_id = $this->create_test_variant( 'donate-q3', 'b' );
+		$popup    = Newspack_Popups_Model::create_popup_object( get_post( $popup_id ) );
+		self::assertSame( 'donate-q3', $popup['ab_test_id'] );
+		self::assertSame( 'b', $popup['ab_variant'] );
+
+		$plain_popup = Newspack_Popups_Model::create_popup_object( get_post( self::$popup_id ) );
+		self::assertArrayNotHasKey( 'ab_test_id', $plain_popup );
+	}
+
+	/**
+	 * Rendered containers expose data-ab-test-id and data-ab-variant attributes.
+	 */
+	public function test_container_markup_has_ab_attributes() {
+		$overlay_options = [
+			'frequency' => 'always',
+			'placement' => 'center',
+		];
+		$this->create_test_variant( 'overlay-test', 'a', $overlay_options, [], 60 );
+		$this->create_test_variant( 'overlay-test', 'b', $overlay_options );
+		$this->renderPost();
+
+		$nodes = self::$dom_xpath->query( '//*[@data-ab-test-id="overlay-test"]' );
+		self::assertSame( 2, $nodes->length, 'Both test variants should carry the test ID attribute.' );
+
+		$variants = [];
+		foreach ( $nodes as $node ) {
+			$variants[] = $node->getAttribute( 'data-ab-variant' );
+		}
+		sort( $variants );
+		self::assertSame( [ 'a', 'b' ], $variants );
+
+		// The non-test popup created in set_up must not carry A/B attributes.
+		$plain = self::$dom_xpath->query( '//*[contains(@class,"newspack-popup-container") and not(@data-ab-test-id)]' );
+		self::assertGreaterThanOrEqual( 1, $plain->length );
+	}
+
+	/**
+	 * The tests config includes only valid tests (control + challenger, published).
+	 */
+	public function test_tests_config_builder() {
+		$this->create_test_variant( 'valid-test', 'a', null, [], 70 );
+		$this->create_test_variant( 'valid-test', 'b' );
+		// Control-only test: invalid.
+		$this->create_test_variant( 'control-only', 'a' );
+		// Draft challenger: its test is control-only among published prompts.
+		$this->create_test_variant( 'draft-challenger', 'a' );
+		$this->create_test_variant( 'draft-challenger', 'b', null, [ 'post_status' => 'draft' ] );
+
+		$config = Newspack_Popups_AB_Tests::get_tests_config();
+
+		self::assertArrayHasKey( 'valid-test', $config );
+		self::assertSame( [ 'a', 'b' ], $config['valid-test']['variants'] );
+		self::assertSame( 70, $config['valid-test']['control_share'] );
+		self::assertArrayNotHasKey( 'control-only', $config );
+		self::assertArrayNotHasKey( 'draft-challenger', $config );
+	}
+
+	/**
+	 * Control share defaults to 50 when the control prompt has no explicit share.
+	 */
+	public function test_tests_config_default_control_share() {
+		$this->create_test_variant( 'default-share', 'a' );
+		$this->create_test_variant( 'default-share', 'b' );
+		$config = Newspack_Popups_AB_Tests::get_tests_config();
+		self::assertSame( 50, $config['default-share']['control_share'] );
+	}
+
+	/**
+	 * Bucket computation is deterministic and respects weighted ranges.
+	 */
+	public function test_compute_bucket() {
+		$config = [
+			'variants'      => [ 'a', 'b' ],
+			'control_share' => 80,
+		];
+
+		// Deterministic: same input, same output.
+		$first = Newspack_Popups_AB_Tests::compute_bucket( 'reader-123', 'test-x', $config );
+		self::assertSame( $first, Newspack_Popups_AB_Tests::compute_bucket( 'reader-123', 'test-x', $config ) );
+		self::assertContains( $first, [ 'a', 'b' ] );
+
+		// Weighted distribution: with an 80% control share, most readers land on A.
+		$a_count = 0;
+		for ( $i = 0; $i < 500; $i++ ) {
+			if ( 'a' === Newspack_Popups_AB_Tests::compute_bucket( "reader-$i", 'test-x', $config ) ) {
+				$a_count++;
+			}
+		}
+		self::assertGreaterThan( 350, $a_count, 'Roughly 80% of readers should be bucketed to control.' );
+		self::assertLessThan( 470, $a_count, 'Some readers should be bucketed to the challenger.' );
+
+		// Degenerate config falls back to control.
+		$degenerate_config = [
+			'variants'      => [ 'a' ],
+			'control_share' => 50,
+		];
+		self::assertSame( 'a', Newspack_Popups_AB_Tests::compute_bucket( 'reader-123', 'test-x', $degenerate_config ) );
+	}
+
+	/**
+	 * Logged-in buckets are persisted in user meta and stable across config changes.
+	 */
+	public function test_logged_in_bucket_persisted() {
+		$this->create_test_variant( 'sticky-test', 'a', null, [], 50 );
+		$this->create_test_variant( 'sticky-test', 'b' );
+
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+
+		$buckets = Newspack_Popups_AB_Tests::get_logged_in_buckets( Newspack_Popups_AB_Tests::get_tests_config() );
+		self::assertArrayHasKey( 'sticky-test', $buckets );
+		$assigned = $buckets['sticky-test'];
+		self::assertContains( $assigned, [ 'a', 'b' ] );
+		self::assertSame( $assigned, get_user_meta( $user_id, 'np_ab_bucket_sticky-test', true ) );
+
+		// A changed control share must not re-bucket an already-assigned reader.
+		update_user_meta( $user_id, 'np_ab_bucket_sticky-test', 'b' );
+		$buckets = Newspack_Popups_AB_Tests::get_logged_in_buckets( Newspack_Popups_AB_Tests::get_tests_config() );
+		self::assertSame( 'b', $buckets['sticky-test'] );
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * GA event metadata includes A/B params for test prompts.
+	 */
+	public function test_ga_metadata_includes_ab_params() {
+		$popup_id = $this->create_test_variant( 'ga-test', 'b' );
+		$metadata = Newspack_Popups_Data_Api::get_popup_metadata( $popup_id );
+		self::assertSame( 'ga-test', $metadata['ab_test_id'] );
+		self::assertSame( 'b', $metadata['ab_variant'] );
+
+		$plain_metadata = Newspack_Popups_Data_Api::get_popup_metadata( self::$popup_id );
+		self::assertArrayNotHasKey( 'ab_test_id', $plain_metadata );
+	}
+}

--- a/plugins/newspack-popups/tests/test-ab-tests.php
+++ b/plugins/newspack-popups/tests/test-ab-tests.php
@@ -55,16 +55,31 @@ class ABTestsTest extends WP_UnitTestCase_PageWithPopups {
 	}
 
 	/**
-	 * The popup object carries A/B fields when the prompt is part of a test.
+	 * The popup object carries A/B fields when the prompt is part of a valid test.
 	 */
 	public function test_popup_object_has_ab_fields() {
-		$popup_id = $this->create_test_variant( 'donate-q3', 'b' );
-		$popup    = Newspack_Popups_Model::create_popup_object( get_post( $popup_id ) );
+		$control_id    = $this->create_test_variant( 'donate-q3', 'a' );
+		$challenger_id = $this->create_test_variant( 'donate-q3', 'b' );
+		$popup         = Newspack_Popups_Model::create_popup_object( get_post( $challenger_id ) );
 		self::assertSame( 'donate-q3', $popup['ab_test_id'] );
 		self::assertSame( 'b', $popup['ab_variant'] );
 
 		$plain_popup = Newspack_Popups_Model::create_popup_object( get_post( self::$popup_id ) );
 		self::assertArrayNotHasKey( 'ab_test_id', $plain_popup );
+	}
+
+	/**
+	 * An invalid test (no published challenger) must not present itself as a live
+	 * experiment: no popup-object fields, no markup attributes, no GA params.
+	 */
+	public function test_invalid_test_does_not_emit_ab_fields() {
+		$control_only = $this->create_test_variant( 'control-only-test', 'a' );
+		$popup        = Newspack_Popups_Model::create_popup_object( get_post( $control_only ) );
+		self::assertArrayNotHasKey( 'ab_test_id', $popup, 'A control-only test must not emit A/B fields.' );
+
+		// The unvalidated accessor still returns the raw fields (editor use).
+		$raw = Newspack_Popups_AB_Tests::get_popup_ab_fields( $control_only );
+		self::assertSame( 'control-only-test', $raw['test_id'] );
 	}
 
 	/**
@@ -126,6 +141,20 @@ class ABTestsTest extends WP_UnitTestCase_PageWithPopups {
 	}
 
 	/**
+	 * The server-side djb2 hash is bit-for-bit identical to the client-side hash.
+	 * The vector is pinned in src/view/utils/ab.test.js too — if either side
+	 * changes, both parity tests fail together.
+	 */
+	public function test_hash_parity_with_client() {
+		self::assertSame( 809016026, Newspack_Popups_AB_Tests::hash_djb2( 'abc|test-x' ) );
+		$parity_config = [
+			'variants'      => [ 'a', 'b' ],
+			'control_share' => 50,
+		];
+		self::assertSame( 'a', Newspack_Popups_AB_Tests::compute_bucket( 'abc', 'test-x', $parity_config ) );
+	}
+
+	/**
 	 * Bucket computation is deterministic and respects weighted ranges.
 	 */
 	public function test_compute_bucket() {
@@ -182,9 +211,31 @@ class ABTestsTest extends WP_UnitTestCase_PageWithPopups {
 	}
 
 	/**
-	 * GA event metadata includes A/B params for test prompts.
+	 * First logged-in assignment prefers the client ID cookie, so a reader who
+	 * registers mid-test stays in the arm they were seeing anonymously.
+	 */
+	public function test_logged_in_bucket_prefers_client_id() {
+		$this->create_test_variant( 'continuity-test', 'a', null, [], 50 );
+		$this->create_test_variant( 'continuity-test', 'b' );
+
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+		$_COOKIE['newspack-cid'] = 'reader-cid-123'; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+
+		$config   = Newspack_Popups_AB_Tests::get_tests_config();
+		$buckets  = Newspack_Popups_AB_Tests::get_logged_in_buckets( $config );
+		$expected = Newspack_Popups_AB_Tests::compute_bucket( 'reader-cid-123', 'continuity-test', $config['continuity-test'] );
+		self::assertSame( $expected, $buckets['continuity-test'], 'The persisted bucket should derive from the client ID, matching the anonymous assignment.' );
+
+		unset( $_COOKIE['newspack-cid'] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * GA event metadata includes A/B params for valid test prompts only.
 	 */
 	public function test_ga_metadata_includes_ab_params() {
+		$this->create_test_variant( 'ga-test', 'a' );
 		$popup_id = $this->create_test_variant( 'ga-test', 'b' );
 		$metadata = Newspack_Popups_Data_Api::get_popup_metadata( $popup_id );
 		self::assertSame( 'ga-test', $metadata['ab_test_id'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds the core display mechanics for A/B testing Campaigns prompts: two (or more) prompts sharing a test ID split eligible readers deterministically, and each reader always sees their assigned variant.

The A/B testing proof of concept selected variants from *outside* newspack-popups — after the view engine's conflict resolution had already hidden the older overlay — which made variant display unreliable (only the newest prompt in a test ever won). This PR moves selection *inside* the view engine, where per-reader display decisions already happen client-side after page cache:

* **Meta:** registers `newspack_ab_test_id`, `newspack_ab_variant`, `newspack_ab_test_goal`, and `newspack_ab_control_share` on the prompts CPT (REST-exposed with schema validation: variant enum, control share default 50 / range 20–80).
* **Config:** a localized `ab_tests` config is built from published prompts (a test is live only when its control *and* at least one challenger are published) with the post-meta cache primed to keep the always-enqueued path cheap.
* **Assignment:** readers are bucketed by a djb2 hash of the existing client-ID cookie over control-share-weighted ranges — no new identifier is introduced. Logged-in readers get a persisted bucket (user meta) computed from the same cookie identity, so a reader who registers mid-test stays in the same arm, and assignment is stable across devices. Hash parity between PHP and JS is pinned by shared test vectors. With no stable identity (cookies blocked), challengers are suppressed and only the control is eligible, preserving the one-variant invariant.
* **Display:** the A/B gate composes with the view engine's existing override system — non-assigned variants are suppressed *before* the single-overlay slot is claimed, and the assigned variant still passes the normal frequency/segmentation checks. The gate is placement-agnostic, so inline prompt pairs behave the same as overlays.
* **Analytics:** prompt events carry `ab_test_id`/`ab_variant` params via the existing Data API metadata (replacing the POC's gtag patch).
* **Preview:** editors can force a variant with `?view_as=ab_variant:b` — resolved server-side through the existing capability-gated `view_as` handling, so it isn't spoofable by visitors.

There's no editor UI yet (that's the next milestone) — with no test meta set, this is fully dormant: no markup, config, or behavior changes.

Closes NPPD-1499.

### How to test the changes in this Pull Request:

1. On a site with this branch built, create two overlay prompts (same placement, frequency "always") and mark them as a test — no UI yet, so via WP-CLI, creating the *control first* so the old "newest wins" behavior would mask it:
   ```
   wp post meta update <ID_A> newspack_ab_test_id my-test && wp post meta update <ID_A> newspack_ab_variant a
   wp post meta update <ID_B> newspack_ab_test_id my-test && wp post meta update <ID_B> newspack_ab_variant b
   ```
2. Visit a post logged out: exactly **one** variant displays. Verify `newspack_popups_view.ab_tests` in the page source and `data-ab-test-id`/`data-ab-variant` on both containers (loser keeps the `hidden` class).
3. Reload several times: the same variant persists. Change the `newspack-cid` cookie value: the assignment may flip, deterministically per value.
4. Repeat with two *inline* prompts sharing a test ID: exactly one renders in content.
5. Set `newspack_ab_control_share` to `80` on the control: across several fresh cookie values, most land on variant A.
6. As a logged-out visitor, append `?view_as=ab_variant:b` — nothing changes. As an admin, the same URL forces variant B everywhere.
7. While logged in as any user, verify your assignment is persisted (`wp user meta get <user_id> np_ab_bucket_my-test`) and stable even if the control share changes afterward.
8. Delete one variant's test meta (or unpublish it): the test deactivates everywhere — no `data-ab-*` attributes, both prompts behave as normal independent prompts.
9. Run `n test-php` and `npm test` in `plugins/newspack-popups` — both suites green (13 A/B-specific PHP tests, 17 jest tests, including PHP↔JS hash-parity vectors).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
