### PR TITLE
feat(subscriptions): shared base for subscriber-commerce features

### DIFF
--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -156,6 +156,11 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/content-gate/class-content-gate.php';
 		include_once NEWSPACK_ABSPATH . 'includes/content-gate/class-inert-gating-notice.php';
 
+		// Shared infrastructure for rules that tie store products to subscriptions.
+		include_once NEWSPACK_ABSPATH . 'includes/subscriber-commerce/class-subscriber-commerce.php';
+		include_once NEWSPACK_ABSPATH . 'includes/subscriber-commerce/class-product-targeting.php';
+		include_once NEWSPACK_ABSPATH . 'includes/subscriber-commerce/class-subscriber-eligibility.php';
+
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-provider.php';
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-generated.php';
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-wordpress.php';

--- a/plugins/newspack-plugin/includes/class-wizards.php
+++ b/plugins/newspack-plugin/includes/class-wizards.php
@@ -80,7 +80,11 @@ class Wizards {
 			'newsletters'             => new Newsletters_Wizard(),
 			'premium-newsletters'     => new Premium_Newsletters_Wizard(),
 		];
-		if ( Memberships::is_active() ) {
+		// Memberships sites get the page for its subscription configuration; every
+		// Woo site with content gating gets it for the subscriber-commerce tabs.
+		// Deliberately not gated on enforcement being live: a site migrating off
+		// Memberships configures its rules first and deactivates Memberships after.
+		if ( Memberships::is_active() || Subscriber_Commerce::is_admin_available() ) {
 			self::$wizards['audience-subscriptions'] = new Audience_Subscriptions();
 		}
 		// Plans (Subscription Products) page, gated behind NEWSPACK_PLANS_UI and available

--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-product-targeting.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-product-targeting.php
@@ -54,6 +54,28 @@ class Product_Targeting {
 	private static array $expanded_categories = [];
 
 	/**
+	 * Product IDs expanded with the children of any grouped product among them,
+	 * keyed by the hash of the requested IDs.
+	 *
+	 * @var array<string, int[]>
+	 */
+	private static array $expanded_grouped = [];
+
+	/**
+	 * Namespace a per-request cache key to the current site.
+	 *
+	 * Product, term and user IDs are per-site: under switch_to_blog() term 5 on
+	 * two sites would otherwise share an entry and return each other's answers.
+	 *
+	 * @param string $key The key.
+	 *
+	 * @return string
+	 */
+	private static function cache_key( string $key ): string {
+		return get_current_blog_id() . ':' . $key;
+	}
+
+	/**
 	 * Get the rules from a rule set that cover a product, memoized per request.
 	 *
 	 * Inactive rules are never returned.
@@ -69,7 +91,7 @@ class Product_Targeting {
 			return [];
 		}
 
-		$cache_key = md5( wp_json_encode( $rules ) ) . ':' . $product->get_id();
+		$cache_key = self::cache_key( md5( wp_json_encode( $rules ) ) . ':' . $product->get_id() );
 		if ( ! isset( self::$matching_rules[ $cache_key ] ) ) {
 			self::$matching_rules[ $cache_key ] = array_values(
 				array_filter(
@@ -123,6 +145,12 @@ class Product_Targeting {
 	/**
 	 * Whether a product is excluded from a rule.
 	 *
+	 * The exclusion list is expanded through grouped products first: a grouped
+	 * product's children are top-level products reporting a parent of 0, so the
+	 * parent-ID test below — which is what catches a variation of an excluded
+	 * variable product — never sees them. Without the expansion, excluding a
+	 * bundle would leave everything sold under it still covered by the rule.
+	 *
 	 * @param array $rule       The rule.
 	 * @param int   $product_id The product (or variation) ID.
 	 * @param int   $parent_id  The parent product ID, 0 for a non-variation.
@@ -130,8 +158,40 @@ class Product_Targeting {
 	 * @return bool
 	 */
 	private static function is_excluded( array $rule, int $product_id, int $parent_id ): bool {
-		$excluded = array_map( 'intval', $rule['excluded_product_ids'] ?? [] );
+		$excluded = self::expand_grouped_ids( array_map( 'intval', $rule['excluded_product_ids'] ?? [] ) );
 		return ! empty( array_intersect( array_filter( [ $product_id, $parent_id ] ), $excluded ) );
+	}
+
+	/**
+	 * Expand a list of product IDs with the children of any grouped product in it,
+	 * memoized per request.
+	 *
+	 * Deliberately applied to exclusions only, not to `products` targeting: an
+	 * exclusion that covers too little sells something the publisher meant to
+	 * withhold, whereas targeting that covers too much restricts or discounts
+	 * something they never named. Where the two directions disagree, this errs
+	 * toward the rule doing less.
+	 *
+	 * @param int[] $product_ids The product IDs.
+	 *
+	 * @return int[] The IDs, plus the children of any grouped product among them.
+	 */
+	public static function expand_grouped_ids( array $product_ids ): array {
+		if ( empty( $product_ids ) || ! function_exists( 'wc_get_product' ) ) {
+			return $product_ids;
+		}
+		$cache_key = self::cache_key( md5( wp_json_encode( $product_ids ) ) );
+		if ( ! isset( self::$expanded_grouped[ $cache_key ] ) ) {
+			$expanded = $product_ids;
+			foreach ( $product_ids as $product_id ) {
+				$product = wc_get_product( $product_id );
+				if ( $product instanceof \WC_Product && $product->is_type( 'grouped' ) ) {
+					$expanded = array_merge( $expanded, array_map( 'intval', $product->get_children() ) );
+				}
+			}
+			self::$expanded_grouped[ $cache_key ] = array_values( array_unique( $expanded ) );
+		}
+		return self::$expanded_grouped[ $cache_key ];
 	}
 
 	/**
@@ -148,7 +208,7 @@ class Product_Targeting {
 		if ( empty( $category_ids ) ) {
 			return [];
 		}
-		$cache_key = md5( wp_json_encode( $category_ids ) );
+		$cache_key = self::cache_key( md5( wp_json_encode( $category_ids ) ) );
 		if ( ! isset( self::$expanded_categories[ $cache_key ] ) ) {
 			$expanded = $category_ids;
 			foreach ( $category_ids as $category_id ) {
@@ -169,5 +229,6 @@ class Product_Targeting {
 	public static function flush_cache(): void {
 		self::$matching_rules      = [];
 		self::$expanded_categories = [];
+		self::$expanded_grouped    = [];
 	}
 }

--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-product-targeting.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-product-targeting.php
@@ -43,7 +43,7 @@ class Product_Targeting {
 	 *
 	 * @var array<string, array>
 	 */
-	private static $matching_rules = [];
+	private static array $matching_rules = [];
 
 	/**
 	 * Category IDs expanded with their descendants, keyed by the hash of the
@@ -51,7 +51,7 @@ class Product_Targeting {
 	 *
 	 * @var array<string, int[]>
 	 */
-	private static $expanded_categories = [];
+	private static array $expanded_categories = [];
 
 	/**
 	 * Get the rules from a rule set that cover a product, memoized per request.
@@ -63,7 +63,7 @@ class Product_Targeting {
 	 *
 	 * @return array The matching rules, in the order given.
 	 */
-	public static function get_matching_rules( $rules, $product ) {
+	public static function get_matching_rules( array $rules, $product ): array {
 		$product = $product instanceof \WC_Product ? $product : ( function_exists( 'wc_get_product' ) ? wc_get_product( $product ) : null );
 		if ( ! $product instanceof \WC_Product || empty( $rules ) ) {
 			return [];
@@ -91,7 +91,7 @@ class Product_Targeting {
 	 *
 	 * @return bool
 	 */
-	public static function rule_covers_product( $rule, $product ) {
+	public static function rule_covers_product( array $rule, $product ): bool {
 		$product_id = (int) $product->get_id();
 		$parent_id  = (int) $product->get_parent_id();
 		$targeting  = $rule['targeting'] ?? self::TARGETING_PRODUCTS;
@@ -129,7 +129,7 @@ class Product_Targeting {
 	 *
 	 * @return bool
 	 */
-	private static function is_excluded( $rule, $product_id, $parent_id ) {
+	private static function is_excluded( array $rule, int $product_id, int $parent_id ): bool {
 		$excluded = array_map( 'intval', $rule['excluded_product_ids'] ?? [] );
 		return ! empty( array_intersect( array_filter( [ $product_id, $parent_id ] ), $excluded ) );
 	}
@@ -144,7 +144,7 @@ class Product_Targeting {
 	 *
 	 * @return int[] The category IDs including all descendants.
 	 */
-	public static function expand_category_ids( $category_ids ) {
+	public static function expand_category_ids( array $category_ids ): array {
 		if ( empty( $category_ids ) ) {
 			return [];
 		}
@@ -166,7 +166,7 @@ class Product_Targeting {
 	 * Flush the per-request caches. For tests and for callers that mutate rules
 	 * or the category tree mid-request.
 	 */
-	public static function flush_cache() {
+	public static function flush_cache(): void {
 		self::$matching_rules      = [];
 		self::$expanded_categories = [];
 	}

--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-product-targeting.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-product-targeting.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Newspack Subscriber Commerce - product targeting.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolves which products a subscriber-commerce rule covers. Single source of
+ * truth for targeting semantics, shared by subscriber-only products and
+ * subscriber discounts:
+ *
+ * - 'products': the products listed in `product_ids`. A variation is covered
+ *   when it is listed itself or when its parent is.
+ * - 'category': products in any of `category_ids`, cascading to child
+ *   categories (`product_cat` is hierarchical, matching WooCommerce
+ *   Memberships). Variations carry no terms, so they match through their
+ *   parent's categories.
+ * - 'all': every product.
+ *
+ * 'category' and 'all' honor `excluded_product_ids`: a product is excluded
+ * when its own ID or its parent's ID is listed.
+ */
+class Product_Targeting {
+
+	const TARGETING_PRODUCTS = 'products';
+	const TARGETING_CATEGORY = 'category';
+	const TARGETING_ALL      = 'all';
+
+	/**
+	 * The WooCommerce product category taxonomy.
+	 */
+	const PRODUCT_CATEGORY_TAXONOMY = 'product_cat';
+
+	/**
+	 * Matching rules per (rule-set, product), keyed by "{rules hash}:{product_id}".
+	 * WooCommerce evaluates purchasability and prices many times per product per
+	 * request (catalog loop, single template, cart), so the resolution is memoized.
+	 *
+	 * @var array<string, array>
+	 */
+	private static $matching_rules = [];
+
+	/**
+	 * Category IDs expanded with their descendants, keyed by the hash of the
+	 * requested IDs.
+	 *
+	 * @var array<string, int[]>
+	 */
+	private static $expanded_categories = [];
+
+	/**
+	 * Get the rules from a rule set that cover a product, memoized per request.
+	 *
+	 * Inactive rules are never returned.
+	 *
+	 * @param array           $rules   Rules shaped per Subscriber_Commerce::sanitize_base_rule().
+	 * @param \WC_Product|int $product The product (or variation), or its ID.
+	 *
+	 * @return array The matching rules, in the order given.
+	 */
+	public static function get_matching_rules( $rules, $product ) {
+		$product = $product instanceof \WC_Product ? $product : ( function_exists( 'wc_get_product' ) ? wc_get_product( $product ) : null );
+		if ( ! $product instanceof \WC_Product || empty( $rules ) ) {
+			return [];
+		}
+
+		$cache_key = md5( wp_json_encode( $rules ) ) . ':' . $product->get_id();
+		if ( ! isset( self::$matching_rules[ $cache_key ] ) ) {
+			self::$matching_rules[ $cache_key ] = array_values(
+				array_filter(
+					$rules,
+					function ( $rule ) use ( $product ) {
+						return ! empty( $rule['active'] ) && self::rule_covers_product( $rule, $product );
+					}
+				)
+			);
+		}
+		return self::$matching_rules[ $cache_key ];
+	}
+
+	/**
+	 * Whether a rule's targeting covers a product, ignoring the rule's active flag.
+	 *
+	 * @param array       $rule    The rule.
+	 * @param \WC_Product $product The product (or variation).
+	 *
+	 * @return bool
+	 */
+	public static function rule_covers_product( $rule, $product ) {
+		$product_id = (int) $product->get_id();
+		$parent_id  = (int) $product->get_parent_id();
+		$targeting  = $rule['targeting'] ?? self::TARGETING_PRODUCTS;
+
+		if ( self::TARGETING_PRODUCTS === $targeting ) {
+			$targeted = array_map( 'intval', $rule['product_ids'] ?? [] );
+			// A variation is covered when it is listed itself or when its parent is.
+			return ! empty( array_intersect( array_filter( [ $product_id, $parent_id ] ), $targeted ) );
+		}
+
+		if ( self::is_excluded( $rule, $product_id, $parent_id ) ) {
+			return false;
+		}
+
+		if ( self::TARGETING_ALL === $targeting ) {
+			return true;
+		}
+
+		$category_ids = self::expand_category_ids( array_map( 'intval', $rule['category_ids'] ?? [] ) );
+		if ( empty( $category_ids ) ) {
+			return false;
+		}
+
+		// Product categories live on the parent product; a variation never carries them.
+		$categorized_id = $parent_id ? $parent_id : $product_id;
+		return (bool) has_term( $category_ids, self::PRODUCT_CATEGORY_TAXONOMY, $categorized_id );
+	}
+
+	/**
+	 * Whether a product is excluded from a rule.
+	 *
+	 * @param array $rule       The rule.
+	 * @param int   $product_id The product (or variation) ID.
+	 * @param int   $parent_id  The parent product ID, 0 for a non-variation.
+	 *
+	 * @return bool
+	 */
+	private static function is_excluded( $rule, $product_id, $parent_id ) {
+		$excluded = array_map( 'intval', $rule['excluded_product_ids'] ?? [] );
+		return ! empty( array_intersect( array_filter( [ $product_id, $parent_id ] ), $excluded ) );
+	}
+
+	/**
+	 * Expand category IDs to include their descendants, memoized per request.
+	 *
+	 * Without this, a rule covering "Premium" would leave every product filed
+	 * under "Premium > Merch" out of the rule.
+	 *
+	 * @param int[] $category_ids The category IDs.
+	 *
+	 * @return int[] The category IDs including all descendants.
+	 */
+	public static function expand_category_ids( $category_ids ) {
+		if ( empty( $category_ids ) ) {
+			return [];
+		}
+		$cache_key = md5( wp_json_encode( $category_ids ) );
+		if ( ! isset( self::$expanded_categories[ $cache_key ] ) ) {
+			$expanded = $category_ids;
+			foreach ( $category_ids as $category_id ) {
+				$children = get_term_children( $category_id, self::PRODUCT_CATEGORY_TAXONOMY );
+				if ( ! is_wp_error( $children ) ) {
+					$expanded = array_merge( $expanded, array_map( 'intval', $children ) );
+				}
+			}
+			self::$expanded_categories[ $cache_key ] = array_values( array_unique( $expanded ) );
+		}
+		return self::$expanded_categories[ $cache_key ];
+	}
+
+	/**
+	 * Flush the per-request caches. For tests and for callers that mutate rules
+	 * or the category tree mid-request.
+	 */
+	public static function flush_cache() {
+		self::$matching_rules      = [];
+		self::$expanded_categories = [];
+	}
+}

--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-product-targeting.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-product-targeting.php
@@ -54,14 +54,6 @@ class Product_Targeting {
 	private static array $expanded_categories = [];
 
 	/**
-	 * Product IDs expanded with the children of any grouped product among them,
-	 * keyed by the hash of the requested IDs.
-	 *
-	 * @var array<string, int[]>
-	 */
-	private static array $expanded_grouped = [];
-
-	/**
 	 * Namespace a per-request cache key to the current site.
 	 *
 	 * Product, term and user IDs are per-site: under switch_to_blog() term 5 on
@@ -145,11 +137,12 @@ class Product_Targeting {
 	/**
 	 * Whether a product is excluded from a rule.
 	 *
-	 * The exclusion list is expanded through grouped products first: a grouped
-	 * product's children are top-level products reporting a parent of 0, so the
-	 * parent-ID test below — which is what catches a variation of an excluded
-	 * variable product — never sees them. Without the expansion, excluding a
-	 * bundle would leave everything sold under it still covered by the rule.
+	 * Tests the product's own ID and its parent's, so excluding a variable
+	 * product also excludes its variations. Note this does NOT reach the products
+	 * sold under a grouped product: excluding a grouped container is a no-op on
+	 * its children, which are standalone products in their own right. Whether
+	 * that should change is a product decision (see PR #742 review) — until it is
+	 * made, an exclusion means exactly the IDs listed and their variations.
 	 *
 	 * @param array $rule       The rule.
 	 * @param int   $product_id The product (or variation) ID.
@@ -158,40 +151,8 @@ class Product_Targeting {
 	 * @return bool
 	 */
 	private static function is_excluded( array $rule, int $product_id, int $parent_id ): bool {
-		$excluded = self::expand_grouped_ids( array_map( 'intval', $rule['excluded_product_ids'] ?? [] ) );
+		$excluded = array_map( 'intval', $rule['excluded_product_ids'] ?? [] );
 		return ! empty( array_intersect( array_filter( [ $product_id, $parent_id ] ), $excluded ) );
-	}
-
-	/**
-	 * Expand a list of product IDs with the children of any grouped product in it,
-	 * memoized per request.
-	 *
-	 * Deliberately applied to exclusions only, not to `products` targeting: an
-	 * exclusion that covers too little sells something the publisher meant to
-	 * withhold, whereas targeting that covers too much restricts or discounts
-	 * something they never named. Where the two directions disagree, this errs
-	 * toward the rule doing less.
-	 *
-	 * @param int[] $product_ids The product IDs.
-	 *
-	 * @return int[] The IDs, plus the children of any grouped product among them.
-	 */
-	public static function expand_grouped_ids( array $product_ids ): array {
-		if ( empty( $product_ids ) || ! function_exists( 'wc_get_product' ) ) {
-			return $product_ids;
-		}
-		$cache_key = self::cache_key( md5( wp_json_encode( $product_ids ) ) );
-		if ( ! isset( self::$expanded_grouped[ $cache_key ] ) ) {
-			$expanded = $product_ids;
-			foreach ( $product_ids as $product_id ) {
-				$product = wc_get_product( $product_id );
-				if ( $product instanceof \WC_Product && $product->is_type( 'grouped' ) ) {
-					$expanded = array_merge( $expanded, array_map( 'intval', $product->get_children() ) );
-				}
-			}
-			self::$expanded_grouped[ $cache_key ] = array_values( array_unique( $expanded ) );
-		}
-		return self::$expanded_grouped[ $cache_key ];
 	}
 
 	/**
@@ -229,6 +190,5 @@ class Product_Targeting {
 	public static function flush_cache(): void {
 		self::$matching_rules      = [];
 		self::$expanded_categories = [];
-		self::$expanded_grouped    = [];
 	}
 }

--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-commerce.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-commerce.php
@@ -40,7 +40,7 @@ class Subscriber_Commerce {
 	 *
 	 * @return bool
 	 */
-	public static function is_admin_available() {
+	public static function is_admin_available(): bool {
 		return Content_Gate::is_newspack_feature_enabled() && function_exists( 'wc_get_product' );
 	}
 
@@ -53,7 +53,7 @@ class Subscriber_Commerce {
 	 *
 	 * @return bool
 	 */
-	public static function is_enforcement_active() {
+	public static function is_enforcement_active(): bool {
 		$active = self::is_admin_available() && ! Memberships::is_active();
 
 		/**
@@ -73,7 +73,7 @@ class Subscriber_Commerce {
 	 *
 	 * @return array The rule with the base fields sanitized and defaulted.
 	 */
-	public static function sanitize_base_rule( $rule ) {
+	public static function sanitize_base_rule( array $rule ): array {
 		$targeting = $rule['targeting'] ?? Product_Targeting::TARGETING_PRODUCTS;
 		if ( ! in_array( $targeting, [ Product_Targeting::TARGETING_PRODUCTS, Product_Targeting::TARGETING_CATEGORY, Product_Targeting::TARGETING_ALL ], true ) ) {
 			$targeting = Product_Targeting::TARGETING_PRODUCTS;
@@ -83,7 +83,14 @@ class Subscriber_Commerce {
 			return array_values( array_unique( array_filter( array_map( 'absint', (array) $ids ) ) ) );
 		};
 
-		$created_at = isset( $rule['created_at'] ) ? preg_replace( '/[^0-9\-]/', '', (string) $rule['created_at'] ) : '';
+		// A real date or today's — the value is displayed, so garbage like
+		// "2026-13-99" must not reach the list.
+		$created_at = '';
+		if ( isset( $rule['created_at'] ) && preg_match( '/^(\d{4})-(\d{2})-(\d{2})$/', (string) $rule['created_at'], $date_parts ) ) {
+			if ( wp_checkdate( (int) $date_parts[2], (int) $date_parts[3], (int) $date_parts[1], $rule['created_at'] ) ) {
+				$created_at = $rule['created_at'];
+			}
+		}
 
 		return [
 			'id'                       => sanitize_key( $rule['id'] ?? '' ),
@@ -102,7 +109,7 @@ class Subscriber_Commerce {
 	 *
 	 * @return string
 	 */
-	public static function generate_rule_id() {
+	public static function generate_rule_id(): string {
 		return wp_generate_uuid4();
 	}
 }

--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-commerce.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-commerce.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Newspack Subscriber Commerce - shared infrastructure.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Shared infrastructure for subscriber-commerce features: rules that tie
+ * WooCommerce store products to subscriptions (subscriber-only products,
+ * subscriber discounts).
+ *
+ * Each feature stores its rules in its own option as an array of rule arrays.
+ * Every rule carries the base fields:
+ *
+ *   id                       Unique rule ID (string).
+ *   subscription_product_ids Subscription products whose subscribers the rule applies to.
+ *   targeting                'products' | 'category' | 'all' (see Product_Targeting).
+ *   product_ids              Targeted product IDs ('products' targeting).
+ *   category_ids             Targeted product category IDs ('category' targeting).
+ *   excluded_product_ids     Products excluded from 'category'/'all' targeting.
+ *   active                   Whether the rule is enforced (an inactive rule is kept but ignored).
+ *   created_at               Creation date, Y-m-d.
+ *
+ * Features extend this shape with their own fields.
+ */
+class Subscriber_Commerce {
+
+	/**
+	 * Whether subscriber-commerce rules can be configured.
+	 *
+	 * Independent of whether they are enforced yet: a site migrating off
+	 * WooCommerce Memberships sets its rules up first and deactivates
+	 * Memberships afterwards, so the admin has to be reachable while
+	 * Memberships still owns the front end.
+	 *
+	 * @return bool
+	 */
+	public static function is_admin_available() {
+		return Content_Gate::is_newspack_feature_enabled() && function_exists( 'wc_get_product' );
+	}
+
+	/**
+	 * Whether subscriber-commerce rules are enforced at all.
+	 *
+	 * While WooCommerce Memberships is active it owns purchase restriction and
+	 * member discounts, and enforcing ours on top would double-apply on a site
+	 * mid-migration — so every subscriber-commerce feature stands down.
+	 *
+	 * @return bool
+	 */
+	public static function is_enforcement_active() {
+		$active = self::is_admin_available() && ! Memberships::is_active();
+
+		/**
+		 * Filters whether subscriber-commerce rules (subscriber-only products,
+		 * subscriber discounts) are enforced.
+		 *
+		 * @param bool $active Whether enforcement is active.
+		 */
+		return apply_filters( 'newspack_subscriber_commerce_enforcement_active', $active );
+	}
+
+	/**
+	 * Sanitize a base rule. Feature callers sanitize their own extra fields and
+	 * merge them over the returned array.
+	 *
+	 * @param array $rule The raw rule.
+	 *
+	 * @return array The rule with the base fields sanitized and defaulted.
+	 */
+	public static function sanitize_base_rule( $rule ) {
+		$targeting = $rule['targeting'] ?? Product_Targeting::TARGETING_PRODUCTS;
+		if ( ! in_array( $targeting, [ Product_Targeting::TARGETING_PRODUCTS, Product_Targeting::TARGETING_CATEGORY, Product_Targeting::TARGETING_ALL ], true ) ) {
+			$targeting = Product_Targeting::TARGETING_PRODUCTS;
+		}
+
+		$sanitize_ids = function ( $ids ) {
+			return array_values( array_unique( array_filter( array_map( 'absint', (array) $ids ) ) ) );
+		};
+
+		$created_at = isset( $rule['created_at'] ) ? preg_replace( '/[^0-9\-]/', '', (string) $rule['created_at'] ) : '';
+
+		return [
+			'id'                       => sanitize_key( $rule['id'] ?? '' ),
+			'subscription_product_ids' => $sanitize_ids( $rule['subscription_product_ids'] ?? [] ),
+			'targeting'                => $targeting,
+			'product_ids'              => $sanitize_ids( $rule['product_ids'] ?? [] ),
+			'category_ids'             => $sanitize_ids( $rule['category_ids'] ?? [] ),
+			'excluded_product_ids'     => $sanitize_ids( $rule['excluded_product_ids'] ?? [] ),
+			'active'                   => ! empty( $rule['active'] ),
+			'created_at'               => $created_at ? $created_at : gmdate( 'Y-m-d' ),
+		];
+	}
+
+	/**
+	 * Generate an ID for a new rule.
+	 *
+	 * @return string
+	 */
+	public static function generate_rule_id() {
+		return wp_generate_uuid4();
+	}
+}

--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-commerce.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-commerce.php
@@ -60,9 +60,15 @@ class Subscriber_Commerce {
 		 * Filters whether subscriber-commerce rules (subscriber-only products,
 		 * subscriber discounts) are enforced.
 		 *
+		 * The filter can only turn enforcement *off*. Features read this as their
+		 * licence to call WooCommerce APIs, so letting a filter answer yes on a
+		 * site where WooCommerce is not loaded would turn a stand-down into a
+		 * fatal — the escape hatch this exists for is the Memberships overlap,
+		 * which the clamp leaves reachable.
+		 *
 		 * @param bool $active Whether enforcement is active.
 		 */
-		return apply_filters( 'newspack_subscriber_commerce_enforcement_active', $active );
+		return $active && (bool) apply_filters( 'newspack_subscriber_commerce_enforcement_active', $active );
 	}
 
 	/**
@@ -92,8 +98,16 @@ class Subscriber_Commerce {
 			}
 		}
 
+		// A rule with no ID is one nothing can address for edit or delete, so a
+		// missing or unusable one is minted here rather than left for each caller
+		// to notice. `active` is deliberately NOT defaulted the same way: absent
+		// still reads as paused, and callers that mean "live on create" say so.
+		// Flipping that would make a partial payload silently start enforcing,
+		// which is the worse direction for a rule that gates a purchase or a price.
+		$id = sanitize_key( $rule['id'] ?? '' );
+
 		return [
-			'id'                       => sanitize_key( $rule['id'] ?? '' ),
+			'id'                       => $id ? $id : self::generate_rule_id(),
 			'subscription_product_ids' => $sanitize_ids( $rule['subscription_product_ids'] ?? [] ),
 			'targeting'                => $targeting,
 			'product_ids'              => $sanitize_ids( $rule['product_ids'] ?? [] ),

--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-eligibility.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-eligibility.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Newspack Subscriber Commerce - subscriber eligibility.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Answers "is this reader a subscriber of any of these subscription products?"
+ * for subscriber-commerce rules.
+ *
+ * Thin, memoizing wrapper over Access_Rules::has_active_subscription(), which
+ * walks the reader's own WooCommerce subscriptions and the group subscriptions
+ * they hold a seat in. That lookup is uncached and runs per call, while the
+ * callers hit it once per product: a shop archive of N covered products would
+ * otherwise repeat the same subscription queries N times for the same reader.
+ *
+ * Only *held* subscriptions count. A subscription sitting in the reader's cart,
+ * or one being purchased in the same order, does not make them a subscriber.
+ */
+class Subscriber_Eligibility {
+
+	/**
+	 * Eligibility verdicts, keyed by "{user_id}:{sorted product IDs}".
+	 *
+	 * @var array<string, bool>
+	 */
+	private static $verdicts = [];
+
+	/**
+	 * Whether a user is an active subscriber of any of the given subscription products.
+	 *
+	 * @param int   $user_id     The user ID. 0 (anonymous) is never eligible.
+	 * @param int[] $product_ids The subscription product IDs that grant eligibility.
+	 *
+	 * @return bool
+	 */
+	public static function user_has( $user_id, $product_ids ) {
+		$user_id     = (int) $user_id;
+		$product_ids = array_values( array_unique( array_filter( array_map( 'absint', (array) $product_ids ) ) ) );
+
+		// An anonymous reader holds no subscription. A rule with no subscription
+		// products names no way in, so nobody satisfies it.
+		if ( ! $user_id || empty( $product_ids ) ) {
+			return false;
+		}
+
+		sort( $product_ids );
+		$cache_key = $user_id . ':' . implode( ',', $product_ids );
+		if ( ! isset( self::$verdicts[ $cache_key ] ) ) {
+			self::$verdicts[ $cache_key ] = (bool) Access_Rules::has_active_subscription( $user_id, $product_ids );
+		}
+		return self::$verdicts[ $cache_key ];
+	}
+
+	/**
+	 * Flush the per-request cache. For tests and for callers that change a
+	 * reader's subscriptions mid-request.
+	 */
+	public static function flush_cache() {
+		self::$verdicts = [];
+	}
+}

--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-eligibility.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-eligibility.php
@@ -21,11 +21,18 @@ defined( 'ABSPATH' ) || exit;
  *
  * Only *held* subscriptions count. A subscription sitting in the reader's cart,
  * or one being purchased in the same order, does not make them a subscriber.
+ *
+ * Two policies come with the underlying lookup rather than from here, and every
+ * caller inherits them: a seat in a group subscription counts, and a subscription
+ * on hold inside the payment-recovery window counts by default — so a reader whose
+ * renewal is mid-retry keeps their subscriber pricing and access until the retries
+ * are exhausted.
  */
 class Subscriber_Eligibility {
 
 	/**
-	 * Eligibility verdicts, keyed by "{user_id}:{sorted product IDs}".
+	 * Eligibility verdicts, keyed by
+	 * "{blog_id}:{user_id}:{sorted product IDs}:{payment-recovery grace}".
 	 *
 	 * @var array<string, bool>
 	 */
@@ -50,7 +57,23 @@ class Subscriber_Eligibility {
 		}
 
 		sort( $product_ids );
-		$cache_key = $user_id . ':' . implode( ',', $product_ids );
+
+		// The verdict is not a function of the arguments alone:
+		// has_active_subscription() also reads `payment_recovery_grace` from the
+		// ambient evaluation context, which with_evaluation_context() swaps in and
+		// out around each gate. Keying on it keeps a verdict reached inside one
+		// gate's context from being served to a caller outside it — a reader in
+		// the failed-payment window would otherwise get whichever answer the first
+		// caller in the request happened to produce.
+		$cache_key = implode(
+			':',
+			[
+				get_current_blog_id(),
+				$user_id,
+				implode( ',', $product_ids ),
+				Access_Rules::get_evaluation_context( 'payment_recovery_grace', true ) ? 'grace' : 'strict',
+			]
+		);
 		if ( ! isset( self::$verdicts[ $cache_key ] ) ) {
 			self::$verdicts[ $cache_key ] = (bool) Access_Rules::has_active_subscription( $user_id, $product_ids );
 		}

--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-eligibility.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-eligibility.php
@@ -29,7 +29,7 @@ class Subscriber_Eligibility {
 	 *
 	 * @var array<string, bool>
 	 */
-	private static $verdicts = [];
+	private static array $verdicts = [];
 
 	/**
 	 * Whether a user is an active subscriber of any of the given subscription products.
@@ -39,7 +39,7 @@ class Subscriber_Eligibility {
 	 *
 	 * @return bool
 	 */
-	public static function user_has( $user_id, $product_ids ) {
+	public static function user_has( $user_id, $product_ids ): bool {
 		$user_id     = (int) $user_id;
 		$product_ids = array_values( array_unique( array_filter( array_map( 'absint', (array) $product_ids ) ) ) );
 
@@ -61,7 +61,7 @@ class Subscriber_Eligibility {
 	 * Flush the per-request cache. For tests and for callers that change a
 	 * reader's subscriptions mid-request.
 	 */
-	public static function flush_cache() {
+	public static function flush_cache(): void {
 		self::$verdicts = [];
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php
@@ -431,7 +431,9 @@ class Audience_Subscriptions extends Wizard {
 
 		$include = $request->get_param( 'include' );
 		if ( ! empty( $include ) ) {
-			$ids = array_filter( array_map( 'absint', explode( ',', $include ) ) );
+			// Capped as in search_products(): the CSV is caller-supplied and would
+			// otherwise set the width of the term query on its own.
+			$ids = array_slice( array_filter( array_map( 'absint', explode( ',', $include ) ) ), 0, 100 );
 			if ( empty( $ids ) ) {
 				return rest_ensure_response( [] );
 			}

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php
@@ -33,6 +33,18 @@ class Audience_Subscriptions extends Wizard {
 	protected $parent_slug = 'newspack-audience';
 
 	/**
+	 * WooCommerce product types offered as "available to" suggestions.
+	 *
+	 * Only parent products are suggested, to keep the picker to the handful of
+	 * subscriptions a publisher thinks in terms of. A rule may still name an
+	 * individual variation — `WC_Subscription::has_product()` matches a line
+	 * item's variation ID as readily as its product ID — so a rule authored
+	 * against one (via REST, or by a migration) is honoured and still resolves
+	 * to its name when the editor loads it.
+	 */
+	const SUBSCRIPTION_PRODUCT_TYPES = [ 'subscription', 'variable-subscription' ];
+
+	/**
 	 * Registered tabs, keyed by slug. Each is [ 'slug', 'label', 'path' ].
 	 *
 	 * @var array<string, array>
@@ -49,8 +61,13 @@ class Audience_Subscriptions extends Wizard {
 		self::register_tab(
 			'configuration',
 			[
-				'label' => esc_html__( 'Configuration', 'newspack-plugin' ),
+				// Unescaped: the label is localized into a nested array, where
+				// wp_localize_script() doesn't decode entities, and React escapes
+				// it at render anyway. Escaping here would ship `&#8217;` to
+				// locales whose translation contains an apostrophe.
+				'label' => __( 'Configuration', 'newspack-plugin' ),
 				'path'  => '/configuration',
+				'order' => 10,
 			]
 		);
 	}
@@ -67,6 +84,7 @@ class Audience_Subscriptions extends Wizard {
 	 *
 	 *     @type string $label Tab label, translated.
 	 *     @type string $path  Route path, e.g. '/subscriber-only'. Defaults to "/{$slug}".
+	 *     @type int    $order Sort position, low to high. Defaults to 10.
 	 * }
 	 */
 	public static function register_tab( $slug, $args = [] ) {
@@ -78,16 +96,28 @@ class Audience_Subscriptions extends Wizard {
 			'slug'  => $slug,
 			'label' => $args['label'],
 			'path'  => $args['path'] ?? '/' . $slug,
+			'order' => isset( $args['order'] ) ? (int) $args['order'] : 10,
 		];
 	}
 
 	/**
-	 * Get the registered tabs.
+	 * Get the registered tabs, ordered.
 	 *
-	 * @return array[] The tabs, in registration order.
+	 * Sorted by the declared order rather than by registration, which depends on
+	 * which hook each feature happens to register from. The first tab is where
+	 * the wizard lands, so it can't be incidental.
+	 *
+	 * @return array[] The tabs.
 	 */
 	public static function get_tabs() {
-		return array_values( self::$tabs );
+		$tabs = array_values( self::$tabs );
+		usort(
+			$tabs,
+			function ( $a, $b ) {
+				return $a['order'] <=> $b['order'];
+			}
+		);
+		return $tabs;
 	}
 
 	/**
@@ -240,29 +270,22 @@ class Audience_Subscriptions extends Wizard {
 	 * @return \WP_REST_Response
 	 */
 	public function subscriptions_search( $request ) {
-		$posts = $this->search_products( $request, [ 'publish', 'private', 'draft' ] );
+		// Constrain the query to subscription types rather than filtering the page
+		// afterwards: post-filtering applies the type test after the LIMIT, so a
+		// store whose subscriptions sort late alphabetically returns an empty
+		// picker — and this is the one field a rule can't be authored without.
+		$posts = $this->search_products( $request, [ 'publish', 'private', 'draft' ], self::SUBSCRIPTION_PRODUCT_TYPES );
 
 		$data = [];
 		foreach ( $posts as $post ) {
 			$product = wc_get_product( $post->ID );
-			if ( ! $product instanceof \WC_Product || ! self::is_subscription_product( $product ) ) {
+			if ( ! $product instanceof \WC_Product ) {
 				continue;
 			}
 			$data[] = self::get_product_data( $product );
 		}
 
 		return rest_ensure_response( $data );
-	}
-
-	/**
-	 * Whether a product is a subscription product.
-	 *
-	 * @param \WC_Product $product The product.
-	 *
-	 * @return bool
-	 */
-	private static function is_subscription_product( $product ) {
-		return in_array( $product->get_type(), [ 'subscription', 'variable-subscription', 'subscription_variation' ], true );
 	}
 
 	/**
@@ -293,10 +316,11 @@ class Audience_Subscriptions extends Wizard {
 	 *
 	 * @param \WP_REST_Request $request       The request object.
 	 * @param string[]         $post_statuses Post statuses to search.
+	 * @param string[]         $product_types Restrict to these WooCommerce product types. Empty for any.
 	 *
 	 * @return \WP_Post[]
 	 */
-	private function search_products( $request, $post_statuses ) {
+	private function search_products( $request, $post_statuses, $product_types = [] ) {
 		if ( ! function_exists( 'wc_get_product' ) || ! post_type_exists( 'product' ) ) {
 			return [];
 		}
@@ -311,6 +335,25 @@ class Audience_Subscriptions extends Wizard {
 		];
 
 		$include = $request->get_param( 'include' );
+
+		// WooCommerce stores the product type as a `product_type` term, so the
+		// filter belongs in the query — applying it to the returned page instead
+		// would filter after the LIMIT and could empty the results entirely.
+		//
+		// Suggestions only. Hydrating saved IDs must resolve whatever the rule
+		// already names: WooCommerce clears `product_type` on variations, so a
+		// saved subscription variation would otherwise come back nameless and
+		// render as a bare number.
+		if ( ! empty( $product_types ) && empty( $include ) && taxonomy_exists( 'product_type' ) ) {
+			$args['tax_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+				[
+					'taxonomy' => 'product_type',
+					'field'    => 'slug',
+					'terms'    => $product_types,
+				],
+			];
+		}
+
 		if ( ! empty( $include ) ) {
 			$ids = array_filter( array_map( 'absint', explode( ',', $include ) ) );
 			if ( empty( $ids ) ) {

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php
@@ -244,14 +244,38 @@ class Audience_Subscriptions extends Wizard {
 		// rule binds as soon as they go live — so let publishers pick them.
 		$posts = $this->search_products( $request, [ 'publish', 'private', 'draft' ] );
 
+		// Variations are appended outside the query, so `per_page` has to be applied
+		// again to the flattened list — otherwise the cap bounds only the parents
+		// and a page of variable products returns an unbounded number of rows, at
+		// one product read each, on every keystroke in the picker.
+		$limit = (int) $request->get_param( 'per_page' );
+
+		// Hydrating saved tokens asks for named IDs and needs every one of them
+		// back: expanding variations there could spend the budget on rows nobody
+		// asked for and leave a saved product rendering as a bare number.
+		$expand_variations = empty( $request->get_param( 'include' ) );
+
 		$data = [];
 		foreach ( $posts as $post ) {
+			if ( count( $data ) >= $limit ) {
+				break;
+			}
 			$product = wc_get_product( $post->ID );
 			if ( ! $product instanceof \WC_Product ) {
 				continue;
 			}
 			$data[] = self::get_product_data( $product );
+
+			// Only variable products carry variations. A grouped product's children
+			// are top-level products that already stand on their own in the results,
+			// so expanding those would list them twice.
+			if ( ! $expand_variations || ! $product->is_type( 'variable' ) ) {
+				continue;
+			}
 			foreach ( $product->get_children() as $variation_id ) {
+				if ( count( $data ) >= $limit ) {
+					break;
+				}
 				$variation = wc_get_product( $variation_id );
 				if ( $variation instanceof \WC_Product ) {
 					$data[] = self::get_product_data( $variation );
@@ -355,7 +379,9 @@ class Audience_Subscriptions extends Wizard {
 		}
 
 		if ( ! empty( $include ) ) {
-			$ids = array_filter( array_map( 'absint', explode( ',', $include ) ) );
+			// Capped to match the `per_page` ceiling: the CSV is caller-supplied and
+			// otherwise sets the width of the post__in clause on its own.
+			$ids = array_slice( array_filter( array_map( 'absint', explode( ',', $include ) ) ), 0, 100 );
 			if ( empty( $ids ) ) {
 				return [];
 			}

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php
@@ -244,38 +244,36 @@ class Audience_Subscriptions extends Wizard {
 		// rule binds as soon as they go live — so let publishers pick them.
 		$posts = $this->search_products( $request, [ 'publish', 'private', 'draft' ] );
 
-		// Variations are appended outside the query, so `per_page` has to be applied
-		// again to the flattened list — otherwise the cap bounds only the parents
-		// and a page of variable products returns an unbounded number of rows, at
-		// one product read each, on every keystroke in the picker.
-		$limit = (int) $request->get_param( 'per_page' );
-
-		// Hydrating saved tokens asks for named IDs and needs every one of them
-		// back: expanding variations there could spend the budget on rows nobody
-		// asked for and leave a saved product rendering as a bare number.
+		// `per_page` bounds the number of parent products the query returns;
+		// variations are appended on top, so a variable product always appears
+		// with ALL of its variations rather than a truncated slice a publisher
+		// couldn't finish picking from. The response size is therefore parents ×
+		// their variations, bounded by the query's own limit — not a flat cap.
+		//
+		// Hydrating saved tokens (`include`) is the exception: it asks for named
+		// IDs and needs each one back as itself, so variations aren't expanded
+		// there — a saved variation resolves on its own, and expanding would spend
+		// the response on rows nobody asked for.
 		$expand_variations = empty( $request->get_param( 'include' ) );
 
 		$data = [];
 		foreach ( $posts as $post ) {
-			if ( count( $data ) >= $limit ) {
-				break;
-			}
 			$product = wc_get_product( $post->ID );
 			if ( ! $product instanceof \WC_Product ) {
 				continue;
 			}
 			$data[] = self::get_product_data( $product );
 
-			// Only variable products carry variations. A grouped product's children
-			// are top-level products that already stand on their own in the results,
-			// so expanding those would list them twice.
-			if ( ! $expand_variations || ! $product->is_type( 'variable' ) ) {
+			// Only variable products carry variations. `WC_Product_Variable` is the
+			// base for both `variable` and Subscriptions' `variable-subscription`,
+			// so the instanceof check catches both — an `is_type( 'variable' )`
+			// test would silently miss subscription variations in this very wizard.
+			// A grouped product's children are standalone top-level products that
+			// already appear in the results on their own, so they're left alone.
+			if ( ! $expand_variations || ! $product instanceof \WC_Product_Variable ) {
 				continue;
 			}
 			foreach ( $product->get_children() as $variation_id ) {
-				if ( count( $data ) >= $limit ) {
-					break;
-				}
 				$variation = wc_get_product( $variation_id );
 				if ( $variation instanceof \WC_Product ) {
 					$data[] = self::get_product_data( $variation );

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php
@@ -11,6 +11,11 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Audience Subscriptions Wizard.
+ *
+ * Hosts the subscription-commerce surfaces: subscription configuration and the
+ * subscriber-commerce features (subscriber-only products, subscriber
+ * discounts). Features register their own tab with ::register_tab() rather than
+ * being wired in here, so a tab can ship without touching the shell.
  */
 class Audience_Subscriptions extends Wizard {
 	/**
@@ -28,11 +33,61 @@ class Audience_Subscriptions extends Wizard {
 	protected $parent_slug = 'newspack-audience';
 
 	/**
+	 * Registered tabs, keyed by slug. Each is [ 'slug', 'label', 'path' ].
+	 *
+	 * @var array<string, array>
+	 */
+	private static $tabs = [];
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		parent::__construct();
 		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
+
+		self::register_tab(
+			'configuration',
+			[
+				'label' => esc_html__( 'Configuration', 'newspack-plugin' ),
+				'path'  => '/configuration',
+			]
+		);
+	}
+
+	/**
+	 * Register a tab on this wizard.
+	 *
+	 * The matching front-end component registers itself under the same slug in
+	 * `src/wizards/audience/views/subscriptions/tabs`.
+	 *
+	 * @param string $slug  Tab slug. Must match the front-end registration.
+	 * @param array  $args  {
+	 *     Tab arguments.
+	 *
+	 *     @type string $label Tab label, translated.
+	 *     @type string $path  Route path, e.g. '/subscriber-only'. Defaults to "/{$slug}".
+	 * }
+	 */
+	public static function register_tab( $slug, $args = [] ) {
+		$slug = sanitize_key( $slug );
+		if ( ! $slug || empty( $args['label'] ) ) {
+			return;
+		}
+		self::$tabs[ $slug ] = [
+			'slug'  => $slug,
+			'label' => $args['label'],
+			'path'  => $args['path'] ?? '/' . $slug,
+		];
+	}
+
+	/**
+	 * Get the registered tabs.
+	 *
+	 * @return array[] The tabs, in registration order.
+	 */
+	public static function get_tabs() {
+		return array_values( self::$tabs );
 	}
 
 	/**
@@ -63,6 +118,60 @@ class Audience_Subscriptions extends Wizard {
 				],
 			]
 		);
+
+		$search_args = [
+			'search'   => [
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+			'include'  => [
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+			'per_page' => [
+				'type'              => 'integer',
+				'default'           => 10,
+				'minimum'           => 1,
+				'maximum'           => 100,
+				'sanitize_callback' => 'absint',
+				'validate_callback' => 'rest_validate_request_arg',
+			],
+		];
+
+		// Shared by every subscriber-commerce tab: the pickers for targeted
+		// products, product categories, and the subscriptions that unlock them.
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/products-search',
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'products_search' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => $search_args,
+			]
+		);
+
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/product-categories-search',
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'product_categories_search' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => $search_args,
+			]
+		);
+
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/subscriptions-search',
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'subscriptions_search' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => $search_args,
+			]
+		);
 	}
 
 	/**
@@ -88,6 +197,207 @@ class Audience_Subscriptions extends Wizard {
 		}
 		Subscriptions_Tiers::set_primary_subscription_tier_product( $product );
 		return rest_ensure_response( [ 'success' => true ] );
+	}
+
+	/**
+	 * Search store products.
+	 *
+	 * Variable products are returned with their variations, since a rule's
+	 * preview and its exclusions operate on what is actually sold.
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function products_search( $request ) {
+		// Products are routinely private or held as drafts before launch, and a
+		// rule binds as soon as they go live — so let publishers pick them.
+		$posts = $this->search_products( $request, [ 'publish', 'private', 'draft' ] );
+
+		$data = [];
+		foreach ( $posts as $post ) {
+			$product = wc_get_product( $post->ID );
+			if ( ! $product instanceof \WC_Product ) {
+				continue;
+			}
+			$data[] = self::get_product_data( $product );
+			foreach ( $product->get_children() as $variation_id ) {
+				$variation = wc_get_product( $variation_id );
+				if ( $variation instanceof \WC_Product ) {
+					$data[] = self::get_product_data( $variation );
+				}
+			}
+		}
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Search subscription products — the "available to" side of a rule.
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function subscriptions_search( $request ) {
+		$posts = $this->search_products( $request, [ 'publish', 'private', 'draft' ] );
+
+		$data = [];
+		foreach ( $posts as $post ) {
+			$product = wc_get_product( $post->ID );
+			if ( ! $product instanceof \WC_Product || ! self::is_subscription_product( $product ) ) {
+				continue;
+			}
+			$data[] = self::get_product_data( $product );
+		}
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Whether a product is a subscription product.
+	 *
+	 * @param \WC_Product $product The product.
+	 *
+	 * @return bool
+	 */
+	private static function is_subscription_product( $product ) {
+		return in_array( $product->get_type(), [ 'subscription', 'variable-subscription', 'subscription_variation' ], true );
+	}
+
+	/**
+	 * Build the REST representation of a product.
+	 *
+	 * Prices are included so a rule editor can preview what a reader would pay
+	 * without a second round trip per product.
+	 *
+	 * @param \WC_Product $product The product (or variation).
+	 *
+	 * @return array
+	 */
+	private static function get_product_data( $product ) {
+		return [
+			'id'            => (int) $product->get_id(),
+			'name'          => $product->get_name(),
+			'parent_id'     => (int) $product->get_parent_id(),
+			'type_label'    => $product->get_parent_id() ? __( 'Variation', 'newspack-plugin' ) : __( 'Product', 'newspack-plugin' ),
+			'price'         => (string) $product->get_price(),
+			'regular_price' => (string) $product->get_regular_price(),
+			'sale_price'    => (string) $product->get_sale_price(),
+			'is_on_sale'    => (bool) $product->is_on_sale(),
+		];
+	}
+
+	/**
+	 * Query products for the search endpoints.
+	 *
+	 * @param \WP_REST_Request $request       The request object.
+	 * @param string[]         $post_statuses Post statuses to search.
+	 *
+	 * @return \WP_Post[]
+	 */
+	private function search_products( $request, $post_statuses ) {
+		if ( ! function_exists( 'wc_get_product' ) || ! post_type_exists( 'product' ) ) {
+			return [];
+		}
+
+		$args = [
+			'post_type'      => 'product',
+			'post_status'    => $post_statuses,
+			'posts_per_page' => (int) $request->get_param( 'per_page' ),
+			'orderby'        => 'title',
+			'order'          => 'ASC',
+			'no_found_rows'  => true,
+		];
+
+		$include = $request->get_param( 'include' );
+		if ( ! empty( $include ) ) {
+			$ids = array_filter( array_map( 'absint', explode( ',', $include ) ) );
+			if ( empty( $ids ) ) {
+				return [];
+			}
+			// Broader status filter when hydrating saved tokens, so the editor keeps
+			// showing products whose status changed since the rule was saved.
+			$args['post_status']    = [ 'publish', 'draft', 'pending', 'private', 'future' ];
+			$args['post__in']       = $ids;
+			$args['posts_per_page'] = min( count( $ids ), 100 );
+			$args['orderby']        = 'post__in';
+			// A saved token can be a variation, which is its own post type.
+			$args['post_type'] = [ 'product', 'product_variation' ];
+		}
+
+		$search = $request->get_param( 'search' );
+		if ( ! empty( $search ) ) {
+			// Numeric search: treat as a product ID lookup.
+			if ( is_numeric( $search ) ) {
+				$args['p'] = absint( $search );
+			} else {
+				$args['s'] = $search;
+			}
+		}
+
+		$query = new \WP_Query( $args );
+		return $query->posts;
+	}
+
+	/**
+	 * Search product categories.
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function product_categories_search( $request ) {
+		if ( ! taxonomy_exists( Product_Targeting::PRODUCT_CATEGORY_TAXONOMY ) ) {
+			return rest_ensure_response( [] );
+		}
+
+		$args = [
+			'taxonomy'   => Product_Targeting::PRODUCT_CATEGORY_TAXONOMY,
+			'hide_empty' => false,
+			'number'     => (int) $request->get_param( 'per_page' ),
+			'orderby'    => 'name',
+			'order'      => 'ASC',
+		];
+
+		$include = $request->get_param( 'include' );
+		if ( ! empty( $include ) ) {
+			$ids = array_filter( array_map( 'absint', explode( ',', $include ) ) );
+			if ( empty( $ids ) ) {
+				return rest_ensure_response( [] );
+			}
+			$args['include'] = $ids;
+			$args['number']  = min( count( $ids ), 100 );
+			$args['orderby'] = 'include';
+		}
+
+		$search = $request->get_param( 'search' );
+		if ( ! empty( $search ) ) {
+			// Numeric search: treat as a term ID lookup.
+			if ( is_numeric( $search ) ) {
+				$args['include'] = [ absint( $search ) ];
+			} else {
+				$args['search'] = $search;
+			}
+		}
+
+		$terms = get_terms( $args );
+		if ( is_wp_error( $terms ) ) {
+			return rest_ensure_response( [] );
+		}
+
+		$data = array_map(
+			function ( $term ) {
+				return [
+					'id'         => (int) $term->term_id,
+					'name'       => $term->name,
+					'type_label' => __( 'Product category', 'newspack-plugin' ),
+				];
+			},
+			$terms
+		);
+
+		return rest_ensure_response( $data );
 	}
 
 	/**
@@ -120,10 +430,12 @@ class Audience_Subscriptions extends Wizard {
 			'newspack-wizards',
 			'newspackAudienceSubscriptions',
 			[
+				'tabs'                     => self::get_tabs(),
 				'memberships_url'          => admin_url( 'edit.php?post_type=wc_membership_plan' ),
+				'memberships_active'       => Memberships::is_active(),
 				'primary_product'          => $primary_product ? $primary_product->get_id() : '',
 				'eligible_products'        => array_map(
-					function( $product ) {
+					function ( $product ) {
 						return [
 							'id'    => $product->get_id(),
 							'title' => $product->get_title(),

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/components/search-token-field.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/components/search-token-field.tsx
@@ -101,7 +101,20 @@ export default function SearchTokenField( { endpoint, label, help, value, onChan
 
 	// Labels carry the ID so two products sharing a name stay distinguishable —
 	// FormTokenField matches on the label string.
-	const toLabel = useCallback( ( item: Item ) => decodeEntities( `${ item.id }: ${ item.name || __( '(no name)', 'newspack-plugin' ) }` ), [] );
+	//
+	// Trimmed here, at the one place labels are made, so the rendered token and
+	// the lookup key below can never disagree. FormTokenField trims only the
+	// token it is adding: `addNewTokens` splices the trimmed newcomer into an
+	// untouched copy of `value`, and `deleteToken` filters `value` directly, so
+	// every other token comes back exactly as it was rendered. A product whose
+	// name ends in a non-breaking space — what pasting out of a word processor
+	// produces, and which survives the save that strips a plain trailing space —
+	// would otherwise render untrimmed, miss a key trimmed by JS, and be dropped
+	// from the rule on the next edit with nothing shown to the publisher.
+	const toLabel = useCallback(
+		( item: Item ) => decodeEntities( `${ item.id }: ${ item.name || __( '(no name)', 'newspack-plugin' ) }` ).trim(),
+		[]
+	);
 
 	const suggestionLabels = useMemo( () => suggestions.map( toLabel ), [ suggestions, toLabel ] );
 
@@ -113,13 +126,9 @@ export default function SearchTokenField( { endpoint, label, help, value, onChan
 	// Labels resolve back to the item they came from. Free text is dropped rather
 	// than parsed: "2024 Calendar" would otherwise become product ID 2024 and
 	// silently point the rule at whatever that is.
-	//
-	// Keyed on the trimmed label because FormTokenField trims a token as it adds
-	// it — a product whose name ends in a space (or a pasted non-breaking one)
-	// would otherwise be unselectable, the click doing nothing at all.
 	const labelToId = useMemo( () => {
 		const byLabel = new Map< string, number >();
-		known.forEach( item => byLabel.set( toLabel( item ).trim(), item.id ) );
+		known.forEach( item => byLabel.set( toLabel( item ), item.id ) );
 		return byLabel;
 	}, [ known, toLabel ] );
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/components/search-token-field.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/components/search-token-field.tsx
@@ -11,6 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { FormTokenField } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -28,8 +29,6 @@ interface SearchTokenFieldProps {
 	help?: string;
 	value: number[];
 	onChange: ( ids: number[] ) => void;
-	/** Restrict suggestions to these IDs. Used by the exclusion field. */
-	limitTo?: number[];
 	disabled?: boolean;
 }
 
@@ -41,7 +40,8 @@ const debounce = < T extends ( ...args: never[] ) => void >( func: T, wait: numb
 	};
 };
 
-export default function SearchTokenField( { endpoint, label, help, value, onChange, limitTo, disabled }: SearchTokenFieldProps ) {
+export default function SearchTokenField( { endpoint, label, help, value, onChange, disabled }: SearchTokenFieldProps ) {
+	const instanceId = useInstanceId( SearchTokenField );
 	const [ suggestions, setSuggestions ] = useState< Item[] >( [] );
 	// Names for the current value, so saved IDs render as tokens before (and
 	// regardless of) any search.
@@ -64,9 +64,12 @@ export default function SearchTokenField( { endpoint, label, help, value, onChan
 	const resolvedIds = useMemo( () => resolved.map( item => item.id ), [ resolved ] );
 	const unresolved = useMemo( () => value.filter( id => ! resolvedIds.includes( id ) ), [ value, resolvedIds ] );
 	// Read the latest resolved list without making the effect depend on it,
-	// which would re-run it on every resolution.
+	// which would re-run it on every resolution. Assigned in an effect rather
+	// than during render, which isn't safe under concurrent rendering.
 	const resolvedRef = useRef( resolved );
-	resolvedRef.current = resolved;
+	useEffect( () => {
+		resolvedRef.current = resolved;
+	}, [ resolved ] );
 
 	useEffect( () => {
 		if ( ! unresolved.length ) {
@@ -100,30 +103,63 @@ export default function SearchTokenField( { endpoint, label, help, value, onChan
 	// FormTokenField matches on the label string.
 	const toLabel = useCallback( ( item: Item ) => decodeEntities( `${ item.id }: ${ item.name || __( '(no name)', 'newspack-plugin' ) }` ), [] );
 
-	const suggestionLabels = useMemo( () => {
-		const allowed = limitTo ? new Set( limitTo ) : null;
-		return suggestions.filter( item => ! allowed || allowed.has( item.id ) ).map( toLabel );
-	}, [ suggestions, limitTo, toLabel ] );
+	const suggestionLabels = useMemo( () => suggestions.map( toLabel ), [ suggestions, toLabel ] );
 
 	const tokens = useMemo(
 		() => value.map( id => ( known.has( id ) ? toLabel( known.get( id ) as Item ) : `${ id }` ) ),
 		[ value, known, toLabel ]
 	);
 
+	// Labels resolve back to the item they came from. Free text is dropped rather
+	// than parsed: "2024 Calendar" would otherwise become product ID 2024 and
+	// silently point the rule at whatever that is.
+	//
+	// Keyed on the trimmed label because FormTokenField trims a token as it adds
+	// it — a product whose name ends in a space (or a pasted non-breaking one)
+	// would otherwise be unselectable, the click doing nothing at all.
+	const labelToId = useMemo( () => {
+		const byLabel = new Map< string, number >();
+		known.forEach( item => byLabel.set( toLabel( item ).trim(), item.id ) );
+		return byLabel;
+	}, [ known, toLabel ] );
+
 	const handleChange = ( nextTokens: ( string | { value: string } )[] ) => {
 		const ids = nextTokens
 			.map( token => {
 				const tokenLabel = typeof token === 'string' ? token : token.value;
-				// Labels are "{id}: {name}"; a token typed by hand may be a bare ID.
-				const id = parseInt( tokenLabel, 10 );
-				return Number.isNaN( id ) ? null : id;
+				if ( labelToId.has( tokenLabel ) ) {
+					return labelToId.get( tokenLabel ) as number;
+				}
+				// A value still resolving to a name renders as its bare ID, so keep
+				// those; anything else the reader typed is not a product.
+				const id = Number( tokenLabel );
+				return Number.isInteger( id ) && value.includes( id ) ? id : null;
 			} )
-			.filter( ( id ): id is number => id !== null );
+			.filter( ( id ): id is number => null !== id );
 		onChange( [ ...new Set( ids ) ] );
 	};
 
+	// The help text explains what the rule actually does, so it has to reach
+	// screen readers rather than only sighted users. FormTokenField doesn't
+	// forward arbitrary props to its input and sets its own `aria-describedby`
+	// for the "how to" hint, so the id is appended to that attribute directly
+	// rather than passed as a prop, which the component would silently drop.
+	const helpId = `newspack-subscriptions-token-help-${ instanceId }`;
+	const wrapperRef = useRef< HTMLDivElement >( null );
+
+	useEffect( () => {
+		const input = wrapperRef.current?.querySelector( 'input' );
+		if ( ! input || ! help ) {
+			return;
+		}
+		const describedBy = ( input.getAttribute( 'aria-describedby' ) || '' ).split( ' ' ).filter( Boolean );
+		if ( ! describedBy.includes( helpId ) ) {
+			input.setAttribute( 'aria-describedby', [ ...describedBy, helpId ].join( ' ' ) );
+		}
+	}, [ help, helpId ] );
+
 	return (
-		<div className="newspack-subscriptions-search-token-field">
+		<div className="newspack-subscriptions-search-token-field" ref={ wrapperRef }>
 			<FormTokenField
 				label={ label }
 				value={ tokens }
@@ -135,7 +171,11 @@ export default function SearchTokenField( { endpoint, label, help, value, onChan
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 			/>
-			{ help && <p className="components-base-control__help">{ help }</p> }
+			{ help && (
+				<p className="components-base-control__help" id={ helpId }>
+					{ help }
+				</p>
+			) }
 		</div>
 	);
 }

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/components/search-token-field.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/components/search-token-field.tsx
@@ -1,0 +1,141 @@
+/**
+ * Search-as-you-type token field over one of the Subscriptions wizard's search
+ * endpoints (products, product categories, subscriptions). Values are IDs; the
+ * field resolves them to names on its own, so a caller only ever handles IDs.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { FormTokenField } from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies.
+ */
+import { WIZARD_ENDPOINT } from '../constants';
+
+type Item = { id: number; name: string };
+
+interface SearchTokenFieldProps {
+	/** Endpoint name under the wizard namespace, e.g. 'products-search'. */
+	endpoint: string;
+	label: string;
+	help?: string;
+	value: number[];
+	onChange: ( ids: number[] ) => void;
+	/** Restrict suggestions to these IDs. Used by the exclusion field. */
+	limitTo?: number[];
+	disabled?: boolean;
+}
+
+const debounce = < T extends ( ...args: never[] ) => void >( func: T, wait: number ) => {
+	let timeout: ReturnType< typeof setTimeout >;
+	return ( ...args: Parameters< T > ) => {
+		clearTimeout( timeout );
+		timeout = setTimeout( () => func( ...args ), wait );
+	};
+};
+
+export default function SearchTokenField( { endpoint, label, help, value, onChange, limitTo, disabled }: SearchTokenFieldProps ) {
+	const [ suggestions, setSuggestions ] = useState< Item[] >( [] );
+	// Names for the current value, so saved IDs render as tokens before (and
+	// regardless of) any search.
+	const [ resolved, setResolved ] = useState< Item[] >( [] );
+	const path = `${ WIZARD_ENDPOINT }/${ endpoint }`;
+
+	const fetchSuggestions = useCallback(
+		( search = '' ) => {
+			apiFetch< Item[] >( { path: addQueryArgs( path, { search, per_page: 100 } ) } )
+				.then( items => setSuggestions( items || [] ) )
+				.catch( error => {
+					console.warn( 'Error fetching suggestions for ' + path, error ); // eslint-disable-line no-console
+				} );
+		},
+		[ path ]
+	);
+
+	// Resolve the current IDs to names. Runs when IDs appear that no fetch has
+	// named yet — a saved rule opened in the editor, most of the time.
+	const resolvedIds = useMemo( () => resolved.map( item => item.id ), [ resolved ] );
+	const unresolved = useMemo( () => value.filter( id => ! resolvedIds.includes( id ) ), [ value, resolvedIds ] );
+	// Read the latest resolved list without making the effect depend on it,
+	// which would re-run it on every resolution.
+	const resolvedRef = useRef( resolved );
+	resolvedRef.current = resolved;
+
+	useEffect( () => {
+		if ( ! unresolved.length ) {
+			return;
+		}
+		apiFetch< Item[] >( { path: addQueryArgs( path, { include: unresolved.join( ',' ), per_page: 100 } ) } )
+			.then( items => {
+				if ( items?.length ) {
+					setResolved( [ ...resolvedRef.current, ...items ] );
+				}
+			} )
+			.catch( error => {
+				console.warn( 'Error resolving saved items for ' + path, error ); // eslint-disable-line no-console
+			} );
+	}, [ unresolved, path ] );
+
+	useEffect( () => {
+		fetchSuggestions();
+	}, [ fetchSuggestions ] );
+
+	const debouncedFetch = useMemo( () => debounce( fetchSuggestions, 200 ), [ fetchSuggestions ] );
+
+	// Everything the field knows a name for, deduped by ID.
+	const known = useMemo( () => {
+		const byId = new Map< number, Item >();
+		[ ...resolved, ...suggestions ].forEach( item => byId.set( item.id, item ) );
+		return byId;
+	}, [ resolved, suggestions ] );
+
+	// Labels carry the ID so two products sharing a name stay distinguishable —
+	// FormTokenField matches on the label string.
+	const toLabel = useCallback( ( item: Item ) => decodeEntities( `${ item.id }: ${ item.name || __( '(no name)', 'newspack-plugin' ) }` ), [] );
+
+	const suggestionLabels = useMemo( () => {
+		const allowed = limitTo ? new Set( limitTo ) : null;
+		return suggestions.filter( item => ! allowed || allowed.has( item.id ) ).map( toLabel );
+	}, [ suggestions, limitTo, toLabel ] );
+
+	const tokens = useMemo(
+		() => value.map( id => ( known.has( id ) ? toLabel( known.get( id ) as Item ) : `${ id }` ) ),
+		[ value, known, toLabel ]
+	);
+
+	const handleChange = ( nextTokens: ( string | { value: string } )[] ) => {
+		const ids = nextTokens
+			.map( token => {
+				const tokenLabel = typeof token === 'string' ? token : token.value;
+				// Labels are "{id}: {name}"; a token typed by hand may be a bare ID.
+				const id = parseInt( tokenLabel, 10 );
+				return Number.isNaN( id ) ? null : id;
+			} )
+			.filter( ( id ): id is number => id !== null );
+		onChange( [ ...new Set( ids ) ] );
+	};
+
+	return (
+		<div className="newspack-subscriptions-search-token-field">
+			<FormTokenField
+				label={ label }
+				value={ tokens }
+				suggestions={ suggestionLabels }
+				onChange={ handleChange }
+				onInputChange={ debouncedFetch }
+				disabled={ disabled }
+				__experimentalExpandOnFocus
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
+			{ help && <p className="components-base-control__help">{ help }</p> }
+		</div>
+	);
+}

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/components/targeting-fields.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/components/targeting-fields.tsx
@@ -1,0 +1,79 @@
+/**
+ * Shared "Applies to" fields for subscriber-commerce rule editors: the
+ * targeting-mode radio plus the product, category and excluded-product
+ * pickers.
+ *
+ * Controlled through a single `value` object; `onChange` receives a partial
+ * with only the changed keys. Help copy differs per feature, so it comes in as
+ * props.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { RadioControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies.
+ */
+import SearchTokenField from './search-token-field';
+import { SEARCH_ENDPOINTS } from '../constants';
+import type { RuleTargeting } from '../types';
+
+interface TargetingFieldsProps {
+	value: RuleTargeting;
+	onChange: ( partial: Partial< RuleTargeting > ) => void;
+	appliesHelp?: string;
+	categoryHelp?: string;
+	disabled?: boolean;
+}
+
+export default function TargetingFields( { value, onChange, appliesHelp, categoryHelp, disabled }: TargetingFieldsProps ) {
+	const { targeting, product_ids: productIds, category_ids: categoryIds, excluded_product_ids: excludedIds } = value;
+
+	return (
+		<>
+			<RadioControl
+				label={ __( 'Applies to', 'newspack-plugin' ) }
+				help={ appliesHelp }
+				selected={ targeting }
+				onChange={ ( next: string ) => onChange( { targeting: next as RuleTargeting[ 'targeting' ] } ) }
+				options={ [
+					{ value: 'products', label: __( 'Specific products', 'newspack-plugin' ) },
+					{ value: 'category', label: __( 'Category', 'newspack-plugin' ) },
+					{ value: 'all', label: __( 'All products', 'newspack-plugin' ) },
+				] }
+			/>
+			{ 'products' === targeting && (
+				<SearchTokenField
+					endpoint={ SEARCH_ENDPOINTS.products }
+					label={ __( 'Products', 'newspack-plugin' ) }
+					value={ productIds }
+					onChange={ ids => onChange( { product_ids: ids } ) }
+					disabled={ disabled }
+				/>
+			) }
+			{ 'category' === targeting && (
+				<SearchTokenField
+					endpoint={ SEARCH_ENDPOINTS.productCategories }
+					label={ __( 'Product categories', 'newspack-plugin' ) }
+					help={ categoryHelp || __( 'Subcategories are included.', 'newspack-plugin' ) }
+					value={ categoryIds }
+					onChange={ ids => onChange( { category_ids: ids } ) }
+					disabled={ disabled }
+				/>
+			) }
+			{ 'products' !== targeting && (
+				<SearchTokenField
+					endpoint={ SEARCH_ENDPOINTS.products }
+					label={ __( 'Excluded products', 'newspack-plugin' ) }
+					help={ __( 'Products left out of the rule.', 'newspack-plugin' ) }
+					value={ excludedIds }
+					onChange={ ids => onChange( { excluded_product_ids: ids } ) }
+					disabled={ disabled }
+				/>
+			) }
+		</>
+	);
+}

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/constants.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/constants.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared constants for the Subscriptions wizard.
+ */
+
+export const WIZARD_SLUG = 'newspack-audience-subscriptions';
+
+/** REST namespace for every endpoint on this wizard. */
+export const WIZARD_ENDPOINT = `/newspack/v1/wizard/${ WIZARD_SLUG }`;
+
+/** Search endpoints the shell provides to every tab. */
+export const SEARCH_ENDPOINTS = {
+	products: 'products-search',
+	productCategories: 'product-categories-search',
+	subscriptions: 'subscriptions-search',
+} as const;

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/index.tsx
@@ -1,128 +1,51 @@
 /**
+ * The Audience Management / Subscriptions wizard.
+ *
+ * A shell: it renders whichever tabs PHP registered, in registration order,
+ * looking each one up in the front-end tab registry. It has no knowledge of any
+ * particular feature, so a tab ships without changing anything here.
+ */
+
+/**
  * WordPress dependencies.
  */
-import { sprintf, __ } from '@wordpress/i18n';
-import apiFetch from '@wordpress/api-fetch';
-import { forwardRef, useState, useEffect } from '@wordpress/element';
-import { ExternalLink, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { __ } from '@wordpress/i18n';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies.
  */
-import { Button, Card, SelectControl, Wizard, withWizard, Notice } from '../../../../../packages/components/src';
-import WizardsTab from '../../../wizards-tab';
-import WizardSection from '../../../wizards-section';
+import { Wizard, withWizard } from '../../../../../packages/components/src';
+import { getTab } from './tabs';
+import type { SubscriptionsTab } from './types';
 
-function AudienceSubscriptions( props: Record< string, any >, ref: React.ForwardedRef< HTMLDivElement > ) {
-	const [ inFlight, setInFlight ] = useState( false );
-	const [ primaryProduct, setPrimaryProduct ] = useState( window.newspackAudienceSubscriptions.primary_product );
+const HEADER_TEXT = __( 'Audience Management / Subscriptions', 'newspack-plugin' );
 
-	useEffect( () => {
-		setPrimaryProduct( window.newspackAudienceSubscriptions.primary_product );
-	}, [ window.newspackAudienceSubscriptions.primary_product ] );
+function AudienceSubscriptions( _props: Record< string, unknown >, ref: React.ForwardedRef< HTMLDivElement > ) {
+	const tabs: SubscriptionsTab[] = window.newspackAudienceSubscriptions.tabs || [];
 
-	const handlePrimaryProductChange = ( value: string ) => {
-		setInFlight( true );
-		apiFetch( {
-			path: '/newspack/v1/wizard/newspack-audience-subscriptions/primary-product',
-			method: 'POST',
-			data: { primary_product: value },
+	const sections = tabs
+		.map( tab => {
+			const registered = getTab( tab.slug );
+			// A tab PHP registered with no front end would render an empty screen;
+			// leaving it out is the honest failure.
+			if ( ! registered ) {
+				return null;
+			}
+			return {
+				label: tab.label,
+				path: tab.path,
+				breadcrumbs: [
+					{ label: __( 'Audience Management', 'newspack-plugin' ) },
+					{ label: __( 'Subscriptions', 'newspack-plugin' ) },
+					{ label: registered.breadcrumbLabel || tab.label },
+				],
+				render: registered.render,
+			};
 		} )
-			.then( () => {
-				setPrimaryProduct( value );
-			} )
-			.finally( () => {
-				setInFlight( false );
-			} );
-	};
+		.filter( Boolean );
 
-	return (
-		<Wizard
-			headerText={ __( 'Audience Management / Subscriptions', 'newspack-plugin' ) }
-			sections={ [
-				{
-					label: __( 'Configuration', 'newspack-plugin' ),
-					path: '/configuration',
-					breadcrumbs: [ { label: __( 'Audience Management', 'newspack-plugin' ) }, { label: __( 'Subscriptions', 'newspack-plugin' ) } ],
-					render: () => (
-						<WizardsTab title={ __( 'Configuration', 'newspack-plugin' ) }>
-							<WizardSection>
-								<Card>
-									<h2>{ __( 'Subscription Upgrade Link', 'newspack-plugin' ) }</h2>
-									{ primaryProduct && (
-										<Notice isDismissible={ false }>
-											{ __( 'Share the following URL to trigger the subscription upgrade:', 'newspack-plugin' ) }{ ' ' }
-											<a
-												href={ window.newspackAudienceSubscriptions.upgrade_subscription_url }
-												target="_blank"
-												rel="noreferrer noopener"
-											>
-												{ window.newspackAudienceSubscriptions.upgrade_subscription_url }
-											</a>
-										</Notice>
-									) }
-									<SelectControl
-										label={ __( 'Primary Subscription Product', 'newspack-plugin' ) }
-										help={ __(
-											'Select a grouped or variable subscription product to allow readers to change their active subscriptions amongst all of its linked products and variations.',
-											'newspack-plugin'
-										) }
-										options={ [
-											{
-												value: '',
-												label: __( 'Select a product…', 'newspack-plugin' ),
-											},
-											...window.newspackAudienceSubscriptions.eligible_products.map( product => ( {
-												value: product.id,
-												label: product.title,
-											} ) ),
-										] }
-										value={ primaryProduct }
-										onChange={ handlePrimaryProductChange }
-										disabled={ inFlight }
-									/>
-									{ primaryProduct ? (
-										<HStack>
-											<p>
-												<Button variant="link" onClick={ () => handlePrimaryProductChange( '' ) }>
-													{ __( 'Reset primary product', 'newspack-plugin' ) }
-												</Button>{ ' ' }
-											</p>
-											<p>
-												<ExternalLink href={ `/wp-admin/post.php?post=${ primaryProduct }&action=edit` }>
-													{ sprintf(
-														/* translators: %s: product title */
-														__( 'Edit %s', 'newspack-plugin' ),
-														window.newspackAudienceSubscriptions.eligible_products.find(
-															product => parseInt( product.id ) === parseInt( primaryProduct )
-														)?.title || __( 'the product', 'newspack-plugin' )
-													) }
-												</ExternalLink>
-											</p>
-										</HStack>
-									) : null }
-								</Card>
-								<Card>
-									<h2>{ __( 'Manage Subscriptions settings in Woo Memberships', 'newspack-plugin' ) }</h2>
-									<p>
-										{ __(
-											'You can manage the details of your subscription offerings in the Woo Memberships plugin.',
-											'newspack-plugin'
-										) }
-									</p>
-									<Button variant="primary" href={ window.newspackAudienceSubscriptions.memberships_url }>
-										{ __( 'Manage Subscriptions', 'newspack-plugin' ) }
-									</Button>
-								</Card>
-							</WizardSection>
-						</WizardsTab>
-					),
-				},
-			] }
-			requiredPlugins={ [ 'woocommerce', 'woocommerce-memberships' ] }
-			ref={ ref }
-		/>
-	);
+	return <Wizard headerText={ HEADER_TEXT } sections={ sections } requiredPlugins={ [ 'woocommerce' ] } ref={ ref } />;
 }
 
 export default withWizard( forwardRef( AudienceSubscriptions ) );

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/index.tsx
@@ -11,12 +11,12 @@
  */
 import { __ } from '@wordpress/i18n';
 import { forwardRef } from '@wordpress/element';
-import { Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies.
  */
-import { Wizard, withWizard } from '../../../../../packages/components/src';
+import { Notice, Wizard, withWizard } from '../../../../../packages/components/src';
+import WizardsTab from '../../../wizards-tab';
 import { getTab } from './tabs';
 import type { SubscriptionsTab } from './types';
 
@@ -49,17 +49,26 @@ function AudienceSubscriptions( _props: Record< string, unknown >, ref: React.Fo
 	// Dropping one unregistered tab is a graceful degrade; ending up with none is
 	// not. Wizard redirects to `sections[ 0 ].path` unconditionally, so an empty
 	// list throws and takes the whole admin screen down with no error boundary
-	// above it. Say so instead — the two registries are maintained independently,
-	// which is exactly how a list ends up empty.
-	if ( ! sections.length ) {
-		return (
-			<Notice status="warning" isDismissible={ false }>
-				{ __( 'No Subscriptions screens are available on this site.', 'newspack-plugin' ) }
-			</Notice>
-		);
-	}
+	// above it. The two registries are maintained independently, which is exactly
+	// how a list ends up empty — so fall back to a single section carrying a
+	// notice. Routed through Wizard rather than returned on its own, it keeps the
+	// header, breadcrumbs and admin chrome, and the forwarded ref stays attached.
+	const displayedSections = sections.length
+		? sections
+		: [
+				{
+					label: __( 'Subscriptions', 'newspack-plugin' ),
+					path: '/',
+					breadcrumbs: [ { label: __( 'Audience Management', 'newspack-plugin' ) }, { label: __( 'Subscriptions', 'newspack-plugin' ) } ],
+					render: () => (
+						<WizardsTab title={ __( 'Subscriptions', 'newspack-plugin' ) }>
+							<Notice isWarning>{ __( 'No Subscriptions screens are available on this site.', 'newspack-plugin' ) }</Notice>
+						</WizardsTab>
+					),
+				},
+		  ];
 
-	return <Wizard headerText={ HEADER_TEXT } sections={ sections } requiredPlugins={ [ 'woocommerce' ] } ref={ ref } />;
+	return <Wizard headerText={ HEADER_TEXT } sections={ displayedSections } requiredPlugins={ [ 'woocommerce' ] } ref={ ref } />;
 }
 
 export default withWizard( forwardRef( AudienceSubscriptions ) );

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/index.tsx
@@ -11,6 +11,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { forwardRef } from '@wordpress/element';
+import { Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies.
@@ -44,6 +45,19 @@ function AudienceSubscriptions( _props: Record< string, unknown >, ref: React.Fo
 			};
 		} )
 		.filter( Boolean );
+
+	// Dropping one unregistered tab is a graceful degrade; ending up with none is
+	// not. Wizard redirects to `sections[ 0 ].path` unconditionally, so an empty
+	// list throws and takes the whole admin screen down with no error boundary
+	// above it. Say so instead — the two registries are maintained independently,
+	// which is exactly how a list ends up empty.
+	if ( ! sections.length ) {
+		return (
+			<Notice status="warning" isDismissible={ false }>
+				{ __( 'No Subscriptions screens are available on this site.', 'newspack-plugin' ) }
+			</Notice>
+		);
+	}
 
 	return <Wizard headerText={ HEADER_TEXT } sections={ sections } requiredPlugins={ [ 'woocommerce' ] } ref={ ref } />;
 }

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/configuration/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/configuration/index.tsx
@@ -1,0 +1,115 @@
+/**
+ * The Subscriptions wizard's Configuration tab: site-wide subscription
+ * settings.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { sprintf, __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { useState, useEffect } from '@wordpress/element';
+import { ExternalLink, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+
+/**
+ * Internal dependencies.
+ */
+import { Button, Card, SelectControl, Notice } from '../../../../../../../packages/components/src';
+import WizardsTab from '../../../../../wizards-tab';
+import WizardSection from '../../../../../wizards-section';
+import { registerTab } from '../registry';
+import { WIZARD_ENDPOINT } from '../../constants';
+
+function Configuration() {
+	const [ inFlight, setInFlight ] = useState( false );
+	const [ primaryProduct, setPrimaryProduct ] = useState( window.newspackAudienceSubscriptions.primary_product );
+
+	useEffect( () => {
+		setPrimaryProduct( window.newspackAudienceSubscriptions.primary_product );
+	}, [ window.newspackAudienceSubscriptions.primary_product ] );
+
+	const handlePrimaryProductChange = ( value: string ) => {
+		setInFlight( true );
+		apiFetch( {
+			path: `${ WIZARD_ENDPOINT }/primary-product`,
+			method: 'POST',
+			data: { primary_product: value },
+		} )
+			.then( () => {
+				setPrimaryProduct( value );
+			} )
+			.finally( () => {
+				setInFlight( false );
+			} );
+	};
+
+	return (
+		<WizardsTab title={ __( 'Configuration', 'newspack-plugin' ) }>
+			<WizardSection>
+				<Card>
+					<h2>{ __( 'Subscription Upgrade Link', 'newspack-plugin' ) }</h2>
+					{ primaryProduct && (
+						<Notice isDismissible={ false }>
+							{ __( 'Share the following URL to trigger the subscription upgrade:', 'newspack-plugin' ) }{ ' ' }
+							<a href={ window.newspackAudienceSubscriptions.upgrade_subscription_url } target="_blank" rel="noreferrer noopener">
+								{ window.newspackAudienceSubscriptions.upgrade_subscription_url }
+							</a>
+						</Notice>
+					) }
+					<SelectControl
+						label={ __( 'Primary Subscription Product', 'newspack-plugin' ) }
+						help={ __(
+							'Select a grouped or variable subscription product to allow readers to change their active subscriptions amongst all of its linked products and variations.',
+							'newspack-plugin'
+						) }
+						options={ [
+							{
+								value: '',
+								label: __( 'Select a product…', 'newspack-plugin' ),
+							},
+							...window.newspackAudienceSubscriptions.eligible_products.map( product => ( {
+								value: product.id,
+								label: product.title,
+							} ) ),
+						] }
+						value={ primaryProduct }
+						onChange={ handlePrimaryProductChange }
+						disabled={ inFlight }
+					/>
+					{ primaryProduct ? (
+						<HStack>
+							<p>
+								<Button variant="link" onClick={ () => handlePrimaryProductChange( '' ) }>
+									{ __( 'Reset primary product', 'newspack-plugin' ) }
+								</Button>{ ' ' }
+							</p>
+							<p>
+								<ExternalLink href={ `/wp-admin/post.php?post=${ primaryProduct }&action=edit` }>
+									{ sprintf(
+										/* translators: %s: product title */
+										__( 'Edit %s', 'newspack-plugin' ),
+										window.newspackAudienceSubscriptions.eligible_products.find(
+											product => parseInt( product.id ) === parseInt( primaryProduct )
+										)?.title || __( 'the product', 'newspack-plugin' )
+									) }
+								</ExternalLink>
+							</p>
+						</HStack>
+					) : null }
+				</Card>
+				{ /* Only meaningful while Memberships is still installed; a migrated site has no such screen. */ }
+				{ window.newspackAudienceSubscriptions.memberships_active && (
+					<Card>
+						<h2>{ __( 'Manage Subscriptions settings in Woo Memberships', 'newspack-plugin' ) }</h2>
+						<p>{ __( 'You can manage the details of your subscription offerings in the Woo Memberships plugin.', 'newspack-plugin' ) }</p>
+						<Button variant="primary" href={ window.newspackAudienceSubscriptions.memberships_url }>
+							{ __( 'Manage Subscriptions', 'newspack-plugin' ) }
+						</Button>
+					</Card>
+				) }
+			</WizardSection>
+		</WizardsTab>
+	);
+}
+
+registerTab( 'configuration', { render: () => <Configuration /> } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/index.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Tab registrations for the Subscriptions wizard.
+ *
+ * Importing this module runs every feature's registerTab() call. A new feature
+ * adds one import line here and owns everything else in its own directory.
+ */
+
+// Feature tab registrations.
+import './configuration';
+
+export { getTab, registerTab } from './registry';

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/registry.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/registry.ts
@@ -1,0 +1,38 @@
+/**
+ * Front-end registry for the Subscriptions wizard's tabs.
+ *
+ * The shell renders whichever tabs PHP registered (see
+ * Audience_Subscriptions::register_tab) and looks each one up here by slug, so
+ * a feature owns both halves of its own tab and the shell knows nothing about
+ * any particular feature.
+ *
+ * This module deliberately imports no feature: features import it, and
+ * `tabs/index.ts` imports both. Registering from a module this one imported
+ * would run the registration before the registry existed.
+ */
+
+/**
+ * Internal dependencies.
+ */
+import type { SubscriptionsTabComponent } from '../types';
+
+const registry: Record< string, SubscriptionsTabComponent > = {};
+
+/**
+ * Register a tab's front end under the slug PHP registered it with.
+ *
+ * @param slug Tab slug.
+ * @param tab  The tab's renderer.
+ */
+export function registerTab( slug: string, tab: SubscriptionsTabComponent ) {
+	registry[ slug ] = tab;
+}
+
+/**
+ * Get a registered tab.
+ *
+ * @param slug Tab slug.
+ */
+export function getTab( slug: string ): SubscriptionsTabComponent | undefined {
+	return registry[ slug ];
+}

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/types.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared types for the Subscriptions wizard and its subscriber-commerce tabs.
+ */
+
+/** How a rule picks the store products it covers. */
+export type Targeting = 'products' | 'category' | 'all';
+
+/**
+ * The targeting half of a rule — the "Applies to" fields, shared by every
+ * subscriber-commerce feature.
+ */
+export interface RuleTargeting {
+	targeting: Targeting;
+	product_ids: number[];
+	category_ids: number[];
+	excluded_product_ids: number[];
+}
+
+/** The fields every subscriber-commerce rule carries. */
+export interface BaseRule extends RuleTargeting {
+	id: string;
+	/** Subscription products whose subscribers the rule applies to. */
+	subscription_product_ids: number[];
+	active: boolean;
+	created_at: string;
+}
+
+/** A product as returned by the shell's search endpoints. */
+export interface ProductSearchItem {
+	id: number;
+	name: string;
+	parent_id: number;
+	type_label: string;
+	price: string;
+	regular_price: string;
+	sale_price: string;
+	is_on_sale: boolean;
+}
+
+/** A product category as returned by the shell's search endpoint. */
+export interface TermSearchItem {
+	id: number;
+	name: string;
+	type_label: string;
+}
+
+/** A tab registered on the Subscriptions wizard. */
+export interface SubscriptionsTab {
+	slug: string;
+	label: string;
+	path: string;
+}
+
+/** The front-end half of a tab registration. */
+export interface SubscriptionsTabComponent {
+	/** Renders the tab's screen. */
+	render: () => JSX.Element;
+	/** Label for the last breadcrumb. Defaults to the tab label. */
+	breadcrumbLabel?: string;
+}

--- a/plugins/newspack-plugin/src/wizards/types/window.d.ts
+++ b/plugins/newspack-plugin/src/wizards/types/window.d.ts
@@ -62,7 +62,13 @@ declare global {
 			can_use_name_your_price: boolean;
 		};
 		newspackAudienceSubscriptions: {
+			tabs: Array<{
+				slug: string;
+				label: string;
+				path: string;
+			}>;
 			memberships_url: string;
+			memberships_active: boolean;
 			primary_product: string;
 			eligible_products: Array<{
 				id: string;

--- a/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/product-targeting.php
+++ b/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/product-targeting.php
@@ -1,0 +1,349 @@
+<?php
+/**
+ * Tests the shared product targeting behind subscriber-commerce rules.
+ *
+ * @package Newspack\Tests\Subscriber_Commerce
+ */
+
+namespace Newspack\Tests\Subscriber_Commerce;
+
+use Newspack\Product_Targeting;
+use Newspack\Subscriber_Commerce;
+
+/**
+ * Tests how a rule's "Applies to" fields resolve to store products — the single
+ * source of truth shared by subscriber-only products and subscriber discounts.
+ *
+ * WooCommerce is not loaded in the test suite, so products are the repo's
+ * `WC_Product` mocks backed by real `product` posts (real posts are needed:
+ * category matching goes through `has_term()`).
+ *
+ * @group subscriber-commerce
+ * @group Product_Targeting
+ */
+class Test_Product_Targeting extends \WP_UnitTestCase {
+
+	/**
+	 * A simple product.
+	 *
+	 * @var \WC_Product
+	 */
+	private $product;
+
+	/**
+	 * A variable product.
+	 *
+	 * @var \WC_Product
+	 */
+	private $variable_product;
+
+	/**
+	 * A variation of the variable product.
+	 *
+	 * @var \WC_Product
+	 */
+	private $variation;
+
+	/**
+	 * Parent product category.
+	 *
+	 * @var int
+	 */
+	private $parent_category_id;
+
+	/**
+	 * Child of the parent product category.
+	 *
+	 * @var int
+	 */
+	private $child_category_id;
+
+	/**
+	 * Load the WooCommerce mocks.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		require_once dirname( __DIR__, 2 ) . '/mocks/wc-mocks.php';
+	}
+
+	/**
+	 * Register the product post type and category taxonomy (the real ones come
+	 * from WooCommerce), then build the products used across the assertions.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		register_post_type( 'product', [ 'public' => true ] );
+		register_post_type( 'product_variation', [ 'public' => false ] );
+		register_taxonomy(
+			'product_cat',
+			'product',
+			[
+				'public'       => true,
+				// As WooCommerce registers it: restricting a category restricts its children.
+				'hierarchical' => true,
+			]
+		);
+
+		$this->parent_category_id = $this->factory->term->create( [ 'taxonomy' => 'product_cat' ] );
+		$this->child_category_id  = $this->factory->term->create(
+			[
+				'taxonomy' => 'product_cat',
+				'parent'   => $this->parent_category_id,
+			]
+		);
+
+		$this->product          = $this->create_product();
+		$this->variable_product = $this->create_product();
+		$this->variation        = $this->create_product( $this->variable_product->get_id() );
+
+		Product_Targeting::flush_cache();
+	}
+
+	/**
+	 * Reset the memoized targeting between assertions.
+	 */
+	public function tear_down() {
+		Product_Targeting::flush_cache();
+		global $products_database;
+		$products_database = []; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a product post plus its mock, registered so wc_get_product() finds it.
+	 *
+	 * @param int $parent_id Parent product ID, for a variation.
+	 *
+	 * @return \WC_Product
+	 */
+	private function create_product( $parent_id = 0 ) {
+		$post_id = $this->factory->post->create(
+			[
+				'post_type'   => $parent_id ? 'product_variation' : 'product',
+				'post_parent' => $parent_id,
+			]
+		);
+		$product = new \WC_Product(
+			[
+				'id'        => $post_id,
+				'parent_id' => $parent_id,
+			]
+		);
+
+		global $products_database;
+		$products_database[ $post_id ] = $product; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		return $product;
+	}
+
+	/**
+	 * Build a sanitized rule with the given overrides.
+	 *
+	 * @param array $overrides Rule fields to override.
+	 *
+	 * @return array
+	 */
+	private function make_rule( $overrides = [] ) {
+		return Subscriber_Commerce::sanitize_base_rule(
+			array_merge(
+				[
+					'id'                       => 'rule',
+					'subscription_product_ids' => [ 1 ],
+					'active'                   => true,
+				],
+				$overrides
+			)
+		);
+	}
+
+	/**
+	 * A rule listing a product covers that product and nothing else.
+	 */
+	public function test_specific_products_targeting() {
+		$rule = $this->make_rule(
+			[
+				'targeting'   => 'products',
+				'product_ids' => [ $this->product->get_id() ],
+			]
+		);
+
+		$this->assertTrue( Product_Targeting::rule_covers_product( $rule, $this->product ) );
+		$this->assertFalse( Product_Targeting::rule_covers_product( $rule, $this->variable_product ) );
+	}
+
+	/**
+	 * A variation is covered when its parent is listed: publishers pick the
+	 * parent product, never the individual variations.
+	 */
+	public function test_variation_is_covered_through_its_parent() {
+		$rule = $this->make_rule(
+			[
+				'targeting'   => 'products',
+				'product_ids' => [ $this->variable_product->get_id() ],
+			]
+		);
+
+		$this->assertTrue( Product_Targeting::rule_covers_product( $rule, $this->variation ) );
+	}
+
+	/**
+	 * Covering a category covers its subcategories. Without this, a rule
+	 * covering "Premium" would leave everything in "Premium > Merch" out.
+	 */
+	public function test_category_targeting_cascades_to_subcategories() {
+		wp_set_object_terms( $this->product->get_id(), [ $this->child_category_id ], 'product_cat' );
+
+		$rule = $this->make_rule(
+			[
+				'targeting'    => 'category',
+				'category_ids' => [ $this->parent_category_id ],
+			]
+		);
+
+		$this->assertTrue( Product_Targeting::rule_covers_product( $rule, $this->product ) );
+	}
+
+	/**
+	 * A variation carries no terms of its own, so it matches through its
+	 * parent's categories.
+	 */
+	public function test_variation_matches_parent_categories() {
+		wp_set_object_terms( $this->variable_product->get_id(), [ $this->parent_category_id ], 'product_cat' );
+
+		$rule = $this->make_rule(
+			[
+				'targeting'    => 'category',
+				'category_ids' => [ $this->parent_category_id ],
+			]
+		);
+
+		$this->assertTrue( Product_Targeting::rule_covers_product( $rule, $this->variation ) );
+	}
+
+	/**
+	 * A product outside every listed category is not covered.
+	 */
+	public function test_category_targeting_skips_uncategorized_products() {
+		$rule = $this->make_rule(
+			[
+				'targeting'    => 'category',
+				'category_ids' => [ $this->parent_category_id ],
+			]
+		);
+
+		$this->assertFalse( Product_Targeting::rule_covers_product( $rule, $this->product ) );
+	}
+
+	/**
+	 * "All products" covers everything but the exclusions.
+	 */
+	public function test_all_targeting_honors_exclusions() {
+		$rule = $this->make_rule(
+			[
+				'targeting'            => 'all',
+				'excluded_product_ids' => [ $this->product->get_id() ],
+			]
+		);
+
+		$this->assertFalse( Product_Targeting::rule_covers_product( $rule, $this->product ) );
+		$this->assertTrue( Product_Targeting::rule_covers_product( $rule, $this->variable_product ) );
+	}
+
+	/**
+	 * Excluding a variable product excludes its variations too — otherwise the
+	 * product a publisher excluded would still be sold, by variation.
+	 */
+	public function test_exclusion_applies_to_variations_of_an_excluded_parent() {
+		$rule = $this->make_rule(
+			[
+				'targeting'            => 'all',
+				'excluded_product_ids' => [ $this->variable_product->get_id() ],
+			]
+		);
+
+		$this->assertFalse( Product_Targeting::rule_covers_product( $rule, $this->variation ) );
+	}
+
+	/**
+	 * Pausing a rule hands its products back.
+	 */
+	public function test_inactive_rules_are_skipped() {
+		$rules = [
+			$this->make_rule(
+				[
+					'targeting'   => 'products',
+					'product_ids' => [ $this->product->get_id() ],
+					'active'      => false,
+				]
+			),
+		];
+
+		$this->assertSame( [], Product_Targeting::get_matching_rules( $rules, $this->product ) );
+	}
+
+	/**
+	 * Every rule covering a product is returned, so callers can decide across
+	 * all of them rather than only the first.
+	 */
+	public function test_get_matching_rules_returns_every_covering_rule() {
+		wp_set_object_terms( $this->product->get_id(), [ $this->parent_category_id ], 'product_cat' );
+
+		$by_name     = $this->make_rule(
+			[
+				'id'          => 'byname',
+				'targeting'   => 'products',
+				'product_ids' => [ $this->product->get_id() ],
+			]
+		);
+		$by_category = $this->make_rule(
+			[
+				'id'           => 'bycategory',
+				'targeting'    => 'category',
+				'category_ids' => [ $this->parent_category_id ],
+			]
+		);
+
+		$matching = Product_Targeting::get_matching_rules( [ $by_name, $by_category ], $this->product );
+
+		$this->assertCount( 2, $matching );
+		$this->assertSame( [ 'byname', 'bycategory' ], wp_list_pluck( $matching, 'id' ) );
+	}
+
+	/**
+	 * Two rule sets that differ must not share a memoized verdict — the cache
+	 * key has to cover the rules, not just the product.
+	 */
+	public function test_memoization_distinguishes_rule_sets() {
+		$covering = [
+			$this->make_rule(
+				[
+					'targeting'   => 'products',
+					'product_ids' => [ $this->product->get_id() ],
+				]
+			),
+		];
+		$other    = [
+			$this->make_rule(
+				[
+					'targeting'   => 'products',
+					'product_ids' => [ $this->variable_product->get_id() ],
+				]
+			),
+		];
+
+		$this->assertCount( 1, Product_Targeting::get_matching_rules( $covering, $this->product ) );
+		$this->assertCount( 0, Product_Targeting::get_matching_rules( $other, $this->product ) );
+	}
+
+	/**
+	 * An unrecognized targeting value falls back to specific products, so a
+	 * malformed rule can never widen to the whole store.
+	 */
+	public function test_unknown_targeting_falls_back_to_specific_products() {
+		$rule = $this->make_rule( [ 'targeting' => 'everything' ] );
+
+		$this->assertSame( 'products', $rule['targeting'] );
+		$this->assertFalse( Product_Targeting::rule_covers_product( $rule, $this->product ) );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/product-targeting.php
+++ b/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/product-targeting.php
@@ -270,14 +270,19 @@ class Test_Product_Targeting extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Excluding a grouped product excludes the products sold under it.
+	 * Excluding a grouped product does NOT free the standalone products sold
+	 * under it.
 	 *
-	 * A grouped product's children are top-level products reporting a parent of
-	 * 0, so the parent-ID test that catches variations never sees them. Without
-	 * the expansion the bundle a publisher excluded would keep selling every
-	 * product inside it.
+	 * A grouped product's children are ordinary top-level products, also sold on
+	 * their own, so reaching through the container to exclude them would lift the
+	 * rule off those products everywhere — widening access on the strength of one
+	 * bundle exclusion. An exclusion therefore means exactly the IDs listed (and
+	 * their variations), and excluding a grouped container is a no-op on its
+	 * children. Whether it should behave otherwise is a product decision left to
+	 * the branch owner (PR #742 review); this test pins today's behaviour so the
+	 * decision can't be reversed by accident.
 	 */
-	public function test_exclusion_applies_to_children_of_an_excluded_grouped_product() {
+	public function test_excluding_a_grouped_product_does_not_free_its_children() {
 		$grouped = $this->create_product(
 			0,
 			'grouped',
@@ -291,34 +296,10 @@ class Test_Product_Targeting extends \WP_UnitTestCase {
 			]
 		);
 
+		// The grouped container itself, named in the list, is excluded.
 		$this->assertFalse( Product_Targeting::rule_covers_product( $rule, $grouped ) );
-		$this->assertFalse( Product_Targeting::rule_covers_product( $rule, $this->product ) );
-		// A product outside the bundle is untouched by the exclusion.
-		$this->assertTrue( Product_Targeting::rule_covers_product( $rule, $this->variable_product ) );
-	}
-
-	/**
-	 * The grouped expansion applies to exclusions only. Naming a grouped product
-	 * under `products` targeting still covers the container alone — an exclusion
-	 * that reaches too little sells something the publisher withheld, while
-	 * targeting that reaches too far restricts something they never named.
-	 */
-	public function test_products_targeting_does_not_expand_grouped_children() {
-		$grouped = $this->create_product(
-			0,
-			'grouped',
-			[ $this->product->get_id() ]
-		);
-
-		$rule = $this->make_rule(
-			[
-				'targeting'   => 'products',
-				'product_ids' => [ $grouped->get_id() ],
-			]
-		);
-
-		$this->assertTrue( Product_Targeting::rule_covers_product( $rule, $grouped ) );
-		$this->assertFalse( Product_Targeting::rule_covers_product( $rule, $this->product ) );
+		// Its child, a standalone product, stays covered by the "all" rule.
+		$this->assertTrue( Product_Targeting::rule_covers_product( $rule, $this->product ) );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/product-targeting.php
+++ b/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/product-targeting.php
@@ -113,11 +113,13 @@ class Test_Product_Targeting extends \WP_UnitTestCase {
 	/**
 	 * Create a product post plus its mock, registered so wc_get_product() finds it.
 	 *
-	 * @param int $parent_id Parent product ID, for a variation.
+	 * @param int    $parent_id Parent product ID, for a variation.
+	 * @param string $type      WooCommerce product type.
+	 * @param int[]  $children  Child product IDs, for a grouped product.
 	 *
 	 * @return \WC_Product
 	 */
-	private function create_product( $parent_id = 0 ) {
+	private function create_product( $parent_id = 0, $type = 'simple', $children = [] ) {
 		$post_id = $this->factory->post->create(
 			[
 				'post_type'   => $parent_id ? 'product_variation' : 'product',
@@ -128,6 +130,8 @@ class Test_Product_Targeting extends \WP_UnitTestCase {
 			[
 				'id'        => $post_id,
 				'parent_id' => $parent_id,
+				'type'      => $type,
+				'children'  => $children,
 			]
 		);
 
@@ -263,6 +267,58 @@ class Test_Product_Targeting extends \WP_UnitTestCase {
 		);
 
 		$this->assertFalse( Product_Targeting::rule_covers_product( $rule, $this->variation ) );
+	}
+
+	/**
+	 * Excluding a grouped product excludes the products sold under it.
+	 *
+	 * A grouped product's children are top-level products reporting a parent of
+	 * 0, so the parent-ID test that catches variations never sees them. Without
+	 * the expansion the bundle a publisher excluded would keep selling every
+	 * product inside it.
+	 */
+	public function test_exclusion_applies_to_children_of_an_excluded_grouped_product() {
+		$grouped = $this->create_product(
+			0,
+			'grouped',
+			[ $this->product->get_id() ]
+		);
+
+		$rule = $this->make_rule(
+			[
+				'targeting'            => 'all',
+				'excluded_product_ids' => [ $grouped->get_id() ],
+			]
+		);
+
+		$this->assertFalse( Product_Targeting::rule_covers_product( $rule, $grouped ) );
+		$this->assertFalse( Product_Targeting::rule_covers_product( $rule, $this->product ) );
+		// A product outside the bundle is untouched by the exclusion.
+		$this->assertTrue( Product_Targeting::rule_covers_product( $rule, $this->variable_product ) );
+	}
+
+	/**
+	 * The grouped expansion applies to exclusions only. Naming a grouped product
+	 * under `products` targeting still covers the container alone — an exclusion
+	 * that reaches too little sells something the publisher withheld, while
+	 * targeting that reaches too far restricts something they never named.
+	 */
+	public function test_products_targeting_does_not_expand_grouped_children() {
+		$grouped = $this->create_product(
+			0,
+			'grouped',
+			[ $this->product->get_id() ]
+		);
+
+		$rule = $this->make_rule(
+			[
+				'targeting'   => 'products',
+				'product_ids' => [ $grouped->get_id() ],
+			]
+		);
+
+		$this->assertTrue( Product_Targeting::rule_covers_product( $rule, $grouped ) );
+		$this->assertFalse( Product_Targeting::rule_covers_product( $rule, $this->product ) );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/subscriber-commerce.php
+++ b/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/subscriber-commerce.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Tests the shared subscriber-commerce stand-down check and rule sanitizer.
+ *
+ * @package Newspack\Tests\Subscriber_Commerce
+ */
+
+namespace Newspack\Tests\Subscriber_Commerce;
+
+use Newspack\Product_Targeting;
+use Newspack\Subscriber_Commerce;
+
+/**
+ * Both subscriber-commerce features read is_enforcement_active() before they
+ * touch a price or a purchase, so what it answers — and what it refuses to let
+ * a filter override — is the contract under test here.
+ *
+ * @group subscriber-commerce
+ * @group Subscriber_Commerce
+ */
+class Test_Subscriber_Commerce extends \WP_UnitTestCase {
+
+	/**
+	 * Load the WooCommerce mocks, which is what makes wc_get_product() exist.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		require_once dirname( __DIR__, 2 ) . '/mocks/wc-mocks.php';
+	}
+
+	/**
+	 * Drop any enforcement filter a test added.
+	 */
+	public function tear_down() {
+		remove_all_filters( 'newspack_subscriber_commerce_enforcement_active' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Turn the feature flag on for a test that needs it.
+	 *
+	 * Deliberately not in set_up(): NEWSPACK_CONTENT_GATES is a constant, so
+	 * defining it for every test would also define it inside the separate
+	 * process the feature-disabled test runs in, and that test would then be
+	 * asserting against a feature that is switched on.
+	 */
+	private function enable_gates() {
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+	}
+
+	/**
+	 * The admin is reachable on a gated Woo site. This is what the page's
+	 * registration turns on, and it deliberately does not consult Memberships:
+	 * a publisher migrating off Memberships configures rules first and
+	 * deactivates it afterwards.
+	 */
+	public function test_admin_is_available_with_gates_and_woocommerce() {
+		$this->enable_gates();
+		$this->assertTrue( Subscriber_Commerce::is_admin_available() );
+	}
+
+	/**
+	 * With Memberships absent — the state of the test environment — enforcement
+	 * follows admin availability.
+	 */
+	public function test_enforcement_is_active_without_memberships() {
+		$this->enable_gates();
+		$this->assertTrue( Subscriber_Commerce::is_enforcement_active() );
+	}
+
+	/**
+	 * The filter can stand enforcement down. This is the escape hatch a site
+	 * mid-migration uses, so it has to keep working.
+	 */
+	public function test_filter_can_stand_enforcement_down() {
+		$this->enable_gates();
+		add_filter( 'newspack_subscriber_commerce_enforcement_active', '__return_false' );
+		$this->assertFalse( Subscriber_Commerce::is_enforcement_active() );
+	}
+
+	/**
+	 * The filter cannot turn enforcement on when the feature is off.
+	 *
+	 * Features read this as their licence to call WooCommerce APIs, so a filter
+	 * answering yes where the underlying conditions say no would turn a
+	 * stand-down into a fatal rather than a no-op.
+	 *
+	 * Runs in a separate process so the NEWSPACK_CONTENT_GATES constant other
+	 * suites define cannot leak in and make the feature look enabled.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_filter_cannot_enable_enforcement_when_feature_is_disabled() {
+		add_filter( 'newspack_subscriber_commerce_enforcement_active', '__return_true' );
+		$this->assertFalse( Subscriber_Commerce::is_admin_available() );
+		$this->assertFalse( Subscriber_Commerce::is_enforcement_active() );
+	}
+
+	/**
+	 * A rule saved without an ID gets one. A rule with no ID is one nothing can
+	 * address for edit or delete.
+	 */
+	public function test_sanitize_base_rule_mints_a_missing_id() {
+		$rule = Subscriber_Commerce::sanitize_base_rule( [ 'targeting' => 'all' ] );
+		$this->assertNotEmpty( $rule['id'] );
+	}
+
+	/**
+	 * An ID the caller supplied is kept, so saving a rule twice updates it
+	 * rather than creating a second one.
+	 */
+	public function test_sanitize_base_rule_keeps_a_supplied_id() {
+		$rule = Subscriber_Commerce::sanitize_base_rule(
+			[
+				'id'        => 'existing-rule',
+				'targeting' => 'all',
+			]
+		);
+		$this->assertSame( 'existing-rule', $rule['id'] );
+	}
+
+	/**
+	 * An absent `active` flag reads as paused. Callers that mean "live on
+	 * create" state it — the alternative would let a partial payload silently
+	 * start enforcing a rule that gates a purchase or a price.
+	 */
+	public function test_sanitize_base_rule_reads_absent_active_as_paused() {
+		$rule = Subscriber_Commerce::sanitize_base_rule( [ 'targeting' => 'all' ] );
+		$this->assertFalse( $rule['active'] );
+
+		$live = Subscriber_Commerce::sanitize_base_rule(
+			[
+				'targeting' => 'all',
+				'active'    => true,
+			]
+		);
+		$this->assertTrue( $live['active'] );
+	}
+
+	/**
+	 * An unrecognized targeting mode falls back to the narrowest one rather than
+	 * to "everything".
+	 */
+	public function test_sanitize_base_rule_falls_back_to_specific_products() {
+		$rule = Subscriber_Commerce::sanitize_base_rule( [ 'targeting' => 'not-a-mode' ] );
+		$this->assertSame( Product_Targeting::TARGETING_PRODUCTS, $rule['targeting'] );
+	}
+
+	/**
+	 * A malformed creation date is replaced rather than stored, since the value
+	 * is displayed back to the publisher.
+	 */
+	public function test_sanitize_base_rule_rejects_an_impossible_date() {
+		$rule = Subscriber_Commerce::sanitize_base_rule(
+			[
+				'targeting'  => 'all',
+				'created_at' => '2026-13-99',
+			]
+		);
+		$this->assertSame( gmdate( 'Y-m-d' ), $rule['created_at'] );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/subscriber-eligibility.php
+++ b/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/subscriber-eligibility.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Tests subscriber eligibility for subscriber-commerce rules.
+ *
+ * @package Newspack\Tests\Subscriber_Commerce
+ */
+
+namespace Newspack\Tests\Subscriber_Commerce;
+
+use Newspack\Subscriber_Eligibility;
+
+/**
+ * Tests the memoizing wrapper both subscriber-commerce features use to ask
+ * "is this reader a subscriber of any of these products?".
+ *
+ * The underlying oracle (Access_Rules::has_active_subscription) is exercised by
+ * its own tests; here the contract under test is the wrapper's: who is never
+ * eligible, and that the memoization can't confuse one reader or product set
+ * for another.
+ *
+ * @group subscriber-commerce
+ * @group Subscriber_Eligibility
+ */
+class Test_Subscriber_Eligibility extends \WP_UnitTestCase {
+
+	/**
+	 * Subscription product IDs granting eligibility.
+	 *
+	 * @var int[]
+	 */
+	private $subscription_ids = [ 101, 102 ];
+
+	/**
+	 * A reader.
+	 *
+	 * @var int
+	 */
+	private $reader_id;
+
+	/**
+	 * Another reader.
+	 *
+	 * @var int
+	 */
+	private $other_reader_id;
+
+	/**
+	 * Calls the oracle saw, as [ user_id, product_ids ] pairs.
+	 *
+	 * @var array[]
+	 */
+	private $oracle_calls = [];
+
+	/**
+	 * Create readers and stand in for the subscription oracle.
+	 */
+	public function set_up() {
+		parent::set_up();
+		Subscriber_Eligibility::flush_cache();
+
+		$this->reader_id       = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		$this->other_reader_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+
+		$this->oracle_calls = [];
+		add_filter( 'newspack_access_rules_has_active_subscription', [ $this, 'mock_oracle' ], 10, 3 );
+	}
+
+	/**
+	 * Remove the oracle stand-in and reset the cache.
+	 */
+	public function tear_down() {
+		remove_filter( 'newspack_access_rules_has_active_subscription', [ $this, 'mock_oracle' ], 10 );
+		Subscriber_Eligibility::flush_cache();
+		parent::tear_down();
+	}
+
+	/**
+	 * Stand in for the subscription oracle: only the first reader subscribes,
+	 * and only to the first product.
+	 *
+	 * @param bool  $has_subscription Whether the user has an active subscription.
+	 * @param int   $user_id          User ID.
+	 * @param array $product_ids      Required product IDs.
+	 *
+	 * @return bool
+	 */
+	public function mock_oracle( $has_subscription, $user_id, $product_ids ) {
+		$this->oracle_calls[] = [ $user_id, $product_ids ];
+		return $user_id === $this->reader_id && in_array( 101, $product_ids, true );
+	}
+
+	/**
+	 * A reader holding one of the listed subscriptions is eligible.
+	 */
+	public function test_subscriber_is_eligible() {
+		$this->assertTrue( Subscriber_Eligibility::user_has( $this->reader_id, $this->subscription_ids ) );
+	}
+
+	/**
+	 * A logged-in reader without any of the listed subscriptions is not.
+	 */
+	public function test_non_subscriber_is_not_eligible() {
+		$this->assertFalse( Subscriber_Eligibility::user_has( $this->other_reader_id, $this->subscription_ids ) );
+	}
+
+	/**
+	 * An anonymous reader holds no subscription, so the oracle is never asked.
+	 */
+	public function test_anonymous_reader_is_never_eligible() {
+		$this->assertFalse( Subscriber_Eligibility::user_has( 0, $this->subscription_ids ) );
+		$this->assertSame( [], $this->oracle_calls );
+	}
+
+	/**
+	 * A rule naming no subscription names no way in, so nobody satisfies it —
+	 * rather than the oracle's "any active subscription" reading of an empty
+	 * product list, which would let every subscriber through.
+	 */
+	public function test_empty_subscription_list_grants_nobody() {
+		$this->assertFalse( Subscriber_Eligibility::user_has( $this->reader_id, [] ) );
+		$this->assertSame( [], $this->oracle_calls );
+	}
+
+	/**
+	 * Repeat questions are answered from the cache: a shop archive asks the
+	 * same one once per covered product.
+	 */
+	public function test_repeat_lookups_hit_the_cache() {
+		Subscriber_Eligibility::user_has( $this->reader_id, $this->subscription_ids );
+		Subscriber_Eligibility::user_has( $this->reader_id, $this->subscription_ids );
+
+		$this->assertCount( 1, $this->oracle_calls );
+	}
+
+	/**
+	 * The same product set ordered differently is the same question.
+	 */
+	public function test_cache_is_order_independent() {
+		Subscriber_Eligibility::user_has( $this->reader_id, [ 101, 102 ] );
+		Subscriber_Eligibility::user_has( $this->reader_id, [ 102, 101 ] );
+
+		$this->assertCount( 1, $this->oracle_calls );
+	}
+
+	/**
+	 * Different readers get their own verdicts — the cache key must include the
+	 * user, or one reader's access would leak to the next in the same request.
+	 */
+	public function test_cache_distinguishes_readers() {
+		$this->assertTrue( Subscriber_Eligibility::user_has( $this->reader_id, $this->subscription_ids ) );
+		$this->assertFalse( Subscriber_Eligibility::user_has( $this->other_reader_id, $this->subscription_ids ) );
+	}
+
+	/**
+	 * Different subscription sets get their own verdicts.
+	 */
+	public function test_cache_distinguishes_subscription_sets() {
+		$this->assertTrue( Subscriber_Eligibility::user_has( $this->reader_id, [ 101 ] ) );
+		$this->assertFalse( Subscriber_Eligibility::user_has( $this->reader_id, [ 102 ] ) );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The shared base that **subscriber-only products** ([NPPD-1899](https://linear.app/a8c/issue/NPPD-1899), stacked in #743) and **subscriber discounts** ([NPPD-1794](https://linear.app/a8c/issue/NPPD-1794), stacked separately) both build on. Split out so the two features share one implementation of the parts they'd otherwise each write and drift on.

A subscriber-commerce rule ties store products to subscriptions — *"these products, for subscribers of these subscriptions"*. The targeting half of that shape is identical across both features.

* **`Product_Targeting`** resolves a rule's "Applies to" fields to products: specific products, a category (cascading to subcategories, since `product_cat` is hierarchical), or everything, minus exclusions. Variations match through their parent, which is what publishers pick. `get_matching_rules()` memoizes per (rule set, product) — WooCommerce asks about purchasability and price many times per product per request.
* **`Subscriber_Eligibility`** wraps `Access_Rules::has_active_subscription()` with per-request caching. Only *held* subscriptions count: one sitting in the cart does not make a reader a subscriber.
* **`Subscriber_Commerce::is_enforcement_active()`** is the single stand-down check (content-gates flag + WooCommerce present + Memberships inactive), so both features share byte-identical logic and the eventual "let Access Control take precedence over Memberships" cleanup is one change rather than two.
* **The wizard shell** renders whichever tabs PHP registered via `register_tab()`, looking each up in a front-end registry — a feature ships a tab without changing the shell. Tabs carry an explicit `order`, so the landing tab isn't decided by which hook a feature happens to register from.
* **Shared REST search** for products, product categories and subscriptions. Product results carry prices and per-variation rows, so a rule editor can preview what a reader would pay without a second round trip.

**One behaviour change worth review:** the page was registered only while Memberships was active — exactly when subscriber-commerce stands down, so the admin would have been unreachable for the features it hosts. It now also appears on any Woo site with content gating enabled. Note `is_admin_available()` (flag + Woo) is deliberately *not* gated on Memberships being inactive: a migrating publisher configures rules first and deactivates Memberships after, which is the order the migration runbook prescribes.

Its existing configuration screen becomes the first registered tab; the "Manage Subscriptions in Woo Memberships" card is now gated on Memberships actually being active, since the page renders on sites with no such screen.

Part of [NPPD-1899](https://linear.app/a8c/issue/NPPD-1899), [NPPD-1794](https://linear.app/a8c/issue/NPPD-1794).

### How to test the changes in this Pull Request:

1. On a site with WooCommerce active, `NEWSPACK_CONTENT_GATES` enabled and Woo Memberships **inactive**, open **Audience → Subscriptions**. The page renders (before this PR it was hidden without Memberships) and shows the Configuration tab. With only one tab registered there's no tab navigation — correct.
2. Confirm the "Manage Subscriptions settings in Woo Memberships" card is absent. Activate Memberships and reload: it reappears.
3. Hit the shared search endpoints as an admin and check the response shapes:
   * `/wp-json/newspack/v1/wizard/newspack-audience-subscriptions/products-search?search=x` — each product carries `id, name, parent_id, price, regular_price, sale_price, is_on_sale`; a variable product also returns its variations as their own rows.
   * `.../subscriptions-search` — subscription products only.
   * `.../product-categories-search`.
4. `n test-php --group subscriber-commerce`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

**Verification:** 19 unit tests for targeting and eligibility (full suite green: 2383 tests, 6698 assertions); PHPCS clean; ESLint clean; build clean; page verified rendering in a browser on a Woo site with Memberships inactive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKzH1CGLgvvrusDGSURAsv