### PR TITLE
feat(subscribers): subscriber-only products demo (NPPD-1899)

### DIFF
--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/README.md
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/README.md
@@ -7,7 +7,7 @@ internal review. It is a **hidden wizard** (not in the admin menu) with mock dat
 reachable at `admin.php?page=newspack-subscriptions-demo` **when the site is in
 Newspack debug mode**.
 
-Two tabs, both full-width DataViews lists. There is **no subscription detail
+Three tabs, all full-width DataViews lists. There is **no subscription detail
 view** — the list is the overview, and per-row actions do the rest (an earlier
 full-page/drawer detail was explored and dropped; see the design notes).
 
@@ -18,11 +18,19 @@ full-page/drawer detail was explored and dropped; see the design notes).
     this subscription (`admin.php?page=newspack-subscribers-demo#/?subscription=…`).
   - **Add subscriber discount** — opens the discount editor pre-scoped to this
     subscription (audience locked, picker hidden).
+  - **Add subscriber-only products** — opens the restriction editor with this
+    subscription pre-selected (editable, since several subscriptions can unlock
+    the same products).
   - **View in WooCommerce** — opens the products screen, pre-searched by name.
 - **Subscriber discounts** (`/discounts`, `screens/DiscountList.jsx`) — one row
   per discount rule: which subscription's subscribers get what off which store
   products. Subscription, Discount, Applies to, Status, Created. Row actions
   (Edit / Pause·Resume / Delete) and header actions (Add discount, Settings).
+- **Subscriber-only products** (`/subscriber-only`, `screens/RestrictionList.jsx`) — one
+  row per purchase restriction: which store products are subscriber-only and which
+  subscriptions unlock them. Products, Available to, Status, Created. Row actions
+  (Edit / Pause·Resume / Delete) and header actions (Add restriction, Settings —
+  a hide-from-product-lists toggle).
 
 ## The discount model
 
@@ -33,19 +41,32 @@ specific products, with exclusions). In a real build the membership oracle is
 `Access_Rules::has_active_subscription( $user_id, $product_ids )` and the price is
 applied via WooCommerce price filters.
 
+## The restriction model
+
+A subscriber-only restriction says *"store products **Y** are purchasable only by
+subscribers of **any** of subscriptions **X**"* — the Subscriptions-wizard reframing
+of WooCommerce Memberships' purchase restriction (NPPD-1899). Readers still see the
+product and its price; only purchasing is blocked. In a real build enforcement is
+PR #607's mechanics (`woocommerce_is_purchasable` at 999, product-page notice), with
+the copy reworded to subscriber vocabulary.
+
 ## Structure
 
 ```
 subscriptionsDemo/
-├── index.js                Entry point: mounts the Wizard with the two tabbed sections.
+├── index.js                Entry point: mounts the Wizard with the three tabbed sections.
 ├── screens/
 │   ├── SubscriptionList.jsx  Subscriptions list + row actions.
 │   ├── DiscountList.jsx      Subscriber-discounts list.
+│   ├── RestrictionList.jsx   Subscriber-only products list.
 │   └── style.scss
 ├── flows/                  Modals (all drawer/dialog chrome shared via __sub-detail-*).
-│   ├── DiscountRuleFlow.jsx     The discount editor (right-edge drawer).
-│   ├── DiscountSettingsFlow.jsx Global discount settings.
-│   └── ConfirmFlow.jsx          Shared confirm scaffold (pause/resume/delete).
+│   ├── DiscountRuleFlow.jsx        The discount editor (right-edge drawer).
+│   ├── DiscountSettingsFlow.jsx    Global discount settings.
+│   ├── RestrictionFlow.jsx         The restriction editor (right-edge drawer).
+│   ├── RestrictionSettingsFlow.jsx Global restriction settings.
+│   ├── TargetingFields.jsx         Shared 'Applies to' fields for both editors.
+│   └── ConfirmFlow.jsx             Shared confirm scaffold (pause/resume/delete).
 ├── data/                   The prototype↔production seam (see below).
 ├── format.js               Currency / date formatting.
 └── labels.js               Publisher-configurable group label.
@@ -64,7 +85,9 @@ People and plan data have a **single source of truth: the Subscribers demo.**
 | `mock-subscribers.js` | Re-exports `SUBSCRIBERS` and the plan definitions from `../../subscribersDemo/data/mock-subscribers`, layering on the plan-level commercial extras (`status`, `totalSales`, `totalRevenue`). |
 | `mock-groups.js` | Re-exports the Subscribers demo's group dataset, layering the same extras onto `TEAM_PLANS`. |
 | `mock-discounts.js` | Subscriber-discount rules + presentation helpers (`discountLabel`, `targetingLabel`, `subscriberPrice`, …). Specific to this demo. |
+| `mock-restrictions.js` | Subscriber-only purchase restrictions + settings. Specific to this demo. |
 | `mock-catalog.js` | The store products/categories a discount can target. Specific to this demo. |
+| `targeting.js` | Shared product-targeting resolution and labels for discounts and restrictions. |
 | `plan-stats.js` | Pure roll-ups over the shared stores into per-subscription figures (`getAllPlans`, `getPlanStats`, `getSubscribersForPlan`). |
 | `storage.js` | `localStorage` persistence for demo edits (discount rules/settings). |
 

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-discounts.js
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-discounts.js
@@ -8,15 +8,16 @@
 /**
  * WordPress dependencies.
  */
-import { __, sprintf, _n } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies.
  */
 import { STORAGE_PREFIX, readStore, writeStore } from './storage';
-import { PRODUCTS, getProductById } from './mock-catalog';
 import { TEAM_PLANS } from './mock-groups';
 import { fmtCurrency } from '../format';
+
+export { productsForRule, targetingBaseLabel, excludedLabel, targetingLabel } from './targeting';
 
 const DISCOUNTS_KEY = STORAGE_PREFIX + 'discounts';
 const SETTINGS_KEY = STORAGE_PREFIX + 'discount-settings';
@@ -156,58 +157,12 @@ export function subscriberPrice( price, rule ) {
 	return Math.max( 0, Math.round( value * 100 ) / 100 );
 }
 
-export function productsForRule( rule ) {
-	let matches;
-	if ( rule.targeting === 'products' ) {
-		matches = ( rule.productIds || [] ).map( getProductById ).filter( Boolean );
-	} else {
-		matches = PRODUCTS.filter( p => rule.targeting === 'all' || p.category === rule.category );
-	}
-	// A variable product is sold through its variations, so previews and
-	// exclusions operate on those instead of the parent.
-	const expanded = matches.flatMap( p => ( ( p.variations || [] ).length ? p.variations.map( v => getProductById( v.id ) ) : [ p ] ) );
-	const excluded = new Set( rule.excludedIds || [] );
-	return expanded.filter( p => ! excluded.has( p.id ) && ! excluded.has( p.parentId ) );
-}
-
 export function discountLabel( rule ) {
 	if ( rule.type === 'percent' ) {
 		// translators: %s: percentage number.
 		return sprintf( __( '%s%%', 'newspack-plugin' ), rule.amount );
 	}
 	return fmtCurrency( rule.amount );
-}
-
-export function targetingBaseLabel( rule ) {
-	if ( rule.targeting === 'all' ) {
-		return __( 'All products', 'newspack-plugin' );
-	}
-	if ( rule.targeting === 'category' ) {
-		// translators: %s: product category name.
-		return sprintf( __( '%s category', 'newspack-plugin' ), rule.category );
-	}
-	const count = ( rule.productIds || [] ).length;
-	// translators: %d: number of products.
-	return sprintf( _n( '%d product', '%d products', count, 'newspack-plugin' ), count );
-}
-
-export function excludedLabel( rule ) {
-	const excluded = ( rule.excludedIds || [] ).length;
-	if ( ! excluded ) {
-		return '';
-	}
-	// translators: %d: number of excluded products.
-	return sprintf( __( '%d excluded', 'newspack-plugin' ), excluded );
-}
-
-export function targetingLabel( rule ) {
-	const base = targetingBaseLabel( rule );
-	const excluded = excludedLabel( rule );
-	if ( excluded ) {
-		// translators: %1$s: targeting label, %2$s: excluded products label.
-		return sprintf( __( '%1$s · %2$s', 'newspack-plugin' ), base, excluded );
-	}
-	return base;
 }
 
 export const benefitsForPlans = planNames => getAllDiscounts().filter( rule => rule.active && ( planNames || [] ).includes( rule.audience ) );

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-restrictions.js
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-restrictions.js
@@ -1,0 +1,126 @@
+/**
+ * Mock subscriber-only product restrictions for the Subscriptions Demo.
+ *
+ * A restriction says "these store products are purchasable only by subscribers
+ * of ANY of these subscriptions". Mirrors the storage pattern of
+ * mock-discounts: a static seed plus a localStorage override store, so demo
+ * mutations survive a refresh.
+ */
+
+/**
+ * Internal dependencies.
+ */
+import { STORAGE_PREFIX, readStore, writeStore } from './storage';
+import { TEAM_PLANS } from './mock-groups';
+
+const RESTRICTIONS_KEY = STORAGE_PREFIX + 'restrictions';
+const SETTINGS_KEY = STORAGE_PREFIX + 'restriction-settings';
+
+// Seeded to exercise every list state: a hand-picked product list unlocked by
+// two subscriptions, a category rule with an exclusion, a group-plan rule, and
+// a paused rule.
+const SEED = [
+	{
+		id: 'rest_books',
+		subscriptions: [ 'Supporter Annual', 'Yearly Digital' ],
+		targeting: 'products',
+		productIds: [ 'prod_book_v1', 'prod_book_v2', 'prod_book_v3' ],
+		category: null,
+		excludedIds: [],
+		active: true,
+		createdAt: '2026-05-06',
+	},
+	{
+		id: 'rest_courses',
+		subscriptions: [ 'Supporter Annual' ],
+		targeting: 'category',
+		productIds: [],
+		category: 'Courses',
+		excludedIds: [ 'prod_course_writing' ],
+		active: true,
+		createdAt: '2026-05-24',
+	},
+	{
+		id: 'rest_gala',
+		subscriptions: [ TEAM_PLANS[ 0 ].name, 'Monthly Digital' ],
+		targeting: 'products',
+		productIds: [ 'prod_gala' ],
+		category: null,
+		excludedIds: [],
+		active: true,
+		createdAt: '2026-06-14',
+	},
+	{
+		id: 'rest_walk',
+		subscriptions: [ 'Monthly Digital' ],
+		targeting: 'products',
+		productIds: [ 'prod_photo_walk' ],
+		category: null,
+		excludedIds: [],
+		active: false,
+		createdAt: '2026-06-28',
+	},
+];
+
+// ---- Storage: seed + overrides (mirrors mock-discounts). ----
+
+function readOverrides() {
+	return readStore( RESTRICTIONS_KEY );
+}
+
+export function getAllRestrictions() {
+	const overrides = readOverrides();
+	const rules = SEED.map( rule => ( overrides[ rule.id ] === 'deleted' ? null : { ...rule, ...( overrides[ rule.id ] || {} ) } ) ).filter(
+		Boolean
+	);
+	Object.keys( overrides ).forEach( id => {
+		if ( ! SEED.some( rule => rule.id === id ) && overrides[ id ] !== 'deleted' ) {
+			rules.push( overrides[ id ] );
+		}
+	} );
+	return rules.sort( ( a, b ) => ( b.createdAt || '' ).localeCompare( a.createdAt || '' ) );
+}
+
+export const getRestrictionById = id => getAllRestrictions().find( rule => rule.id === id ) || null;
+
+export function saveRestriction( rule ) {
+	const overrides = readOverrides();
+	const saved = {
+		subscriptions: [],
+		productIds: [],
+		category: null,
+		excludedIds: [],
+		active: true,
+		...rule,
+		id: rule.id || 'rest_new_' + Date.now(),
+		createdAt: rule.createdAt || new Date().toISOString().slice( 0, 10 ),
+	};
+	overrides[ saved.id ] = saved;
+	writeStore( RESTRICTIONS_KEY, overrides );
+	return saved;
+}
+
+export function deleteRestriction( id ) {
+	const overrides = readOverrides();
+	if ( SEED.some( rule => rule.id === id ) ) {
+		overrides[ id ] = 'deleted';
+	} else {
+		delete overrides[ id ];
+	}
+	writeStore( RESTRICTIONS_KEY, overrides );
+}
+
+export function setRestrictionActive( id, active ) {
+	const rule = getRestrictionById( id );
+	if ( rule ) {
+		saveRestriction( { ...rule, active } );
+	}
+}
+
+// ---- Global settings. ----
+
+const DEFAULT_SETTINGS = { hideFromCatalog: false };
+
+export const getRestrictionSettings = () => ( { ...DEFAULT_SETTINGS, ...readStore( SETTINGS_KEY ) } );
+
+export const saveRestrictionSettings = settings => writeStore( SETTINGS_KEY, { ...getRestrictionSettings(), ...settings } );

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-restrictions.test.js
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/mock-restrictions.test.js
@@ -1,0 +1,91 @@
+/**
+ * Internal dependencies.
+ */
+import { CATEGORIES, getProductById } from './mock-catalog';
+import {
+	getAllRestrictions,
+	getRestrictionById,
+	saveRestriction,
+	deleteRestriction,
+	setRestrictionActive,
+	getRestrictionSettings,
+	saveRestrictionSettings,
+} from './mock-restrictions';
+import { coveredParentProductIds, productNamesForRule } from './targeting';
+import { ALL_PLANS } from './mock-subscribers';
+import { TEAM_PLANS } from './mock-groups';
+
+const PLAN_NAMES = [ ...ALL_PLANS, ...TEAM_PLANS ].map( p => p.name );
+
+beforeEach( () => window.localStorage.clear() );
+
+describe( 'seeded restrictions', () => {
+	it( 'reference real plans, products and categories', () => {
+		getAllRestrictions().forEach( rule => {
+			expect( rule.subscriptions.length ).toBeGreaterThan( 0 );
+			rule.subscriptions.forEach( name => expect( PLAN_NAMES ).toContain( name ) );
+			( rule.productIds || [] ).forEach( id => expect( getProductById( id ) ).toBeTruthy() );
+			( rule.excludedIds || [] ).forEach( id => expect( getProductById( id ) ).toBeTruthy() );
+			if ( rule.targeting === 'category' ) {
+				expect( CATEGORIES ).toContain( rule.category );
+			}
+		} );
+	} );
+
+	it( 'cover every list state: product list, category, multi-subscription, paused, exclusion', () => {
+		const rules = getAllRestrictions();
+		expect( rules.some( r => r.targeting === 'products' && r.productIds.length > 1 ) ).toBe( true );
+		expect( rules.some( r => r.targeting === 'category' ) ).toBe( true );
+		expect( rules.some( r => r.subscriptions.length > 1 ) ).toBe( true );
+		expect( rules.some( r => ! r.active ) ).toBe( true );
+		expect( rules.some( r => ( r.excludedIds || [] ).length > 0 ) ).toBe( true );
+	} );
+
+	it( 'resolves product names for specific-products rules only', () => {
+		const listRule = getAllRestrictions().find( r => r.targeting === 'products' && r.productIds.length > 1 );
+		const names = productNamesForRule( listRule );
+		expect( names ).toHaveLength( listRule.productIds.length );
+		names.forEach( name => expect( typeof name ).toBe( 'string' ) );
+		const categoryRule = getAllRestrictions().find( r => r.targeting === 'category' );
+		expect( productNamesForRule( categoryRule ) ).toEqual( [] );
+	} );
+
+	it( 'covers products through category and all targeting, minus exclusions', () => {
+		const categoryRule = getAllRestrictions().find( r => r.targeting === 'category' );
+		const covered = coveredParentProductIds( categoryRule );
+		expect( covered ).toContain( 'prod_course_journalism' );
+		expect( covered ).not.toContain( 'prod_course_writing' );
+		const all = coveredParentProductIds( { targeting: 'all', productIds: [], excludedIds: [] } );
+		expect( all.filter( id => id === 'prod_album' ) ).toHaveLength( 1 );
+	} );
+} );
+
+describe( 'storage-backed mutations', () => {
+	it( 'persists save, toggle and delete via localStorage overrides', () => {
+		const rule = saveRestriction( {
+			subscriptions: [ ALL_PLANS[ 0 ].name ],
+			targeting: 'all',
+			productIds: [],
+			category: null,
+			excludedIds: [],
+			active: true,
+		} );
+		expect( getRestrictionById( rule.id ) ).toBeTruthy();
+		setRestrictionActive( rule.id, false );
+		expect( getRestrictionById( rule.id ).active ).toBe( false );
+		deleteRestriction( rule.id );
+		expect( getRestrictionById( rule.id ) ).toBeFalsy();
+	} );
+
+	it( 'tombstones deleted seeds so they stay deleted after refresh', () => {
+		const seeded = getAllRestrictions()[ 0 ];
+		deleteRestriction( seeded.id );
+		expect( getAllRestrictions().some( r => r.id === seeded.id ) ).toBe( false );
+	} );
+
+	it( 'round-trips settings', () => {
+		expect( getRestrictionSettings() ).toEqual( { hideFromCatalog: false } );
+		saveRestrictionSettings( { hideFromCatalog: true } );
+		expect( getRestrictionSettings() ).toEqual( { hideFromCatalog: true } );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/targeting.js
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/data/targeting.js
@@ -1,0 +1,77 @@
+/**
+ * Shared product-targeting helpers for the Subscriptions Demo — how a rule's
+ * `{ targeting, productIds, category, excludedIds }` resolves to store
+ * products and to the "Applies to" labels. Used by both subscriber discounts
+ * and subscriber-only product restrictions.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __, sprintf, _n } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies.
+ */
+import { PRODUCTS, getProductById } from './mock-catalog';
+
+export function productsForRule( rule ) {
+	let matches;
+	if ( rule.targeting === 'products' ) {
+		matches = ( rule.productIds || [] ).map( getProductById ).filter( Boolean );
+	} else {
+		matches = PRODUCTS.filter( p => rule.targeting === 'all' || p.category === rule.category );
+	}
+	// A variable product is sold through its variations, so previews and
+	// exclusions operate on those instead of the parent.
+	const expanded = matches.flatMap( p => ( ( p.variations || [] ).length ? p.variations.map( v => getProductById( v.id ) ) : [ p ] ) );
+	const excluded = new Set( rule.excludedIds || [] );
+	return expanded.filter( p => ! excluded.has( p.id ) && ! excluded.has( p.parentId ) );
+}
+
+// Parent-level product names for a specific-products rule, for list cells that
+// show which products are targeted rather than just a count.
+export function productNamesForRule( rule ) {
+	if ( rule.targeting !== 'products' ) {
+		return [];
+	}
+	return ( rule.productIds || [] ).map( id => getProductById( id )?.name ).filter( Boolean );
+}
+
+// Parent-level ids of every product a rule's targeting covers, exclusions
+// applied — the membership test behind the list's product filter.
+export function coveredParentProductIds( rule ) {
+	return [ ...new Set( productsForRule( rule ).map( p => p.parentId || p.id ) ) ];
+}
+
+export function targetingBaseLabel( rule ) {
+	if ( rule.targeting === 'all' ) {
+		return __( 'All products', 'newspack-plugin' );
+	}
+	if ( rule.targeting === 'category' ) {
+		// translators: %s: product category name.
+		return sprintf( __( '%s category', 'newspack-plugin' ), rule.category );
+	}
+	const count = ( rule.productIds || [] ).length;
+	// translators: %d: number of products.
+	return sprintf( _n( '%d product', '%d products', count, 'newspack-plugin' ), count );
+}
+
+export function excludedLabel( rule ) {
+	const excluded = ( rule.excludedIds || [] ).length;
+	if ( ! excluded ) {
+		return '';
+	}
+	// translators: %d: number of excluded products.
+	return sprintf( __( '%d excluded', 'newspack-plugin' ), excluded );
+}
+
+export function targetingLabel( rule ) {
+	const base = targetingBaseLabel( rule );
+	const excluded = excludedLabel( rule );
+	if ( excluded ) {
+		// translators: %1$s: targeting label, %2$s: excluded products label.
+		return sprintf( __( '%1$s · %2$s', 'newspack-plugin' ), base, excluded );
+	}
+	return base;
+}

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/DiscountRuleFlow.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/DiscountRuleFlow.jsx
@@ -16,19 +16,19 @@ import {
 	__experimentalVStack as VStack,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack,
-	FormTokenField,
-	RadioControl,
 	TextControl,
 } from '@wordpress/components';
 import { close } from '@wordpress/icons';
 import { Button, Modal, SelectControl } from '../../../../packages/components/src';
-import { CATEGORIES, PRODUCTS, getProductById } from '../data/mock-catalog';
-import { saveDiscount, subscriberPrice, productsForRule } from '../data/mock-discounts';
+import { CATEGORIES } from '../data/mock-catalog';
+import { saveDiscount, subscriberPrice } from '../data/mock-discounts';
+import { productsForRule } from '../data/targeting';
 import { DIGITAL_PLANS, PRINT_PLANS } from '../data/mock-subscribers';
 import { TEAM_PLANS } from '../data/mock-groups';
 import { GROUP_LABEL } from '../labels';
 import { fmtCurrency } from '../format';
 import ConfirmFlow from './ConfirmFlow';
+import TargetingFields from './TargetingFields';
 
 // Every subscription, in list order. Group (team) subscriptions are tagged
 // "(Group)" — matching how the Subscribers demo marks them — while individual
@@ -71,17 +71,24 @@ export default function DiscountRuleFlow( { rule, onClose, onSaved } ) {
 	const [ busy, setBusy ] = useState( false );
 	const [ confirmDiscard, setConfirmDiscard ] = useState( false );
 
-	const onProductsChange = names => {
-		setProductIds( names.map( name => PRODUCTS.find( p => p.name === name )?.id ).filter( Boolean ) );
+	const onTargetChange = patch => {
+		if ( patch.targeting !== undefined ) {
+			setTargeting( patch.targeting );
+		}
+		if ( patch.productIds !== undefined ) {
+			setProductIds( patch.productIds );
+		}
+		if ( patch.category !== undefined ) {
+			setCategory( patch.category );
+		}
+		if ( patch.excludedIds !== undefined ) {
+			setExcludedIds( patch.excludedIds );
+		}
 	};
 
 	// Products currently in scope with no exclusions applied yet, so the
 	// exclusion picker only ever offers what could actually be excluded.
 	const scopeProducts = productsForRule( { targeting, productIds, category, excludedIds: [] } );
-
-	const onExcludedChange = names => {
-		setExcludedIds( names.map( name => scopeProducts.find( p => p.name === name )?.id ).filter( Boolean ) );
-	};
 
 	// Drop exclusions no longer in scope (e.g. left over after switching targeting
 	// or category) so the saved rule and its "N excluded" label never count
@@ -171,49 +178,12 @@ export default function DiscountRuleFlow( { rule, onClose, onSaved } ) {
 					__next40pxDefaultSize
 				/>
 			) }
-			<RadioControl
-				label={ __( 'Applies to', 'newspack-plugin' ) }
-				help={ __( 'Choose which store products this discount applies to.', 'newspack-plugin' ) }
-				selected={ targeting }
-				onChange={ setTargeting }
-				options={ [
-					{ value: 'products', label: __( 'Specific products', 'newspack-plugin' ) },
-					{ value: 'category', label: __( 'Category', 'newspack-plugin' ) },
-					{ value: 'all', label: __( 'All products', 'newspack-plugin' ) },
-				] }
+			<TargetingFields
+				value={ { targeting, productIds, category, excludedIds } }
+				onChange={ onTargetChange }
+				appliesHelp={ __( 'Choose which products this discount applies to.', 'newspack-plugin' ) }
+				categoryHelp={ __( 'Subscribers get the discount on every product in this category.', 'newspack-plugin' ) }
 			/>
-			{ targeting === 'products' && (
-				<FormTokenField
-					label={ __( 'Products', 'newspack-plugin' ) }
-					value={ productIds.map( id => getProductById( id )?.name ).filter( Boolean ) }
-					suggestions={ PRODUCTS.map( p => p.name ) }
-					onChange={ onProductsChange }
-					__experimentalExpandOnFocus
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-				/>
-			) }
-			{ targeting === 'category' && (
-				<SelectControl
-					label={ __( 'Category', 'newspack-plugin' ) }
-					help={ __( 'Subscribers get the discount on every product in this category.', 'newspack-plugin' ) }
-					value={ category }
-					options={ CATEGORIES.map( c => ( { label: c, value: c } ) ) }
-					onChange={ setCategory }
-					__next40pxDefaultSize
-				/>
-			) }
-			{ targeting !== 'products' && (
-				<FormTokenField
-					label={ __( 'Excluded products', 'newspack-plugin' ) }
-					value={ excludedIds.map( id => scopeProducts.find( p => p.id === id )?.name ).filter( Boolean ) }
-					suggestions={ scopeProducts.map( p => p.name ) }
-					onChange={ onExcludedChange }
-					__experimentalExpandOnFocus
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-				/>
-			) }
 			<ToggleGroupControl
 				label={ __( 'Discount type', 'newspack-plugin' ) }
 				value={ type }

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/RestrictionFlow.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/RestrictionFlow.jsx
@@ -1,0 +1,238 @@
+/**
+ * Restriction editor — drawer flow for adding or editing a subscriber-only
+ * products restriction: which subscriptions unlock purchasing of which store
+ * products. `rule` is `{}` for a new restriction (optionally with
+ * `subscriptions` pre-filled from a subscription row's kebab) or an existing
+ * restriction to edit. Mirrors DiscountRuleFlow's drawer scaffolding.
+ */
+
+import { useState } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import {
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalHStack as HStack,
+	FormTokenField,
+} from '@wordpress/components';
+import { close } from '@wordpress/icons';
+import { Button, Modal } from '../../../../packages/components/src';
+import { CATEGORIES } from '../data/mock-catalog';
+import { productsForRule } from '../data/targeting';
+import { saveRestriction } from '../data/mock-restrictions';
+import { DIGITAL_PLANS, PRINT_PLANS } from '../data/mock-subscribers';
+import { TEAM_PLANS } from '../data/mock-groups';
+import { GROUP_LABEL } from '../labels';
+import { fmtCurrency } from '../format';
+import ConfirmFlow from './ConfirmFlow';
+import TargetingFields from './TargetingFields';
+
+// Every subscription, in list order, tagged "(Group)" for team plans — same
+// treatment as the discount editor.
+const ALL_PLANS = [ ...DIGITAL_PLANS, ...PRINT_PLANS, ...TEAM_PLANS ];
+const isGroupPlan = name => TEAM_PLANS.some( p => p.name === name );
+const planLabel = name => ( isGroupPlan( name ) ? `${ name } (${ GROUP_LABEL })` : name );
+// Tokens display the tagged label, so map labels back to plan names on change.
+const LABEL_TO_NAME = {};
+ALL_PLANS.forEach( p => {
+	LABEL_TO_NAME[ planLabel( p.name ) ] = p.name;
+} );
+
+// The saved shape of a restriction, normalized so a mode switch before saving
+// doesn't persist stale ids. Shared by the draft and the dirty comparison.
+function restrictionShape( { subscriptions, targeting, productIds, category, excludedIds } ) {
+	return {
+		subscriptions,
+		targeting,
+		productIds: targeting === 'products' ? productIds : [],
+		category: targeting === 'category' ? category : null,
+		excludedIds: targeting === 'products' ? [] : excludedIds,
+	};
+}
+
+export default function RestrictionFlow( { rule, onClose, onSaved } ) {
+	const isEdit = Boolean( rule.id );
+	// Adding from a subscription's row pre-fills that subscription, but the
+	// field stays editable — unlike the discount editor's locked audience —
+	// because a restriction can be unlocked by several subscriptions.
+	const isScopedAdd = ! isEdit && ( rule.subscriptions || [] ).length > 0;
+
+	const [ subscriptions, setSubscriptions ] = useState( rule.subscriptions || [] );
+	const [ targeting, setTargeting ] = useState( rule.targeting || 'products' );
+	const [ productIds, setProductIds ] = useState( rule.productIds || [] );
+	const [ category, setCategory ] = useState( rule.category || CATEGORIES[ 0 ] );
+	const [ excludedIds, setExcludedIds ] = useState( rule.excludedIds || [] );
+	const [ busy, setBusy ] = useState( false );
+	const [ confirmDiscard, setConfirmDiscard ] = useState( false );
+
+	const onSubscriptionsChange = labels => {
+		setSubscriptions( labels.map( label => LABEL_TO_NAME[ label ] ).filter( Boolean ) );
+	};
+
+	const onTargetChange = patch => {
+		if ( patch.targeting !== undefined ) {
+			setTargeting( patch.targeting );
+		}
+		if ( patch.productIds !== undefined ) {
+			setProductIds( patch.productIds );
+		}
+		if ( patch.category !== undefined ) {
+			setCategory( patch.category );
+		}
+		if ( patch.excludedIds !== undefined ) {
+			setExcludedIds( patch.excludedIds );
+		}
+	};
+
+	// Drop exclusions no longer in scope (e.g. left over after switching
+	// targeting or category) so the saved restriction never counts products the
+	// editor isn't showing.
+	const scopeProducts = productsForRule( { targeting, productIds, category, excludedIds: [] } );
+	const scopedExcludedIds = excludedIds.filter( id => scopeProducts.some( p => p.id === id ) );
+
+	const draft = restrictionShape( { subscriptions, targeting, productIds, category, excludedIds: scopedExcludedIds } );
+	const products = productsForRule( draft );
+
+	// What the restriction looked like when the editor opened; Save stays
+	// disabled until the draft differs from it (and is valid).
+	const initial = restrictionShape( {
+		subscriptions: rule.subscriptions || [],
+		targeting: rule.targeting || 'products',
+		productIds: rule.productIds || [],
+		category: rule.category || CATEGORIES[ 0 ],
+		excludedIds: rule.excludedIds || [],
+	} );
+	const isDirty = JSON.stringify( draft ) !== JSON.stringify( initial );
+	const isValid = subscriptions.length > 0 && ( targeting !== 'products' || productIds.length > 0 );
+	const canSave = isDirty && isValid;
+
+	const onSave = () => {
+		setBusy( true );
+		setTimeout( () => {
+			saveRestriction( { ...rule, ...draft } );
+			onSaved( rule.id ? __( 'Restriction updated.', 'newspack-plugin' ) : __( 'Restriction added.', 'newspack-plugin' ) );
+		}, 700 );
+	};
+
+	// Guard an unsaved close behind a discard confirmation. Blocked while busy
+	// so a discard during the in-flight save's timeout can't unmount the flow
+	// out from under the pending saveRestriction()/onSaved() call.
+	const attemptClose = () => {
+		if ( busy ) {
+			return;
+		}
+		if ( isDirty ) {
+			setConfirmDiscard( true );
+		} else {
+			onClose();
+		}
+	};
+
+	const previewRows = products.slice( 0, 8 );
+	const extra = products.length - previewRows.length;
+
+	let title = __( 'Add restriction', 'newspack-plugin' );
+	if ( isEdit ) {
+		title = __( 'Edit restriction', 'newspack-plugin' );
+	} else if ( isScopedAdd ) {
+		title = sprintf(
+			// translators: %s: subscription name, e.g. "Education Annual (Group)".
+			__( 'Add subscriber-only products to %s', 'newspack-plugin' ),
+			planLabel( rule.subscriptions[ 0 ] )
+		);
+	}
+
+	const content = (
+		<VStack spacing={ 4 } className="newspack-subscribers-demo__flow">
+			<VStack spacing={ 2 }>
+				<FormTokenField
+					label={ __( 'Available to', 'newspack-plugin' ) }
+					value={ subscriptions.map( planLabel ) }
+					suggestions={ ALL_PLANS.map( p => planLabel( p.name ) ) }
+					onChange={ onSubscriptionsChange }
+					__experimentalExpandOnFocus
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				/>
+				<span className="newspack-subscribers-demo__muted">
+					{ __( 'Subscribers of any of these subscriptions can purchase the products.', 'newspack-plugin' ) }
+				</span>
+			</VStack>
+			<TargetingFields
+				value={ { targeting, productIds, category, excludedIds } }
+				onChange={ onTargetChange }
+				appliesHelp={ __( 'Choose which products are subscriber-only.', 'newspack-plugin' ) }
+				categoryHelp={ __( 'Every product in this category becomes subscriber-only.', 'newspack-plugin' ) }
+			/>
+			{ products.length > 0 && (
+				<table className="newspack-subscribers-demo__discount-preview">
+					<thead>
+						<tr>
+							<th>{ __( 'Product', 'newspack-plugin' ) }</th>
+							<th>{ __( 'Price', 'newspack-plugin' ) }</th>
+						</tr>
+					</thead>
+					<tbody>
+						{ previewRows.map( p => (
+							<tr key={ p.id }>
+								<td>{ p.name }</td>
+								<td>{ fmtCurrency( p.price ) }</td>
+							</tr>
+						) ) }
+						{ extra > 0 && (
+							<tr className="newspack-subscribers-demo__discount-preview-more">
+								<td colSpan={ 2 }>
+									{ sprintf(
+										// translators: %d: number of additional matching products not shown in the preview.
+										_n( '…and %d more product', '…and %d more products', extra, 'newspack-plugin' ),
+										extra
+									) }
+								</td>
+							</tr>
+						) }
+					</tbody>
+				</table>
+			) }
+		</VStack>
+	);
+	const footer = (
+		<HStack spacing={ 2 } justify="flex-end">
+			<Button variant="secondary" disabled={ busy } onClick={ attemptClose }>
+				{ __( 'Cancel', 'newspack-plugin' ) }
+			</Button>
+			<Button variant="primary" isBusy={ busy } disabled={ busy || ! canSave } onClick={ onSave }>
+				{ __( 'Save', 'newspack-plugin' ) }
+			</Button>
+		</HStack>
+	);
+
+	return (
+		<>
+			<Modal
+				__experimentalHideHeader
+				size="small"
+				onRequestClose={ attemptClose }
+				className="newspack-subscribers-demo__sub-detail-modal newspack-subscribers-demo__sub-detail-modal--form"
+				overlayClassName="newspack-subscribers-demo__sub-detail-overlay"
+			>
+				<HStack className="newspack-subscribers-demo__sub-detail-header" spacing={ 2 } alignment="center">
+					<h2 className="newspack-subscribers-demo__sub-detail-title">{ title }</h2>
+					<Button icon={ close } size="small" label={ __( 'Close', 'newspack-plugin' ) } disabled={ busy } onClick={ attemptClose } />
+				</HStack>
+				<div className="newspack-subscribers-demo__sub-detail-content">{ content }</div>
+				<div className="newspack-subscribers-demo__sub-detail-footer">{ footer }</div>
+			</Modal>
+			{ confirmDiscard && (
+				<ConfirmFlow
+					title={ __( 'Discard changes?', 'newspack-plugin' ) }
+					confirmLabel={ __( 'Discard changes', 'newspack-plugin' ) }
+					isDestructive
+					onCancel={ () => setConfirmDiscard( false ) }
+					onConfirm={ onClose }
+				>
+					{ __( 'You have unsaved changes that will be lost.', 'newspack-plugin' ) }
+				</ConfirmFlow>
+			) }
+		</>
+	);
+}

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/RestrictionSettingsFlow.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/RestrictionSettingsFlow.jsx
@@ -1,0 +1,50 @@
+/**
+ * Flow — Global restriction settings. One setting for i1: whether
+ * subscriber-only products are hidden from product lists for readers who can't
+ * purchase them. This goes beyond NPPD-1899's purchase-only parity (it borders
+ * WCM's separate view restriction) and is called out as such in the PR.
+ */
+
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	ToggleControl,
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
+import { Button, Modal } from '../../../../packages/components/src';
+import { getRestrictionSettings, saveRestrictionSettings } from '../data/mock-restrictions';
+
+export default function RestrictionSettingsFlow( { onClose, onSaved } ) {
+	const [ draft, setDraft ] = useState( getRestrictionSettings );
+
+	const onSave = () => {
+		saveRestrictionSettings( draft );
+		onSaved( __( 'Restriction settings saved.', 'newspack-plugin' ) );
+	};
+
+	return (
+		<Modal title={ __( 'Restriction settings', 'newspack-plugin' ) } onRequestClose={ onClose } size="small">
+			<VStack spacing={ 6 }>
+				<ToggleControl
+					label={ __( 'Hide from product lists', 'newspack-plugin' ) }
+					help={ __(
+						'Hide subscriber-only products from search results and product lists for readers who can’t purchase them. Direct links still work.',
+						'newspack-plugin'
+					) }
+					checked={ draft.hideFromCatalog }
+					onChange={ hideFromCatalog => setDraft( { ...draft, hideFromCatalog } ) }
+					__nextHasNoMarginBottom
+				/>
+				<HStack spacing={ 2 } justify="flex-end">
+					<Button variant="tertiary" size="compact" onClick={ onClose }>
+						{ __( 'Cancel', 'newspack-plugin' ) }
+					</Button>
+					<Button variant="primary" size="compact" onClick={ onSave }>
+						{ __( 'Save', 'newspack-plugin' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</Modal>
+	);
+}

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/TargetingFields.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/flows/TargetingFields.jsx
@@ -1,0 +1,78 @@
+/**
+ * Shared "Applies to" targeting fields for the discount and restriction
+ * editors: the targeting-mode radio plus the product, category, and
+ * excluded-products pickers. Controlled via a single `value` object
+ * ({ targeting, productIds, category, excludedIds }); `onChange` receives a
+ * partial with just the changed keys. Help copy differs per feature, so it
+ * comes in as props.
+ */
+
+import { __ } from '@wordpress/i18n';
+import { FormTokenField, RadioControl } from '@wordpress/components';
+import { SelectControl } from '../../../../packages/components/src';
+import { CATEGORIES, PRODUCTS, getProductById } from '../data/mock-catalog';
+import { productsForRule } from '../data/targeting';
+
+export default function TargetingFields( { value, onChange, appliesHelp, categoryHelp } ) {
+	const { targeting, productIds, category, excludedIds } = value;
+
+	const onProductsChange = names => {
+		onChange( { productIds: names.map( name => PRODUCTS.find( p => p.name === name )?.id ).filter( Boolean ) } );
+	};
+
+	// Products currently in scope with no exclusions applied yet, so the
+	// exclusion picker only ever offers what could actually be excluded.
+	const scopeProducts = productsForRule( { targeting, productIds, category, excludedIds: [] } );
+
+	const onExcludedChange = names => {
+		onChange( { excludedIds: names.map( name => scopeProducts.find( p => p.name === name )?.id ).filter( Boolean ) } );
+	};
+
+	return (
+		<>
+			<RadioControl
+				label={ __( 'Applies to', 'newspack-plugin' ) }
+				help={ appliesHelp }
+				selected={ targeting }
+				onChange={ next => onChange( { targeting: next } ) }
+				options={ [
+					{ value: 'products', label: __( 'Specific products', 'newspack-plugin' ) },
+					{ value: 'category', label: __( 'Category', 'newspack-plugin' ) },
+					{ value: 'all', label: __( 'All products', 'newspack-plugin' ) },
+				] }
+			/>
+			{ targeting === 'products' && (
+				<FormTokenField
+					label={ __( 'Products', 'newspack-plugin' ) }
+					value={ productIds.map( id => getProductById( id )?.name ).filter( Boolean ) }
+					suggestions={ PRODUCTS.map( p => p.name ) }
+					onChange={ onProductsChange }
+					__experimentalExpandOnFocus
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				/>
+			) }
+			{ targeting === 'category' && (
+				<SelectControl
+					label={ __( 'Category', 'newspack-plugin' ) }
+					help={ categoryHelp }
+					value={ category }
+					options={ CATEGORIES.map( c => ( { label: c, value: c } ) ) }
+					onChange={ next => onChange( { category: next } ) }
+					__next40pxDefaultSize
+				/>
+			) }
+			{ targeting !== 'products' && (
+				<FormTokenField
+					label={ __( 'Excluded products', 'newspack-plugin' ) }
+					value={ excludedIds.map( id => scopeProducts.find( p => p.id === id )?.name ).filter( Boolean ) }
+					suggestions={ scopeProducts.map( p => p.name ) }
+					onChange={ onExcludedChange }
+					__experimentalExpandOnFocus
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				/>
+			) }
+		</>
+	);
+}

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/index.js
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/index.js
@@ -5,9 +5,9 @@ import '../../shared/js/public-path';
  * people-first subscriber management prototype, transplanted from the
  * discounts demo (PR #544).
  *
- * Entry point: mounts a Wizard with two visible tabs — Subscriptions (plan
- * list) and Discounts — plus hidden plan-detail, subscriber-profile, and
- * group-detail routes reached by row click.
+ * Entry point: mounts a Wizard with three visible tabs — Subscriptions (plan
+ * list), Discounts, and Subscriber-only products — plus hidden plan-detail,
+ * subscriber-profile, and group-detail routes reached by row click.
  */
 
 /**
@@ -22,6 +22,7 @@ import { __ } from '@wordpress/i18n';
 import { Wizard } from '../../../packages/components/src';
 import SubscriptionList from './screens/SubscriptionList';
 import DiscountList from './screens/DiscountList';
+import RestrictionList from './screens/RestrictionList';
 import { purgeStaleStorage } from './data/storage';
 
 function SubscribersDemoApp() {
@@ -42,6 +43,13 @@ function SubscribersDemoApp() {
 					exact: true,
 					fullWidth: true,
 					render: DiscountList,
+				},
+				{
+					label: __( 'Subscriber-only products', 'newspack-plugin' ),
+					path: '/subscriber-only',
+					exact: true,
+					fullWidth: true,
+					render: RestrictionList,
 				},
 			] }
 		/>

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/screens/EmptyRestrictions.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/screens/EmptyRestrictions.jsx
@@ -1,16 +1,15 @@
 /**
- * L0 — Discounts empty state (onboarding).
+ * L0 — Restrictions empty state (onboarding).
  *
- * Shown when there are no discount rules: a genuinely empty store, or the
- * `?empty=1` preview param on the discounts tab. Mirrors the audience
- * institutions onboarding so it reads as part of the design system.
+ * Shown when there are no restrictions: a genuinely empty store, or the
+ * `?empty=1` preview param on the subscriber-only tab. Mirrors EmptyDiscounts.
  */
 
 /**
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { percent } from '@wordpress/icons';
+import { store } from '@wordpress/icons';
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 import { __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components';
 
@@ -19,7 +18,7 @@ import { __experimentalHStack as HStack, __experimentalVStack as VStack } from '
  */
 import { Button, Grid, SectionHeader } from '../../../../packages/components/src';
 
-export default function EmptyDiscounts( { onAdd } ) {
+export default function EmptyRestrictions( { onAdd } ) {
 	return (
 		<div
 			style={ {
@@ -31,10 +30,10 @@ export default function EmptyDiscounts( { onAdd } ) {
 			<Grid columns={ 4 } noMargin>
 				<VStack start={ 2 } end={ 4 } spacing={ 8 }>
 					<SectionHeader
-						icon={ percent }
-						title={ __( 'Get started with subscriber discounts', 'newspack-plugin' ) }
+						icon={ store }
+						title={ __( 'Get started with subscriber-only products', 'newspack-plugin' ) }
 						description={ __(
-							'Offer subscribers a discount on your products. Create your first rule to choose which plan gets what off which products.',
+							'Make products available exclusively to subscribers. Create your first restriction to choose which products are subscriber-only and which subscriptions unlock them.',
 							'newspack-plugin'
 						) }
 						pageHeader
@@ -42,7 +41,7 @@ export default function EmptyDiscounts( { onAdd } ) {
 					/>
 					<HStack alignment="center">
 						<Button variant="primary" onClick={ onAdd }>
-							{ __( 'Add discount', 'newspack-plugin' ) }
+							{ __( 'Add restriction', 'newspack-plugin' ) }
 						</Button>
 					</HStack>
 				</VStack>

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/screens/RestrictionList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/screens/RestrictionList.jsx
@@ -1,0 +1,351 @@
+/* eslint-disable @wordpress/i18n-translator-comments */
+/**
+ * L0 — Subscriber-only products list (DataViews, full-width).
+ *
+ * Admin-facing list of purchase restrictions: which store products are
+ * subscriber-only, and which subscriptions unlock them. Mirrors DiscountList's
+ * list idioms.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { useEffect, useMemo, useState } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+import {
+	Snackbar,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies.
+ */
+import { Badge, Button, DataViews, Router } from '../../../../packages/components/src';
+import EmptyRestrictions from './EmptyRestrictions';
+import './style.scss';
+import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
+import { getAllRestrictions, deleteRestriction, setRestrictionActive } from '../data/mock-restrictions';
+import { targetingLabel, targetingBaseLabel, excludedLabel, productNamesForRule, coveredParentProductIds } from '../data/targeting';
+import { PRODUCTS } from '../data/mock-catalog';
+import { getAllPlans } from '../data/plan-stats';
+import { TEAM_PLANS } from '../data/mock-groups';
+import { GROUP_LABEL } from '../labels';
+import { fmtDate } from '../format';
+import ConfirmFlow from '../flows/ConfirmFlow';
+import RestrictionFlow from '../flows/RestrictionFlow';
+import RestrictionSettingsFlow from '../flows/RestrictionSettingsFlow';
+
+const DEFAULT_VIEW = {
+	type: 'table',
+	page: 1,
+	perPage: 20,
+	sort: { field: 'createdAt', direction: 'desc' },
+	search: '',
+	fields: [ 'availableTo', 'status', 'createdAt' ],
+	filters: [],
+	layout: {},
+	titleField: 'products',
+};
+
+const { useLocation } = Router;
+
+// How many product names a specific-products row lists before collapsing the
+// rest into a muted "+N more".
+const MAX_PRODUCT_NAMES = 2;
+
+// Group (team) subscriptions are tagged "(Group)" — matching the editor and the
+// Subscribers demo — while individual ones show a plain name.
+const planLabel = name => ( TEAM_PLANS.some( p => p.name === name ) ? `${ name } (${ GROUP_LABEL })` : name );
+
+export default function RestrictionList() {
+	// `?empty=1` forces the onboarding for demos/screenshots without touching
+	// stored restrictions (nothing to restore afterwards).
+	const previewEmpty = new URLSearchParams( useLocation().search ).get( 'empty' ) !== null;
+
+	const [ view, setView ] = useState( DEFAULT_VIEW );
+	// Restrictions mutate in place on this screen (pause/resume/delete are
+	// direct storage writes), so re-reading the store is enough to refresh.
+	const [ rules, setRules ] = useState( () => getAllRestrictions() );
+	const refresh = () => setRules( getAllRestrictions() );
+
+	const [ editorRule, setEditorRule ] = useState( null );
+	const [ settingsOpen, setSettingsOpen ] = useState( false );
+	const [ confirmAction, setConfirmAction ] = useState( null );
+	const [ snackbar, setSnackbar ] = useState( null );
+
+	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
+
+	const closeConfirm = () => setConfirmAction( null );
+
+	const applyPauseResume = () => {
+		const { item, kind } = confirmAction;
+		setRestrictionActive( item.id, kind === 'resume' );
+		refresh();
+		setSnackbar( {
+			message: kind === 'resume' ? __( 'Restriction resumed.', 'newspack-plugin' ) : __( 'Restriction paused.', 'newspack-plugin' ),
+		} );
+		closeConfirm();
+	};
+
+	const applyDelete = () => {
+		deleteRestriction( confirmAction.item.id );
+		refresh();
+		setSnackbar( { message: __( 'Restriction deleted.', 'newspack-plugin' ) } );
+		closeConfirm();
+	};
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'products',
+				label: __( 'Products', 'newspack-plugin' ),
+				enableGlobalSearch: true,
+				// Product names are included so global search finds a restriction by
+				// the products it covers, not just its targeting label.
+				getValue: ( { item } ) => [ targetingLabel( item ), ...productNamesForRule( item ) ].join( ' ' ),
+				render: ( { item } ) => {
+					const names = productNamesForRule( item );
+					const shown = names.slice( 0, MAX_PRODUCT_NAMES );
+					const extra = names.length - shown.length;
+					const excluded = excludedLabel( item );
+					return (
+						<VStack spacing={ 0 } alignment="flex-start" expanded={ false }>
+							{ shown.length > 0 ? (
+								shown.map( name => <span key={ name }>{ name }</span> )
+							) : (
+								<span>{ targetingBaseLabel( item ) }</span>
+							) }
+							{ extra > 0 && (
+								<span className="newspack-subscribers-demo__muted">
+									{ sprintf( _n( '+%d more product', '+%d more products', extra, 'newspack-plugin' ), extra ) }
+								</span>
+							) }
+							{ excluded && <span className="newspack-subscribers-demo__muted">{ excluded }</span> }
+						</VStack>
+					);
+				},
+				enableSorting: false,
+			},
+			{
+				id: 'availableTo',
+				label: __( 'Available to', 'newspack-plugin' ),
+				enableGlobalSearch: true,
+				elements: getAllPlans().map( plan => ( { value: plan.name, label: planLabel( plan.name ) } ) ),
+				filterBy: { operators: [ 'isAny' ] },
+				// The raw name array: isAny matches any of the rule's subscriptions.
+				getValue: ( { item } ) => item.subscriptions,
+				render: ( { item } ) => <span>{ item.subscriptions.map( planLabel ).join( ', ' ) }</span>,
+				enableSorting: false,
+			},
+			{
+				// Filter-only: not in the visible columns (see DEFAULT_VIEW.fields).
+				// A rule matches when its effective scope covers the product —
+				// named directly, via its category, or via an all-products rule,
+				// with exclusions applied.
+				id: 'product',
+				label: __( 'Product', 'newspack-plugin' ),
+				elements: PRODUCTS.map( p => ( { value: p.id, label: p.name } ) ),
+				filterBy: { operators: [ 'isAny' ] },
+				getValue: ( { item } ) => coveredParentProductIds( item ),
+				enableSorting: false,
+			},
+			{
+				id: 'status',
+				label: __( 'Status', 'newspack-plugin' ),
+				elements: [
+					{ value: 'active', label: __( 'Active', 'newspack-plugin' ) },
+					{ value: 'paused', label: __( 'Paused', 'newspack-plugin' ) },
+				],
+				filterBy: { operators: [ 'isAny' ] },
+				getValue: ( { item } ) => ( item.active ? 'active' : 'paused' ),
+				render: ( { item } ) => (
+					<Badge
+						level={ item.active ? 'success' : 'default' }
+						text={ item.active ? __( 'Active', 'newspack-plugin' ) : __( 'Paused', 'newspack-plugin' ) }
+					/>
+				),
+			},
+			{
+				id: 'createdAt',
+				label: __( 'Created', 'newspack-plugin' ),
+				getValue: ( { item } ) => item.createdAt,
+				render: ( { item } ) => <span>{ fmtDate( item.createdAt ) }</span>,
+				enableSorting: true,
+			},
+		],
+		[]
+	);
+
+	const actions = useMemo(
+		() => [
+			{
+				id: 'edit',
+				label: __( 'Edit', 'newspack-plugin' ),
+				callback: items => setEditorRule( items[ 0 ] ),
+			},
+			{
+				id: 'toggle-active',
+				label: items => ( items[ 0 ].active ? __( 'Pause', 'newspack-plugin' ) : __( 'Resume', 'newspack-plugin' ) ),
+				callback: items => setConfirmAction( { kind: items[ 0 ].active ? 'pause' : 'resume', item: items[ 0 ] } ),
+			},
+			{
+				id: 'delete',
+				label: __( 'Delete', 'newspack-plugin' ),
+				isDestructive: true,
+				callback: items => setConfirmAction( { kind: 'delete', item: items[ 0 ] } ),
+			},
+		],
+		[]
+	);
+
+	const { data: processedData, paginationInfo } = useMemo( () => filterSortAndPaginate( rules, view, fields ), [ rules, view, fields ] );
+
+	// Whole-row click → edit (DataViews only wires up the title cell).
+	const onRowClick = event => {
+		if ( event.target.closest( 'a, button, input, label, [role="button"], [role="checkbox"]' ) ) {
+			return;
+		}
+		const row = event.target.closest( 'tbody tr.dataviews-view-table__row' );
+		if ( ! row ) {
+			return;
+		}
+		const index = Array.from( row.parentNode.children ).indexOf( row );
+		const item = processedData[ index ];
+		if ( item ) {
+			setEditorRule( item );
+		}
+	};
+
+	// Onboarding shows for a genuinely empty store (or the preview param), but a
+	// search/filter that returns nothing keeps the normal DataViews "No results".
+	const isEmpty = previewEmpty || rules.length === 0;
+	const total = previewEmpty ? 0 : paginationInfo?.totalItems ?? 0;
+
+	// Surface the count in the header breadcrumb, e.g. "/ Subscriber-only products (4)".
+	useEffect( () => {
+		setHeaderData( {
+			sectionName: (
+				<>
+					{ __( 'Subscriber-only products', 'newspack-plugin' ) }{ ' ' }
+					<span
+						className="newspack-subscribers-demo__header-count"
+						aria-label={ sprintf( _n( '%d restriction total', '%d restrictions total', total, 'newspack-plugin' ), total ) }
+					>
+						{ `(${ total.toLocaleString() })` }
+					</span>
+				</>
+			),
+			// When empty, the onboarding owns the CTA — don't duplicate it in the header.
+			actions: isEmpty
+				? []
+				: [
+						{
+							type: 'primary',
+							label: __( 'Add restriction', 'newspack-plugin' ),
+							action: () => setEditorRule( {} ),
+						},
+				  ],
+		} );
+	}, [ setHeaderData, total, isEmpty ] );
+
+	return (
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+		<div className="newspack-subscribers-demo__clickable-rows" onClick={ onRowClick }>
+			{ isEmpty ? (
+				<EmptyRestrictions onAdd={ () => setEditorRule( {} ) } />
+			) : (
+				<DataViews
+					data={ processedData }
+					fields={ fields }
+					view={ view }
+					onChangeView={ setView }
+					actions={ actions }
+					paginationInfo={ paginationInfo }
+					defaultLayouts={ { table: {} } }
+					getItemId={ item => item.id }
+					onClickItem={ item => setEditorRule( item ) }
+					search
+					header={
+						<Button variant="secondary" size="compact" onClick={ () => setSettingsOpen( true ) }>
+							{ __( 'Settings', 'newspack-plugin' ) }
+						</Button>
+					}
+				/>
+			) }
+
+			{ editorRule !== null && (
+				<RestrictionFlow
+					rule={ editorRule }
+					onClose={ () => setEditorRule( null ) }
+					onSaved={ message => {
+						refresh();
+						setEditorRule( null );
+						setSnackbar( { message } );
+					} }
+				/>
+			) }
+
+			{ settingsOpen && (
+				<RestrictionSettingsFlow
+					onClose={ () => setSettingsOpen( false ) }
+					onSaved={ message => {
+						setSettingsOpen( false );
+						setSnackbar( { message } );
+					} }
+				/>
+			) }
+
+			{ confirmAction?.kind === 'pause' && (
+				<ConfirmFlow
+					title={ __( 'Pause restriction', 'newspack-plugin' ) }
+					confirmLabel={ __( 'Pause restriction', 'newspack-plugin' ) }
+					onCancel={ closeConfirm }
+					onConfirm={ applyPauseResume }
+				>
+					{ sprintf(
+						__( 'Pause the restriction on %s? Everyone can purchase these products until you resume it.', 'newspack-plugin' ),
+						targetingBaseLabel( confirmAction.item )
+					) }
+				</ConfirmFlow>
+			) }
+
+			{ confirmAction?.kind === 'resume' && (
+				<ConfirmFlow
+					title={ __( 'Resume restriction', 'newspack-plugin' ) }
+					confirmLabel={ __( 'Resume restriction', 'newspack-plugin' ) }
+					onCancel={ closeConfirm }
+					onConfirm={ applyPauseResume }
+				>
+					{ sprintf(
+						__( 'Resume the restriction on %s? Purchasing becomes subscriber-only again immediately.', 'newspack-plugin' ),
+						targetingBaseLabel( confirmAction.item )
+					) }
+				</ConfirmFlow>
+			) }
+
+			{ confirmAction?.kind === 'delete' && (
+				<ConfirmFlow
+					title={ __( 'Delete restriction', 'newspack-plugin' ) }
+					confirmLabel={ __( 'Delete restriction', 'newspack-plugin' ) }
+					isDestructive
+					onCancel={ closeConfirm }
+					onConfirm={ applyDelete }
+				>
+					{ sprintf(
+						__( 'Delete the restriction on %s? Everyone can purchase these products immediately.', 'newspack-plugin' ),
+						targetingBaseLabel( confirmAction.item )
+					) }
+				</ConfirmFlow>
+			) }
+
+			{ snackbar && (
+				<div className="newspack-subscribers-demo__snackbar">
+					<Snackbar onRemove={ () => setSnackbar( null ) }>{ snackbar.message }</Snackbar>
+				</div>
+			) }
+		</div>
+	);
+}

--- a/plugins/newspack-plugin/src/wizards/subscriptionsDemo/screens/SubscriptionList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscriptionsDemo/screens/SubscriptionList.jsx
@@ -26,6 +26,7 @@ import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wiza
 import { getAllPlans, getPlanStats } from '../data/plan-stats';
 import { GROUP_LABEL } from '../labels';
 import DiscountRuleFlow from '../flows/DiscountRuleFlow';
+import RestrictionFlow from '../flows/RestrictionFlow';
 
 // Product status labels; retired plans are no longer sold but keep existing
 // subscribers.
@@ -86,6 +87,7 @@ const DEFAULT_VIEW = {
 export default function SubscriptionList() {
 	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ editorRule, setEditorRule ] = useState( null );
+	const [ editorRestriction, setEditorRestriction ] = useState( null );
 	const [ snackbar, setSnackbar ] = useState( null );
 	// Bumped after a discount is saved so statsByPlan (below) re-reads
 	// getPlanStats(), which pulls discount rules from localStorage and isn't
@@ -221,6 +223,11 @@ export default function SubscriptionList() {
 				callback: items => setEditorRule( { audience: items[ 0 ].name } ),
 			},
 			{
+				id: 'add-restriction',
+				label: __( 'Add subscriber-only products', 'newspack-plugin' ),
+				callback: items => setEditorRestriction( { subscriptions: [ items[ 0 ].name ] } ),
+			},
+			{
 				id: 'view-in-woocommerce',
 				label: __( 'View in WooCommerce', 'newspack-plugin' ),
 				callback: items => openWooCommerce( items[ 0 ].name ),
@@ -285,6 +292,16 @@ export default function SubscriptionList() {
 						setEditorRule( null );
 						setSnackbar( { message } );
 						setStatsRevision( n => n + 1 );
+					} }
+				/>
+			) }
+			{ editorRestriction !== null && (
+				<RestrictionFlow
+					rule={ editorRestriction }
+					onClose={ () => setEditorRestriction( null ) }
+					onSaved={ message => {
+						setEditorRestriction( null );
+						setSnackbar( { message } );
 					} }
 				/>
 			) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Design iteration for member-only purchasing (WooCommerce Memberships parity). Following [the Slack discussion](https://a8c.slack.com/archives/C015W6BES8J/p1784114871923609), this moves the feature out of Access Control gates (#607, now draft) and into the Subscriptions wizard, as a sibling of Subscriber discounts.

Adds a third tab to the Subscriptions demo prototype: **Subscriber-only products**. A restriction makes selected products purchasable only by subscribers of any of its chosen subscriptions. Everyone still sees the product and its price; only purchasing is gated.

* **List**: one row per restriction, leading with the actual product names (capped, then "+N more"), or the category / all-products scope. Columns: Products, Available to, Status, Created. Filters for Status, subscription, and product. The product filter matches what a restriction effectively covers: named directly, via its category, or via an all-products rule, with exclusions respected.
* **Editor drawer**: mirrors the discount editor. Multi-select "Available to" (any selected subscription unlocks purchase), the shared "Applies to" targeting controls (specific products / category / all, with exclusions), and a live preview of affected products.
* **Settings**: a single "Hide from product lists" toggle, default off. Worth calling out: this goes a step beyond the ticket's purchase-only parity and borders WCM's separate view restriction. Direct links still work and show the product page with its notice.
* **Subscriptions list**: new "Add subscriber-only products" kebab action, opening the editor with that subscription pre-selected (editable, since several subscriptions can unlock the same products).
* **Shared with discounts**: targeting resolution and labels extracted to `data/targeting.js`, and the "Applies to" fields into a shared `TargetingFields` component used by both editors.

**Reader-facing decision (deliberately not a design iteration):** keep #607's mechanics as they are. Product and price stay visible, enforcement rides `woocommerce_is_purchasable` at 999, archives show Woo's native "Read more", and the product page notice lists the unlocking subscriptions. Only the vocabulary changes to subscriber terms, e.g. "This product is available to subscribers." Publisher-facing copy avoids shop/store vocabulary throughout: newsrooms sell books and event tickets, they don't run "a store".

Mock data only, no PHP changes. The wizard stays hidden behind Newspack debug mode. Stacked on #547 (`feat/subscriptions-demo` is the base branch).

Part of NPPD-1899.

### How to test the changes in this Pull Request:

1. In an env with the demo (e.g. `subscribers-demo`), open `admin.php?page=newspack-subscriptions-demo#/subscriber-only`.
2. The tab lists 4 seeded restrictions, newest first: rows lead with product names ("Photography Walk", "Annual Gala Ticket", "Centennial History, Vol. 1 / Vol. 2 / +1 more product") or scope ("Courses category · 1 excluded"). The header shows the count and an Add restriction button.
3. Add a restriction: Save stays disabled until at least one subscription is chosen and, for specific products, at least one product. The preview lists affected products with prices. Closing with changes prompts a discard confirmation.
4. Edit (row click or kebab), Pause/Resume, and Delete, each with a confirm dialog and snackbar; changes persist across a reload (localStorage).
5. Filters: Status; Available to, which matches a restriction if any of its subscriptions is selected; Product, where a product covered via its category or an all-products rule matches, and an excluded product returns no results.
6. Settings: toggle "Hide from product lists", save, reopen to confirm it persists.
7. On the Subscriptions tab, use "Add subscriber-only products" in a row kebab: the drawer opens titled for that subscription with it pre-filled and editable.
8. Append `?empty=1` to the tab URL for the onboarding empty state.
9. On the Subscriber discounts tab, open a discount and switch targeting modes: behavior is unchanged after the shared-fields refactor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
