### PR TITLE
docs(agents): require PR bodies to follow the repo template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,7 @@ One repository, so a cross-plugin change is one branch and one PR. Before changi
 - **Squash merge** (`gh pr merge --squash`). The exception is branch promotions between `main`, `alpha` and `release`, which use merge commits to preserve history.
 - **Never push or merge unless asked.**
 - **One Copilot pass per PR**, requested when the PR opens. After addressing its feedback do not re-request it; the next review should be a human's.
+- **PR bodies follow [the repository template](.github/PULL_REQUEST_TEMPLATE.md).** `gh pr create --body`/`--body-file` bypasses GitHub's automatic template application, so compose the body into the template's sections yourself, and tick only the checklist items that are actually true.
 
 With the `newspack` plugin installed: `newspack:pr-create` → `newspack:pr-feedback` → `newspack:pr-ready` → `newspack:pr-merge`, plus `newspack:pr-test` to test a PR in an isolated env. Install it with `n setup-agents`, or:
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)? *(docs only; no code)*
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`AGENTS.md` covers how to merge a PR but not how to write one. Its "Pull requests" section documents merge strategy, push discipline, and the Copilot pass, and stops before the body.

GitHub applies [`.github/PULL_REQUEST_TEMPLATE.md`](../blob/main/.github/PULL_REQUEST_TEMPLATE.md) when a PR is opened through the web UI. `gh pr create --body` and `--body-file` supply a body directly, so the template never loads. #728 and #736 were opened that way and went out without it. Both bodies now follow the template.

This adds one bullet to that section: follow the repository template, and since `--body`/`--body-file` bypasses it, compose the sections yourself and tick only the boxes that are true.

### How to test the changes in this Pull Request:

1. Open `AGENTS.md` on this branch and find the "Pull requests" section. The new bullet appears below the Copilot bullet.
2. Follow the template link in that bullet. It resolves to `.github/PULL_REQUEST_TEMPLATE.md`, which exists on `main`.
3. Compare this PR's own body against that template. The sections match.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? *(docs only; no tests apply)*
* [ ] Have you successfully run tests with your changes locally? *(docs only; no tests apply)*

#829 edits the same section: it removes the two devkit paragraphs below this bullet list. The two changes touch different lines and merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
