### PR TITLE
fix(access-control): complete gate access-rule option lists (NPPD-2135)

### DIFF
--- a/plugins/newspack-plugin/includes/cli/class-membership-gates-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-membership-gates-migration.php
@@ -1060,7 +1060,10 @@ class Membership_Gates_Migration {
 	 * was, so the caller warns rather than staying silent.
 	 *
 	 * Product variations keep the behavior this command has always had: they are
-	 * dropped, because gates reference parent products only.
+	 * dropped. A gate can carry a variation ID — the rule matches a line item on its
+	 * variation_id as well as its product_id, and the editor's picker now offers them —
+	 * so this is a conservative default rather than a limitation, and the warning tells
+	 * the operator what to add back by hand. Keeping them is NPPD-2135's follow-up.
 	 *
 	 * @param array[] $group Plan descriptors, each carrying a 'product_ids' key.
 	 *
@@ -1152,7 +1155,7 @@ class Membership_Gates_Migration {
 		if ( ! empty( $dropped['variations'] ) ) {
 			WP_CLI::warning(
 				sprintf(
-					'"%s": dropped product variation ID(s) %s. Gates restrict access by parent product, not by variation, so a plan that required one of these specific variations no longer has that restriction from this gate. Check the plan\'s products.',
+					'"%s": dropped product variation ID(s) %s, so a plan that required one of these specific variations no longer has that restriction from this gate. The gate editor lists a variable subscription\'s variations, so add them back there if the restriction was meant to survive. Check the plan\'s products.',
 					$gate_title,
 					implode( ', ', $dropped['variations'] )
 				)

--- a/plugins/newspack-plugin/includes/cli/class-premium-newsletters-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-premium-newsletters-migration.php
@@ -910,9 +910,9 @@ class Premium_Newsletters_Migration {
 	 * variation — which is what the plan granted. Substituting the parent would also
 	 * admit holders of its sibling variations, and dropping the ID restricts readers
 	 * the plan admitted, who Premium_Newsletters::check_access() then unsubscribes at
-	 * cutover. The cost is that the gate editor's product picker is built from
-	 * Access_Rules::get_subscription_products_options(), which lists parent products
-	 * only, so a variation ID is not shown there and is lost if that field is re-saved.
+	 * cutover. The gate editor's product picker lists a variable subscription's
+	 * variations alongside its parent, so a migrated variation ID is shown there and
+	 * survives a re-save of that field.
 	 *
 	 * @param array[] $group Plan descriptors, each carrying a 'product_ids' key.
 	 *
@@ -1004,7 +1004,7 @@ class Premium_Newsletters_Migration {
 		if ( ! empty( $payload['variation_ids'] ) ) {
 			WP_CLI::warning(
 				sprintf(
-					'"%s": its paid access rule keeps product variation ID(s) %s, which is what the plan granted. The gate editor\'s product picker lists parent products only, so they are not shown there — and re-saving that field in the editor drops them. Leave it alone unless you mean to change what the gate grants.',
+					'"%s": its paid access rule keeps product variation ID(s) %s, which is what the plan granted — narrower than the parent product, which would also admit holders of its sibling variations. The gate editor lists them, so they survive a re-save. Leave them alone unless you mean to change what the gate grants.',
 					$payload['title'],
 					implode( ', ', $payload['variation_ids'] )
 				)

--- a/plugins/newspack-plugin/includes/cli/class-woocommerce-subscriptions.php
+++ b/plugins/newspack-plugin/includes/cli/class-woocommerce-subscriptions.php
@@ -23,20 +23,26 @@ defined( 'ABSPATH' ) || exit;
  */
 class WooCommerce_Subscriptions {
 	/**
-	 * Product statuses the gate product picker offers (mirrors the default statuses
-	 * `Access_Rules::get_subscription_products_options` -> `wc_get_products` lists). A
-	 * subscription line item on a product outside this set is not gate-selectable, so
-	 * Access Control can never reference it. Single source of truth shared by the audit
+	 * Product statuses the gate product picker offers for a parent product (mirrors the
+	 * default statuses `Access_Rules::get_subscription_products_options` -> `wc_get_products`
+	 * lists). A subscription line item whose parent product is outside this set has no
+	 * gate-selectable product behind it. Single source of truth shared by the audit
 	 * classifier and the repair target check so the two can't drift.
+	 *
+	 * Variations are the picker's other half and are deliberately not modelled here: it
+	 * lists a variable subscription's publish and private variations alongside the parent,
+	 * but only while it lists the parent, so the parent is what decides whether a line item
+	 * is reachable at all. {@see classify_subscription_product_link()}.
 	 *
 	 * @var string[]
 	 */
 	const SELECTABLE_PRODUCT_STATUSES = [ 'publish', 'private', 'draft', 'pending' ];
 
 	/**
-	 * Product types the gate product picker offers. A repair target outside this set can
-	 * never be referenced by a gate (and a non-`product` post such as a variation would
-	 * also throw in WC_Order_Item_Product::set_product_id()).
+	 * Parent product types the gate product picker offers. A repair target outside this set
+	 * is not a product a repair may point a line item at — a non-`product` post such as a
+	 * variation also throws in WC_Order_Item_Product::set_product_id(), which is why a
+	 * variation stays out of this set even though a gate can now reference one.
 	 *
 	 * @var string[]
 	 */
@@ -902,8 +908,9 @@ class WooCommerce_Subscriptions {
 	 *
 	 * Liveness keys on the line item's parent `product_id`: the picker
 	 * (`Access_Rules::get_subscription_products_options`) offers `subscription` /
-	 * `variable-subscription` parents, never variations, so it is the parent's liveness — not
-	 * the specific variation's — that decides whether a fresh gate can be configured to match.
+	 * `variable-subscription` parents, and a variable subscription's variations only
+	 * alongside the parent it lists, so it is the parent's liveness — not the specific
+	 * variation's — that decides whether a fresh gate can be configured to match.
 	 * The access-referenced check is wider: `WC_Subscription::has_product()` compares a stored
 	 * rule value against both `product_id` and `variation_id`, so an already-persisted rule
 	 * holding either ID keeps granting access and both are honored here.
@@ -1224,8 +1231,10 @@ class WooCommerce_Subscriptions {
 	/**
 	 * Fetch the gate-selectable subscription products, for guess-matching.
 	 *
-	 * Mirrors `Access_Rules::get_subscription_products_options`: the same product types and
-	 * statuses the gate product picker lists (via the shared allowlist constants).
+	 * Mirrors the parent products in `Access_Rules::get_subscription_products_options`: the
+	 * same types and statuses the gate product picker lists (via the shared allowlist
+	 * constants). The picker's variations are left out — this set feeds name-matching for a
+	 * repair, and a repair may not point a line item at a variation.
 	 *
 	 * @return array List of `[ 'id' => int, 'name' => string ]`.
 	 */
@@ -1248,9 +1257,9 @@ class WooCommerce_Subscriptions {
 	}
 
 	/**
-	 * Whether a product is one the gate picker would list — the same type + status allowlist
-	 * as `get_live_subscription_products()`, so the repair target check and the audit's
-	 * live-product set can't drift.
+	 * Whether a product is a parent product the gate picker would list — the same type +
+	 * status allowlist as `get_live_subscription_products()`, so the repair target check and
+	 * the audit's live-product set can't drift.
 	 *
 	 * @param \WC_Product $product The product to test.
 	 * @return bool

--- a/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
@@ -458,7 +458,26 @@ class Access_Rules {
 	/**
 	 * Get subscriptions eligible for access rules.
 	 *
-	 * @return array Active subscription IDs.
+	 * Variations of a variable subscription are listed alongside their parent, because the
+	 * rule evaluates them: `WC_Subscription::has_product()` matches a line item's
+	 * `variation_id` as well as its `product_id`. Selecting the parent therefore grants
+	 * access to subscribers of any of its variations, while selecting a single variation
+	 * narrows the rule to that one — gating on the annual tier of a variable subscription
+	 * but not the monthly, say. Without the variations listed, that narrower rule can be
+	 * held by a gate (migrated data carries variation IDs) but never configured or read
+	 * back in the editor.
+	 *
+	 * Unpublished products are listed too — `wc_get_products()` defaults to draft, pending,
+	 * private and publish. Unlike institutions, whose options are published-only, a
+	 * subscription to a product the publisher has since drafted still evaluates: the line
+	 * item is what the rule matches, and it does not stop existing when the product is
+	 * unpublished. Hiding those products would make the readers still paying for them
+	 * ungateable.
+	 *
+	 * The list is unbounded and rebuilt per call. See NPPD-2138 for memoizing it — gate
+	 * saves rebuild it once per rule.
+	 *
+	 * @return array Array of [ 'label' => string, 'value' => int ].
 	 */
 	public static function get_subscription_products_options() {
 		if ( ! function_exists( 'wc_get_products' ) ) {
@@ -470,14 +489,100 @@ class Access_Rules {
 				'limit' => -1,
 			]
 		);
-		$options = [];
+		$variations_by_parent = self::get_subscription_variation_posts( $products );
+		$options              = [];
 		foreach ( $products as $product ) {
 			$options[] = [
 				'label' => $product->get_name(),
 				'value' => $product->get_id(),
 			];
+			foreach ( $variations_by_parent[ $product->get_id() ] ?? [] as $variation ) {
+				$options[] = [
+					'label' => self::get_variation_option_label( $product->get_name(), $variation ),
+					'value' => $variation->ID,
+				];
+			}
 		}
 		return $options;
+	}
+
+	/**
+	 * Fetch the variation posts of the given variable subscriptions, keyed by parent ID.
+	 *
+	 * The post row carries everything a label needs — WooCommerce stores a variation's
+	 * generated title in `post_title` and its attribute summary in `post_excerpt` — so this
+	 * reads the posts directly rather than hydrating a `WC_Product` per variation.
+	 * Hydrating would cost a full meta read, a parent re-read and two term lookups each,
+	 * and this runs on every admin page load that localises the access rules, including
+	 * every block editor load.
+	 *
+	 * Private variations are included alongside published ones: a reader can hold an active
+	 * subscription to a tier the publisher has since hidden, and the rule still has to be
+	 * able to name it.
+	 *
+	 * @param \WC_Product[] $products The subscription products to collect variations for.
+	 *
+	 * @return array<int, \WP_Post[]> Variation posts keyed by parent product ID.
+	 */
+	private static function get_subscription_variation_posts( $products ) {
+		$parent_ids = [];
+		foreach ( $products as $product ) {
+			if ( $product->is_type( 'variable-subscription' ) ) {
+				$parent_ids[] = $product->get_id();
+			}
+		}
+		if ( empty( $parent_ids ) ) {
+			return [];
+		}
+		$variations = \get_posts(
+			[
+				'post_type'              => 'product_variation',
+				'post_parent__in'        => $parent_ids,
+				'post_status'            => [ 'publish', 'private' ],
+				'posts_per_page'         => -1,
+				'orderby'                => [
+					'menu_order' => 'ASC',
+					'ID'         => 'ASC',
+				],
+				// Only the title, excerpt, ID and parent are read.
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+			]
+		);
+		$by_parent = [];
+		foreach ( $variations as $variation ) {
+			$by_parent[ $variation->post_parent ][] = $variation;
+		}
+		return $by_parent;
+	}
+
+	/**
+	 * Build the option label for a subscription variation.
+	 *
+	 * WooCommerce generates a variation's title as "Parent - Attribute" and names it that
+	 * way throughout its own admin, so that title is the label wherever it is usable. But it
+	 * drops the attribute suffix when the parent carries three or more attributes, or two or
+	 * more where an attribute name is multi-word — leaving the variation titled exactly like
+	 * its parent. Recover the attributes from the summary in that case, so the variation
+	 * still reads as the tier it is rather than as a second copy of its parent. The summary
+	 * spells out attribute names where the generated title omits them ("Term: Annual" rather
+	 * than "Annual"); matching the generated style would mean hydrating the variation, which
+	 * costs more than the fallback is worth.
+	 *
+	 * Labels need not be unique: the pickers render every option as `<name> (#<id>)` and
+	 * resolve a token by the ID it carries, so two options sharing a name stay distinct.
+	 *
+	 * @param string   $parent_name The variable subscription parent's name.
+	 * @param \WP_Post $variation   The variation post.
+	 *
+	 * @return string The option label.
+	 */
+	private static function get_variation_option_label( string $parent_name, \WP_Post $variation ): string {
+		$label = $variation->post_title;
+		if ( $label !== $parent_name ) {
+			return $label;
+		}
+		return '' !== $variation->post_excerpt ? sprintf( '%s - %s', $label, $variation->post_excerpt ) : $label;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
@@ -24,6 +24,28 @@ class Access_Rules {
 	private static $rules = [];
 
 	/**
+	 * Request-scoped memo for the subscription product options.
+	 *
+	 * Building the list costs a full-catalog product query plus a variation query, and
+	 * `get_access_rules()` resolves every registered rule's options callback on every
+	 * call. It is public and several admin screens localize it, so a request that reaches
+	 * it more than once pays that cost once.
+	 *
+	 * @var array|null
+	 */
+	private static $subscription_products_options = null;
+
+	/**
+	 * Request-scoped memo for the one-time purchase product options.
+	 *
+	 * Same reasoning as {@see self::$subscription_products_options}, over a shop's whole
+	 * simple/variable catalog.
+	 *
+	 * @var array|null
+	 */
+	private static $one_time_purchase_products_options = null;
+
+	/**
 	 * Valid duration units for the one-time purchase rule.
 	 *
 	 * @var array
@@ -49,17 +71,6 @@ class Access_Rules {
 	 * @var array
 	 */
 	private static $evaluation_context = [];
-
-	/**
-	 * Request-scoped memo for the subscription product options.
-	 *
-	 * `sanitize_access_rule()` resolves every registered rule's options callback once per
-	 * rule in a gate's payload, so saving a six-rule gate would otherwise run the
-	 * full-catalog product query and its variation query six times over.
-	 *
-	 * @var array|null
-	 */
-	private static $subscription_products_options = null;
 
 	/**
 	 * Initialize hooks.
@@ -526,14 +537,17 @@ class Access_Rules {
 	}
 
 	/**
-	 * Flush the request-scoped subscription product options memo.
+	 * Flush the request-scoped product options memos.
 	 *
-	 * Primarily for tests; in production the memo is per-request by nature.
+	 * For tests; in production the memos are per-request by nature. A PHPUnit run is one
+	 * request for the whole suite, so `Newspack_Request_Memo_Reset` calls this before
+	 * every test to put the request boundary back where the memos assume it is.
 	 *
 	 * @return void
 	 */
-	public static function flush_subscription_products_options_memo() {
-		self::$subscription_products_options = null;
+	public static function flush_product_options_memos() {
+		self::$subscription_products_options      = null;
+		self::$one_time_purchase_products_options = null;
 	}
 
 	/**
@@ -591,14 +605,20 @@ class Access_Rules {
 	 * Build the option label for a subscription variation.
 	 *
 	 * WooCommerce generates a variation's title as "Parent - Attribute" and names it that
-	 * way throughout its own admin, so that title is the label wherever it is usable. But it
-	 * drops the attribute suffix when the parent carries three or more attributes, or two or
-	 * more where an attribute name is multi-word — leaving the variation titled exactly like
-	 * its parent. Recover the attributes from the summary in that case, so the variation
-	 * still reads as the tier it is rather than as a second copy of its parent. The summary
-	 * spells out attribute names where the generated title omits them ("Term: Annual" rather
-	 * than "Annual"); matching the generated style would mean hydrating the variation, which
-	 * costs more than the fallback is worth.
+	 * way throughout its own admin, so that title is the label wherever it is usable. It is
+	 * usable when it still opens with the parent's current name and adds something to it.
+	 * Two things break that. WooCommerce drops the attribute suffix when the parent carries
+	 * three or more attributes, or two or more where an attribute name is multi-word,
+	 * leaving the variation titled exactly like its parent. And the title is generated at
+	 * the variation's last save: `WC_Product_Variable_Data_Store_CPT::sync_variation_names()`
+	 * rewrites it when the parent is renamed through the CRUD path, but an importer or a
+	 * direct `wp_update_post()` leaves it on the old name.
+	 *
+	 * Either way the title stops telling a publisher which tier they are picking, so
+	 * recover the attributes from the summary and pair them with the parent's current name.
+	 * The summary spells out attribute names where the generated title omits them
+	 * ("Term: Annual" rather than "Annual"); matching the generated style would mean
+	 * hydrating the variation, which costs more than the fallback is worth.
 	 *
 	 * Labels need not be unique: the pickers render every option as `<name> (#<id>)` and
 	 * resolve a token by the ID it carries, so two options sharing a name stay distinct.
@@ -612,17 +632,15 @@ class Access_Rules {
 	 * @return string The option label.
 	 */
 	private static function get_variation_option_label( string $parent_name, \WP_Post $variation ): string {
-		$label = $variation->post_title;
-		if ( $label !== $parent_name ) {
-			return $label;
-		}
-		if ( '' === $variation->post_excerpt ) {
-			return $label;
+		$title             = $variation->post_title;
+		$names_this_parent = str_starts_with( $title, $parent_name ) && strlen( $title ) > strlen( $parent_name );
+		if ( $names_this_parent || '' === $variation->post_excerpt ) {
+			return $title;
 		}
 		return sprintf(
 			/* translators: 1: variable subscription name, e.g. "Membership". 2: the variation's attribute summary, e.g. "Term: Annual". */
 			__( '%1$s - %2$s', 'newspack-plugin' ),
-			$label,
+			$parent_name,
 			$variation->post_excerpt
 		);
 	}
@@ -705,18 +723,13 @@ class Access_Rules {
 	 * @return array Product options as label/value pairs.
 	 */
 	public static function get_one_time_purchase_products_options() {
-		// Request-scoped memo: the full-catalog query would otherwise run once per
-		// rule sanitized on a gate save (Content_Gate_API resolves all rule options
-		// for each rule in the payload).
-		//
 		// TODO (NPPD-2132): unlike the subscription and institution options (also
 		// full dumps, but inherently small), a shop's simple/variable catalog can be
 		// large, and this list is serialized into every block-editor payload. Move to
 		// a bounded/REST-searchable product picker; the memo only helps within a
 		// single request.
-		static $options = null;
-		if ( null !== $options ) {
-			return $options;
+		if ( null !== self::$one_time_purchase_products_options ) {
+			return self::$one_time_purchase_products_options;
 		}
 		if ( ! function_exists( 'wc_get_products' ) ) {
 			return [];
@@ -734,6 +747,7 @@ class Access_Rules {
 				'value' => $product->get_id(),
 			];
 		}
+		self::$one_time_purchase_products_options = $options;
 		return $options;
 	}
 

--- a/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
@@ -51,6 +51,17 @@ class Access_Rules {
 	private static $evaluation_context = [];
 
 	/**
+	 * Request-scoped memo for the subscription product options.
+	 *
+	 * `sanitize_access_rule()` resolves every registered rule's options callback once per
+	 * rule in a gate's payload, so saving a six-rule gate would otherwise run the
+	 * full-catalog product query and its variation query six times over.
+	 *
+	 * @var array|null
+	 */
+	private static $subscription_products_options = null;
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
@@ -472,14 +483,21 @@ class Access_Rules {
 	 * subscription to a product the publisher has since drafted still evaluates: the line
 	 * item is what the rule matches, and it does not stop existing when the product is
 	 * unpublished. Hiding those products would make the readers still paying for them
-	 * ungateable.
+	 * ungateable. Variations narrow that set to publish and private, which is not a
+	 * different policy but the same one: WooCommerce reads a variable product's children
+	 * as `post_status IN ( 'publish', 'private' )`, so draft is not a state its own admin
+	 * produces for a variation, and nothing can have been bought in it.
 	 *
-	 * The list is unbounded and rebuilt per call. See NPPD-2138 for memoizing it — gate
-	 * saves rebuild it once per rule.
+	 * The result is memoized per request. The list itself is still unbounded and is
+	 * serialized into every editor payload; NPPD-2132 replaces it with a searchable
+	 * picker, which is what removes that cost rather than deferring it.
 	 *
 	 * @return array Array of [ 'label' => string, 'value' => int ].
 	 */
 	public static function get_subscription_products_options() {
+		if ( null !== self::$subscription_products_options ) {
+			return self::$subscription_products_options;
+		}
 		if ( ! function_exists( 'wc_get_products' ) ) {
 			return [];
 		}
@@ -503,7 +521,19 @@ class Access_Rules {
 				];
 			}
 		}
+		self::$subscription_products_options = $options;
 		return $options;
+	}
+
+	/**
+	 * Flush the request-scoped subscription product options memo.
+	 *
+	 * Primarily for tests; in production the memo is per-request by nature.
+	 *
+	 * @return void
+	 */
+	public static function flush_subscription_products_options_memo() {
+		self::$subscription_products_options = null;
 	}
 
 	/**
@@ -516,9 +546,10 @@ class Access_Rules {
 	 * and this runs on every admin page load that localises the access rules, including
 	 * every block editor load.
 	 *
-	 * Private variations are included alongside published ones: a reader can hold an active
-	 * subscription to a tier the publisher has since hidden, and the rule still has to be
-	 * able to name it.
+	 * Publish and private is the whole set WooCommerce itself reads a variable product's
+	 * children as, so it is every variation that can exist for a publisher to have sold.
+	 * Private earns its place: a reader can hold an active subscription to a tier the
+	 * publisher has since hidden, and the rule still has to be able to name it.
 	 *
 	 * @param \WC_Product[] $products The subscription products to collect variations for.
 	 *
@@ -539,7 +570,7 @@ class Access_Rules {
 				'post_type'              => 'product_variation',
 				'post_parent__in'        => $parent_ids,
 				'post_status'            => [ 'publish', 'private' ],
-				'posts_per_page'         => -1,
+				'posts_per_page'         => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Variations of the subscription products already fetched; config-scale.
 				'orderby'                => [
 					'menu_order' => 'ASC',
 					'ID'         => 'ASC',
@@ -571,6 +602,9 @@ class Access_Rules {
 	 *
 	 * Labels need not be unique: the pickers render every option as `<name> (#<id>)` and
 	 * resolve a token by the ID it carries, so two options sharing a name stay distinct.
+	 * That ` (#<id>)` suffix is a parsing contract and stays fixed, but the separator
+	 * joining a name to its attributes carries no such role, so it is translatable —
+	 * WooCommerce makes its own equivalent filterable for the same reason.
 	 *
 	 * @param string   $parent_name The variable subscription parent's name.
 	 * @param \WP_Post $variation   The variation post.
@@ -582,7 +616,15 @@ class Access_Rules {
 		if ( $label !== $parent_name ) {
 			return $label;
 		}
-		return '' !== $variation->post_excerpt ? sprintf( '%s - %s', $label, $variation->post_excerpt ) : $label;
+		if ( '' === $variation->post_excerpt ) {
+			return $label;
+		}
+		return sprintf(
+			/* translators: 1: variable subscription name, e.g. "Membership". 2: the variation's attribute summary, e.g. "Term: Annual". */
+			__( '%1$s - %2$s', 'newspack-plugin' ),
+			$label,
+			$variation->post_excerpt
+		);
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate-api.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate-api.php
@@ -324,7 +324,14 @@ class Content_Gate_API {
 	 * @return mixed|\WP_Error The sanitized access rule or error if invalid.
 	 */
 	public static function sanitize_access_rule( $access_rule ) {
-		$rules = Access_Rules::get_access_rules();
+		// The registered rules, not the resolved ones: sanitizing reads only `is_boolean`,
+		// `sanitize_callback` and whether the rule is options-backed at all, none of which
+		// an options callback affects. Resolving here would run each rule's full-catalog
+		// query once per rule in the payload — six times over on a six-rule gate — and the
+		// options-backed test would then turn on whether the shop currently has any
+		// products, sending a valid ID list down the plain-string branch on an empty
+		// catalog. Values are sanitized off the request and never checked against the list.
+		$rules = Access_Rules::get_registered_rules();
 		$slug  = sanitize_text_field( $access_rule['slug'] );
 
 		if ( empty( $slug ) || ! isset( $rules[ $slug ] ) ) {

--- a/plugins/newspack-plugin/includes/content-gate/class-institution.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-institution.php
@@ -170,16 +170,26 @@ class Institution {
 	/**
 	 * Get institution options for the access rule multi-select.
 	 *
+	 * Published institutions only, matching `rebuild_cache()`: an institution that is not
+	 * published is never evaluated and so can never grant access, and offering one here
+	 * would let a publisher build a rule that silently does nothing. The institution editor
+	 * always saves with `publish`, so any other status comes from editing the post directly.
+	 *
 	 * @return array Array of [ 'label' => string, 'value' => int ].
 	 */
 	public static function get_options() {
 		$posts   = \get_posts(
 			[
-				'post_type'      => self::POST_TYPE,
-				'post_status'    => 'publish',
-				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Institution CPT; config-scale.
-				'orderby'        => 'title',
-				'order'          => 'ASC',
+				'post_type'              => self::POST_TYPE,
+				'post_status'            => 'publish',
+				'posts_per_page'         => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Institution CPT; config-scale.
+				'orderby'                => 'title',
+				'order'                  => 'ASC',
+				// Only the title and ID are read, and this runs on every admin page load
+				// that localises the access rules. `get_posts()` already forces
+				// `no_found_rows`, so there is no row count to suppress here.
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
 			]
 		);
 		$options = [];

--- a/plugins/newspack-plugin/phpunit.xml
+++ b/plugins/newspack-plugin/phpunit.xml
@@ -10,6 +10,9 @@
       <directory suffix=".php">./vendor</directory>
     </exclude>
   </coverage>
+  <extensions>
+    <extension class="Newspack_Request_Memo_Reset"/>
+  </extensions>
   <testsuites>
     <testsuite name="Newspack Test Suite">
       <directory suffix=".php">./tests/unit-tests</directory>

--- a/plugins/newspack-plugin/src/content-gate/access-rule-option-sources.test.js
+++ b/plugins/newspack-plugin/src/content-gate/access-rule-option-sources.test.js
@@ -36,6 +36,16 @@ describe( 'getAccessRuleOptionSource', () => {
 		expect( apiFetch ).toHaveBeenCalledWith( { path: expect.stringContaining( 'per_page=-1' ) } );
 	} );
 
+	// `Institution::get_options()` localises published institutions only, and an
+	// institution that is not published can never grant access. Core defaults the
+	// collection to published, so this pins the two lists to the same rows rather than to
+	// the same default.
+	it( 'asks for published institutions only, matching the localised list', async () => {
+		await fetchInstitutions();
+
+		expect( apiFetch ).toHaveBeenCalledWith( { path: expect.stringContaining( 'status=publish' ) } );
+	} );
+
 	// api-fetch walks the collection a page at a time, and the block editor remounts its
 	// picker on every block selection, so a fetch per reader would be a walk per reader.
 	it( 'walks the collection once however many readers ask for it', async () => {

--- a/plugins/newspack-plugin/src/content-gate/access-rule-option-sources.ts
+++ b/plugins/newspack-plugin/src/content-gate/access-rule-option-sources.ts
@@ -38,10 +38,13 @@ export const INSTITUTION_RULE_SLUG = 'institution';
  */
 const ACCESS_RULE_OPTION_SOURCES: Record< string, () => Promise< AccessRuleOption[] > > = {
 	[ INSTITUTION_RULE_SLUG ]: async () => {
-		// Ordered by title to match `Institution::get_options()`, so the picker reads the
-		// same way whichever list rendered it.
+		// Ordered by title and pinned to published posts to match
+		// `Institution::get_options()`, so the picker reads the same way and offers the same
+		// institutions whichever list rendered it. Core already defaults the collection to
+		// published, so `status` changes nothing today; it is named so the two lists stay in
+		// step if a `rest_np_institution_collection_params` filter moves that default.
 		const items = await apiFetch< InstitutionItem[] >( {
-			path: '/wp/v2/np_institution?context=edit&orderby=title&order=asc&per_page=-1&_fields=id,title',
+			path: '/wp/v2/np_institution?context=edit&status=publish&orderby=title&order=asc&per_page=-1&_fields=id,title',
 		} );
 		return items.map( item => ( { value: item.id, label: item.title.raw } ) );
 	},

--- a/plugins/newspack-plugin/src/content-gate/access-rule-option-sources.ts
+++ b/plugins/newspack-plugin/src/content-gate/access-rule-option-sources.ts
@@ -41,7 +41,7 @@ const ACCESS_RULE_OPTION_SOURCES: Record< string, () => Promise< AccessRuleOptio
 		// Ordered by title to match `Institution::get_options()`, so the picker reads the
 		// same way whichever list rendered it.
 		const items = await apiFetch< InstitutionItem[] >( {
-			path: '/wp/v2/np_institution?context=edit&orderby=title&order=asc&per_page=-1',
+			path: '/wp/v2/np_institution?context=edit&orderby=title&order=asc&per_page=-1&_fields=id,title',
 		} );
 		return items.map( item => ( { value: item.id, label: item.title.raw } ) );
 	},

--- a/plugins/newspack-plugin/src/content-gate/access-rule-options.test.js
+++ b/plugins/newspack-plugin/src/content-gate/access-rule-options.test.js
@@ -8,6 +8,7 @@ import {
 	getAccessRuleOptionTokens,
 	getAccessRuleTokenFieldMessages,
 	getMissingOptionLabel,
+	getUnlistedAccessRuleValuesNotice,
 	hasUnlistedAccessRuleValues,
 	isAccessRuleOptionInput,
 	resolveAccessRuleOptionTokens,
@@ -46,9 +47,9 @@ describe( 'formatAccessRuleOptionLabel', () => {
 } );
 
 describe( 'getMissingOptionLabel', () => {
-	// "not listed" rather than "deleted": an option list holds parent products and
-	// published institutions, while evaluation also resolves variation IDs, so a value
-	// missing from the list is often still granting access.
+	// "not listed" rather than "deleted": an option list holds what its picker can offer,
+	// while evaluation resolves more than that — a one-time purchase matches an order
+	// item's variation ID — so a value missing from the list is often still granting access.
 	it( 'names the right kind of thing per rule', () => {
 		expect( getMissingOptionLabel( 'subscription' ) ).toBe( '(product not listed)' );
 		expect( getMissingOptionLabel( 'institution' ) ).toBe( '(institution not listed)' );
@@ -189,7 +190,7 @@ describe( 'isAccessRuleOptionInput', () => {
 describe( 'hasUnlistedAccessRuleValues', () => {
 	it( 'reports whether the rule holds a value no option describes', () => {
 		expect( hasUnlistedAccessRuleValues( OPTIONS, [ 188250, 300000 ] ) ).toBe( false );
-		// A subscription variation ID, for instance: not in the option list, still granting.
+		// A deleted product, for instance: not in the option list, still granting.
 		expect( hasUnlistedAccessRuleValues( OPTIONS, [ 188250, 999999 ] ) ).toBe( true );
 		expect( hasUnlistedAccessRuleValues( OPTIONS, 'not-an-array' ) ).toBe( false );
 	} );
@@ -211,5 +212,27 @@ describe( 'getAccessRuleTokenFieldMessages', () => {
 		// No "type its ID" for a gate: the list is every gate there is, so an ID outside
 		// it is refused and offering it would be a promise the field does not keep.
 		expect( getAccessRuleTokenFieldMessages( 'gate' ).__experimentalInvalid ).toBe( 'Not a selectable gate. Pick one from the list.' );
+	} );
+} );
+
+describe( 'getUnlistedAccessRuleValuesNotice', () => {
+	// The notice names the causes a publisher should go looking for, so a rule whose
+	// picker cannot produce a given cause must not name it. The subscription picker lists
+	// a variable subscription's variations, so a variation is not why an entry is missing
+	// there; the institution picker holds no products at all.
+	it( 'names only causes the rule can have', () => {
+		expect( getUnlistedAccessRuleValuesNotice( 'subscription' ) ).not.toMatch( /unpublished/ );
+		expect( getUnlistedAccessRuleValuesNotice( 'institution' ) ).toMatch( /institution that was deleted or unpublished/ );
+		expect( getUnlistedAccessRuleValuesNotice( 'institution' ) ).not.toMatch( /product/ );
+	} );
+
+	it( 'falls back to slug-agnostic wording, since rules can be registered by anyone', () => {
+		expect( getUnlistedAccessRuleValuesNotice( 'something-else' ) ).toMatch( /an item that was deleted/ );
+	} );
+
+	it( 'always says that removing an entry widens the gate, whatever the rule', () => {
+		for ( const slug of [ 'subscription', 'institution', 'something-else' ] ) {
+			expect( getUnlistedAccessRuleValuesNotice( slug ) ).toMatch( /widens who this gate lets in/ );
+		}
 	} );
 } );

--- a/plugins/newspack-plugin/src/content-gate/access-rule-options.ts
+++ b/plugins/newspack-plugin/src/content-gate/access-rule-options.ts
@@ -30,6 +30,19 @@ import type { TokenItem } from '@wordpress/components/build-types/form-token-fie
 export type AccessRuleOption = { value: string | number; label: string };
 
 /**
+ * How many suggestions a picker renders when nothing has been typed.
+ *
+ * `FormTokenField` defaults to 100, which is a display cap rather than a fetch cap: it
+ * ranks by the typed query before slicing, so an option past the cap is still reachable
+ * by name or ID. But with `__experimentalExpandOnFocus` the unfiltered list is what a
+ * publisher sees on focus, and a site with more than 100 institutions read that as the
+ * rest not existing. This raises the cap far enough that browsing works at realistic list
+ * sizes while still bounding the DOM — the suggestion list is not virtualised, so it
+ * renders one node per suggestion. Past it, an option is reached by typing its name or ID.
+ */
+export const MAX_OPTION_SUGGESTIONS = 500;
+
+/**
  * The ID a token carries, e.g. `188250` in `Annual (#188250)`.
  */
 const TOKEN_ID_PATTERN = /\(#([^)]+)\)\s*$/;

--- a/plugins/newspack-plugin/src/content-gate/access-rule-options.ts
+++ b/plugins/newspack-plugin/src/content-gate/access-rule-options.ts
@@ -39,6 +39,9 @@ export type AccessRuleOption = { value: string | number; label: string };
  * rest not existing. This raises the cap far enough that browsing works at realistic list
  * sizes while still bounding the DOM — the suggestion list is not virtualised, so it
  * renders one node per suggestion. Past it, an option is reached by typing its name or ID.
+ *
+ * This moves the cliff rather than removing it. NPPD-2132 removes it, by making the picker
+ * query the server as the publisher types instead of rendering a whole list up front.
  */
 export const MAX_OPTION_SUGGESTIONS = 500;
 

--- a/plugins/newspack-plugin/src/content-gate/access-rule-options.ts
+++ b/plugins/newspack-plugin/src/content-gate/access-rule-options.ts
@@ -74,13 +74,12 @@ const EXHAUSTIVE_OPTION_RULES = [ 'gate', 'institution' ];
  * so the wording names the right kind of thing.
  *
  * The wording says "not listed", not "deleted" or "unavailable", because the two are not
- * the same and only one of them is safe to remove. An option list holds parent products
- * and published institutions, while evaluation resolves more than that — an "Active
- * subscription" rule matches a variation ID, and a one-time purchase matches the
- * `_variation_id` on an order item. Such an ID grants access every day while never
- * appearing in the list, so a publisher must not read it as dead configuration: removing
- * it widens the gate, and removing a rule's last value widens it further, since an empty
- * value list applies no filter at all.
+ * the same and only one of them is safe to remove. An option list holds what a picker can
+ * currently offer, while evaluation resolves more than that — a one-time purchase rule
+ * matches the `_variation_id` on an order item, and its picker lists parent products only.
+ * Such an ID grants access every day while never appearing in the list, so a publisher
+ * must not read it as dead configuration: removing it widens the gate, and removing a
+ * rule's last value widens it further, since an empty value list applies no filter at all.
  */
 const MISSING_OPTION_LABELS: Record< string, () => string > = {
 	subscription: () => __( '(product not listed)', 'newspack-plugin' ),
@@ -316,14 +315,43 @@ export function hasUnlistedAccessRuleValues( options: AccessRuleOption[], value:
 }
 
 /**
- * Caution shown alongside a picker holding values no option describes, so the reading
+ * Caution shown alongside a picker holding values no option describes, keyed by rule slug
+ * the way `MISSING_OPTION_LABELS` is. What a picker can fail to list differs per rule: the
+ * subscription picker offers a variable subscription's variations, while the institution
+ * picker offers published institutions only, so naming a cause the rule cannot have sends
+ * a publisher looking for the wrong thing.
+ */
+const UNLISTED_VALUES_NOTICES: Record< string, () => string > = {
+	subscription: () =>
+		__(
+			'Entries marked “not listed” are not in this list — a product or variation that was deleted, or a product that is no longer a subscription. They are still checked when access is evaluated, so removing one widens who this gate lets in.',
+			'newspack-plugin'
+		),
+	institution: () =>
+		__(
+			'Entries marked “not listed” are not in this list — an institution that was deleted or unpublished. They are still checked when access is evaluated, so removing one widens who this gate lets in.',
+			'newspack-plugin'
+		),
+};
+
+/**
+ * Wording for a rule this module knows nothing about. `Access_Rules::register_rule()` is
+ * public, so an options-backed rule may come from anywhere and need not hold products.
+ */
+const DEFAULT_UNLISTED_VALUES_NOTICE = () =>
+	__(
+		'Entries marked “not listed” are not in this list — an item that was deleted, unpublished, or is not offered here. They are still checked when access is evaluated, so removing one widens who this gate lets in.',
+		'newspack-plugin'
+	);
+
+/**
+ * The caution shown alongside a picker holding values no option describes, so the reading
  * that the token invites — stale entry, safe to delete — does not go unchallenged.
+ *
+ * @param slug The rule slug.
  *
  * @return The caution text.
  */
-export function getUnlistedAccessRuleValuesNotice(): string {
-	return __(
-		'Entries marked “not listed” are not in this list — a product variation, or an item that was deleted or unpublished. They are still checked when access is evaluated, so removing one widens who this gate lets in.',
-		'newspack-plugin'
-	);
+export function getUnlistedAccessRuleValuesNotice( slug: string ): string {
+	return ( UNLISTED_VALUES_NOTICES[ slug ] ?? DEFAULT_UNLISTED_VALUES_NOTICE )();
 }

--- a/plugins/newspack-plugin/src/content-gate/components/one-time-purchase-rule-control.tsx
+++ b/plugins/newspack-plugin/src/content-gate/components/one-time-purchase-rule-control.tsx
@@ -111,7 +111,7 @@ export default function OneTimePurchaseRuleControl( {
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 			/>
-			<UnlistedValuesNotice options={ options } value={ currentValue.product_ids } />
+			<UnlistedValuesNotice slug={ RULE_SLUG } options={ options } value={ currentValue.product_ids } />
 			<Flex align="flex-start" gap={ 2 } style={ { marginTop: '8px' } }>
 				<FlexBlock>
 					<SelectControl

--- a/plugins/newspack-plugin/src/content-gate/components/unlisted-values-notice.test.tsx
+++ b/plugins/newspack-plugin/src/content-gate/components/unlisted-values-notice.test.tsx
@@ -44,13 +44,24 @@ describe( 'the caution for values no option describes', () => {
 	} );
 
 	it( 'is a note, and appears only while a stored value has no option', () => {
-		const { rerender } = render( <UnlistedValuesNotice options={ OPTIONS } value={ [ 188250, 999999 ] } /> );
+		const { rerender } = render( <UnlistedValuesNotice slug="subscription" options={ OPTIONS } value={ [ 188250, 999999 ] } /> );
 
 		expect( screen.getByRole( 'note' ) ).toHaveTextContent( /removing one widens who this gate lets in/ );
 
-		rerender( <UnlistedValuesNotice options={ OPTIONS } value={ [ 188250 ] } /> );
+		rerender( <UnlistedValuesNotice slug="subscription" options={ OPTIONS } value={ [ 188250 ] } /> );
 
 		expect( screen.queryByRole( 'note' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'is spoken again for a second rule, whose caution says something the first did not', () => {
+		// The wording names what that rule's picker can fail to list — a deleted
+		// institution, a product that is no longer a subscription — so suppressing the
+		// second one would leave a screen reader with the wrong cause.
+		( speak as jest.Mock ).mockClear();
+
+		render( <UnlistedValuesNotice slug="institution" options={ OPTIONS } value={ [ 188250, 999999 ] } /> );
+
+		expect( speak ).toHaveBeenCalledWith( expect.stringContaining( 'institution that was deleted or unpublished' ), 'polite' );
 	} );
 
 	it( 'reaches the one-time purchase picker', () => {

--- a/plugins/newspack-plugin/src/content-gate/components/unlisted-values-notice.tsx
+++ b/plugins/newspack-plugin/src/content-gate/components/unlisted-values-notice.tsx
@@ -20,34 +20,35 @@ import { useEffect } from '@wordpress/element';
 import { getUnlistedAccessRuleValuesNotice, hasUnlistedAccessRuleValues, type AccessRuleOption } from '../access-rule-options';
 
 /**
- * Whether the caution has been spoken yet in this page's lifetime.
+ * Rules whose caution has been spoken in this page's lifetime.
  *
  * Module scope rather than component state, because the repetition to suppress happens
  * across mounts: the block inspector unmounts on deselection, so an effect keyed on the
  * component's own lifetime read the whole paragraph out again every time a publisher
  * clicked between two blocks carrying an unlisted value. `@wordpress/a11y` will not
  * absorb the repeat either — it appends a non-breaking space to a message matching the
- * previous one, precisely to force a re-announcement. The wording is the same whichever
- * picker raises it, so a second reading carries nothing the first did not.
+ * previous one, precisely to force a re-announcement. Keyed by rule, because the wording
+ * names what that rule's picker can fail to list: a second rule's caution says something
+ * the first did not.
  */
-let hasSpokenNotice = false;
+const slugsSpokenFor = new Set< string >();
 
-export default function UnlistedValuesNotice( { options, value }: { options: AccessRuleOption[]; value: unknown } ) {
+export default function UnlistedValuesNotice( { slug, options, value }: { slug: string; options: AccessRuleOption[]; value: unknown } ) {
 	const hasUnlisted = hasUnlistedAccessRuleValues( options, value );
 
 	useEffect( () => {
-		if ( hasUnlisted && ! hasSpokenNotice ) {
-			hasSpokenNotice = true;
-			speak( getUnlistedAccessRuleValuesNotice(), 'polite' );
+		if ( hasUnlisted && ! slugsSpokenFor.has( slug ) ) {
+			slugsSpokenFor.add( slug );
+			speak( getUnlistedAccessRuleValuesNotice( slug ), 'polite' );
 		}
-	}, [ hasUnlisted ] );
+	}, [ hasUnlisted, slug ] );
 
 	if ( ! hasUnlisted ) {
 		return null;
 	}
 	return (
 		<p role="note" className="newspack-access-rule-values-notice">
-			{ getUnlistedAccessRuleValuesNotice() }
+			{ getUnlistedAccessRuleValuesNotice( slug ) }
 		</p>
 	);
 }

--- a/plugins/newspack-plugin/src/content-gate/editor/block-visibility.tsx
+++ b/plugins/newspack-plugin/src/content-gate/editor/block-visibility.tsx
@@ -238,7 +238,7 @@ const AccessRuleValueControl = ( {
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
 				/>
-				<UnlistedValuesNotice options={ options } value={ selected } />
+				<UnlistedValuesNotice slug={ slug } options={ options } value={ selected } />
 			</>
 		);
 	} else {

--- a/plugins/newspack-plugin/src/content-gate/editor/block-visibility.tsx
+++ b/plugins/newspack-plugin/src/content-gate/editor/block-visibility.tsx
@@ -27,6 +27,7 @@ import './block-visibility.scss';
 import {
 	formatAccessRuleOptionLabel,
 	getAccessRuleOptionTokens,
+	MAX_OPTION_SUGGESTIONS,
 	getAccessRuleTokenFieldMessages,
 	getAccessRuleOptionsFetchFailedNotice,
 	getMissingOptionLabel,
@@ -149,6 +150,7 @@ const GateControls = ( { gateIds, onChange }: { gateIds: number[]; onChange: ( i
 				label={ __( 'Gates', 'newspack-plugin' ) }
 				value={ getAccessRuleOptionTokens( gateOptions, gateIds, getMissingOptionLabel( GATE_RULE_SLUG ) ) }
 				suggestions={ gateOptions.map( formatAccessRuleOptionLabel ) }
+				maxSuggestions={ MAX_OPTION_SUGGESTIONS }
 				onChange={ ( tokens: ( string | TokenItem )[] ) =>
 					// The attribute is typed as integers, and a preserved value may come
 					// back as the string the token carried, so coerce before storing.
@@ -225,6 +227,7 @@ const AccessRuleValueControl = ( {
 					label={ config.name }
 					value={ getAccessRuleOptionTokens( options, selected, getMissingOptionLabel( slug ) ) }
 					suggestions={ options.map( formatAccessRuleOptionLabel ) }
+					maxSuggestions={ MAX_OPTION_SUGGESTIONS }
 					onChange={ ( tokens: ( string | TokenItem )[] ) =>
 						onChange( resolveAccessRuleOptionTokens( tokens, options, { slug, stored: selected } ) )
 					}

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/access-rule-control.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/access-rule-control.test.jsx
@@ -8,9 +8,6 @@ import { render, screen, fireEvent, waitFor, within, act } from '@testing-librar
  */
 import apiFetch from '@wordpress/api-fetch';
 import { select } from '@wordpress/data';
-import apiFetch from '@wordpress/api-fetch';
-
-jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
 /**
  * Internal dependencies
@@ -52,15 +49,6 @@ const renderControl = ( { slug = 'subscription', name = 'Active subscription', o
 	};
 	return render( <AccessRuleControl slug={ slug } value={ value } onChange={ onChange } /> );
 };
-
-/**
- * More institutions than the REST API's own `per_page` ceiling of 100, which is the size
- * the list used to be silently cut to.
- */
-const MANY_INSTITUTIONS = Array.from( { length: 105 }, ( _, i ) => ( {
-	id: i + 1,
-	title: { raw: `Institution ${ i + 1 }` },
-} ) );
 
 describe( 'AccessRuleControl option picker', () => {
 	it( 'labels each selected option with its ID so same-named products are distinguishable', () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/access-rule-control.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/access-rule-control.test.jsx
@@ -1,13 +1,16 @@
 /**
  * External dependencies
  */
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
 
 /**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
 import { select } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
 /**
  * Internal dependencies
@@ -41,14 +44,23 @@ const DUPLICATE_NAME_PRODUCTS = [
 	{ value: 300000, label: 'Monthly' },
 ];
 
-const renderControl = ( { options, value, onChange } ) => {
+const renderControl = ( { slug = 'subscription', name = 'Active subscription', options, value, onChange } ) => {
 	window.newspackAudienceContentGates = {
 		available_access_rules: {
-			subscription: { name: 'Active subscription', options },
+			[ slug ]: { name, options },
 		},
 	};
-	return render( <AccessRuleControl slug="subscription" value={ value } onChange={ onChange } /> );
+	return render( <AccessRuleControl slug={ slug } value={ value } onChange={ onChange } /> );
 };
+
+/**
+ * More institutions than the REST API's own `per_page` ceiling of 100, which is the size
+ * the list used to be silently cut to.
+ */
+const MANY_INSTITUTIONS = Array.from( { length: 105 }, ( _, i ) => ( {
+	id: i + 1,
+	title: { raw: `Institution ${ i + 1 }` },
+} ) );
 
 describe( 'AccessRuleControl option picker', () => {
 	it( 'labels each selected option with its ID so same-named products are distinguishable', () => {
@@ -181,5 +193,23 @@ describe( 'AccessRuleControl, a rule whose options are fetched', () => {
 			)
 		);
 		expect( screen.getByText( 'City Library (#12)' ) ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'AccessRuleControl suggestion cap', () => {
+	it( 'offers every option on focus, past the field default of 100', async () => {
+		const manyProducts = Array.from( { length: 105 }, ( _, i ) => ( { value: i + 1, label: `Product ${ i + 1 }` } ) );
+		renderControl( { options: manyProducts, value: [], onChange: jest.fn() } );
+
+		const input = await screen.findByRole( 'combobox' );
+		// A real focus, not a synthetic event: `__experimentalExpandOnFocus` only expands
+		// when the input is the document's active element.
+		act( () => input.focus() );
+
+		// Cut to 100, the rest read to a publisher as not existing — the list on focus is
+		// unfiltered, so nothing they could type would be ranked in front of the cap.
+		const suggestions = await screen.findAllByRole( 'option' );
+		expect( suggestions ).toHaveLength( manyProducts.length );
+		expect( suggestions[ 104 ] ).toHaveTextContent( 'Product 105 (#105)' );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/access-rule-control.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/access-rule-control.tsx
@@ -53,7 +53,7 @@ export default function AccessRuleControl( { slug, value, onChange }: GateRuleCo
 					__experimentalExpandOnFocus
 					__next40pxDefaultSize
 				/>
-				<UnlistedValuesNotice options={ options } value={ selected } />
+				<UnlistedValuesNotice slug={ slug } options={ options } value={ selected } />
 			</>
 		);
 	}

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/access-rule-control.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/access-rule-control.tsx
@@ -12,6 +12,7 @@ import { FormTokenField } from '../../../../../../packages/components/src';
 import {
 	formatAccessRuleOptionLabel,
 	getAccessRuleOptionTokens,
+	MAX_OPTION_SUGGESTIONS,
 	getAccessRuleTokenFieldMessages,
 	getMissingOptionLabel,
 	isAccessRuleOptionInput,
@@ -45,6 +46,7 @@ export default function AccessRuleControl( { slug, value, onChange }: GateRuleCo
 						onChange( resolveAccessRuleOptionTokens( tokens, options, { slug, stored: selected } ) )
 					}
 					suggestions={ options.map( formatAccessRuleOptionLabel ) }
+					maxSuggestions={ MAX_OPTION_SUGGESTIONS }
 					messages={ getAccessRuleTokenFieldMessages( slug ) }
 					__experimentalValidateInput={ ( input: string ) => isAccessRuleOptionInput( input, options, slug ) }
 					__experimentalAutoSelectFirstMatch

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/institutions/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/institutions/index.tsx
@@ -78,7 +78,13 @@ export default function Institutions() {
 
 	const fetchData = useCallback( () => {
 		setIsLoading( true );
-		apiFetch< Institution[] >( { path: `${ API_PATH }?per_page=100&context=edit&_embed=wp:featuredmedia` } )
+		// The table paginates, sorts and searches client-side, so it needs the whole
+		// collection. `per_page=-1` is apiFetch's unbounded form — fetchAllMiddleware walks
+		// the `Link: rel="next"` headers and resolves to every page merged. A fixed page
+		// size put the institutions past it out of reach entirely: not listed, and so not
+		// editable. The value is apiFetch's, not the REST API's: the posts controller caps
+		// `per_page` at 100 and would reject -1 outright.
+		apiFetch< Institution[] >( { path: `${ API_PATH }?per_page=-1&context=edit&_embed=wp:featuredmedia` } )
 			.then( institutions => {
 				setData( institutions );
 				// Keep the gates screen header in sync: it promotes the

--- a/plugins/newspack-plugin/tests/class-newspack-request-memo-reset.php
+++ b/plugins/newspack-plugin/tests/class-newspack-request-memo-reset.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Resets request-scoped memos between tests.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Access_Rules;
+use PHPUnit\Runner\BeforeTestHook;
+
+/**
+ * Production code memoizes per request, and a request ends on its own, so nothing in
+ * production has to invalidate anything. A PHPUnit run is one request for the whole
+ * suite, while fixtures are per test class: a memo built from one class's catalogue
+ * would answer the next class's assertions, and the failure names neither.
+ *
+ * Resetting here makes the test boundary the request boundary the memos assume, so a
+ * new test class inherits the guarantee instead of each one having to remember it.
+ */
+class Newspack_Request_Memo_Reset implements BeforeTestHook {
+	/**
+	 * Flush every request-scoped memo before each test.
+	 *
+	 * @param string $test The test being run, as `Class::method`.
+	 *
+	 * @return void
+	 */
+	public function executeBeforeTest( string $test ): void { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Defined by PHPUnit's BeforeTestHook.
+		Access_Rules::flush_product_options_memos();
+		Access_Rules::flush_one_time_purchase_memo();
+	}
+}

--- a/plugins/newspack-plugin/tests/class-newspack-unit-tests-bootstrap.php
+++ b/plugins/newspack-plugin/tests/class-newspack-unit-tests-bootstrap.php
@@ -75,6 +75,10 @@ class Newspack_Unit_Tests_Bootstrap {
 		// Load the WP testing environment.
 		require_once $_tests_dir . '/includes/bootstrap.php';
 
+		// PHPUnit resolves the extensions in phpunit.xml after this bootstrap runs, and
+		// this one is not autoloaded.
+		require_once __DIR__ . '/class-newspack-request-memo-reset.php';
+
 		ini_set( 'error_log', 'php://stdout' ); // phpcs:ignore WordPress.PHP.IniSet.Risky
 
 		define( 'IS_TEST_ENV', 1 );

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -547,6 +547,9 @@ class WC_Product {
 	public function get_children() {
 		return $this->data['children'] ?? [];
 	}
+	public function get_status() {
+		return $this->data['status'] ?? 'publish';
+	}
 	public function get_regular_price() {
 		return $this->data['regular_price'] ?? ( $this->meta['_regular_price'] ?? 0 );
 	}
@@ -615,7 +618,7 @@ if ( ! class_exists( 'WC_Subscriptions_Cart' ) ) {
 /**
  * Register a mock product in the global products database.
  *
- * @param array $data Product data including 'id', 'children', 'type', 'name', 'price'.
+ * @param array $data Product data including 'id', 'type', 'name', 'status', 'price', 'children'.
  * @return WC_Product
  */
 function wc_create_mock_product( $data = [] ) {
@@ -623,6 +626,62 @@ function wc_create_mock_product( $data = [] ) {
 	$product = new WC_Product( $data );
 	$products_database[ $product->get_id() ] = $product;
 	return $product;
+}
+
+/**
+ * Query the mock products database.
+ *
+ * Supports the arguments Newspack's callers actually pass: `type` (one type or a list of
+ * them), `status`, `limit` and `return`. Registration order stands in for real
+ * WooCommerce's ordering, which none of the callers depend on. Any other filtering
+ * argument is fatal rather than ignored: this mock is defined unconditionally, so a
+ * caller silently getting an unfiltered result is a test that passes for the wrong reason.
+ *
+ * Arguments real WooCommerce discards are the exception — neither a `WC_Product_Query`
+ * default var nor a mapped meta key, so ignoring one is what production does too.
+ *
+ * @param array $args Query args.
+ * @return WC_Product[]|int[] Matching products, or their IDs with `return => 'ids'`.
+ * @throws InvalidArgumentException When passed a filtering argument the mock does not implement.
+ */
+function wc_get_products( $args = [] ) {
+	global $products_database;
+	// Not every consumer of this file registers a product, and the mock is defined
+	// unconditionally, so the global may still be unset when a caller lands here.
+	$products_database = $products_database ?? [];
+	$supported         = [ 'type', 'status', 'limit', 'return' ];
+	// Passed by Donations, discarded by WooCommerce.
+	$inert             = [ 'only_get_newspack_subscriptions' ];
+	$unknown           = array_diff( array_keys( $args ), $supported, $inert );
+	if ( ! empty( $unknown ) ) {
+		throw new InvalidArgumentException(
+			esc_html( 'wc_get_products mock does not implement: ' . implode( ', ', $unknown ) . '. Add it to tests/mocks/wc-mocks.php.' )
+		);
+	}
+	$types    = isset( $args['type'] ) ? (array) $args['type'] : [];
+	$statuses = isset( $args['status'] ) ? (array) $args['status'] : [];
+	$products = array_values(
+		array_filter(
+			$products_database,
+			function ( $product ) use ( $types, $statuses ) {
+				if ( ! empty( $types ) && ! $product->is_type( $types ) ) {
+					return false;
+				}
+				return empty( $statuses ) || in_array( $product->get_status(), $statuses, true );
+			}
+		)
+	);
+	$limit    = isset( $args['limit'] ) ? (int) $args['limit'] : -1;
+	$products = $limit > 0 ? array_slice( $products, 0, $limit ) : $products;
+	if ( isset( $args['return'] ) && 'ids' === $args['return'] ) {
+		return array_map(
+			function ( $product ) {
+				return $product->get_id();
+			},
+			$products
+		);
+	}
+	return $products;
 }
 
 class WC_Order {

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -547,9 +547,6 @@ class WC_Product {
 	public function get_children() {
 		return $this->data['children'] ?? [];
 	}
-	public function get_status() {
-		return $this->data['status'] ?? 'publish';
-	}
 	public function get_regular_price() {
 		return $this->data['regular_price'] ?? ( $this->meta['_regular_price'] ?? 0 );
 	}
@@ -1710,33 +1707,6 @@ if ( ! function_exists( 'get_woocommerce_currency' ) ) {
 	function get_woocommerce_currency() {
 		return 'USD';
 	}
-}
-/**
- * Minimal WC_Product_Query stand-in: filters $products_database on `type` and `status`.
- *
- * The `status` default reproduces WC_Product_Query's own default
- * ( draft, pending, private, publish ), which is what a caller that omits `status`
- * actually gets — the property the CLI's SELECTABLE_PRODUCT_STATUSES constant claims to
- * mirror. `limit` is accepted and ignored (fixtures are small).
- *
- * @param array $args Query args.
- * @return WC_Product[] The matching products.
- */
-function wc_get_products( $args = [] ) {
-	global $products_database;
-	$types    = isset( $args['type'] ) ? (array) $args['type'] : null;
-	$statuses = isset( $args['status'] ) ? (array) $args['status'] : [ 'draft', 'pending', 'private', 'publish' ];
-	$matches  = [];
-	foreach ( $products_database as $product ) {
-		if ( null !== $types && ! in_array( $product->get_type(), $types, true ) ) {
-			continue;
-		}
-		if ( ! in_array( $product->get_status(), $statuses, true ) ) {
-			continue;
-		}
-		$matches[] = $product;
-	}
-	return $matches;
 }
 /**
  * Minimal stand-in for WooCommerce's admin field renderer. Only enough markup to let a metabox

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -616,6 +616,11 @@ if ( ! class_exists( 'WC_Subscriptions_Cart' ) ) {
 }
 
 /**
+ * The post statuses `WC_Product_Query` searches when a query passes no `status`.
+ */
+const WC_PRODUCT_QUERY_DEFAULT_STATUSES = [ 'draft', 'pending', 'private', 'publish' ];
+
+/**
  * Register a mock product in the global products database.
  *
  * @param array $data Product data including 'id', 'type', 'name', 'status', 'price', 'children'.
@@ -636,6 +641,12 @@ function wc_create_mock_product( $data = [] ) {
  * WooCommerce's ordering, which none of the callers depend on. Any other filtering
  * argument is fatal rather than ignored: this mock is defined unconditionally, so a
  * caller silently getting an unfiltered result is a test that passes for the wrong reason.
+ *
+ * Omitting `status` is not "no status filter": `WC_Product_Query` defaults it to draft,
+ * pending, private and publish, and callers rely on that default — the access-rule
+ * subscription picker lists a drafted product deliberately, because readers still hold
+ * subscriptions to it. Applying the same default here is what lets a test tell that
+ * behaviour apart from a mock that never filtered.
  *
  * Arguments real WooCommerce discards are the exception — neither a `WC_Product_Query`
  * default var nor a mapped meta key, so ignoring one is what production does too.
@@ -659,7 +670,7 @@ function wc_get_products( $args = [] ) {
 		);
 	}
 	$types    = isset( $args['type'] ) ? (array) $args['type'] : [];
-	$statuses = isset( $args['status'] ) ? (array) $args['status'] : [];
+	$statuses = isset( $args['status'] ) ? (array) $args['status'] : WC_PRODUCT_QUERY_DEFAULT_STATUSES;
 	$products = array_values(
 		array_filter(
 			$products_database,
@@ -667,7 +678,7 @@ function wc_get_products( $args = [] ) {
 				if ( ! empty( $types ) && ! $product->is_type( $types ) ) {
 					return false;
 				}
-				return empty( $statuses ) || in_array( $product->get_status(), $statuses, true );
+				return in_array( $product->get_status(), $statuses, true );
 			}
 		)
 	);

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-access-rules.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-access-rules.php
@@ -78,9 +78,10 @@ class Newspack_Test_Access_Rules extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		// Reset the subscriptions database.
-		global $subscriptions_database;
+		// Reset the subscriptions and products databases.
+		global $subscriptions_database, $products_database;
 		$subscriptions_database = [];
+		$products_database      = [];
 
 		// Create test users.
 		self::$owner_user_id      = $this->factory->user->create( [ 'role' => 'subscriber' ] );
@@ -736,5 +737,161 @@ class Newspack_Test_Access_Rules extends WP_UnitTestCase {
 		);
 
 		wp_delete_post( $plumbing_gate_id, true );
+	}
+
+	/**
+	 * Create a real `product_variation` post, the way WooCommerce stores one: the generated
+	 * title in `post_title` and the attribute summary in `post_excerpt`.
+	 *
+	 * The variation options are read from the post rows rather than from hydrated products,
+	 * so these have to be real posts for the tests to exercise the query that ships.
+	 *
+	 * @param int    $parent_id The variable subscription's product ID.
+	 * @param string $title     The variation's generated title.
+	 * @param string $summary   The attribute summary, if any.
+	 * @param string $status    The post status.
+	 *
+	 * @return int The variation post ID.
+	 */
+	private function create_variation_post( $parent_id, $title, $summary = '', $status = 'publish' ) {
+		return $this->factory->post->create(
+			[
+				'post_type'    => 'product_variation',
+				'post_parent'  => $parent_id,
+				'post_title'   => $title,
+				'post_excerpt' => $summary,
+				'post_status'  => $status,
+			]
+		);
+	}
+
+	/**
+	 * A variable subscription's variations are selectable in their own right, so a gate can
+	 * require one tier of it without requiring the others.
+	 *
+	 * The rule already evaluates variation IDs — `WC_Subscription::has_product()` matches a
+	 * line item's `variation_id` as well as its `product_id` — so leaving them out of the
+	 * options made a rule the system honours impossible to configure, or to read back once
+	 * migrated data had put one in a gate.
+	 *
+	 * @group Access_Rules
+	 */
+	public function test_get_subscription_products_options_includes_variations() {
+		wc_create_mock_product(
+			[
+				'id'   => 900,
+				'type' => 'subscription',
+				'name' => 'Supporter',
+			]
+		);
+		wc_create_mock_product(
+			[
+				'id'   => 901,
+				'type' => 'variable-subscription',
+				'name' => 'Membership',
+			]
+		);
+		$monthly_variation_id = $this->create_variation_post( 901, 'Membership - Monthly' );
+		$annual_variation_id  = $this->create_variation_post( 901, 'Membership - Annual' );
+
+		$options_by_value = array_column( Access_Rules::get_subscription_products_options(), 'label', 'value' );
+
+		$this->assertSame(
+			[
+				900                   => 'Supporter',
+				901                   => 'Membership',
+				$monthly_variation_id => 'Membership - Monthly',
+				$annual_variation_id  => 'Membership - Annual',
+			],
+			$options_by_value,
+			'Options should list simple subscriptions, variable subscription parents, and each parent\'s variations.'
+		);
+	}
+
+	/**
+	 * A private variation is listed, a draft one is not.
+	 *
+	 * A publisher can hide a tier without the readers still paying for it losing their
+	 * subscription, so a rule has to be able to name it. A draft variation has never been
+	 * purchasable, so listing it would only offer a rule that matches nothing.
+	 *
+	 * @group Access_Rules
+	 */
+	public function test_get_subscription_products_options_includes_private_variations_only() {
+		wc_create_mock_product(
+			[
+				'id'   => 910,
+				'type' => 'variable-subscription',
+				'name' => 'Membership',
+			]
+		);
+		$private_variation_id = $this->create_variation_post( 910, 'Membership - Retired', '', 'private' );
+		$this->create_variation_post( 910, 'Membership - Draft', '', 'draft' );
+
+		$values = array_column( Access_Rules::get_subscription_products_options(), 'value' );
+
+		$this->assertSame( [ 910, $private_variation_id ], $values, 'A private variation should be listed; a draft one should not.' );
+	}
+
+	/**
+	 * A variation belonging to a product that is not a variable subscription is not listed,
+	 * so an unrelated variable product's tiers cannot leak into the subscription rule.
+	 *
+	 * @group Access_Rules
+	 */
+	public function test_get_subscription_products_options_ignores_non_subscription_variations() {
+		wc_create_mock_product(
+			[
+				'id'   => 915,
+				'type' => 'variable',
+				'name' => 'Tote bag',
+			]
+		);
+		$this->create_variation_post( 915, 'Tote bag - Large' );
+
+		$values = array_column( Access_Rules::get_subscription_products_options(), 'value' );
+
+		$this->assertSame( [], $values, 'A plain variable product and its variations should not be listed.' );
+	}
+
+	/**
+	 * WooCommerce drops the attribute suffix from a variation's generated title when the
+	 * parent carries three or more attributes (or two or more where an attribute name is
+	 * multi-word), leaving the variation titled exactly like its parent.
+	 *
+	 * A picker listing "Membership" four times tells a publisher nothing about which tier
+	 * each entry is, so recover the attributes from the variation's summary. Where there is
+	 * no summary to recover, the bare parent title stands: the pickers render every option
+	 * as `<name> (#<id>)`, so the entries stay individually selectable either way.
+	 *
+	 * @group Access_Rules
+	 */
+	public function test_get_subscription_products_options_names_variations_titled_like_their_parent() {
+		wc_create_mock_product(
+			[
+				'id'   => 920,
+				'type' => 'variable-subscription',
+				'name' => 'Membership',
+			]
+		);
+		// Titled exactly like the parent, but carrying an attribute summary.
+		$monthly_variation_id = $this->create_variation_post( 920, 'Membership', 'Term: Monthly' );
+		$annual_variation_id  = $this->create_variation_post( 920, 'Membership', 'Term: Annual' );
+		// Titled like the parent with no attribute summary to fall back on.
+		$bare_variation_id = $this->create_variation_post( 920, 'Membership' );
+
+		$options_by_value = array_column( Access_Rules::get_subscription_products_options(), 'label', 'value' );
+
+		$this->assertSame(
+			[
+				920                   => 'Membership',
+				$monthly_variation_id => 'Membership - Term: Monthly',
+				$annual_variation_id  => 'Membership - Term: Annual',
+				// No attribute summary to recover, so the generated title stands.
+				$bare_variation_id    => 'Membership',
+			],
+			$options_by_value,
+			'A variation titled like its parent should take its attribute summary where it has one.'
+		);
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-access-rules.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-access-rules.php
@@ -83,6 +83,9 @@ class Newspack_Test_Access_Rules extends WP_UnitTestCase {
 		$subscriptions_database = [];
 		$products_database      = [];
 
+		// The subscription options are memoized per request, and a test run is one request.
+		Access_Rules::flush_subscription_products_options_memo();
+
 		// Create test users.
 		self::$owner_user_id      = $this->factory->user->create( [ 'role' => 'subscriber' ] );
 		self::$member_user_id     = $this->factory->user->create( [ 'role' => 'subscriber' ] );
@@ -892,6 +895,77 @@ class Newspack_Test_Access_Rules extends WP_UnitTestCase {
 			],
 			$options_by_value,
 			'A variation titled like its parent should take its attribute summary where it has one.'
+		);
+	}
+
+	/**
+	 * A drafted subscription product stays selectable, because unpublishing a product does
+	 * not end the subscriptions bought through it: the rule matches the order's line item,
+	 * which still names the product. Dropping it from the options would leave the readers
+	 * still paying for that product ungateable.
+	 *
+	 * `wc_get_products()` gives this for free — its default status set is draft, pending,
+	 * private and publish — so the point of the assertion is that the picker does not
+	 * narrow it back to published, the way the institution options deliberately do.
+	 *
+	 * @group Access_Rules
+	 */
+	public function test_get_subscription_products_options_includes_unpublished_products() {
+		wc_create_mock_product(
+			[
+				'id'     => 930,
+				'type'   => 'subscription',
+				'name'   => 'Retired tier',
+				'status' => 'draft',
+			]
+		);
+		wc_create_mock_product(
+			[
+				'id'     => 931,
+				'type'   => 'subscription',
+				'name'   => 'Deleted tier',
+				'status' => 'trash',
+			]
+		);
+
+		$values = array_column( Access_Rules::get_subscription_products_options(), 'value' );
+
+		$this->assertSame( [ 930 ], $values, 'A draft subscription should be listed; a trashed one should not.' );
+	}
+
+	/**
+	 * The options are built once per request. Saving a gate resolves every rule's options
+	 * callback once per rule in the payload, so without the memo a six-rule gate ran the
+	 * full-catalog product query and its variation query six times over.
+	 *
+	 * @group Access_Rules
+	 */
+	public function test_get_subscription_products_options_is_memoized_per_request() {
+		wc_create_mock_product(
+			[
+				'id'   => 940,
+				'type' => 'subscription',
+				'name' => 'Supporter',
+			]
+		);
+		$first = Access_Rules::get_subscription_products_options();
+
+		wc_create_mock_product(
+			[
+				'id'   => 941,
+				'type' => 'subscription',
+				'name' => 'Patron',
+			]
+		);
+
+		$this->assertSame( $first, Access_Rules::get_subscription_products_options(), 'A second call within the request should reuse the built options.' );
+
+		Access_Rules::flush_subscription_products_options_memo();
+
+		$this->assertSame(
+			[ 940, 941 ],
+			array_column( Access_Rules::get_subscription_products_options(), 'value' ),
+			'Flushing the memo should rebuild the options.'
 		);
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-access-rules.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-access-rules.php
@@ -8,6 +8,7 @@
 use Newspack\Access_Rules;
 use Newspack\Block_Visibility;
 use Newspack\Content_Gate;
+use Newspack\Content_Gate_API;
 use Newspack\Content_Restriction_Control;
 use Newspack\Group_Subscription;
 use Newspack\Reader_Activation;
@@ -82,9 +83,6 @@ class Newspack_Test_Access_Rules extends WP_UnitTestCase {
 		global $subscriptions_database, $products_database;
 		$subscriptions_database = [];
 		$products_database      = [];
-
-		// The subscription options are memoized per request, and a test run is one request.
-		Access_Rules::flush_subscription_products_options_memo();
 
 		// Create test users.
 		self::$owner_user_id      = $this->factory->user->create( [ 'role' => 'subscriber' ] );
@@ -934,9 +932,10 @@ class Newspack_Test_Access_Rules extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The options are built once per request. Saving a gate resolves every rule's options
-	 * callback once per rule in the payload, so without the memo a six-rule gate ran the
-	 * full-catalog product query and its variation query six times over.
+	 * The options are built once per request. `get_access_rules()` resolves every registered
+	 * rule's options callback on every call, and more than one admin screen localizes it, so
+	 * without the memo a request reaching it twice runs the full-catalog product query and
+	 * its variation query twice.
 	 *
 	 * @group Access_Rules
 	 */
@@ -960,12 +959,114 @@ class Newspack_Test_Access_Rules extends WP_UnitTestCase {
 
 		$this->assertSame( $first, Access_Rules::get_subscription_products_options(), 'A second call within the request should reuse the built options.' );
 
-		Access_Rules::flush_subscription_products_options_memo();
+		Access_Rules::flush_product_options_memos();
 
 		$this->assertSame(
 			[ 940, 941 ],
 			array_column( Access_Rules::get_subscription_products_options(), 'value' ),
 			'Flushing the memo should rebuild the options.'
+		);
+	}
+
+	/**
+	 * WooCommerce rewrites a variation's title when its parent is renamed through the CRUD
+	 * path, but an importer or a direct `wp_update_post()` does not, leaving the title on
+	 * the old name. The label then names a product the publisher can no longer find — and
+	 * where the parent has three or more attributes, the stale title is the parent's old
+	 * name alone, which is the indistinguishable-siblings defect all over again.
+	 *
+	 * @group Access_Rules
+	 */
+	public function test_get_subscription_products_options_names_variations_of_a_renamed_parent() {
+		wc_create_mock_product(
+			[
+				'id'   => 925,
+				'type' => 'variable-subscription',
+				'name' => 'Membership',
+			]
+		);
+		// Titles generated while the parent was still called "Supporter".
+		$monthly_variation_id = $this->create_variation_post( 925, 'Supporter', 'Term: Monthly' );
+		$annual_variation_id  = $this->create_variation_post( 925, 'Supporter - Annual', 'Term: Annual' );
+
+		$options_by_value = array_column( Access_Rules::get_subscription_products_options(), 'label', 'value' );
+
+		$this->assertSame(
+			[
+				925                   => 'Membership',
+				$monthly_variation_id => 'Membership - Term: Monthly',
+				$annual_variation_id  => 'Membership - Term: Annual',
+			],
+			$options_by_value,
+			'A stale title should give way to the parent\'s current name and the variation\'s attributes.'
+		);
+	}
+
+	/**
+	 * The point of listing variations: selecting one narrows the rule to that tier, while
+	 * selecting the parent still admits every tier under it.
+	 *
+	 * `WC_Subscription::has_product()` matches a line item on its `variation_id` as well as
+	 * its `product_id`, so this is the evaluation the options exist to make configurable.
+	 *
+	 * @group Access_Rules
+	 */
+	public function test_a_variation_rule_admits_only_that_variation() {
+		$annual_variation_id  = 9501;
+		$monthly_variation_id = 9502;
+		$this->create_subscription(
+			[
+				// No `products` shorthand: the line item is what carries the parent/variation
+				// split this test is about.
+				'products' => [],
+				'items'    => [
+					new WC_Order_Item_Product(
+						[
+							'product_id'   => self::$product_id,
+							'variation_id' => $annual_variation_id,
+						]
+					),
+				],
+			]
+		);
+
+		$this->assertTrue(
+			Access_Rules::has_active_subscription( self::$owner_user_id, [ $annual_variation_id ] ),
+			'A rule naming the purchased variation should grant access.'
+		);
+		$this->assertFalse(
+			Access_Rules::has_active_subscription( self::$owner_user_id, [ $monthly_variation_id ] ),
+			'A rule naming a sibling variation should not.'
+		);
+		$this->assertTrue(
+			Access_Rules::has_active_subscription( self::$owner_user_id, [ self::$product_id ] ),
+			'A rule naming the parent should still admit any of its variations.'
+		);
+	}
+
+	/**
+	 * Sanitizing a gate's rules reads the registered rules, not the resolved ones, so it
+	 * neither runs a rule's options query nor depends on what that query returns. An empty
+	 * catalog used to make the subscription rule read as though it had no options, sending
+	 * its ID list down the plain-string branch.
+	 *
+	 * @group Access_Rules
+	 */
+	public function test_sanitize_access_rule_keeps_product_ids_with_an_empty_catalog() {
+		$sanitized_rule = Content_Gate_API::sanitize_access_rule(
+			[
+				'slug'  => 'subscription',
+				'value' => [ '188250', 9501 ],
+			]
+		);
+
+		$this->assertSame(
+			[
+				'slug'  => 'subscription',
+				'value' => [ 188250, 9501 ],
+			],
+			$sanitized_rule,
+			'A subscription rule\'s IDs should survive sanitizing whether or not the shop has products.'
 		);
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/audit-subscription-products.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/audit-subscription-products.php
@@ -774,33 +774,58 @@ class Newspack_Test_Audit_Subscription_Products extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The CLI's live-product set must stay identical to the gate picker's. The allowlist
-	 * constants restate `Access_Rules::get_subscription_products_options()`'s implicit
-	 * defaults, so this pins Newspack-side drift: a `status` argument or a third type added
-	 * there (and not here) makes the sets diverge and this test fail. It cannot catch
-	 * WooCommerce-side drift — the `wc_get_products` mock hardcodes WC's current no-`status`
-	 * default (draft/pending/private/publish), so a change to `WC_Product_Query`'s defaults
-	 * would move the real picker while the mock (and this test) stand still.
+	 * The CLI's live-product set must stay identical to the parent products the gate picker
+	 * offers. The allowlist constants restate `Access_Rules::get_subscription_products_options()`'s
+	 * implicit defaults, so this pins Newspack-side drift: a `status` argument or a third
+	 * type added there (and not here) makes the sets diverge and this test fail. It cannot
+	 * catch WooCommerce-side drift — the `wc_get_products` mock hardcodes WC's current
+	 * no-`status` default (draft/pending/private/publish), so a change to `WC_Product_Query`'s
+	 * defaults would move the real picker while the mock (and this test) stand still.
+	 *
+	 * The picker's variations are excluded from the comparison rather than added to the CLI
+	 * set, and asserted absent so the exclusion cannot go unnoticed. This set feeds
+	 * `guess_products_by_name()` and the repair target check, and a repair may not point a
+	 * line item at a variation: `WC_Order_Item_Product::set_product_id()` rejects a
+	 * `product_variation` post outright.
 	 */
-	public function test_live_product_set_matches_the_gate_picker() {
-		$this->register_product( 10, 'Published Sub', 'publish' );
-		$this->register_product( 11, 'Draft Sub', 'draft' );
-		$this->register_product( 12, 'Pending Sub', 'pending' );
-		$this->register_product( 13, 'Private Sub', 'private' );
-		$this->register_product( 14, 'Variable Sub', 'publish', 'variable-subscription' );
-		$this->register_product( 15, 'Trashed Sub', 'trash' );
-		$this->register_product( 16, 'Simple Product', 'publish', 'simple' );
+	public function test_live_product_set_matches_the_gate_pickers_parent_products() {
+		// Numbered clear of the post IDs the factory hands out: mock products are not real
+		// posts, so a collision would make the variation filter below drop one of them.
+		$this->register_product( 9010, 'Published Sub', 'publish' );
+		$this->register_product( 9011, 'Draft Sub', 'draft' );
+		$this->register_product( 9012, 'Pending Sub', 'pending' );
+		$this->register_product( 9013, 'Private Sub', 'private' );
+		$this->register_product( 9014, 'Variable Sub', 'publish', 'variable-subscription' );
+		$this->register_product( 9015, 'Trashed Sub', 'trash' );
+		$this->register_product( 9016, 'Simple Product', 'publish', 'simple' );
+		$variation_id = self::factory()->post->create(
+			[
+				'post_type'   => 'product_variation',
+				'post_parent' => 9014,
+				'post_title'  => 'Variable Sub - Annual',
+			]
+		);
 
 		$get_live_subscription_products = new ReflectionMethod( WooCommerce_Subscriptions::class, 'get_live_subscription_products' );
 		$get_live_subscription_products->setAccessible( true );
 		$cli_ids = wp_list_pluck( $get_live_subscription_products->invoke( null ), 'id' );
 
 		$picker_ids = wp_list_pluck( Access_Rules::get_subscription_products_options(), 'value' );
+		$parent_ids = array_values(
+			array_filter(
+				$picker_ids,
+				function ( $id ) {
+					return 'product_variation' !== get_post_type( $id );
+				}
+			)
+		);
 
 		sort( $cli_ids );
-		sort( $picker_ids );
-		$this->assertSame( [ 10, 11, 12, 13, 14 ], $cli_ids, 'Only gate-selectable types and statuses belong in the live set.' );
-		$this->assertSame( $picker_ids, $cli_ids, 'The audit\'s live-product set must be exactly what the gate picker offers.' );
+		sort( $parent_ids );
+		$this->assertSame( [ 9010, 9011, 9012, 9013, 9014 ], $cli_ids, 'Only gate-selectable types and statuses belong in the live set.' );
+		$this->assertContains( $variation_id, $picker_ids, 'The gate picker offers a variable subscription\'s variations.' );
+		$this->assertNotContains( $variation_id, $cli_ids, 'A repair can never point a line item at a variation, so the live set holds parents only.' );
+		$this->assertSame( $parent_ids, $cli_ids, 'The audit\'s live-product set must be exactly the parent products the gate picker offers.' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The gate editor's Paid Access pickers could not offer every value a gate may legitimately hold.

Institutions were fetched at a fixed page size of 100, in both pickers and on the Institutions list screen. All three now fetch unbounded.

Subscription options listed parent products only, so a gate holding a *variation* ID had no option to render or re-select — Woo Memberships–migrated data carries those IDs, and the rule already honours them. Variations are now listed alongside their parent, so a gate can require one tier without requiring the others.

Saving a gate no longer builds any option list: sanitizing reads the registered rules rather than the resolved ones. That also stops a shop with no products from sending a valid ID list down the plain-string branch. The lists stay memoized per request for the screens that do render them.

The picker's "not listed" caution is now keyed on the rule slug, so it names only causes that rule can have.

Institution options stay published-only: an unpublished institution is never evaluated, so offering one would build a rule that silently does nothing.

The one-time purchase picker #756 adds has the same missing-variation defect, deliberately left for its own change — its evaluators are `wc_customer_bought_product()` rather than `WC_Subscription::has_product()`, so the fix needs its own evaluation testing.

Closes NPPD-2135.

### How to test the changes in this Pull Request:

1. Check out this branch. Enable `NEWSPACK_CONTENT_GATES`. Activate WooCommerce and WooCommerce Subscriptions.
2. Create 120 institutions under Audience > Access Control > Institutions.
3. Open the Institutions list. Confirm the table lists all 120.
4. Create a subscription product. Create a variable subscription product with two variations.
5. Open Audience > Access Control and edit a gate. Enable Paid Access.
6. Enable the Institutional access rule. Click its field.
7. Confirm the list shows all 120 institutions. Before this change it stopped at 100.
8. Enable the Active subscription rule. Click its field.
9. Confirm both variations are listed, each as `<name> (#<id>)`. Before this change only the parents appeared.
10. Select one variation. Save the gate. Reload the page.
11. Confirm the variation is still selected and shows its name.
12. Edit a post. Add a Group block. Open Access Control in the block sidebar.
13. Enable the Institutional access rule. Confirm the list shows all 120 institutions.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

`OK (3315 tests, 9512 assertions)` and 924 JS tests, PHPCS clean against vipwpcs 3.1.0 as well as the pinned 3.0.1.

NPPD-2143 — the institutional rule fails open when a site has no institutions, because the picker degrades to free text and a string value grants access to everyone. Pre-existing; not addressed here.