### PR TITLE
feat(subscriptions): subscriber-only products (NPPD-1899)

### DIFF
--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -160,6 +160,9 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/subscriber-commerce/class-subscriber-commerce.php';
 		include_once NEWSPACK_ABSPATH . 'includes/subscriber-commerce/class-product-targeting.php';
 		include_once NEWSPACK_ABSPATH . 'includes/subscriber-commerce/class-subscriber-eligibility.php';
+		include_once NEWSPACK_ABSPATH . 'includes/subscriber-commerce/class-subscriber-only-products.php';
+		include_once NEWSPACK_ABSPATH . 'includes/subscriber-commerce/class-product-purchase-restriction.php';
+		include_once NEWSPACK_ABSPATH . 'includes/subscriber-commerce/class-subscriber-only-products-api.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-provider.php';
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-generated.php';

--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-product-purchase-restriction.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-product-purchase-restriction.php
@@ -211,6 +211,11 @@ class Product_Purchase_Restriction {
 	 * would be incoherent. Singular queries are left alone so a direct link
 	 * still resolves.
 	 *
+	 * Secondary listings are in scope by the same reasoning: related products,
+	 * cross-sells and cart upsells all recommend something the reader cannot
+	 * buy. `newspack_subscriber_only_hide_from_query` is the escape hatch for a
+	 * publisher who wants hiding confined to the primary catalog.
+	 *
 	 * @param \WP_Query $query The query.
 	 */
 	public static function filter_product_query( $query ) {
@@ -228,6 +233,24 @@ class Product_Purchase_Restriction {
 		}
 		$settings = Subscriber_Only_Products::get_settings();
 		if ( empty( $settings['hide_from_product_lists'] ) ) {
+			return;
+		}
+
+		/**
+		 * Filters whether restricted products are hidden from a given product query.
+		 *
+		 * Every front-end product listing is covered by default, secondary ones
+		 * included. Return false to leave a listing alone — scoping hiding to the
+		 * primary catalog and leaving related products, cross-sells or cart
+		 * upsells untouched, for instance.
+		 *
+		 * Purchase restriction is unaffected either way: a product left visible
+		 * by this filter still cannot be bought.
+		 *
+		 * @param bool      $hide  Whether to hide restricted products from this query.
+		 * @param \WP_Query $query The query being filtered.
+		 */
+		if ( ! apply_filters( 'newspack_subscriber_only_hide_from_query', true, $query ) ) {
 			return;
 		}
 

--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-product-purchase-restriction.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-product-purchase-restriction.php
@@ -25,7 +25,8 @@ defined( 'ABSPATH' ) || exit;
 class Product_Purchase_Restriction {
 
 	/**
-	 * Whether the reader may purchase a product, keyed by "{product_id}_{user_id}".
+	 * Whether the reader may purchase a product, keyed by
+	 * "{product_id}_{user_id}_{payment-recovery grace}".
 	 * WooCommerce asks several times per product per request (list loop, single
 	 * product template, cart validation), so the decision is memoized.
 	 *
@@ -120,8 +121,20 @@ class Product_Purchase_Restriction {
 			return true;
 		}
 
-		$user_id   = null === $user_id ? get_current_user_id() : (int) $user_id;
-		$cache_key = $product_id . '_' . $user_id;
+		$user_id = null === $user_id ? get_current_user_id() : (int) $user_id;
+		// The verdict rests on Subscriber_Eligibility::user_has(), which reads
+		// `payment_recovery_grace` from the ambient evaluation context that
+		// with_evaluation_context() swaps around each gate. Key on it for the same
+		// reason that layer does, so a verdict reached inside one gate's context
+		// is never served to a caller outside it.
+		$cache_key = implode(
+			'_',
+			[
+				$product_id,
+				$user_id,
+				Access_Rules::get_evaluation_context( 'payment_recovery_grace', true ) ? 'grace' : 'strict',
+			]
+		);
 		if ( ! isset( self::$purchase_verdicts[ $cache_key ] ) ) {
 			self::$purchase_verdicts[ $cache_key ] = self::evaluate_purchase( $product, $user_id );
 		}
@@ -220,6 +233,21 @@ class Product_Purchase_Restriction {
 
 		$hidden = self::get_hidden_product_ids();
 		if ( empty( $hidden ) ) {
+			return;
+		}
+
+		// WordPress drops `post__not_in` entirely once `post__in` is set, so a
+		// curated listing — a hand-picked Products block, a Product Collection with
+		// chosen products — has to be narrowed instead of excluded from, or it
+		// would keep showing what every other listing hides.
+		$included = array_filter( array_map( 'absint', (array) $query->get( 'post__in' ) ) );
+		if ( ! empty( $included ) ) {
+			$remaining = array_values( array_diff( $included, $hidden ) );
+			// An empty `post__in` reads as "no constraint" and would list the whole
+			// catalog. Post ID 0 exists for no post, so asking for it is how a
+			// listing whose every pick is hidden comes back empty.
+			// phpcs:ignore WordPressVIPMinimum.Hooks.PreGetPosts.PreGetPosts -- Deliberately covers secondary product listings too; see the doc block.
+			$query->set( 'post__in', empty( $remaining ) ? [ 0 ] : $remaining );
 			return;
 		}
 
@@ -347,11 +375,20 @@ class Product_Purchase_Restriction {
 	 * @return string The block content, with the notice appended when the reader can't purchase.
 	 */
 	public static function filter_add_to_cart_block( $block_content, $block, $instance = null ) {
-		// Only the single-product add-to-cart blocks. The product list's button is
-		// left alone: lists stay as WooCommerce renders them, exactly as for a
-		// product that's out of stock.
+		// Only the single-product add-to-cart blocks. WooCommerce's own lists use a
+		// different block (`woocommerce/product-button`), which is left alone so
+		// lists render exactly as they do for a product that's out of stock.
 		$add_to_cart_blocks = [ 'woocommerce/add-to-cart-form', 'woocommerce/add-to-cart-with-options' ];
 		if ( ! in_array( $block['blockName'] ?? '', $add_to_cart_blocks, true ) ) {
+			return $block_content;
+		}
+
+		// A product's own page, which is the whole surface the classic path covers
+		// too. Nothing stops a custom listing from putting one of those blocks on
+		// every card, and the notice would then repeat down the page; pinning both
+		// paths to the same surface keeps that out without resting on which block
+		// WooCommerce happens to use in its own list templates.
+		if ( ! is_singular( 'product' ) ) {
 			return $block_content;
 		}
 
@@ -406,12 +443,14 @@ class Product_Purchase_Restriction {
 		if ( isset( self::$rendered_notices[ $product_id ] ) ) {
 			return '';
 		}
-		self::$rendered_notices[ $product_id ] = true;
 
 		$message = self::get_restricted_message( $product );
 		if ( ! $message ) {
 			return '';
 		}
+		// Marked only once something is actually emitted, so a filter that blanks
+		// the message on one path doesn't suppress the other path's notice too.
+		self::$rendered_notices[ $product_id ] = true;
 
 		return sprintf(
 			'<div class="woocommerce-info newspack-subscriber-only-notice">%s</div>',
@@ -477,9 +516,13 @@ class Product_Purchase_Restriction {
 				if ( ! $subscription || ! self::can_purchase( $subscription ) ) {
 					continue;
 				}
+				// The product's own permalink, not the post's: a subscription
+				// variation can be named by a rule, and its post permalink points at
+				// a page nobody can buy from, where WC_Product_Variation resolves to
+				// the parent URL carrying the variation's attributes.
 				$links[ $subscription_id ] = sprintf(
 					'<a href="%s">%s</a>',
-					esc_url( (string) get_permalink( $subscription_id ) ),
+					esc_url( (string) $subscription->get_permalink() ),
 					esc_html( $subscription->get_name() )
 				);
 			}

--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-product-purchase-restriction.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-product-purchase-restriction.php
@@ -82,7 +82,7 @@ class Product_Purchase_Restriction {
 		// Priority 31: right after the add-to-cart form (30), where Memberships puts its own notice.
 		add_action( 'woocommerce_single_product_summary', [ __CLASS__, 'render_restricted_message' ], 31 );
 		// Block themes never fire the action above; the notice rides the add-to-cart block instead.
-		add_filter( 'render_block', [ __CLASS__, 'filter_add_to_cart_block' ], 10, 2 );
+		add_filter( 'render_block', [ __CLASS__, 'filter_add_to_cart_block' ], 10, 3 );
 		// Optional, off by default: keep restricted products out of product lists.
 		add_action( 'pre_get_posts', [ __CLASS__, 'filter_product_query' ] );
 	}
@@ -204,15 +204,17 @@ class Product_Purchase_Restriction {
 		if ( is_admin() || ! $query instanceof \WP_Query ) {
 			return;
 		}
+		// Cheapest test first: this fires on every front-end query, and the vast
+		// majority aren't about products at all. Only product listings qualify —
+		// a single product's own query must still find it.
+		if ( $query->is_singular() || ! self::is_product_query( $query ) ) {
+			return;
+		}
 		if ( ! Subscriber_Commerce::is_enforcement_active() ) {
 			return;
 		}
 		$settings = Subscriber_Only_Products::get_settings();
 		if ( empty( $settings['hide_from_product_lists'] ) ) {
-			return;
-		}
-		// Only product listings: a single product's own query must still find it.
-		if ( $query->is_singular() || ! self::is_product_query( $query ) ) {
 			return;
 		}
 
@@ -255,6 +257,12 @@ class Product_Purchase_Restriction {
 		if ( null !== self::$hidden_product_ids ) {
 			return self::$hidden_product_ids;
 		}
+		// Enumerating the covered products runs a product query, which fires
+		// `pre_get_posts` — straight back into the filter that called us. Publish
+		// the empty result first so that re-entry hides nothing and returns,
+		// instead of recursing until PHP dies.
+		self::$hidden_product_ids = [];
+
 		$hidden = [];
 		foreach ( self::covered_product_ids() as $product_id ) {
 			$product = wc_get_product( $product_id );
@@ -332,12 +340,13 @@ class Product_Purchase_Restriction {
 	 * so without this the purchase is blocked with no explanation — the reader
 	 * just finds the button missing.
 	 *
-	 * @param string $block_content The block's rendered content.
-	 * @param array  $block         The parsed block.
+	 * @param string    $block_content The block's rendered content.
+	 * @param array     $block         The parsed block.
+	 * @param \WP_Block $instance      The block instance, which carries the block context.
 	 *
 	 * @return string The block content, with the notice appended when the reader can't purchase.
 	 */
-	public static function filter_add_to_cart_block( $block_content, $block ) {
+	public static function filter_add_to_cart_block( $block_content, $block, $instance = null ) {
 		// Only the single-product add-to-cart blocks. The product list's button is
 		// left alone: lists stay as WooCommerce renders them, exactly as for a
 		// product that's out of stock.
@@ -346,7 +355,7 @@ class Product_Purchase_Restriction {
 			return $block_content;
 		}
 
-		$product = self::get_block_product( $block );
+		$product = self::get_block_product( $block, $instance );
 		if ( ! $product ) {
 			return $block_content;
 		}
@@ -357,12 +366,18 @@ class Product_Purchase_Restriction {
 	/**
 	 * Resolve the product a block is rendering for.
 	 *
-	 * @param array $block The parsed block.
+	 * Block context lives on the block instance, not on the parsed block array,
+	 * so a block rendering for a product other than the one in the loop is
+	 * resolved from its own context rather than from ambient loop state.
+	 *
+	 * @param array     $block    The parsed block.
+	 * @param \WP_Block $instance The block instance, if the filter supplied one.
 	 *
 	 * @return \WC_Product|null The product, or null if it can't be resolved.
 	 */
-	private static function get_block_product( $block ) {
-		$product_id = (int) ( $block['attrs']['productId'] ?? $block['context']['postId'] ?? get_the_ID() );
+	private static function get_block_product( $block, $instance = null ) {
+		$context_id = $instance instanceof \WP_Block ? ( $instance->context['postId'] ?? null ) : null;
+		$product_id = (int) ( $block['attrs']['productId'] ?? $context_id ?? get_the_ID() );
 		if ( ! $product_id || ! function_exists( 'wc_get_product' ) ) {
 			return null;
 		}

--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-product-purchase-restriction.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-product-purchase-restriction.php
@@ -1,0 +1,486 @@
+<?php
+/**
+ * Newspack Subscriber Commerce - product purchase restriction.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Enforces subscriber-only product restrictions.
+ *
+ * Only the purchase is blocked: the product page, its price and the product
+ * lists stay visible, and a notice on the product page tells the reader which
+ * subscriptions unlock it. This mirrors WooCommerce Memberships' product
+ * purchase restriction, which Access Control replaces.
+ *
+ * A reader may buy a restricted product if they subscribe to any subscription
+ * named by any restriction covering it — each restriction is an offer, not an
+ * additional hurdle. Publishers can also hide restricted products from product
+ * lists entirely, which goes beyond purchase restriction and is off by default.
+ */
+class Product_Purchase_Restriction {
+
+	/**
+	 * Whether the reader may purchase a product, keyed by "{product_id}_{user_id}".
+	 * WooCommerce asks several times per product per request (list loop, single
+	 * product template, cart validation), so the decision is memoized.
+	 *
+	 * @var array<string, bool>
+	 */
+	private static $purchase_verdicts = [];
+
+	/**
+	 * The active restrictions. Null until first read.
+	 *
+	 * @var array[]|null
+	 */
+	private static $rules = null;
+
+	/**
+	 * Products the notice has already been rendered for this request, so the
+	 * classic and block templates can't both emit it.
+	 *
+	 * @var array<int, bool>
+	 */
+	private static $rendered_notices = [];
+
+	/**
+	 * Products hidden from the current reader's product lists, or null before
+	 * they have been worked out. A page can run many product queries; the set
+	 * depends only on the rules and the reader, so it is computed once.
+	 *
+	 * @var int[]|null
+	 */
+	private static $hidden_product_ids = null;
+
+	/**
+	 * How many covered products the hiding pass will consider.
+	 *
+	 * Hiding has to name the products to exclude, so it enumerates what the
+	 * restrictions cover. That is bounded by what a publisher restricted rather
+	 * than by the catalog, and these are newsroom stores — books, tickets,
+	 * merchandise — so the ceiling is far above any real configuration. Past it
+	 * the excess stays listed (but still unpurchasable): over-listing is the
+	 * safe failure for an opt-in convenience, where a slow query is not.
+	 */
+	const MAX_HIDDEN_PRODUCTS = 500;
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		// Priority 999, as WooCommerce Memberships does: the restriction must have
+		// the final say, or a later callback (e.g. WooCommerce Subscriptions'
+		// renewal-cart limiter, which runs at 12 and returns true) hands the
+		// purchase back.
+		add_filter( 'woocommerce_is_purchasable', [ __CLASS__, 'filter_is_purchasable' ], 999, 2 );
+		add_filter( 'woocommerce_variation_is_purchasable', [ __CLASS__, 'filter_is_purchasable' ], 999, 2 );
+		// Priority 31: right after the add-to-cart form (30), where Memberships puts its own notice.
+		add_action( 'woocommerce_single_product_summary', [ __CLASS__, 'render_restricted_message' ], 31 );
+		// Block themes never fire the action above; the notice rides the add-to-cart block instead.
+		add_filter( 'render_block', [ __CLASS__, 'filter_add_to_cart_block' ], 10, 2 );
+		// Optional, off by default: keep restricted products out of product lists.
+		add_action( 'pre_get_posts', [ __CLASS__, 'filter_product_query' ] );
+	}
+
+	/**
+	 * Block purchasing of a restricted product for readers who don't subscribe.
+	 *
+	 * @param bool        $purchasable Whether the product is purchasable.
+	 * @param \WC_Product $product     The product (or variation).
+	 *
+	 * @return bool Whether the product is purchasable.
+	 */
+	public static function filter_is_purchasable( $purchasable, $product ) {
+		// Never make purchasable a product WooCommerce already ruled out.
+		if ( ! $purchasable ) {
+			return $purchasable;
+		}
+		return self::can_purchase( $product );
+	}
+
+	/**
+	 * Whether the reader may purchase a product.
+	 *
+	 * @param \WC_Product $product The product (or variation).
+	 * @param int|null    $user_id Optional user ID. Defaults to the current user.
+	 *
+	 * @return bool
+	 */
+	public static function can_purchase( $product, $user_id = null ) {
+		if ( ! Subscriber_Commerce::is_enforcement_active() || ! $product instanceof \WC_Product ) {
+			return true;
+		}
+		$product_id = (int) $product->get_id();
+		if ( ! $product_id ) {
+			return true;
+		}
+
+		$user_id   = null === $user_id ? get_current_user_id() : (int) $user_id;
+		$cache_key = $product_id . '_' . $user_id;
+		if ( ! isset( self::$purchase_verdicts[ $cache_key ] ) ) {
+			self::$purchase_verdicts[ $cache_key ] = self::evaluate_purchase( $product, $user_id );
+		}
+		return self::$purchase_verdicts[ $cache_key ];
+	}
+
+	/**
+	 * Work out whether a reader may purchase a product.
+	 *
+	 * @param \WC_Product $product The product (or variation).
+	 * @param int         $user_id The user ID (0 for anonymous readers).
+	 *
+	 * @return bool
+	 */
+	private static function evaluate_purchase( $product, $user_id ) {
+		$can_purchase = true;
+		$rules        = self::get_restricting_rules( $product );
+
+		if ( ! empty( $rules ) ) {
+			// Shop managers always keep purchasing rights, so a restriction can't
+			// lock a publisher out of their own products (Memberships parity).
+			if ( user_can( $user_id, 'manage_woocommerce' ) ) {
+				$can_purchase = true;
+			} else {
+				// Any restriction the reader satisfies unlocks the product: each
+				// rule names a way in, so more rules can only widen access.
+				$can_purchase = false;
+				foreach ( $rules as $rule ) {
+					if ( Subscriber_Eligibility::user_has( $user_id, $rule['subscription_product_ids'] ) ) {
+						$can_purchase = true;
+						break;
+					}
+				}
+			}
+		}
+
+		/**
+		 * Filters whether a reader may purchase a subscriber-only product.
+		 *
+		 * @param bool        $can_purchase Whether the reader may purchase it.
+		 * @param \WC_Product $product      The product (or variation).
+		 * @param int         $user_id      The user ID (0 for anonymous readers).
+		 * @param array[]     $rules        The restrictions covering the product.
+		 */
+		return (bool) apply_filters( 'newspack_subscriber_only_product_can_purchase', $can_purchase, $product, $user_id, $rules );
+	}
+
+	/**
+	 * Get the active restrictions covering a product.
+	 *
+	 * @param \WC_Product $product The product (or variation).
+	 *
+	 * @return array[] The restrictions.
+	 */
+	public static function get_restricting_rules( $product ) {
+		if ( null === self::$rules ) {
+			self::$rules = Subscriber_Only_Products::get_active_rules();
+		}
+		return Product_Targeting::get_matching_rules( self::$rules, $product );
+	}
+
+	/**
+	 * Keep restricted products out of product lists, when the publisher asked
+	 * for it.
+	 *
+	 * Goes beyond purchase restriction, so it is opt-in. Direct links still
+	 * work and show the product page with its notice — this only affects
+	 * listings, so a reader who has the URL is never left wondering where the
+	 * product went.
+	 *
+	 * Applies to every front-end product listing, not only the main query: a
+	 * "product list" here means any of them — the shop, a category archive, a
+	 * products block in a post — and hiding a product from one but not the next
+	 * would be incoherent. Singular queries are left alone so a direct link
+	 * still resolves.
+	 *
+	 * @param \WP_Query $query The query.
+	 */
+	public static function filter_product_query( $query ) {
+		if ( is_admin() || ! $query instanceof \WP_Query ) {
+			return;
+		}
+		if ( ! Subscriber_Commerce::is_enforcement_active() ) {
+			return;
+		}
+		$settings = Subscriber_Only_Products::get_settings();
+		if ( empty( $settings['hide_from_product_lists'] ) ) {
+			return;
+		}
+		// Only product listings: a single product's own query must still find it.
+		if ( $query->is_singular() || ! self::is_product_query( $query ) ) {
+			return;
+		}
+
+		$hidden = self::get_hidden_product_ids();
+		if ( empty( $hidden ) ) {
+			return;
+		}
+
+		$excluded = array_map( 'absint', (array) $query->get( 'post__not_in' ) );
+		// phpcs:ignore WordPressVIPMinimum.Hooks.PreGetPosts.PreGetPosts -- Deliberately covers secondary product listings too; see the doc block.
+		$query->set( 'post__not_in', array_values( array_unique( array_merge( $excluded, $hidden ) ) ) );
+	}
+
+	/**
+	 * Whether a query lists products.
+	 *
+	 * @param \WP_Query $query The query.
+	 *
+	 * @return bool
+	 */
+	private static function is_product_query( $query ) {
+		$post_types = (array) $query->get( 'post_type' );
+		if ( in_array( 'product', $post_types, true ) ) {
+			return true;
+		}
+		// The shop and product taxonomy archives don't set post_type explicitly.
+		return function_exists( 'is_shop' ) && ( $query->is_post_type_archive( 'product' ) || $query->is_tax( get_object_taxonomies( 'product' ) ) );
+	}
+
+	/**
+	 * Get the products the current reader may not purchase, for hiding.
+	 *
+	 * Only products covered by a restriction are considered, so the cost is
+	 * bounded by what the publisher actually restricted rather than by the
+	 * catalog size.
+	 *
+	 * @return int[] The product IDs to hide.
+	 */
+	private static function get_hidden_product_ids() {
+		if ( null !== self::$hidden_product_ids ) {
+			return self::$hidden_product_ids;
+		}
+		$hidden = [];
+		foreach ( self::covered_product_ids() as $product_id ) {
+			$product = wc_get_product( $product_id );
+			if ( $product instanceof \WC_Product && ! self::can_purchase( $product ) ) {
+				$hidden[] = (int) $product_id;
+			}
+		}
+		self::$hidden_product_ids = $hidden;
+		return self::$hidden_product_ids;
+	}
+
+	/**
+	 * Get the IDs of every product covered by an active restriction.
+	 *
+	 * @return int[] The product IDs.
+	 */
+	private static function covered_product_ids() {
+		$rules = Subscriber_Only_Products::get_active_rules();
+		if ( empty( $rules ) ) {
+			return [];
+		}
+
+		$named       = [];
+		$category_ids = [];
+		$covers_all  = false;
+		foreach ( $rules as $rule ) {
+			if ( Product_Targeting::TARGETING_ALL === $rule['targeting'] ) {
+				$covers_all = true;
+			} elseif ( Product_Targeting::TARGETING_CATEGORY === $rule['targeting'] ) {
+				$category_ids = array_merge( $category_ids, Product_Targeting::expand_category_ids( $rule['category_ids'] ) );
+			} else {
+				$named = array_merge( $named, $rule['product_ids'] );
+			}
+		}
+
+		$args = [
+			'post_type'      => 'product',
+			'post_status'    => 'publish',
+			// phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page -- Bounded by what the publisher restricted, not by the catalog; see MAX_HIDDEN_PRODUCTS.
+			'posts_per_page' => self::MAX_HIDDEN_PRODUCTS,
+			'fields'         => 'ids',
+			'no_found_rows'  => true,
+		];
+		if ( ! $covers_all ) {
+			if ( empty( $category_ids ) ) {
+				return array_values( array_unique( array_map( 'absint', $named ) ) );
+			}
+			$args['tax_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+				[
+					'taxonomy'         => Product_Targeting::PRODUCT_CATEGORY_TAXONOMY,
+					'terms'            => array_unique( $category_ids ),
+					'include_children' => false, // Already expanded.
+				],
+			];
+		}
+
+		$ids = get_posts( $args );
+		return array_values( array_unique( array_merge( array_map( 'absint', $named ), array_map( 'absint', $ids ) ) ) );
+	}
+
+	/**
+	 * Render the notice on a classic product template.
+	 */
+	public static function render_restricted_message() {
+		global $product;
+
+		echo wp_kses_post( self::get_restricted_message_html( $product ) );
+	}
+
+	/**
+	 * Render the notice on a block-theme product template, where
+	 * `woocommerce_single_product_summary` never fires.
+	 *
+	 * The add-to-cart block renders nothing for a product the reader can't buy,
+	 * so without this the purchase is blocked with no explanation — the reader
+	 * just finds the button missing.
+	 *
+	 * @param string $block_content The block's rendered content.
+	 * @param array  $block         The parsed block.
+	 *
+	 * @return string The block content, with the notice appended when the reader can't purchase.
+	 */
+	public static function filter_add_to_cart_block( $block_content, $block ) {
+		// Only the single-product add-to-cart blocks. The product list's button is
+		// left alone: lists stay as WooCommerce renders them, exactly as for a
+		// product that's out of stock.
+		$add_to_cart_blocks = [ 'woocommerce/add-to-cart-form', 'woocommerce/add-to-cart-with-options' ];
+		if ( ! in_array( $block['blockName'] ?? '', $add_to_cart_blocks, true ) ) {
+			return $block_content;
+		}
+
+		$product = self::get_block_product( $block );
+		if ( ! $product ) {
+			return $block_content;
+		}
+
+		return $block_content . self::get_restricted_message_html( $product );
+	}
+
+	/**
+	 * Resolve the product a block is rendering for.
+	 *
+	 * @param array $block The parsed block.
+	 *
+	 * @return \WC_Product|null The product, or null if it can't be resolved.
+	 */
+	private static function get_block_product( $block ) {
+		$product_id = (int) ( $block['attrs']['productId'] ?? $block['context']['postId'] ?? get_the_ID() );
+		if ( ! $product_id || ! function_exists( 'wc_get_product' ) ) {
+			return null;
+		}
+		$product = wc_get_product( $product_id );
+		return $product instanceof \WC_Product ? $product : null;
+	}
+
+	/**
+	 * Build the notice markup for a product the reader can't purchase.
+	 *
+	 * Returns an empty string when the product is purchasable, so both the
+	 * classic and block templates can call it unconditionally. The notice is
+	 * emitted once per product per request, so a template running both paths
+	 * can't double it up.
+	 *
+	 * @param \WC_Product|null $product The product.
+	 *
+	 * @return string The notice HTML, escaped, or an empty string.
+	 */
+	private static function get_restricted_message_html( $product ): string {
+		if ( ! $product instanceof \WC_Product || self::can_purchase( $product ) ) {
+			return '';
+		}
+
+		$product_id = (int) $product->get_id();
+		if ( isset( self::$rendered_notices[ $product_id ] ) ) {
+			return '';
+		}
+		self::$rendered_notices[ $product_id ] = true;
+
+		$message = self::get_restricted_message( $product );
+		if ( ! $message ) {
+			return '';
+		}
+
+		return sprintf(
+			'<div class="woocommerce-info newspack-subscriber-only-notice">%s</div>',
+			wp_kses_post( $message )
+		);
+	}
+
+	/**
+	 * Build the message shown to a reader who can't purchase a product.
+	 *
+	 * @param \WC_Product $product The product.
+	 *
+	 * @return string The message. May contain links, so it is escaped with wp_kses_post() on output.
+	 */
+	public static function get_restricted_message( $product ) {
+		$links = self::get_subscription_links( $product );
+
+		if ( empty( $links ) ) {
+			$message = __( 'This product is available to subscribers.', 'newspack-plugin' );
+		} else {
+			$message = sprintf(
+				/* translators: %s: list of linked subscription names. */
+				__( 'This product is available to subscribers. To purchase it, subscribe to %s.', 'newspack-plugin' ),
+				// wp_sprintf( '%l' ) builds the list with the locale's separators ("A, B and C").
+				wp_sprintf( '%l', $links )
+			);
+		}
+
+		/**
+		 * Filters the notice shown to a reader who can't purchase a subscriber-only product.
+		 *
+		 * @param string      $message The message. Rendered through wp_kses_post().
+		 * @param \WC_Product $product The product.
+		 */
+		return apply_filters( 'newspack_subscriber_only_product_message', $message, $product );
+	}
+
+	/**
+	 * Get links to the subscriptions that unlock a product, so the reader knows
+	 * what to buy.
+	 *
+	 * A subscription the reader can't buy either — because a restriction covers
+	 * it too — is left out rather than pointed at, so the notice never sends
+	 * someone to a product they've just been barred from purchasing.
+	 *
+	 * @param \WC_Product $product The product.
+	 *
+	 * @return string[] The links, keyed by subscription product ID.
+	 */
+	private static function get_subscription_links( $product ) {
+		if ( ! function_exists( 'wc_get_product' ) ) {
+			return [];
+		}
+
+		$links = [];
+		foreach ( self::get_restricting_rules( $product ) as $rule ) {
+			foreach ( $rule['subscription_product_ids'] as $subscription_id ) {
+				$subscription_id = (int) $subscription_id;
+				if ( isset( $links[ $subscription_id ] ) ) {
+					continue;
+				}
+				$subscription = wc_get_product( $subscription_id );
+				if ( ! $subscription || ! self::can_purchase( $subscription ) ) {
+					continue;
+				}
+				$links[ $subscription_id ] = sprintf(
+					'<a href="%s">%s</a>',
+					esc_url( (string) get_permalink( $subscription_id ) ),
+					esc_html( $subscription->get_name() )
+				);
+			}
+		}
+		return $links;
+	}
+
+	/**
+	 * Flush the per-request caches. For tests and for callers that change the
+	 * rules mid-request.
+	 */
+	public static function flush_cache() {
+		self::$purchase_verdicts  = [];
+		self::$rules              = null;
+		self::$rendered_notices   = [];
+		self::$hidden_product_ids = null;
+	}
+}
+Product_Purchase_Restriction::init();

--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-only-products-api.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-only-products-api.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Newspack Subscriber Commerce - subscriber-only products REST API.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST routes and wizard-tab registration for subscriber-only products.
+ *
+ * Reachable whenever the admin is available, not only when enforcement is
+ * live: a site migrating off WooCommerce Memberships authors its restrictions
+ * first and deactivates Memberships afterwards.
+ */
+class Subscriber_Only_Products_API {
+
+	/**
+	 * The wizard tab slug. Matches the front-end registration.
+	 */
+	const TAB_SLUG = 'subscriber-only';
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( 'rest_api_init', [ __CLASS__, 'register_routes' ] );
+		add_action( 'init', [ __CLASS__, 'register_tab' ] );
+	}
+
+	/**
+	 * Register the wizard tab.
+	 */
+	public static function register_tab() {
+		if ( ! Subscriber_Commerce::is_admin_available() ) {
+			return;
+		}
+		Audience_Subscriptions::register_tab(
+			self::TAB_SLUG,
+			[
+				'label' => __( 'Subscriber-only products', 'newspack-plugin' ),
+				'path'  => '/' . self::TAB_SLUG,
+				// Last of the subscriber-commerce tabs, per the design's tab order.
+				'order' => 30,
+			]
+		);
+	}
+
+	/**
+	 * Whether the current user may manage restrictions.
+	 *
+	 * @return bool
+	 */
+	public static function permissions_check() {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Register the REST routes.
+	 */
+	public static function register_routes() {
+		if ( ! Subscriber_Commerce::is_admin_available() ) {
+			return;
+		}
+
+		$namespace = NEWSPACK_API_NAMESPACE;
+		$base      = '/wizard/newspack-audience-subscriptions/restrictions';
+
+		register_rest_route(
+			$namespace,
+			$base,
+			[
+				[
+					'methods'             => 'GET',
+					'callback'            => [ __CLASS__, 'api_get_rules' ],
+					'permission_callback' => [ __CLASS__, 'permissions_check' ],
+				],
+				[
+					'methods'             => 'POST',
+					'callback'            => [ __CLASS__, 'api_save_rule' ],
+					'permission_callback' => [ __CLASS__, 'permissions_check' ],
+					'args'                => self::get_rule_args(),
+				],
+			]
+		);
+
+		register_rest_route(
+			$namespace,
+			$base . '/(?P<id>[a-zA-Z0-9\-]+)',
+			[
+				[
+					'methods'             => 'POST',
+					'callback'            => [ __CLASS__, 'api_save_rule' ],
+					'permission_callback' => [ __CLASS__, 'permissions_check' ],
+					'args'                => self::get_rule_args(),
+				],
+				[
+					'methods'             => 'DELETE',
+					'callback'            => [ __CLASS__, 'api_delete_rule' ],
+					'permission_callback' => [ __CLASS__, 'permissions_check' ],
+				],
+			]
+		);
+
+		register_rest_route(
+			$namespace,
+			'/wizard/newspack-audience-subscriptions/restriction-settings',
+			[
+				'methods'             => 'POST',
+				'callback'            => [ __CLASS__, 'api_update_settings' ],
+				'permission_callback' => [ __CLASS__, 'permissions_check' ],
+				'args'                => [
+					'hide_from_product_lists' => [
+						'type'    => 'boolean',
+						'default' => false,
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * REST argument schema for a restriction.
+	 *
+	 * @return array
+	 */
+	private static function get_rule_args() {
+		$id_list = [
+			'type'    => 'array',
+			'items'   => [ 'type' => 'integer' ],
+			'default' => [],
+		];
+		return [
+			'subscription_product_ids' => $id_list,
+			'product_ids'              => $id_list,
+			'category_ids'             => $id_list,
+			'excluded_product_ids'     => $id_list,
+			'targeting'                => [
+				'type'    => 'string',
+				'enum'    => [ Product_Targeting::TARGETING_PRODUCTS, Product_Targeting::TARGETING_CATEGORY, Product_Targeting::TARGETING_ALL ],
+				'default' => Product_Targeting::TARGETING_PRODUCTS,
+			],
+			'active'                   => [
+				'type'    => 'boolean',
+				'default' => true,
+			],
+		];
+	}
+
+	/**
+	 * Get every restriction plus the feature's settings.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function api_get_rules() {
+		return rest_ensure_response(
+			[
+				'restrictions' => Subscriber_Only_Products::get_rules(),
+				'settings'     => Subscriber_Only_Products::get_settings(),
+			]
+		);
+	}
+
+	/**
+	 * Create or update a restriction.
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public static function api_save_rule( $request ) {
+		$id = $request->get_param( 'id' );
+		if ( $id && ! Subscriber_Only_Products::get_rule( $id ) ) {
+			return new \WP_Error( 'newspack_restriction_not_found', __( 'Restriction not found.', 'newspack-plugin' ), [ 'status' => 404 ] );
+		}
+
+		$rule = [
+			'id'                       => $id,
+			'subscription_product_ids' => $request->get_param( 'subscription_product_ids' ),
+			'targeting'                => $request->get_param( 'targeting' ),
+			'product_ids'              => $request->get_param( 'product_ids' ),
+			'category_ids'             => $request->get_param( 'category_ids' ),
+			'excluded_product_ids'     => $request->get_param( 'excluded_product_ids' ),
+			'active'                   => $request->get_param( 'active' ),
+		];
+
+		Subscriber_Only_Products::save_rule( $rule );
+		return self::api_get_rules();
+	}
+
+	/**
+	 * Delete a restriction.
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public static function api_delete_rule( $request ) {
+		if ( ! Subscriber_Only_Products::delete_rule( $request->get_param( 'id' ) ) ) {
+			return new \WP_Error( 'newspack_restriction_not_found', __( 'Restriction not found.', 'newspack-plugin' ), [ 'status' => 404 ] );
+		}
+		return self::api_get_rules();
+	}
+
+	/**
+	 * Update the feature's settings.
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function api_update_settings( $request ) {
+		Subscriber_Only_Products::update_settings( [ 'hide_from_product_lists' => $request->get_param( 'hide_from_product_lists' ) ] );
+		return self::api_get_rules();
+	}
+}
+Subscriber_Only_Products_API::init();

--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-only-products-api.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-only-products-api.php
@@ -143,9 +143,11 @@ class Subscriber_Only_Products_API {
 				'enum'    => [ Product_Targeting::TARGETING_PRODUCTS, Product_Targeting::TARGETING_CATEGORY, Product_Targeting::TARGETING_ALL ],
 				'default' => Product_Targeting::TARGETING_PRODUCTS,
 			],
+			// Deliberately undefaulted, so an absent `active` reaches
+			// sanitize_base_rule() as absent and lands on its fail-safe: a partial
+			// payload leaves the rule paused rather than silently gating purchases.
 			'active'                   => [
-				'type'    => 'boolean',
-				'default' => true,
+				'type' => 'boolean',
 			],
 		];
 	}

--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-only-products-api.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-only-products-api.php
@@ -74,12 +74,12 @@ class Subscriber_Only_Products_API {
 			$base,
 			[
 				[
-					'methods'             => 'GET',
+					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => [ __CLASS__, 'api_get_rules' ],
 					'permission_callback' => [ __CLASS__, 'permissions_check' ],
 				],
 				[
-					'methods'             => 'POST',
+					'methods'             => \WP_REST_Server::EDITABLE,
 					'callback'            => [ __CLASS__, 'api_save_rule' ],
 					'permission_callback' => [ __CLASS__, 'permissions_check' ],
 					'args'                => self::get_rule_args(),
@@ -92,13 +92,13 @@ class Subscriber_Only_Products_API {
 			$base . '/(?P<id>[a-zA-Z0-9\-]+)',
 			[
 				[
-					'methods'             => 'POST',
+					'methods'             => \WP_REST_Server::EDITABLE,
 					'callback'            => [ __CLASS__, 'api_save_rule' ],
 					'permission_callback' => [ __CLASS__, 'permissions_check' ],
 					'args'                => self::get_rule_args(),
 				],
 				[
-					'methods'             => 'DELETE',
+					'methods'             => \WP_REST_Server::DELETABLE,
 					'callback'            => [ __CLASS__, 'api_delete_rule' ],
 					'permission_callback' => [ __CLASS__, 'permissions_check' ],
 				],
@@ -109,7 +109,7 @@ class Subscriber_Only_Products_API {
 			$namespace,
 			'/wizard/newspack-audience-subscriptions/restriction-settings',
 			[
-				'methods'             => 'POST',
+				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ __CLASS__, 'api_update_settings' ],
 				'permission_callback' => [ __CLASS__, 'permissions_check' ],
 				'args'                => [

--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-only-products.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-only-products.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Newspack Subscriber Commerce - subscriber-only products.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Storage for subscriber-only product restrictions.
+ *
+ * A restriction says "these store products are purchasable only by subscribers
+ * of any of these subscriptions". Readers still see the product and its price;
+ * only the purchase is blocked. This replaces WooCommerce Memberships' product
+ * purchase restriction.
+ *
+ * Rules are a handful per site with no per-rule content, so they live in a
+ * single option rather than a post type: one read, no meta queries.
+ */
+class Subscriber_Only_Products {
+
+	/**
+	 * Option holding the restrictions.
+	 */
+	const OPTION_NAME = 'newspack_subscriber_product_restrictions';
+
+	/**
+	 * Option holding the feature's settings.
+	 */
+	const SETTINGS_OPTION_NAME = 'newspack_subscriber_product_restrictions_settings';
+
+	/**
+	 * Get every restriction, newest first.
+	 *
+	 * @return array[] The restrictions.
+	 */
+	public static function get_rules() {
+		$rules = get_option( self::OPTION_NAME, [] );
+		if ( ! is_array( $rules ) ) {
+			return [];
+		}
+		return array_values( array_filter( $rules, 'is_array' ) );
+	}
+
+	/**
+	 * Get the restrictions that are enforced right now.
+	 *
+	 * A restriction naming no subscription names no way in, which would make
+	 * its products unbuyable by everyone. That is far more likely to be a
+	 * half-finished rule than an intent to withdraw the products from sale, so
+	 * it is skipped — the same fail-open reading the content gate takes.
+	 *
+	 * @return array[] The active, enforceable restrictions.
+	 */
+	public static function get_active_rules() {
+		return array_values(
+			array_filter(
+				self::get_rules(),
+				function ( $rule ) {
+					return ! empty( $rule['active'] ) && ! empty( $rule['subscription_product_ids'] );
+				}
+			)
+		);
+	}
+
+	/**
+	 * Get a restriction by ID.
+	 *
+	 * @param string $id The rule ID.
+	 *
+	 * @return array|null The rule, or null if there is none.
+	 */
+	public static function get_rule( $id ) {
+		foreach ( self::get_rules() as $rule ) {
+			if ( $rule['id'] === $id ) {
+				return $rule;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Create or update a restriction.
+	 *
+	 * @param array $rule The rule. Without an ID, a new one is created.
+	 *
+	 * @return array The saved rule.
+	 */
+	public static function save_rule( $rule ) {
+		$sanitized = Subscriber_Commerce::sanitize_base_rule( $rule );
+		if ( empty( $sanitized['id'] ) ) {
+			$sanitized['id'] = Subscriber_Commerce::generate_rule_id();
+		}
+
+		$rules   = self::get_rules();
+		$updated = false;
+		foreach ( $rules as $index => $existing ) {
+			if ( $existing['id'] === $sanitized['id'] ) {
+				// Keep the original creation date: saving a rule doesn't re-create it.
+				$sanitized['created_at'] = $existing['created_at'] ?? $sanitized['created_at'];
+				$rules[ $index ]         = $sanitized;
+				$updated                 = true;
+				break;
+			}
+		}
+		if ( ! $updated ) {
+			array_unshift( $rules, $sanitized );
+		}
+
+		self::update_rules( $rules );
+		return $sanitized;
+	}
+
+	/**
+	 * Delete a restriction.
+	 *
+	 * @param string $id The rule ID.
+	 *
+	 * @return bool Whether a rule was deleted.
+	 */
+	public static function delete_rule( $id ) {
+		$rules     = self::get_rules();
+		$remaining = array_values(
+			array_filter(
+				$rules,
+				function ( $rule ) use ( $id ) {
+					return $rule['id'] !== $id;
+				}
+			)
+		);
+		if ( count( $remaining ) === count( $rules ) ) {
+			return false;
+		}
+		self::update_rules( $remaining );
+		return true;
+	}
+
+	/**
+	 * Persist the rules and drop the caches keyed on them.
+	 *
+	 * @param array[] $rules The rules.
+	 */
+	private static function update_rules( $rules ) {
+		update_option( self::OPTION_NAME, $rules );
+		Product_Targeting::flush_cache();
+		Product_Purchase_Restriction::flush_cache();
+	}
+
+	/**
+	 * Get the feature's settings.
+	 *
+	 * @return array The settings.
+	 */
+	public static function get_settings() {
+		$settings = get_option( self::SETTINGS_OPTION_NAME, [] );
+		return [
+			// Off by default: the parity feature blocks purchasing, and hiding a
+			// product goes further than that. A publisher opts in.
+			'hide_from_product_lists' => ! empty( $settings['hide_from_product_lists'] ),
+		];
+	}
+
+	/**
+	 * Update the feature's settings.
+	 *
+	 * @param array $settings The settings.
+	 *
+	 * @return array The saved settings.
+	 */
+	public static function update_settings( $settings ) {
+		$sanitized = [ 'hide_from_product_lists' => ! empty( $settings['hide_from_product_lists'] ) ];
+		update_option( self::SETTINGS_OPTION_NAME, $sanitized );
+		return $sanitized;
+	}
+}

--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-only-products.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-only-products.php
@@ -37,12 +37,21 @@ class Subscriber_Only_Products {
 	 *
 	 * @return array[] The restrictions.
 	 */
-	public static function get_rules() {
+	public static function get_rules(): array {
 		$rules = get_option( self::OPTION_NAME, [] );
 		if ( ! is_array( $rules ) ) {
 			return [];
 		}
-		return array_values( array_filter( $rules, 'is_array' ) );
+		// Rows without an ID can't be matched, updated or deleted, so they're
+		// dropped at the boundary rather than warning on every front-end request.
+		return array_values(
+			array_filter(
+				$rules,
+				function ( $rule ) {
+					return is_array( $rule ) && ! empty( $rule['id'] );
+				}
+			)
+		);
 	}
 
 	/**
@@ -55,7 +64,7 @@ class Subscriber_Only_Products {
 	 *
 	 * @return array[] The active, enforceable restrictions.
 	 */
-	public static function get_active_rules() {
+	public static function get_active_rules(): array {
 		return array_values(
 			array_filter(
 				self::get_rules(),
@@ -89,7 +98,7 @@ class Subscriber_Only_Products {
 	 *
 	 * @return array The saved rule.
 	 */
-	public static function save_rule( $rule ) {
+	public static function save_rule( array $rule ): array {
 		$sanitized = Subscriber_Commerce::sanitize_base_rule( $rule );
 		if ( empty( $sanitized['id'] ) ) {
 			$sanitized['id'] = Subscriber_Commerce::generate_rule_id();
@@ -121,7 +130,7 @@ class Subscriber_Only_Products {
 	 *
 	 * @return bool Whether a rule was deleted.
 	 */
-	public static function delete_rule( $id ) {
+	public static function delete_rule( $id ): bool {
 		$rules     = self::get_rules();
 		$remaining = array_values(
 			array_filter(
@@ -143,7 +152,7 @@ class Subscriber_Only_Products {
 	 *
 	 * @param array[] $rules The rules.
 	 */
-	private static function update_rules( $rules ) {
+	private static function update_rules( array $rules ): void {
 		update_option( self::OPTION_NAME, $rules );
 		Product_Targeting::flush_cache();
 		Product_Purchase_Restriction::flush_cache();
@@ -154,7 +163,7 @@ class Subscriber_Only_Products {
 	 *
 	 * @return array The settings.
 	 */
-	public static function get_settings() {
+	public static function get_settings(): array {
 		$settings = get_option( self::SETTINGS_OPTION_NAME, [] );
 		return [
 			// Off by default: the parity feature blocks purchasing, and hiding a
@@ -170,9 +179,12 @@ class Subscriber_Only_Products {
 	 *
 	 * @return array The saved settings.
 	 */
-	public static function update_settings( $settings ) {
+	public static function update_settings( array $settings ): array {
 		$sanitized = [ 'hide_from_product_lists' => ! empty( $settings['hide_from_product_lists'] ) ];
 		update_option( self::SETTINGS_OPTION_NAME, $sanitized );
+		// The hiding pass is memoized per request, so a settings change has to drop
+		// it for the same reason a rule change does.
+		Product_Purchase_Restriction::flush_cache();
 		return $sanitized;
 	}
 }

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/index.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/index.ts
@@ -7,5 +7,6 @@
 
 // Feature tab registrations.
 import './configuration';
+import './subscriber-only';
 
 export { getTab, registerTab } from './registry';

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/index.tsx
@@ -1,0 +1,313 @@
+/**
+ * The Subscriptions wizard's Subscriber-only products tab.
+ *
+ * Lists the restrictions that make products purchasable only by subscribers,
+ * and hosts the editor, the settings and the empty state.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { useMemo, useState } from '@wordpress/element';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+import { __experimentalHStack as HStack, CheckboxControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies.
+ */
+import { Badge, Button, DataViews, Modal, Notice, SectionHeader, Waiting } from '../../../../../../../packages/components/src';
+import type { Action, Field, View } from '../../../../../../../packages/components/src/dataviews';
+import WizardsTab from '../../../../../wizards-tab';
+import WizardSection from '../../../../../wizards-section';
+import { registerTab } from '../registry';
+import { SEARCH_ENDPOINTS } from '../../constants';
+import { useRestrictions } from './use-restrictions';
+import { useNames } from './use-names';
+import { excludedLabel, leadingProductNames, moreProductsLabel, scopeLabel } from './labels';
+import RestrictionEditor from './restriction-editor';
+import type { Restriction, RestrictionSettings } from './types';
+import './style.scss';
+
+const DEFAULT_VIEW = {
+	type: 'table' as const,
+	page: 1,
+	perPage: 20,
+	sort: { field: 'created_at', direction: 'desc' as const },
+	search: '',
+	fields: [ 'availableTo', 'status', 'created_at' ],
+	filters: [],
+	layout: {},
+	titleField: 'products',
+};
+
+function SubscriberOnlyProducts() {
+	const { restrictions, settings, loading, saving, error, saveRestriction, deleteRestriction, setActive, saveSettings } = useRestrictions();
+	const [ editing, setEditing ] = useState< Partial< Restriction > | null >( null );
+	const [ deleting, setDeleting ] = useState< Restriction | null >( null );
+	const [ settingsOpen, setSettingsOpen ] = useState( false );
+	const [ view, setView ] = useState( DEFAULT_VIEW );
+
+	// Resolve the IDs the rules store into names for the list.
+	const productIds = useMemo( () => restrictions.flatMap( rule => rule.product_ids || [] ), [ restrictions ] );
+	const categoryIds = useMemo( () => restrictions.flatMap( rule => rule.category_ids || [] ), [ restrictions ] );
+	const subscriptionIds = useMemo( () => restrictions.flatMap( rule => rule.subscription_product_ids || [] ), [ restrictions ] );
+	const productNames = useNames( SEARCH_ENDPOINTS.products, productIds );
+	const categoryNames = useNames( SEARCH_ENDPOINTS.productCategories, categoryIds );
+	const subscriptionNames = useNames( SEARCH_ENDPOINTS.subscriptions, subscriptionIds );
+
+	const fields: Field< Restriction >[] = useMemo(
+		() => [
+			{
+				id: 'products',
+				label: __( 'Products', 'newspack-plugin' ),
+				enableGlobalSearch: true,
+				enableSorting: false,
+				getValue: ( { item }: { item: Restriction } ) =>
+					'products' === item.targeting
+						? ( item.product_ids || [] ).map( id => productNames[ id ] || '' ).join( ' ' )
+						: scopeLabel( item, id => categoryNames[ id ] ),
+				render: ( { item }: { item: Restriction } ) => {
+					const excluded = excludedLabel( item );
+					if ( 'products' !== item.targeting ) {
+						return (
+							<div>
+								<div>{ scopeLabel( item, id => categoryNames[ id ] ) }</div>
+								{ excluded && <div className="newspack-subscriber-only__muted">{ excluded }</div> }
+							</div>
+						);
+					}
+					const { shown, remaining } = leadingProductNames( item, id => productNames[ id ] );
+					return (
+						<div>
+							{ shown.length ? (
+								shown.map( name => <div key={ name }>{ name }</div> )
+							) : (
+								<div className="newspack-subscriber-only__muted">{ __( 'No products', 'newspack-plugin' ) }</div>
+							) }
+							{ remaining > 0 && <div className="newspack-subscriber-only__muted">{ moreProductsLabel( remaining ) }</div> }
+						</div>
+					);
+				},
+			},
+			{
+				id: 'availableTo',
+				label: __( 'Available to', 'newspack-plugin' ),
+				enableSorting: false,
+				getValue: ( { item }: { item: Restriction } ) =>
+					( item.subscription_product_ids || [] ).map( id => subscriptionNames[ id ] || '' ).join( ', ' ),
+				render: ( { item }: { item: Restriction } ) => {
+					const names = ( item.subscription_product_ids || [] ).map( id => subscriptionNames[ id ] ).filter( Boolean );
+					return <span>{ names.length ? names.join( ', ' ) : __( 'No subscriptions', 'newspack-plugin' ) }</span>;
+				},
+			},
+			{
+				id: 'status',
+				label: __( 'Status', 'newspack-plugin' ),
+				elements: [
+					{ value: 'active', label: __( 'Active', 'newspack-plugin' ) },
+					{ value: 'paused', label: __( 'Paused', 'newspack-plugin' ) },
+				],
+				filterBy: { operators: [ 'isAny' as const ] },
+				getValue: ( { item }: { item: Restriction } ) => ( item.active ? 'active' : 'paused' ),
+				render: ( { item }: { item: Restriction } ) =>
+					item.active ? (
+						<Badge level="success" text={ __( 'Active', 'newspack-plugin' ) } />
+					) : (
+						<Badge level="warning" text={ __( 'Paused', 'newspack-plugin' ) } />
+					),
+			},
+			{
+				id: 'created_at',
+				label: __( 'Created', 'newspack-plugin' ),
+				getValue: ( { item }: { item: Restriction } ) => item.created_at,
+				enableSorting: true,
+			},
+		],
+		[ productNames, categoryNames, subscriptionNames ]
+	);
+
+	const actions: Action< Restriction >[] = useMemo(
+		() => [
+			{
+				id: 'edit',
+				label: __( 'Edit', 'newspack-plugin' ),
+				isPrimary: true,
+				callback: ( items: Restriction[] ) => setEditing( items[ 0 ] ),
+			},
+			{
+				id: 'toggle',
+				label: ( items: Restriction[] ) => ( items[ 0 ]?.active ? __( 'Pause', 'newspack-plugin' ) : __( 'Resume', 'newspack-plugin' ) ),
+				callback: ( items: Restriction[] ) => setActive( items[ 0 ], ! items[ 0 ].active ),
+			},
+			{
+				id: 'delete',
+				label: __( 'Delete', 'newspack-plugin' ),
+				isDestructive: true,
+				callback: ( items: Restriction[] ) => setDeleting( items[ 0 ] ),
+			},
+		],
+		[ setActive ]
+	);
+
+	const { data: processedData, paginationInfo } = useMemo(
+		() => filterSortAndPaginate( restrictions, view, fields ),
+		[ restrictions, view, fields ]
+	);
+
+	const total = paginationInfo?.totalItems ?? 0;
+
+	const handleSave = ( rule: Partial< Restriction > ) => {
+		saveRestriction( rule ).then( ( ok: boolean ) => {
+			if ( ok ) {
+				setEditing( null );
+			}
+		} );
+	};
+
+	const handleDelete = () => {
+		if ( ! deleting ) {
+			return;
+		}
+		deleteRestriction( deleting.id ).then( ( ok: boolean ) => {
+			if ( ok ) {
+				setDeleting( null );
+			}
+		} );
+	};
+
+	return (
+		<WizardsTab
+			title={
+				restrictions.length
+					? sprintf(
+							/* translators: %d: number of restrictions. */
+							_n( 'Subscriber-only products (%d)', 'Subscriber-only products (%d)', total, 'newspack-plugin' ),
+							total
+					  )
+					: __( 'Subscriber-only products', 'newspack-plugin' )
+			}
+		>
+			<WizardSection>
+				{ error && <Notice isError noticeText={ error } /> }
+				{ loading ? (
+					<Waiting />
+				) : (
+					<>
+						{ restrictions.length ? (
+							<>
+								<HStack justify="flex-end" spacing={ 2 }>
+									<Button variant="secondary" onClick={ () => setSettingsOpen( true ) }>
+										{ __( 'Settings', 'newspack-plugin' ) }
+									</Button>
+									<Button variant="primary" onClick={ () => setEditing( {} ) }>
+										{ __( 'Add restriction', 'newspack-plugin' ) }
+									</Button>
+								</HStack>
+								{ /* The DataViews wrapper isn't generic — its props resolve to
+								     `unknown`, so the typed definitions above are cast at the
+								     boundary rather than being written untyped. */ }
+								<DataViews
+									data={ processedData }
+									fields={ fields as unknown as Field< unknown >[] }
+									view={ view as View }
+									onChangeView={ nextView => setView( nextView as typeof view ) }
+									actions={ actions as unknown as Action< unknown >[] }
+									paginationInfo={ paginationInfo }
+									getItemId={ ( item: unknown ) => ( item as Restriction ).id }
+									defaultLayouts={ { table: {} } }
+									isLoading={ saving }
+								/>
+							</>
+						) : (
+							<SectionHeader
+								title={ __( 'Get started with subscriber-only products', 'newspack-plugin' ) }
+								description={ __(
+									'Make selected products purchasable only by subscribers. Readers still see the product and its price — only the purchase is blocked.',
+									'newspack-plugin'
+								) }
+								noMargin
+							>
+								<Button variant="primary" onClick={ () => setEditing( {} ) }>
+									{ __( 'Add restriction', 'newspack-plugin' ) }
+								</Button>
+							</SectionHeader>
+						) }
+					</>
+				) }
+			</WizardSection>
+
+			{ editing && <RestrictionEditor restriction={ editing } saving={ saving } onSave={ handleSave } onClose={ () => setEditing( null ) } /> }
+
+			{ deleting && (
+				<Modal title={ __( 'Delete restriction?', 'newspack-plugin' ) } onRequestClose={ () => setDeleting( null ) }>
+					<p>
+						{ __(
+							'The products it covers become purchasable by everyone. To keep the restriction but stop enforcing it, pause it instead.',
+							'newspack-plugin'
+						) }
+					</p>
+					<HStack justify="flex-end" spacing={ 2 }>
+						<Button variant="secondary" onClick={ () => setDeleting( null ) } disabled={ saving }>
+							{ __( 'Cancel', 'newspack-plugin' ) }
+						</Button>
+						<Button variant="primary" isDestructive onClick={ handleDelete } disabled={ saving }>
+							{ __( 'Delete', 'newspack-plugin' ) }
+						</Button>
+					</HStack>
+				</Modal>
+			) }
+
+			{ settingsOpen && (
+				<SettingsModal settings={ settings } saving={ saving } onSave={ saveSettings } onClose={ () => setSettingsOpen( false ) } />
+			) }
+		</WizardsTab>
+	);
+}
+
+interface SettingsModalProps {
+	settings: RestrictionSettings;
+	saving: boolean;
+	onSave: ( settings: RestrictionSettings ) => Promise< boolean >;
+	onClose: () => void;
+}
+
+function SettingsModal( { settings, saving, onSave, onClose }: SettingsModalProps ) {
+	const [ hide, setHide ] = useState( settings.hide_from_product_lists );
+
+	return (
+		<Modal title={ __( 'Restriction settings', 'newspack-plugin' ) } onRequestClose={ onClose }>
+			<CheckboxControl
+				label={ __( 'Hide from product lists', 'newspack-plugin' ) }
+				help={ __(
+					'Keep subscriber-only products out of product lists for readers who cannot purchase them. Direct links still work.',
+					'newspack-plugin'
+				) }
+				checked={ hide }
+				onChange={ setHide }
+				__nextHasNoMarginBottom
+			/>
+			<HStack justify="flex-end" spacing={ 2 }>
+				<Button variant="secondary" onClick={ onClose } disabled={ saving }>
+					{ __( 'Cancel', 'newspack-plugin' ) }
+				</Button>
+				<Button
+					variant="primary"
+					disabled={ saving }
+					onClick={ () => {
+						onSave( { hide_from_product_lists: hide } ).then( ( ok: boolean ) => {
+							if ( ok ) {
+								onClose();
+							}
+						} );
+					} }
+				>
+					{ __( 'Save', 'newspack-plugin' ) }
+				</Button>
+			</HStack>
+		</Modal>
+	);
+}
+
+registerTab( 'subscriber-only', { render: () => <SubscriberOnlyProducts /> } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/labels.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/labels.tsx
@@ -1,0 +1,85 @@
+/**
+ * Row labels for the subscriber-only products list.
+ *
+ * Rows lead with the products themselves, because that is what a publisher
+ * scans the list for. Category and all-products rules have no product names to
+ * show, so they show their scope instead.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies.
+ */
+import type { Restriction } from './types';
+
+/** How many product names a row shows before collapsing the rest into "+N more". */
+export const MAX_NAMED_PRODUCTS = 2;
+
+/**
+ * The names a row leads with, and how many are left over.
+ *
+ * @param restriction The restriction.
+ * @param nameOf      Resolves a product ID to its name.
+ */
+export function leadingProductNames( restriction: Restriction, nameOf: ( id: number ) => string | undefined ) {
+	const names = ( restriction.product_ids || [] ).map( nameOf ).filter( Boolean ) as string[];
+	return {
+		shown: names.slice( 0, MAX_NAMED_PRODUCTS ),
+		remaining: Math.max( 0, names.length - MAX_NAMED_PRODUCTS ),
+	};
+}
+
+/**
+ * The scope label for a category or all-products restriction.
+ *
+ * @param restriction The restriction.
+ * @param nameOf      Resolves a category ID to its name.
+ */
+export function scopeLabel( restriction: Restriction, nameOf: ( id: number ) => string | undefined ) {
+	if ( 'all' === restriction.targeting ) {
+		return __( 'All products', 'newspack-plugin' );
+	}
+	const names = ( restriction.category_ids || [] ).map( nameOf ).filter( Boolean ) as string[];
+	if ( ! names.length ) {
+		return __( 'No categories', 'newspack-plugin' );
+	}
+	return sprintf(
+		/* translators: %s: comma-separated product category names. */
+		__( '%s category', 'newspack-plugin' ),
+		names.join( ', ' )
+	);
+}
+
+/**
+ * The "N excluded" suffix, or an empty string when nothing is excluded.
+ *
+ * @param restriction The restriction.
+ */
+export function excludedLabel( restriction: Restriction ) {
+	const count = ( restriction.excluded_product_ids || [] ).length;
+	if ( ! count ) {
+		return '';
+	}
+	return sprintf(
+		/* translators: %d: number of excluded products. */
+		_n( '%d excluded', '%d excluded', count, 'newspack-plugin' ),
+		count
+	);
+}
+
+/**
+ * The "+N more" line under a product-targeted row.
+ *
+ * @param remaining How many product names are not shown.
+ */
+export function moreProductsLabel( remaining: number ) {
+	return sprintf(
+		/* translators: %d: number of further products. */
+		_n( '+%d more product', '+%d more products', remaining, 'newspack-plugin' ),
+		remaining
+	);
+}

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/labels.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/labels.tsx
@@ -49,7 +49,7 @@ export function scopeLabel( restriction: Restriction, nameOf: ( id: number ) => 
 	}
 	return sprintf(
 		/* translators: %s: comma-separated product category names. */
-		__( '%s category', 'newspack-plugin' ),
+		_n( '%s category', '%s categories', names.length, 'newspack-plugin' ),
 		names.join( ', ' )
 	);
 }

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/restriction-editor.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/restriction-editor.tsx
@@ -1,0 +1,107 @@
+/**
+ * Editor for a subscriber-only product restriction: which subscriptions unlock
+ * purchasing of which products. A right-edge drawer, mirroring the rest of the
+ * Subscriptions wizard's editors.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+import { __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components';
+
+/**
+ * Internal dependencies.
+ */
+import { Button, Modal } from '../../../../../../../packages/components/src';
+import SearchTokenField from '../../components/search-token-field';
+import TargetingFields from '../../components/targeting-fields';
+import { SEARCH_ENDPOINTS } from '../../constants';
+import type { RuleTargeting } from '../../types';
+import type { Restriction } from './types';
+
+interface RestrictionEditorProps {
+	/** The restriction to edit, or a partial one for a new restriction. */
+	restriction: Partial< Restriction >;
+	saving: boolean;
+	onSave: ( rule: Partial< Restriction > ) => void;
+	onClose: () => void;
+}
+
+const emptyTargeting: RuleTargeting = {
+	targeting: 'products',
+	product_ids: [],
+	category_ids: [],
+	excluded_product_ids: [],
+};
+
+export default function RestrictionEditor( { restriction, saving, onSave, onClose }: RestrictionEditorProps ) {
+	const isEdit = Boolean( restriction.id );
+	const [ subscriptionIds, setSubscriptionIds ] = useState< number[] >( restriction.subscription_product_ids || [] );
+	const [ targeting, setTargeting ] = useState< RuleTargeting >( {
+		targeting: restriction.targeting || emptyTargeting.targeting,
+		product_ids: restriction.product_ids || [],
+		category_ids: restriction.category_ids || [],
+		excluded_product_ids: restriction.excluded_product_ids || [],
+	} );
+
+	// A restriction naming no subscription would be unbuyable by everyone, and a
+	// "specific products" one naming no product would restrict nothing. Neither
+	// is savable, so Save stays disabled until the rule says something.
+	const isComplete =
+		subscriptionIds.length > 0 &&
+		( 'products' !== targeting.targeting || targeting.product_ids.length > 0 ) &&
+		( 'category' !== targeting.targeting || targeting.category_ids.length > 0 );
+
+	const handleSave = () => {
+		onSave( {
+			...restriction,
+			subscription_product_ids: subscriptionIds,
+			targeting: targeting.targeting,
+			// Only the fields the chosen targeting uses, so switching mode before
+			// saving can't persist ids the rule no longer means.
+			product_ids: 'products' === targeting.targeting ? targeting.product_ids : [],
+			category_ids: 'category' === targeting.targeting ? targeting.category_ids : [],
+			excluded_product_ids: 'products' === targeting.targeting ? [] : targeting.excluded_product_ids,
+			active: restriction.active ?? true,
+		} );
+	};
+
+	return (
+		<Modal
+			title={ isEdit ? __( 'Edit restriction', 'newspack-plugin' ) : __( 'Add restriction', 'newspack-plugin' ) }
+			onRequestClose={ onClose }
+			className="newspack-subscriptions-drawer"
+			overlayClassName="newspack-subscriptions-drawer__overlay"
+			shouldCloseOnClickOutside={ false }
+		>
+			<VStack spacing={ 4 } className="newspack-subscriptions-drawer__content">
+				<SearchTokenField
+					endpoint={ SEARCH_ENDPOINTS.subscriptions }
+					label={ __( 'Available to', 'newspack-plugin' ) }
+					help={ __( 'Subscribers of any of these subscriptions can purchase the products.', 'newspack-plugin' ) }
+					value={ subscriptionIds }
+					onChange={ setSubscriptionIds }
+					disabled={ saving }
+				/>
+				<TargetingFields
+					value={ targeting }
+					onChange={ partial => setTargeting( current => ( { ...current, ...partial } ) ) }
+					appliesHelp={ __( 'Choose which products are subscriber-only.', 'newspack-plugin' ) }
+					categoryHelp={ __( 'Subcategories are included.', 'newspack-plugin' ) }
+					disabled={ saving }
+				/>
+			</VStack>
+			<HStack className="newspack-subscriptions-drawer__footer" justify="flex-end" spacing={ 2 }>
+				<Button variant="secondary" onClick={ onClose } disabled={ saving }>
+					{ __( 'Cancel', 'newspack-plugin' ) }
+				</Button>
+				<Button variant="primary" onClick={ handleSave } disabled={ saving || ! isComplete }>
+					{ __( 'Save', 'newspack-plugin' ) }
+				</Button>
+			</HStack>
+		</Modal>
+	);
+}

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/style.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/style.scss
@@ -1,0 +1,102 @@
+@use "~@wordpress/base-styles/variables" as wp-vars;
+@use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/breakpoints" as wp-breakpoints;
+
+// Secondary lines in a list row: the "+N more products" and "N excluded"
+// suffixes, and the placeholder when a rule names nothing.
+.newspack-subscriber-only__muted {
+	color: wp-colors.$gray-700;
+	font-size: 12px;
+}
+
+// Rule editor: a right-edge slide-in panel rather than a centered modal, so the
+// list stays visible while a rule is edited.
+.newspack-subscriptions-drawer__overlay {
+	align-items: stretch;
+	justify-content: flex-end;
+	padding: 0;
+}
+
+.components-modal__frame.newspack-subscriptions-drawer {
+	animation: 0.2s ease-out forwards newspack-subscriptions-drawer-slide-in;
+	border-radius: 0;
+	box-shadow: -1px 0 16px rgb( 0 0 0 / 8% );
+	display: flex;
+	flex-direction: column;
+	height: 100vh;
+	margin: 0;
+	max-height: 100vh;
+	width: 380px;
+
+	@media ( max-width: wp-breakpoints.$break-small ) {
+		width: 100vw;
+	}
+
+	// Drop the modal's built-in content padding so the content and footer below
+	// own the spacing, and let the inner wrappers flex so the content area
+	// scrolls within the full height.
+	.components-modal__content {
+		display: flex;
+		flex-direction: column;
+		padding: 0;
+	}
+
+	.components-modal__children-container {
+		display: flex;
+		flex: 1 1 auto;
+		flex-direction: column;
+		min-height: 0;
+	}
+}
+
+.newspack-subscriptions-drawer__content {
+	flex: 1 1 auto;
+	overflow-y: auto;
+	padding: wp-vars.$grid-unit-30;
+}
+
+.newspack-subscriptions-drawer__footer {
+	border-top: 1px solid wp-colors.$gray-300;
+	flex: 0 0 auto;
+	padding: wp-vars.$grid-unit-20 wp-vars.$grid-unit-30;
+}
+
+@keyframes newspack-subscriptions-drawer-slide-in {
+	from {
+		transform: translateX( 100% );
+	}
+
+	to {
+		transform: translateX( 0 );
+	}
+}
+
+@keyframes newspack-subscriptions-drawer-slide-out {
+	from {
+		transform: translateX( 0 );
+	}
+
+	to {
+		transform: translateX( 100% );
+	}
+}
+
+// Mirror the slide-in on close. @wp/components' Modal adds `is-animating-out`
+// and keeps the panel mounted until an animationend fires, so animating the
+// frame is enough. Suppress the overlay's default fade so the motion stays a
+// slide.
+.components-modal__screen-overlay.newspack-subscriptions-drawer__overlay.is-animating-out {
+	animation: none;
+}
+
+.components-modal__screen-overlay.newspack-subscriptions-drawer__overlay.is-animating-out .components-modal__frame {
+	animation: 0.2s ease-in forwards newspack-subscriptions-drawer-slide-out;
+}
+
+@media ( prefers-reduced-motion: reduce ) {
+	.newspack-subscriptions-drawer__overlay,
+	.components-modal__frame.newspack-subscriptions-drawer,
+	.components-modal__screen-overlay.newspack-subscriptions-drawer__overlay.is-animating-out .components-modal__frame {
+		animation: none;
+	}
+}

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/types.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/types.ts
@@ -1,0 +1,17 @@
+/**
+ * Types for the Subscriber-only products tab.
+ */
+
+/**
+ * Internal dependencies.
+ */
+import type { BaseRule } from '../../types';
+
+/** A subscriber-only product restriction. */
+export type Restriction = BaseRule;
+
+/** The tab's settings. */
+export interface RestrictionSettings {
+	/** Keep restricted products out of product lists for readers who can't buy them. */
+	hide_from_product_lists: boolean;
+}

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/use-names.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/use-names.ts
@@ -18,6 +18,9 @@ import { WIZARD_ENDPOINT } from '../../constants';
 
 type NameMap = Record< number, string >;
 
+/** The search endpoints cap `per_page` at 100, so larger ID sets go in batches. */
+const BATCH_SIZE = 100;
+
 /**
  * Look up names for a set of IDs on one of the wizard's search endpoints.
  *
@@ -36,16 +39,30 @@ export function useNames( endpoint: string, ids: number[] ): NameMap {
 			return;
 		}
 		let cancelled = false;
-		apiFetch< { id: number; name: string }[] >( {
-			path: addQueryArgs( `${ WIZARD_ENDPOINT }/${ endpoint }`, { include: key, per_page: 100 } ),
-		} )
-			.then( items => {
+		// One request per batch rather than one truncated request: an ID the
+		// endpoint never returns renders as a blank name, so silently dropping the
+		// overflow would leave the list lying about what a rule covers.
+		const batches: string[][] = [];
+		const uniqueIds = key.split( ',' );
+		for ( let index = 0; index < uniqueIds.length; index += BATCH_SIZE ) {
+			batches.push( uniqueIds.slice( index, index + BATCH_SIZE ) );
+		}
+		Promise.all(
+			batches.map( batch =>
+				apiFetch< { id: number; name: string }[] >( {
+					path: addQueryArgs( `${ WIZARD_ENDPOINT }/${ endpoint }`, { include: batch.join( ',' ), per_page: BATCH_SIZE } ),
+				} )
+			)
+		)
+			.then( responses => {
 				if ( cancelled ) {
 					return;
 				}
 				const map: NameMap = {};
-				( items || [] ).forEach( item => {
-					map[ item.id ] = decodeEntities( item.name );
+				responses.forEach( items => {
+					( items || [] ).forEach( item => {
+						map[ item.id ] = decodeEntities( item.name );
+					} );
 				} );
 				setNames( map );
 			} )

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/use-names.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/use-names.ts
@@ -1,0 +1,61 @@
+/**
+ * Resolves product, product category and subscription IDs to names for the
+ * restriction list, which stores only IDs.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies.
+ */
+import { WIZARD_ENDPOINT } from '../../constants';
+
+type NameMap = Record< number, string >;
+
+/**
+ * Look up names for a set of IDs on one of the wizard's search endpoints.
+ *
+ * @param endpoint Endpoint name, e.g. 'products-search'.
+ * @param ids      The IDs to resolve.
+ */
+export function useNames( endpoint: string, ids: number[] ): NameMap {
+	const [ names, setNames ] = useState< NameMap >( {} );
+	// Depend on the ID set's content rather than the array identity, which is
+	// new on every render.
+	const key = [ ...new Set( ids ) ].sort( ( a, b ) => a - b ).join( ',' );
+
+	useEffect( () => {
+		if ( ! key ) {
+			setNames( {} );
+			return;
+		}
+		let cancelled = false;
+		apiFetch< { id: number; name: string }[] >( {
+			path: addQueryArgs( `${ WIZARD_ENDPOINT }/${ endpoint }`, { include: key, per_page: 100 } ),
+		} )
+			.then( items => {
+				if ( cancelled ) {
+					return;
+				}
+				const map: NameMap = {};
+				( items || [] ).forEach( item => {
+					map[ item.id ] = decodeEntities( item.name );
+				} );
+				setNames( map );
+			} )
+			.catch( error => {
+				console.warn( 'Error resolving names for ' + endpoint, error ); // eslint-disable-line no-console
+			} );
+		return () => {
+			cancelled = true;
+		};
+	}, [ key, endpoint ] );
+
+	return names;
+}

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/use-restrictions.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/use-restrictions.ts
@@ -1,0 +1,86 @@
+/**
+ * Data access for subscriber-only product restrictions.
+ *
+ * Every mutation returns the full server state, so the hook never has to
+ * reconcile a local guess against what was saved.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { useCallback, useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies.
+ */
+import { WIZARD_ENDPOINT } from '../../constants';
+import type { Restriction, RestrictionSettings } from './types';
+
+const RULES_PATH = `${ WIZARD_ENDPOINT }/restrictions`;
+const SETTINGS_PATH = `${ WIZARD_ENDPOINT }/restriction-settings`;
+
+interface RestrictionsResponse {
+	restrictions: Restriction[];
+	settings: RestrictionSettings;
+}
+
+export function useRestrictions() {
+	const [ restrictions, setRestrictions ] = useState< Restriction[] >( [] );
+	const [ settings, setSettings ] = useState< RestrictionSettings >( { hide_from_product_lists: false } );
+	const [ loading, setLoading ] = useState( true );
+	const [ saving, setSaving ] = useState( false );
+	const [ error, setError ] = useState( '' );
+
+	const apply = useCallback( ( response: RestrictionsResponse ) => {
+		setRestrictions( response.restrictions || [] );
+		setSettings( response.settings || { hide_from_product_lists: false } );
+	}, [] );
+
+	const load = useCallback( () => {
+		setLoading( true );
+		setError( '' );
+		return apiFetch< RestrictionsResponse >( { path: RULES_PATH } )
+			.then( apply )
+			.catch( ( err: { message?: string } ) => setError( err?.message || __( 'Could not load restrictions.', 'newspack-plugin' ) ) )
+			.finally( () => setLoading( false ) );
+	}, [ apply ] );
+
+	useEffect( () => {
+		load();
+	}, [ load ] );
+
+	// Every mutation shares one shape: fire, replace state with the server's
+	// answer, and surface any failure rather than leaving the UI out of step.
+	const mutate = useCallback(
+		( path: string, method: string, data?: Record< string, unknown > ) => {
+			setSaving( true );
+			setError( '' );
+			return apiFetch< RestrictionsResponse >( { path, method, data } )
+				.then( response => {
+					apply( response );
+					return true;
+				} )
+				.catch( ( err: { message?: string } ) => {
+					setError( err?.message || __( 'Could not save. Please try again.', 'newspack-plugin' ) );
+					return false;
+				} )
+				.finally( () => setSaving( false ) );
+		},
+		[ apply ]
+	);
+
+	const saveRestriction = useCallback(
+		( rule: Partial< Restriction > ) => mutate( rule.id ? `${ RULES_PATH }/${ rule.id }` : RULES_PATH, 'POST', { ...rule } ),
+		[ mutate ]
+	);
+
+	const deleteRestriction = useCallback( ( id: string ) => mutate( `${ RULES_PATH }/${ id }`, 'DELETE' ), [ mutate ] );
+
+	const setActive = useCallback( ( rule: Restriction, active: boolean ) => saveRestriction( { ...rule, active } ), [ saveRestriction ] );
+
+	const saveSettings = useCallback( ( next: RestrictionSettings ) => mutate( SETTINGS_PATH, 'POST', { ...next } ), [ mutate ] );
+
+	return { restrictions, settings, loading, saving, error, saveRestriction, deleteRestriction, setActive, saveSettings, reload: load };
+}

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -447,6 +447,19 @@ class WC_Product {
 	public function get_parent_id() {
 		return $this->data['parent_id'] ?? 0;
 	}
+	/**
+	 * WC_Product_Variation resolves its permalink through the parent, whose page
+	 * is the only one a reader can buy from — the variation post has none. Code
+	 * that links a product goes through here rather than get_permalink( $id ),
+	 * so the mock has to model that or a test would see a URL production never
+	 * emits.
+	 *
+	 * @return string
+	 */
+	public function get_permalink() {
+		$parent_id = $this->get_parent_id();
+		return get_permalink( $parent_id ? $parent_id : $this->get_id() );
+	}
 	public function get_children() {
 		return $this->data['children'] ?? [];
 	}

--- a/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/product-purchase-restriction.php
+++ b/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/product-purchase-restriction.php
@@ -483,6 +483,27 @@ class Test_Product_Purchase_Restriction extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Hiding covers secondary listings — related products, cross-sells, cart
+	 * upsells — by design, so a publisher who wants it confined to the primary
+	 * catalog needs a way to say so.
+	 *
+	 * Purchase restriction is untouched by the filter: the point is a listing
+	 * that still shows the product, not one that sells it.
+	 */
+	public function test_a_filter_can_exempt_a_listing_from_hiding() {
+		update_option( Subscriber_Only_Products::SETTINGS_OPTION_NAME, [ 'hide_from_product_lists' => true ] );
+		$this->flush_caches();
+		add_filter( 'newspack_subscriber_only_hide_from_query', '__return_false' );
+
+		$query = $this->run_product_query();
+
+		$this->assertEmpty( $query->get( 'post__not_in' ) );
+		$this->assertFalse( Product_Purchase_Restriction::can_purchase( $this->restricted_product ) );
+
+		remove_filter( 'newspack_subscriber_only_hide_from_query', '__return_false' );
+	}
+
+	/**
 	 * A subscriber sees everything: hiding follows purchasability, so it must
 	 * not hide a product from the very readers it is sold to.
 	 */

--- a/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/product-purchase-restriction.php
+++ b/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/product-purchase-restriction.php
@@ -1,0 +1,450 @@
+<?php
+/**
+ * Tests subscriber-only product purchase restriction.
+ *
+ * @package Newspack\Tests\Subscriber_Commerce
+ */
+
+namespace Newspack\Tests\Subscriber_Commerce;
+
+use Newspack\Product_Purchase_Restriction;
+use Newspack\Product_Targeting;
+use Newspack\Subscriber_Eligibility;
+use Newspack\Subscriber_Only_Products;
+
+/**
+ * Tests the WooCommerce Memberships purchase-restriction parity: a reader who
+ * doesn't subscribe can still *see* a restricted product, but cannot *buy* it.
+ *
+ * Enforcement rides `woocommerce_is_purchasable`, so these exercise the filter
+ * callback the same way WooCommerce does.
+ *
+ * The two process-wide guards in `is_enforcement_active()` — the
+ * NEWSPACK_CONTENT_GATES flag and Memberships being inactive — are verified at
+ * runtime rather than here: both are a `define()` or a `class_exists()`, so
+ * faking either would leak into every test that runs afterwards in the process.
+ *
+ * @group subscriber-commerce
+ * @group Product_Purchase_Restriction
+ */
+class Test_Product_Purchase_Restriction extends \WP_UnitTestCase {
+
+	/**
+	 * The restricted product.
+	 *
+	 * @var \WC_Product
+	 */
+	private $restricted_product;
+
+	/**
+	 * A product no restriction covers.
+	 *
+	 * @var \WC_Product
+	 */
+	private $open_product;
+
+	/**
+	 * The subscription that unlocks the restricted product.
+	 *
+	 * @var \WC_Product
+	 */
+	private $subscription;
+
+	/**
+	 * A reader who subscribes.
+	 *
+	 * @var int
+	 */
+	private $subscriber_id;
+
+	/**
+	 * A reader who doesn't.
+	 *
+	 * @var int
+	 */
+	private $non_subscriber_id;
+
+	/**
+	 * Enable the content gates flag and load the WooCommerce mocks.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+		require_once dirname( __DIR__, 2 ) . '/mocks/wc-mocks.php';
+	}
+
+	/**
+	 * Register the product post type, build the products, and seed a
+	 * restriction covering one of them.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		register_post_type( 'product', [ 'public' => true ] );
+		register_post_type( 'product_variation', [ 'public' => false ] );
+		register_taxonomy( 'product_cat', 'product', [ 'hierarchical' => true ] );
+
+		$this->restricted_product = $this->create_product();
+		$this->open_product       = $this->create_product();
+		$this->subscription       = $this->create_product();
+
+		$this->subscriber_id     = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		$this->non_subscriber_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+
+		add_filter( 'newspack_access_rules_has_active_subscription', [ $this, 'mock_oracle' ], 10, 2 );
+
+		$this->set_rules(
+			[
+				[
+					'id'                       => 'rule',
+					'subscription_product_ids' => [ $this->subscription->get_id() ],
+					'targeting'                => 'products',
+					'product_ids'              => [ $this->restricted_product->get_id() ],
+					'active'                   => true,
+				],
+			]
+		);
+	}
+
+	/**
+	 * Reset everything the restriction memoizes.
+	 */
+	public function tear_down() {
+		remove_filter( 'newspack_access_rules_has_active_subscription', [ $this, 'mock_oracle' ], 10 );
+		delete_option( Subscriber_Only_Products::OPTION_NAME );
+		delete_option( Subscriber_Only_Products::SETTINGS_OPTION_NAME );
+		$this->flush_caches();
+		wp_set_current_user( 0 );
+		global $products_database;
+		$products_database = []; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		parent::tear_down();
+	}
+
+	/**
+	 * Stand in for the subscription oracle: only the subscriber subscribes.
+	 *
+	 * @param bool $has_subscription Whether the user has an active subscription.
+	 * @param int  $user_id          User ID.
+	 *
+	 * @return bool
+	 */
+	public function mock_oracle( $has_subscription, $user_id ) {
+		return $user_id === $this->subscriber_id;
+	}
+
+	/**
+	 * Drop every per-request cache the restriction relies on.
+	 */
+	private function flush_caches() {
+		Product_Purchase_Restriction::flush_cache();
+		Product_Targeting::flush_cache();
+		Subscriber_Eligibility::flush_cache();
+	}
+
+	/**
+	 * Store the restrictions and drop the caches keyed on them.
+	 *
+	 * @param array[] $rules The rules.
+	 */
+	private function set_rules( $rules ) {
+		$sanitized = array_map( [ 'Newspack\Subscriber_Commerce', 'sanitize_base_rule' ], $rules );
+		update_option( Subscriber_Only_Products::OPTION_NAME, $sanitized );
+		$this->flush_caches();
+	}
+
+	/**
+	 * Create a product post plus its mock, registered so wc_get_product() finds it.
+	 *
+	 * @param int $parent_id Parent product ID, for a variation.
+	 *
+	 * @return \WC_Product
+	 */
+	private function create_product( $parent_id = 0 ) {
+		$post_id = $this->factory->post->create(
+			[
+				'post_type'   => $parent_id ? 'product_variation' : 'product',
+				'post_parent' => $parent_id,
+				'post_title'  => 'Product ' . wp_rand(),
+			]
+		);
+		$product = new \WC_Product(
+			[
+				'id'        => $post_id,
+				'parent_id' => $parent_id,
+			]
+		);
+
+		global $products_database;
+		$products_database[ $post_id ] = $product; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		return $product;
+	}
+
+	/**
+	 * A reader who doesn't subscribe cannot buy a restricted product.
+	 */
+	public function test_non_subscriber_cannot_purchase() {
+		wp_set_current_user( $this->non_subscriber_id );
+
+		$this->assertFalse( Product_Purchase_Restriction::filter_is_purchasable( true, $this->restricted_product ) );
+	}
+
+	/**
+	 * A subscriber can.
+	 */
+	public function test_subscriber_can_purchase() {
+		wp_set_current_user( $this->subscriber_id );
+
+		$this->assertTrue( Product_Purchase_Restriction::filter_is_purchasable( true, $this->restricted_product ) );
+	}
+
+	/**
+	 * An anonymous reader cannot.
+	 */
+	public function test_anonymous_reader_cannot_purchase() {
+		$this->assertFalse( Product_Purchase_Restriction::filter_is_purchasable( true, $this->restricted_product ) );
+	}
+
+	/**
+	 * A product no restriction covers is untouched.
+	 */
+	public function test_unrestricted_product_is_left_alone() {
+		$this->assertTrue( Product_Purchase_Restriction::filter_is_purchasable( true, $this->open_product ) );
+	}
+
+	/**
+	 * A product WooCommerce already ruled unpurchasable stays that way: the
+	 * filter may only take purchasability away, never grant it.
+	 */
+	public function test_never_grants_purchasability_woocommerce_denied() {
+		wp_set_current_user( $this->subscriber_id );
+
+		$this->assertFalse( Product_Purchase_Restriction::filter_is_purchasable( false, $this->restricted_product ) );
+	}
+
+	/**
+	 * Shop managers keep purchasing rights, so a restriction can't lock a
+	 * publisher out of their own products.
+	 */
+	public function test_shop_manager_can_always_purchase() {
+		$manager_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		// WooCommerce registers manage_woocommerce; it isn't loaded here, so the
+		// capability the check actually reads has to be granted explicitly.
+		get_user_by( 'id', $manager_id )->add_cap( 'manage_woocommerce' );
+		wp_set_current_user( $manager_id );
+
+		$this->assertTrue( Product_Purchase_Restriction::filter_is_purchasable( true, $this->restricted_product ) );
+	}
+
+	/**
+	 * Pausing a restriction hands its products back.
+	 */
+	public function test_inactive_restriction_does_not_block() {
+		$this->set_rules(
+			[
+				[
+					'id'                       => 'rule',
+					'subscription_product_ids' => [ $this->subscription->get_id() ],
+					'targeting'                => 'products',
+					'product_ids'              => [ $this->restricted_product->get_id() ],
+					'active'                   => false,
+				],
+			]
+		);
+
+		$this->assertTrue( Product_Purchase_Restriction::filter_is_purchasable( true, $this->restricted_product ) );
+	}
+
+	/**
+	 * A restriction naming no subscription names no way in. Blocking everyone
+	 * is far more likely to be a half-finished rule than an intent to withdraw
+	 * the product from sale, so it fails open.
+	 */
+	public function test_restriction_without_subscriptions_fails_open() {
+		$this->set_rules(
+			[
+				[
+					'id'                       => 'rule',
+					'subscription_product_ids' => [],
+					'targeting'                => 'products',
+					'product_ids'              => [ $this->restricted_product->get_id() ],
+					'active'                   => true,
+				],
+			]
+		);
+
+		$this->assertTrue( Product_Purchase_Restriction::filter_is_purchasable( true, $this->restricted_product ) );
+	}
+
+	/**
+	 * Two restrictions covering one product are alternatives, not hurdles:
+	 * satisfying either one unlocks the purchase. Each rule is an offer, so
+	 * adding one can only widen access.
+	 */
+	public function test_overlapping_restrictions_are_ored() {
+		$other_subscription = $this->create_product();
+		$this->set_rules(
+			[
+				[
+					'id'                       => 'unsatisfied',
+					// A subscription nobody in this test holds.
+					'subscription_product_ids' => [ $other_subscription->get_id() ],
+					'targeting'                => 'products',
+					'product_ids'              => [ $this->restricted_product->get_id() ],
+					'active'                   => true,
+				],
+				[
+					'id'                       => 'satisfied',
+					'subscription_product_ids' => [ $this->subscription->get_id() ],
+					'targeting'                => 'products',
+					'product_ids'              => [ $this->restricted_product->get_id() ],
+					'active'                   => true,
+				],
+			]
+		);
+		wp_set_current_user( $this->subscriber_id );
+
+		$this->assertTrue( Product_Purchase_Restriction::filter_is_purchasable( true, $this->restricted_product ) );
+	}
+
+	/**
+	 * A variation is restricted through its parent, which is what the publisher
+	 * picked.
+	 */
+	public function test_variation_is_restricted_through_its_parent() {
+		$variation = $this->create_product( $this->restricted_product->get_id() );
+
+		$this->assertFalse( Product_Purchase_Restriction::filter_is_purchasable( true, $variation ) );
+	}
+
+	/**
+	 * The notice names the subscription that unlocks the product, so the reader
+	 * knows what to buy.
+	 */
+	public function test_notice_links_the_unlocking_subscription() {
+		$message = Product_Purchase_Restriction::get_restricted_message( $this->restricted_product );
+
+		$this->assertStringContainsString( 'available to subscribers', $message );
+		$this->assertStringContainsString( get_permalink( $this->subscription->get_id() ), $message );
+	}
+
+	/**
+	 * Reader-facing copy says "subscribers", never Memberships' "members".
+	 */
+	public function test_notice_uses_subscriber_vocabulary() {
+		$message = Product_Purchase_Restriction::get_restricted_message( $this->restricted_product );
+
+		$this->assertStringNotContainsStringIgnoringCase( 'member', $message );
+	}
+
+	/**
+	 * A subscription the reader can't buy either is left out of the notice,
+	 * rather than pointing them at a product they've just been barred from.
+	 */
+	public function test_notice_omits_subscriptions_the_reader_cannot_buy() {
+		$this->set_rules(
+			[
+				[
+					'id'                       => 'rule',
+					'subscription_product_ids' => [ $this->subscription->get_id() ],
+					'targeting'                => 'products',
+					'product_ids'              => [ $this->restricted_product->get_id() ],
+					'active'                   => true,
+				],
+				[
+					'id'                       => 'locks-the-subscription',
+					'subscription_product_ids' => [ $this->open_product->get_id() ],
+					'targeting'                => 'products',
+					'product_ids'              => [ $this->subscription->get_id() ],
+					'active'                   => true,
+				],
+			]
+		);
+
+		$message = Product_Purchase_Restriction::get_restricted_message( $this->restricted_product );
+
+		$this->assertStringNotContainsString( get_permalink( $this->subscription->get_id() ), $message );
+	}
+
+	/**
+	 * Hiding is off by default: the parity feature blocks purchasing and leaves
+	 * the product listed.
+	 */
+	public function test_products_stay_listed_by_default() {
+		$query = $this->run_product_query();
+
+		$this->assertEmpty( $query->get( 'post__not_in' ) );
+	}
+
+	/**
+	 * With hiding on, a reader who can't buy the product doesn't see it listed.
+	 */
+	public function test_hiding_removes_unpurchasable_products_from_lists() {
+		update_option( Subscriber_Only_Products::SETTINGS_OPTION_NAME, [ 'hide_from_product_lists' => true ] );
+		$this->flush_caches();
+
+		$query = $this->run_product_query();
+
+		$this->assertContains( $this->restricted_product->get_id(), (array) $query->get( 'post__not_in' ) );
+		$this->assertNotContains( $this->open_product->get_id(), (array) $query->get( 'post__not_in' ) );
+	}
+
+	/**
+	 * A subscriber sees everything: hiding follows purchasability, so it must
+	 * not hide a product from the very readers it is sold to.
+	 */
+	public function test_hiding_leaves_subscribers_lists_intact() {
+		update_option( Subscriber_Only_Products::SETTINGS_OPTION_NAME, [ 'hide_from_product_lists' => true ] );
+		$this->flush_caches();
+		wp_set_current_user( $this->subscriber_id );
+
+		$query = $this->run_product_query();
+
+		$this->assertNotContains( $this->restricted_product->get_id(), (array) $query->get( 'post__not_in' ) );
+	}
+
+	/**
+	 * A direct link still resolves: hiding covers listings only, so a reader
+	 * holding the URL isn't left wondering where the product went.
+	 */
+	public function test_hiding_leaves_the_product_page_reachable() {
+		update_option( Subscriber_Only_Products::SETTINGS_OPTION_NAME, [ 'hide_from_product_lists' => true ] );
+		$this->flush_caches();
+
+		$query = new \WP_Query();
+		$query->query_vars = [
+			'post_type' => 'product',
+			'p'         => $this->restricted_product->get_id(),
+		];
+		$query->is_singular = true;
+		Product_Purchase_Restriction::filter_product_query( $query );
+
+		$this->assertEmpty( $query->get( 'post__not_in' ) );
+	}
+
+	/**
+	 * Run a product listing query through the hiding filter.
+	 *
+	 * @return \WP_Query
+	 */
+	private function run_product_query() {
+		$query             = new \WP_Query();
+		$query->query_vars = [ 'post_type' => 'product' ];
+		Product_Purchase_Restriction::filter_product_query( $query );
+		return $query;
+	}
+
+	/**
+	 * Saving a restriction takes effect immediately: the memoized verdicts must
+	 * not outlive the rules they were computed from.
+	 */
+	public function test_saving_a_restriction_invalidates_the_cache() {
+		$this->assertFalse( Product_Purchase_Restriction::filter_is_purchasable( true, $this->restricted_product ) );
+
+		Subscriber_Only_Products::delete_rule( 'rule' );
+
+		$this->assertTrue( Product_Purchase_Restriction::filter_is_purchasable( true, $this->restricted_product ) );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/product-purchase-restriction.php
+++ b/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/product-purchase-restriction.php
@@ -425,6 +425,40 @@ class Test_Product_Purchase_Restriction extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Working out what to hide has to enumerate the covered products, and that
+	 * query fires `pre_get_posts` again — straight back into this filter. Run a
+	 * category rule through the real hook (not the callback directly, which
+	 * can't reproduce it) to prove the re-entry terminates.
+	 */
+	public function test_hiding_a_category_does_not_recurse_through_pre_get_posts() {
+		$category_id = $this->factory->term->create( [ 'taxonomy' => 'product_cat' ] );
+		wp_set_object_terms( $this->restricted_product->get_id(), [ $category_id ], 'product_cat' );
+		$this->set_rules(
+			[
+				[
+					'id'                       => 'rule',
+					'subscription_product_ids' => [ $this->subscription->get_id() ],
+					'targeting'                => 'category',
+					'category_ids'             => [ $category_id ],
+					'active'                   => true,
+				],
+			]
+		);
+		update_option( Subscriber_Only_Products::SETTINGS_OPTION_NAME, [ 'hide_from_product_lists' => true ] );
+		Product_Purchase_Restriction::flush_cache();
+
+		add_action( 'pre_get_posts', [ 'Newspack\Product_Purchase_Restriction', 'filter_product_query' ] );
+		try {
+			$query = new \WP_Query( [ 'post_type' => 'product' ] );
+		} finally {
+			remove_action( 'pre_get_posts', [ 'Newspack\Product_Purchase_Restriction', 'filter_product_query' ] );
+		}
+
+		$this->assertContains( $this->restricted_product->get_id(), (array) $query->get( 'post__not_in' ) );
+		$this->assertNotContains( $this->open_product->get_id(), (array) $query->get( 'post__not_in' ) );
+	}
+
+	/**
 	 * Run a product listing query through the hiding filter.
 	 *
 	 * @return \WP_Query

--- a/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/product-purchase-restriction.php
+++ b/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/product-purchase-restriction.php
@@ -369,6 +369,69 @@ class Test_Product_Purchase_Restriction extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * The subscription picker offers variations of a variable subscription, so a
+	 * rule can name one. A variation post has no page a reader can buy from, so
+	 * the notice has to link the parent instead.
+	 */
+	public function test_notice_links_a_subscription_variation_through_its_parent() {
+		$variable_subscription = $this->create_product();
+		$variation             = $this->create_product( $variable_subscription->get_id() );
+		$this->set_rules(
+			[
+				[
+					'id'                       => 'rule',
+					'subscription_product_ids' => [ $variation->get_id() ],
+					'targeting'                => 'products',
+					'product_ids'              => [ $this->restricted_product->get_id() ],
+					'active'                   => true,
+				],
+			]
+		);
+
+		$message = Product_Purchase_Restriction::get_restricted_message( $this->restricted_product );
+
+		$this->assertStringContainsString( get_permalink( $variable_subscription->get_id() ), $message );
+		$this->assertStringNotContainsString( get_permalink( $variation->get_id() ), $message );
+	}
+
+	/**
+	 * On a block theme the notice rides the add-to-cart block, because
+	 * `woocommerce_single_product_summary` never fires.
+	 */
+	public function test_add_to_cart_block_carries_the_notice_on_the_product_page() {
+		$this->go_to( get_permalink( $this->restricted_product->get_id() ) );
+
+		$this->assertStringContainsString(
+			'newspack-subscriber-only-notice',
+			Product_Purchase_Restriction::filter_add_to_cart_block( 'cart', $this->add_to_cart_block() )
+		);
+	}
+
+	/**
+	 * Anywhere else it stays out. Nothing stops a custom listing from putting a
+	 * single-product add-to-cart block on every card, and the notice would then
+	 * repeat down the page — so the block path covers the same surface as the
+	 * classic one and no more.
+	 */
+	public function test_add_to_cart_block_carries_no_notice_off_the_product_page() {
+		$this->go_to( home_url( '/' ) );
+
+		$this->assertSame( 'cart', Product_Purchase_Restriction::filter_add_to_cart_block( 'cart', $this->add_to_cart_block() ) );
+	}
+
+	/**
+	 * A parsed add-to-cart block naming the restricted product.
+	 *
+	 * @return array
+	 */
+	private function add_to_cart_block() {
+		return [
+			'blockName' => 'woocommerce/add-to-cart-form',
+			'attrs'     => [ 'productId' => $this->restricted_product->get_id() ],
+		];
+	}
+
+	/**
 	 * Hiding is off by default: the parity feature blocks purchasing and leaves
 	 * the product listed.
 	 */
@@ -389,6 +452,34 @@ class Test_Product_Purchase_Restriction extends \WP_UnitTestCase {
 
 		$this->assertContains( $this->restricted_product->get_id(), (array) $query->get( 'post__not_in' ) );
 		$this->assertNotContains( $this->open_product->get_id(), (array) $query->get( 'post__not_in' ) );
+	}
+
+	/**
+	 * A curated listing — a hand-picked Products block, a Product Collection
+	 * with chosen products — passes `post__in`, and WordPress then ignores
+	 * `post__not_in` entirely. Hiding has to narrow the picks instead, or that
+	 * one listing keeps showing what every other listing hides.
+	 */
+	public function test_hiding_narrows_a_curated_listing() {
+		update_option( Subscriber_Only_Products::SETTINGS_OPTION_NAME, [ 'hide_from_product_lists' => true ] );
+		$this->flush_caches();
+
+		$query = $this->run_product_query( [ $this->restricted_product->get_id(), $this->open_product->get_id() ] );
+
+		$this->assertSame( [ $this->open_product->get_id() ], (array) $query->get( 'post__in' ) );
+	}
+
+	/**
+	 * When every pick is hidden the listing comes back empty. An emptied
+	 * `post__in` would read as "no constraint" and list the whole catalog.
+	 */
+	public function test_hiding_every_curated_pick_empties_the_listing() {
+		update_option( Subscriber_Only_Products::SETTINGS_OPTION_NAME, [ 'hide_from_product_lists' => true ] );
+		$this->flush_caches();
+
+		$query = $this->run_product_query( [ $this->restricted_product->get_id() ] );
+
+		$this->assertSame( [ 0 ], (array) $query->get( 'post__in' ) );
 	}
 
 	/**
@@ -461,11 +552,16 @@ class Test_Product_Purchase_Restriction extends \WP_UnitTestCase {
 	/**
 	 * Run a product listing query through the hiding filter.
 	 *
+	 * @param int[] $post__in Products a curated listing picked out, if any.
+	 *
 	 * @return \WP_Query
 	 */
-	private function run_product_query() {
+	private function run_product_query( $post__in = [] ) {
 		$query             = new \WP_Query();
 		$query->query_vars = [ 'post_type' => 'product' ];
+		if ( ! empty( $post__in ) ) {
+			$query->query_vars['post__in'] = $post__in;
+		}
 		Product_Purchase_Restriction::filter_product_query( $query );
 		return $query;
 	}

--- a/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/subscriber-only-products-api.php
+++ b/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/subscriber-only-products-api.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Tests the subscriber-only products REST API.
+ *
+ * @package Newspack\Tests\Subscriber_Commerce
+ */
+
+namespace Newspack\Tests\Subscriber_Commerce;
+
+use Newspack\Subscriber_Only_Products;
+
+/**
+ * The endpoint gates purchases, so what a *partial* payload means matters: an
+ * omitted field must never be read as "start enforcing". These dispatch real
+ * REST requests rather than calling the callbacks, because the answer lives in
+ * the argument schema the dispatcher applies.
+ *
+ * @group subscriber-commerce
+ * @group Subscriber_Only_Products_API
+ */
+class Test_Subscriber_Only_Products_API extends \WP_UnitTestCase {
+
+	const ROUTE = '/newspack/v1/wizard/newspack-audience-subscriptions/restrictions';
+
+	/**
+	 * Enable the content gates flag and load the WooCommerce mocks, which the
+	 * routes' availability check reads.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+		require_once dirname( __DIR__, 2 ) . '/mocks/wc-mocks.php';
+	}
+
+	/**
+	 * Build a REST server here rather than reusing whichever one the process
+	 * already has: the routes only register once the flag above is defined, and
+	 * a server built before that would be missing them.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $wp_rest_server;
+		$wp_rest_server = new \WP_REST_Server(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		do_action( 'rest_api_init', $wp_rest_server );
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+	}
+
+	/**
+	 * Reset the server and the stored rules.
+	 */
+	public function tear_down() {
+		global $wp_rest_server;
+		$wp_rest_server = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		delete_option( Subscriber_Only_Products::OPTION_NAME );
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * A payload that says nothing about `active` leaves the restriction paused.
+	 * Defaulting it to true in the schema would let an incomplete save start
+	 * blocking purchases on its own.
+	 */
+	public function test_saving_without_active_leaves_the_restriction_paused() {
+		$this->assertFalse( $this->save_restriction( [] )['active'] );
+	}
+
+	/**
+	 * Saying so still turns it on, so the fail-safe costs the UI nothing.
+	 */
+	public function test_saving_with_active_enforces_the_restriction() {
+		$this->assertTrue( $this->save_restriction( [ 'active' => true ] )['active'] );
+	}
+
+	/**
+	 * POST a restriction and return it as stored.
+	 *
+	 * @param array $params Extra request params, merged over a minimal rule.
+	 *
+	 * @return array The saved restriction.
+	 */
+	private function save_restriction( $params ) {
+		$request = new \WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_body_params(
+			array_merge(
+				[
+					'subscription_product_ids' => [ 1 ],
+					'product_ids'              => [ 2 ],
+				],
+				$params
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$restrictions = $response->get_data()['restrictions'];
+		$this->assertCount( 1, $restrictions );
+		return $restrictions[0];
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

WooCommerce Memberships lets publishers restrict *purchasing* of a product to members. Access Control had no equivalent, which is the last feature gap blocking several publishers from migrating off Memberships.

A restriction says *"these products are purchasable only by subscribers of any of these subscriptions"*, managed under **Audience → Subscriptions → Subscriber-only products**, per the [design](https://newspackdesignp2.wordpress.com/2026/07/23/subscriber-only-products-i1/).

> Supersedes #607, which put the same enforcement on content gates. A restriction isn't a gate on content — it's a rule about the offer — so it belongs beside subscriptions. #607's enforcement engine is carried over; its gate coupling and admin UI are dropped.

**Reader-facing semantics, matching Memberships' purchase restriction:**

* A reader who doesn't subscribe still sees the product, its price and the product lists — only the purchase is blocked. Restricting what a reader may *view* is a separate Memberships feature and stays out of scope, except as the opt-in below.
* A notice on the product page names the subscriptions that unlock it, linking each. A subscription the reader also can't buy is left out rather than pointed at.
* Two restrictions covering one product are **alternatives, not hurdles**: satisfying either unlocks the purchase, so adding a restriction can only widen access. Each one names a way in.
* Only *held* subscriptions count. One sitting in the cart, or bought in the same order, does not.
* Variations are restricted through their parent; restricting a category restricts its subcategories.
* Anyone with `manage_woocommerce` keeps purchasing rights, so a restriction can't lock a publisher out of their own products.
* Enforcement rides `woocommerce_is_purchasable` at 999 (as Memberships does), so a later callback — Subscriptions' renewal-cart limiter at 12, say — can't hand a blocked purchase back. Block themes never fire `woocommerce_single_product_summary`, so the notice also rides the add-to-cart block; it renders once per product either way.

**One setting, "Hide from product lists", off by default.** It keeps restricted products out of listings for readers who can't buy them, which goes a step beyond purchase parity. Direct links still resolve and show the product with its notice, so a reader holding the URL is never left wondering where it went. It covers secondary product queries too (a products block, a category archive), since hiding a product from the shop but not from a block would be incoherent.

**Deliberate fail-open:** a restriction naming no subscription would be unbuyable by everyone. That is far likelier to be half-finished than an intent to withdraw the product from sale, so it is skipped — the same reading the content gate takes of an empty rule.

Two filters are exposed: `newspack_subscriber_only_product_can_purchase` and `newspack_subscriber_only_product_message`.

Closes [NPPD-1899](https://linear.app/a8c/issue/NPPD-1899).

### How to test the changes in this Pull Request:

1. On a site with WooCommerce active, `NEWSPACK_CONTENT_GATES` enabled, Reader Activation on and Woo Memberships **inactive**, create three products: one to restrict, one to leave open, and a subscription product. (If the store is in WooCommerce's "coming soon" mode, turn that off or anonymous visitors see a placeholder instead of the shop.)
2. **Audience → Subscriptions → Subscriber-only products** shows the onboarding empty state. Click **Add restriction**: the drawer opens and **Save stays disabled** until you pick at least one subscription and at least one product.
3. Set "Available to" to the subscription and "Applies to → Specific products" to the restricted product, then Save. The row leads with the product name, with the subscription under "Available to" and an Active badge.
4. In an incognito window open the restricted product: the product and **its price render**, there is **no Add to cart**, and a notice links the subscription. Open the free product: Add to cart works. Open the shop: both are still listed (the restricted one shows Woo's native "Read more", exactly as for any non-purchasable product).
5. Log in as a reader holding that subscription: Add to cart returns and the product can be bought.
6. Pause the restriction from the row's kebab: the product is purchasable again. Resume it.
7. **Settings → Hide from product lists**, save, and reload the shop incognito: the restricted product is gone from the listing, but its direct URL still renders the product page with the notice. Turn it back off.
8. Restrict a *category* instead and confirm a product in one of its **subcategories** is also blocked; add that product to "Excluded products" and confirm it becomes purchasable again.
9. Activate Woo Memberships, or turn off `NEWSPACK_CONTENT_GATES`: enforcement stands down entirely and the product is purchasable again (the admin stays reachable, deliberately — a migrating site configures rules before deactivating Memberships).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

**Verification:** 25 new unit tests covering the purchase decision, the notice, the hiding pass and the REST argument schema (full suite green: 2899 tests, 8447 assertions); PHPCS clean; ESLint clean; build clean. Steps 1–9 exercised end to end in an isolated env — restriction authored through the real UI, and the reader-facing result checked as an anonymous visitor (price visible, no Add to cart, notice naming the subscription; unrestricted product untouched; hiding on/off both confirmed, including the direct link surviving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKzH1CGLgvvrusDGSURAsv
