### PR TITLE
chore(docker): keep memcached alive and fail open on cache delete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,13 +292,35 @@ jobs:
       - name: Install WordPress test suite
         if: steps.check.outputs.has_tests == 'true'
         run: |
+          # Without pipefail, a `curl | tar` pipeline reports only tar's status.
+          # A failed download then surfaces as tar's bare "exit code 2" — the
+          # symptom of a corrupt archive — and the step blames the extraction for
+          # a network problem it never saw.
+          set -o pipefail
+
           # svn isn't on ubuntu-latest runners by default; the WP develop
           # repo's phpunit test library is published over svn.
           sudo apt-get update -qq
           sudo apt-get install -y -qq subversion
-          # Download WP core and test library.
+          # Download WP core and test library. -f so an HTTP error is an error
+          # rather than a body, and --retry so a single dropped connection to
+          # wordpress.org doesn't fail a matrix leg that has nothing to do with
+          # the PR under test.
           mkdir -p "$WP_TESTS_DIR"
-          WP_TESTS_TAG=$(curl -s "https://api.wordpress.org/core/version-check/1.7/" | jq -r '.offers[0].version')
+          WP_TESTS_TAG=$(curl -sSfL --retry 5 --retry-delay 2 --retry-all-errors \
+            "https://api.wordpress.org/core/version-check/1.7/" | jq -r '.offers[0].version')
+
+          # jq prints "null" for a missing key and nothing at all for an empty
+          # body, and both flow on as if they were a version. The URLs built from
+          # them 404, tar chokes on the HTML error page, and the step dies naming
+          # neither the tag nor the API that produced it.
+          case "$WP_TESTS_TAG" in
+            [0-9]*.[0-9]*) ;;
+            *)
+              echo "::error::api.wordpress.org returned no usable version (got '$WP_TESTS_TAG')."
+              exit 1
+              ;;
+          esac
 
           # The tarball's top-level directory is "wordpress/". Extract to
           # $WP_CORE_DIR's parent and strip that prefix so files land at
@@ -306,7 +328,8 @@ jobs:
           # $WP_CORE_DIR happens to be /tmp/wordpress.
           rm -rf "$WP_CORE_DIR"
           mkdir -p "$WP_CORE_DIR"
-          curl -s "https://wordpress.org/wordpress-$WP_TESTS_TAG.tar.gz" \
+          curl -sSfL --retry 5 --retry-delay 2 --retry-all-errors \
+            "https://wordpress.org/wordpress-$WP_TESTS_TAG.tar.gz" \
             | tar xz --strip-components=1 -C "$WP_CORE_DIR"
 
           svn co --quiet "https://develop.svn.wordpress.org/tags/$WP_TESTS_TAG/tests/phpunit/includes/" "$WP_TESTS_DIR/includes"

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -312,12 +312,14 @@ ${worktree_volumes}      - ./envs/${env_name}/html:/var/www/html
       - APACHE_RUN_USER=\${USE_CUSTOM_APACHE_USER:-www-data}
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    ## Probes memcached -- see docker-compose.yml for the rationale. Kept in step
+    ## with the healthcheck migration in env_up().
     healthcheck:
       test: ["CMD", "bash", "-c", "echo > /dev/tcp/127.0.0.1/11211"]
-      interval: 60s
+      interval: 30s
       timeout: 5s
       retries: 3
-      start_period: 30s
+      start_period: 180s
     networks:
       default: {}
       newspack_envs:
@@ -442,6 +444,26 @@ networks:
     external: true
 MIGRATE
             echo "Migrated $env_name: added shared network (domain: $domain)"
+        fi
+        # --- Migration: add the memcached healthcheck if missing ---
+        # Compose files are generated once at create time, so envs predating the
+        # healthcheck would never get it. Keep this block in step with the
+        # healthcheck in the generated YAML above.
+        if ! grep -q 'healthcheck:' "$compose_file"; then
+            awk '
+                { print }
+                /^      - "host\.docker\.internal:host-gateway"$/ && !inserted {
+                    print "    ## Probes memcached -- see docker-compose.yml for the rationale."
+                    print "    healthcheck:"
+                    print "      test: [\"CMD\", \"bash\", \"-c\", \"echo > /dev/tcp/127.0.0.1/11211\"]"
+                    print "      interval: 30s"
+                    print "      timeout: 5s"
+                    print "      retries: 3"
+                    print "      start_period: 180s"
+                    inserted = 1
+                }
+            ' "$compose_file" > "${compose_file}.tmp" && mv "${compose_file}.tmp" "$compose_file"
+            echo "Migrated $env_name: added memcached healthcheck"
         fi
         # Re-read domain after potential migration.
         domain=$(domain_for_env "$compose_file")

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -312,6 +312,12 @@ ${worktree_volumes}      - ./envs/${env_name}/html:/var/www/html
       - APACHE_RUN_USER=\${USE_CUSTOM_APACHE_USER:-www-data}
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD", "bash", "-c", "echo > /dev/tcp/127.0.0.1/11211"]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     networks:
       default: {}
       newspack_envs:

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -463,7 +463,15 @@ MIGRATE
                     inserted = 1
                 }
             ' "$compose_file" > "${compose_file}.tmp" && mv "${compose_file}.tmp" "$compose_file"
-            echo "Migrated $env_name: added memcached healthcheck"
+            # awk's insertion flag is invisible to the shell, so re-read the file:
+            # a compose file without the anchor line passes through unchanged, and
+            # reporting a migration that did not happen would send whoever debugs
+            # a stale env looking in the wrong place.
+            if grep -q 'healthcheck:' "$compose_file"; then
+                echo "Migrated $env_name: added memcached healthcheck"
+            else
+                echo "Warning: could not add the memcached healthcheck to $compose_file (no extra_hosts anchor). Recreate the env to pick it up." >&2
+            fi
         fi
         # Re-read domain after potential migration.
         domain=$(domain_for_env "$compose_file")

--- a/bin/object-cache.php
+++ b/bin/object-cache.php
@@ -147,6 +147,9 @@ class WP_Object_Cache {
 
 	var $connection_errors = array();
 
+	// Servers already reported via error_log this request, keyed by "host:port".
+	var $logged_connection_errors = array();
+
 	var $time_start = 0;
 	var $time_total = 0;
 	var $size_total = 0;
@@ -277,9 +280,11 @@ class WP_Object_Cache {
 
 		$this->group_ops_stats( 'delete', $key, $group, null, $elapsed );
 
-		if ( false !== $result ) {
-			unset( $this->cache[ $key ] );
-		}
+		// Always drop the runtime entry, even when the backend delete fails (server
+		// unreachable, or key absent). Leaving it in place keeps a stale value
+		// readable for the rest of the request, which silently breaks the
+		// read-after-write that update_metadata() and clean_post_cache() rely on.
+		unset( $this->cache[ $key ] );
 
 		return $result;
 	}
@@ -810,6 +815,17 @@ class WP_Object_Cache {
 	}
 
 	function failure_callback( $host, $port ) {
+		$server = $host . ':' . $port;
+
+		// Report each unreachable server once per request. Without this the cache
+		// degrades to a request-scoped array with no outward signal at all, which
+		// is indistinguishable from a healthy cache until results go stale.
+		if ( ! isset( $this->logged_connection_errors[ $server ] ) ) {
+			$this->logged_connection_errors[ $server ] = true;
+
+			error_log( sprintf( 'Memcached object cache: cannot reach %s. Falling back to a request-scoped cache; run `/etc/init.d/memcached start` in the container.', $server ) );
+		}
+
 		$this->connection_errors[] = array(
 			'host' => $host,
 			'port' => $port,

--- a/bin/object-cache.php
+++ b/bin/object-cache.php
@@ -8,6 +8,15 @@ Plugin URI: https://wordpress.org/plugins/memcached/
 Author: Ryan Boren, Denis de Bernardy, Matt Martz, Andy Skelton
 
 Install this file to wp-content/object-cache.php
+
+LOCALLY PATCHED — this is not a pristine copy of upstream 4.0.0. Re-vendoring the
+upstream release will silently revert these; re-apply them:
+  - delete()           always drops the runtime entry, even when the backend delete fails.
+  - replace()          same, so a failed replace cannot leave a stale value readable.
+  - failure_callback() logs an unreachable server once per request.
+Without the first two, an unreachable memcached turns this drop-in into a cache that
+can never be invalidated: set() populates the runtime array unconditionally and get()
+serves from it, so read-after-write within one request returns the stale value.
 */
 
 // Users with setups where multiple installs share a common wp-config.php or $table_prefix
@@ -147,8 +156,11 @@ class WP_Object_Cache {
 
 	var $connection_errors = array();
 
-	// Servers already reported via error_log this request, keyed by "host:port".
-	var $logged_connection_errors = array();
+	// Servers already reported this request, keyed by "host:port". Static because
+	// advanced-cache.php instantiates this class and wp-settings.php then replaces
+	// that instance, so a per-instance map would report the same server once per
+	// instantiation rather than once per request.
+	static $logged_connection_errors = array();
 
 	var $time_start = 0;
 	var $time_total = 0;
@@ -591,6 +603,11 @@ class WP_Object_Cache {
 				'value' => $data,
 				'found' => true,
 			];
+		} else {
+			// Drop the runtime entry rather than leaving the superseded value
+			// readable, for the same reason delete() does: a failed backend write
+			// must not make this request observe stale data.
+			unset( $this->cache[ $key ] );
 		}
 
 		return $result;
@@ -817,14 +834,19 @@ class WP_Object_Cache {
 	function failure_callback( $host, $port ) {
 		$server = $host . ':' . $port;
 
-		// Report each unreachable server once per request. Without this the cache
+		// Record each unreachable server once per request. Without this the cache
 		// degrades to a request-scoped array with no outward signal at all, which
-		// is indistinguishable from a healthy cache until results go stale.
-		if ( ! isset( $this->logged_connection_errors[ $server ] ) ) {
-			$this->logged_connection_errors[ $server ] = true;
-
-			error_log( sprintf( 'Memcached object cache: cannot reach %s. Falling back to a request-scoped cache; run `/etc/init.d/memcached start` in the container.', $server ) );
+		// is indistinguishable from a healthy cache until results go stale. The
+		// guard also bounds $connection_errors, which nothing reads back and which
+		// would otherwise grow one entry per failed operation for the life of a
+		// long-running process.
+		if ( isset( self::$logged_connection_errors[ $server ] ) ) {
+			return;
 		}
+
+		self::$logged_connection_errors[ $server ] = true;
+
+		error_log( sprintf( 'Memcached object cache: cannot reach %s. Falling back to a request-scoped cache. The container watchdog restarts memcached within 30s; if this repeats, check /var/log/memcached.log.', $server ) );
 
 		$this->connection_errors[] = array(
 			'host' => $host,

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -72,7 +72,6 @@ chown memcache:memcache /var/run/memcached || true
 /etc/init.d/memcached start
 
 # Supervise it -- see the script for why nothing else does.
-chmod +x /var/scripts/watchdog-memcached.sh || true
 /var/scripts/watchdog-memcached.sh &
 
 # Run apache in the foreground so the container keeps running

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -57,8 +57,31 @@ echo "Newspack Manager site is available at https://manager.com${WP_HOST_PORT}/"
 echo "Open http://localhost:8025 to see Mailhog inbox."
 echo
 
-# Start memcached
+# Start memcached.
+#
+# memcached.conf points -P at /var/run/memcached/, a directory that lives on
+# tmpfs and so is absent on every container start. init.d tracks the daemon by a
+# separate pid file that its wrapper writes, so this one is redundant -- but
+# without the directory memcached logs a pid file error on each start, which
+# reads as a startup failure when triaging. Create it to keep the log honest.
+mkdir -p /var/run/memcached
+chown memcache:memcache /var/run/memcached
+
 /etc/init.d/memcached start
+
+# Keep memcached alive. Nothing supervises it, and a dead memcached is invisible
+# from the outside: the object cache drop-in keeps serving a request-scoped
+# array, so the site looks fine while cache invalidation silently stops working.
+(
+	while true; do
+		sleep 30
+
+		if ! (echo > /dev/tcp/127.0.0.1/11211) 2>/dev/null; then
+			echo "[run.sh] memcached is not answering on 11211; restarting it."
+			/etc/init.d/memcached restart || /etc/init.d/memcached start
+		fi
+	done
+) &
 
 # Run apache in the foreground so the container keeps running
 echo "Running Apache in the foreground"

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -59,29 +59,21 @@ echo
 
 # Start memcached.
 #
-# memcached.conf points -P at /var/run/memcached/, a directory that lives on
-# tmpfs and so is absent on every container start. init.d tracks the daemon by a
-# separate pid file that its wrapper writes, so this one is redundant -- but
-# without the directory memcached logs a pid file error on each start, which
-# reads as a startup failure when triaging. Create it to keep the log honest.
-mkdir -p /var/run/memcached
-chown memcache:memcache /var/run/memcached
+# memcached.conf points -P at /var/run/memcached/, a directory Debian's package
+# creates through systemd-tmpfiles -- which never runs in a container, so it is
+# absent here. init.d tracks the daemon by a separate pid file that its wrapper
+# writes, so this one is redundant; but without the directory memcached logs a
+# pid file error on every start, which reads as a startup failure when triaging.
+# Create it to keep the log honest. Neither step is worth failing the container
+# for, hence the guards.
+mkdir -p /var/run/memcached || true
+chown memcache:memcache /var/run/memcached || true
 
 /etc/init.d/memcached start
 
-# Keep memcached alive. Nothing supervises it, and a dead memcached is invisible
-# from the outside: the object cache drop-in keeps serving a request-scoped
-# array, so the site looks fine while cache invalidation silently stops working.
-(
-	while true; do
-		sleep 30
-
-		if ! (echo > /dev/tcp/127.0.0.1/11211) 2>/dev/null; then
-			echo "[run.sh] memcached is not answering on 11211; restarting it."
-			/etc/init.d/memcached restart || /etc/init.d/memcached start
-		fi
-	done
-) &
+# Supervise it -- see the script for why nothing else does.
+chmod +x /var/scripts/watchdog-memcached.sh || true
+/var/scripts/watchdog-memcached.sh &
 
 # Run apache in the foreground so the container keeps running
 echo "Running Apache in the foreground"

--- a/bin/watchdog-memcached.sh
+++ b/bin/watchdog-memcached.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Keeps memcached alive inside the container.
+#
+# Nothing else supervises it, and a dead memcached is invisible from the outside:
+# the object cache drop-in keeps serving a request-scoped array, so the site looks
+# fine while cache invalidation silently stops working.
+#
+# This lives in bin/ (bind-mounted at /var/scripts) rather than inline in run.sh so
+# that changes to the supervision logic take effect on a container restart, without
+# rebuilding the image.
+#
+# Deliberately no `set -e`: a failed probe or a failed restart must not end the
+# loop. A watchdog that exits on the first bad night reintroduces exactly the
+# silent degradation it exists to prevent.
+#
+# Named watchdog-memcached rather than memcached-watchdog deliberately: the kernel
+# truncates process names to 15 characters, and `pkill memcached` matches that name
+# as a substring. The other ordering truncates to "memcached-watch", so anyone
+# reaching for pkill to clear a stuck memcached would take the supervisor with it,
+# precisely when it is needed most.
+
+INTERVAL="${MEMCACHED_WATCHDOG_INTERVAL:-30}"
+
+while true; do
+	sleep "$INTERVAL"
+
+	if (echo > /dev/tcp/127.0.0.1/11211) 2>/dev/null; then
+		continue
+	fi
+
+	echo "[watchdog-memcached] memcached is not answering on 11211; restarting it."
+
+	# Kill by exact process name rather than using the init script's stop/restart:
+	# those match on a pid file memcached may have left stale after a crash, and
+	# container pids recycle fast enough that signalling it could hit an unrelated
+	# process. The start wrapper unlinks a stale pid file before forking.
+	pkill -x memcached >/dev/null 2>&1
+	/etc/init.d/memcached start >/dev/null 2>&1 || true
+done

--- a/bin/watchdog-memcached.sh
+++ b/bin/watchdog-memcached.sh
@@ -21,6 +21,12 @@
 # precisely when it is needed most.
 
 INTERVAL="${MEMCACHED_WATCHDOG_INTERVAL:-30}"
+if ! [[ "$INTERVAL" =~ ^[0-9]+$ ]] || [ "$INTERVAL" -lt 1 ]; then
+	# Without `set -e` a non-numeric interval would fail every sleep instantly
+	# and spin the loop at full CPU for the container's whole life.
+	echo "[watchdog-memcached] MEMCACHED_WATCHDOG_INTERVAL='$INTERVAL' is not a positive integer; falling back to 30 seconds."
+	INTERVAL=30
+fi
 
 while true; do
 	sleep "$INTERVAL"
@@ -36,5 +42,10 @@ while true; do
 	# container pids recycle fast enough that signalling it could hit an unrelated
 	# process. The start wrapper unlinks a stale pid file before forking.
 	pkill -x memcached >/dev/null 2>&1
+
+	# Give the old process a moment to release 11211, so the restart below has a
+	# port to bind to. Losing the race only costs one cycle, but the wait is free.
+	sleep 1
+
 	/etc/init.d/memcached start >/dev/null 2>&1 || true
 done

--- a/docker-compose-82.yml
+++ b/docker-compose-82.yml
@@ -61,6 +61,13 @@ services:
       - APACHE_RUN_USER=${USE_CUSTOM_APACHE_USER:-www-data}
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    ## Probes memcached -- see docker-compose.yml for the rationale.
+    healthcheck:
+      test: ["CMD", "bash", "-c", "echo > /dev/tcp/127.0.0.1/11211"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 180s
   mailhog:
     image: arjenz/mailhog:latest
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,16 @@ services:
       - APACHE_RUN_USER=${USE_CUSTOM_APACHE_USER:-www-data}
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    ## Apache runs in the foreground, so it takes the container down with it when
+    ## it dies. memcached does not: it can exit and leave a container that looks
+    ## healthy while the object cache quietly stops invalidating. Probe it so the
+    ## failure is visible in `docker ps`.
+    healthcheck:
+      test: ["CMD", "bash", "-c", "echo > /dev/tcp/127.0.0.1/11211"]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
   mailhog:
     image: arjenz/mailhog:latest
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,14 +63,17 @@ services:
       - "host.docker.internal:host-gateway"
     ## Apache runs in the foreground, so it takes the container down with it when
     ## it dies. memcached does not: it can exit and leave a container that looks
-    ## healthy while the object cache quietly stops invalidating. Probe it so the
-    ## failure is visible in `docker ps`.
+    ## healthy while the object cache quietly stops invalidating. The in-container
+    ## watchdog restarts it within ~30s, so this probe is the second line of
+    ## defence -- it reports unhealthy only for a memcached the watchdog could not
+    ## revive. start_period covers a cold boot, where memcached starts only after
+    ## init-wp.sh has downloaded WordPress and waited for MariaDB.
     healthcheck:
       test: ["CMD", "bash", "-c", "echo > /dev/tcp/127.0.0.1/11211"]
-      interval: 60s
+      interval: 30s
       timeout: 5s
       retries: 3
-      start_period: 30s
+      start_period: 180s
   mailhog:
     image: arjenz/mailhog:latest
     restart: always


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Local dev only — the drop-in is copied into the container by `run.sh` and never ships to publishers.

In an isolated env, `update_post_meta()` followed by `get_post_meta()` in the same request returned the stale value while the DB held the new one. `wp_cache_delete()` and `clean_post_cache()` did not help. Two of fifteen running env containers were affected.

memcached had died, and nothing supervises it. With the backend unreachable, the drop-in treats its in-process array asymmetrically:

| method | runtime cache when memcached is down |
| --- | --- |
| `set()` | writes `$this->cache[$key]` unconditionally |
| `get()` | serves from `$this->cache[$key]` |
| `delete()` | `unset()` only if `false !== $result` — so never |

`Memcache::delete()` returns `false` when the server is unreachable, so the runtime entry survives and the cache degrades into one that can never be invalidated. Core invalidates post meta via delete, so `update_post_meta()` became a no-op against the cache. Anything writing and reading back in one request — CLI migrations, tests — got false results with no outward signal.

Changes:

1. **`delete()` and `replace()` always drop the runtime entry.** The one that matters: it turns a silent correctness bug into, at worst, a slower local site.
2. **Unreachable servers are logged once per process**, which also bounds `connection_errors` (written, never read, previously one entry per failed op).
3. **`bin/watchdog-memcached.sh`** — a 30s TCP probe that restarts memcached. Bind-mounted via `/var/scripts` rather than inline in `run.sh`, so later changes to it need no image rebuild. No `set -e`, so a failed restart can't end the loop.
4. **Container healthchecks** for the main, 8.2 and generated env compose files, plus a migration in `n env up` so the ~43 existing env files get one. Tuned to flag only a memcached the watchdog could not revive, with `start_period` covering a cold boot.
5. **Header note** recording that this vendored copy is patched, so a re-vendor doesn't silently revert it.

`run.sh` is baked into the image, so the watchdog needs one `./build-image.sh` to start; the drop-in applies on container restart.

### How to test the changes in this Pull Request:

1. On `main`, kill memcached in any env container:
   ```
   docker exec <container> sh -c '/etc/init.d/memcached stop; pkill -x memcached'
   ```
   Create a post, `update_post_meta()`, then `get_post_meta()` it back in one `wp eval-file`. Returns `''` while a direct SELECT returns the value.
2. With this branch's `bin/object-cache.php` in the container's `wp-content/`, memcached still down:
   ```
   immediately:   'probe_value'
   after delete:  'probe_value'
   direct db:     'probe_value'
   post title:    'probe-renamed'
   ```
3. `wp-content/debug.log` reports the outage once per process: `Memcached object cache: cannot reach 127.0.0.1:11211…`
4. Run `MEMCACHED_WATCHDOG_INTERVAL=2 /var/scripts/watchdog-memcached.sh`, then kill memcached three times with `pkill -x memcached`. It recovers each time and the loop survives.
5. `docker exec <container> bash -c 'echo > /dev/tcp/127.0.0.1/11211'` exits non-zero with memcached down, zero with it up.
6. `n env up <name>` on an env created before this branch inserts the healthcheck; re-running inserts nothing.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? — no harness covers the container's runtime setup; verified manually per the steps above.
* [x] Have you successfully run tests with your changes locally?

All six steps verified on a live container; both compose files and a migrated env file parse via `docker compose config`.

Unrelated to the memcached work, this branch also carries a CI fix: the PHPUnit job's `Install WordPress test suite` step piped `curl -s` straight into `tar` with no `pipefail`, no `-f` and no retries, so a failed WordPress.org download surfaced as tar's bare exit 2 and failed a matrix leg. It now retries, validates the version string it resolved from `api.wordpress.org`, and reports the download error itself.
