### PR TITLE
fix(newsletters): keep block editor chrome on admin typography

### DIFF
--- a/plugins/newspack-newsletters/src/editor/blocks/ad/editor.scss
+++ b/plugins/newspack-newsletters/src/editor/blocks/ad/editor.scss
@@ -11,11 +11,8 @@
 		align-items: center;
 		box-sizing: content-box;
 		display: flex;
-		// font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu,
-		// 	Cantarell, 'Helvetica Neue', sans-serif;
 		justify-content: center;
 		margin: auto;
-		// padding: 16px;
 		position: relative;
 		width: 100%;
 		overflow: hidden;

--- a/plugins/newspack-newsletters/src/editor/blocks/ad/editor.scss
+++ b/plugins/newspack-newsletters/src/editor/blocks/ad/editor.scss
@@ -1,4 +1,5 @@
 @use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/variables" as wp-vars;
 
 .editor-styles-wrapper {
 	.newspack-newsletters-ad-block {
@@ -36,6 +37,7 @@
 			background: white;
 			border: 1px dashed rgba(wp-colors.$gray-900, 0.4);
 			color: wp-colors.$gray-900;
+			font-family: wp-vars.$default-font;
 			font-size: 10px;
 			line-height: 1.6;
 			padding: 4px 8px;

--- a/plugins/newspack-newsletters/src/editor/legacy-block-styles/style.scss
+++ b/plugins/newspack-newsletters/src/editor/legacy-block-styles/style.scss
@@ -9,7 +9,8 @@
 //
 // The selector nesting mirrors the original location under
 // `.editor-styles-wrapper .block-editor-block-list__layout` in `style.scss`, so
-// when both stylesheets load (flag off) the result is identical to before.
+// when both stylesheets load (flag off) the result is identical to before,
+// except for editor chrome (see the exclusion list below).
 
 @use "~@wordpress/base-styles/variables" as wp-vars;
 
@@ -62,6 +63,10 @@
 		// the email, so it is excluded here rather than overridden afterwards,
 		// leaving core's own typography intact. `:where()` holds the exclusion
 		// at zero specificity, so these rules keep their original weight.
+		//
+		// This is the registry of canvas chrome, not just the selectors that
+		// currently lose to the blanket — some already out-specify it, and
+		// listing them keeps that from being load-bearing.
 		*:where(:not(
 			.components-placeholder, .components-placeholder *,
 			.block-editor-warning, .block-editor-warning *,
@@ -69,7 +74,9 @@
 			.newsletters-block__conditional-content__label,
 			.newsletters-block__conditional-content__label *,
 			.newsletters-block-visibility-label,
-			.newsletters-block-visibility-label *
+			.newsletters-block-visibility-label *,
+			.newspack-newsletters-ad-block-ad-label,
+			.newspack-newsletters-ad-block-ad-label *
 		)) {
 			line-height: 1.5;
 

--- a/plugins/newspack-newsletters/src/editor/legacy-block-styles/style.scss
+++ b/plugins/newspack-newsletters/src/editor/legacy-block-styles/style.scss
@@ -58,16 +58,18 @@
 
 		// Blanket font-family and line-height overrides — moved from
 		// `../style.scss` (Task 5). Forces georgia/arial regardless of theme;
-		// only applies when flag is off (MJML path). Block editor chrome is UI
-		// that never reaches the email, so it is excluded here rather than
-		// overridden afterwards, which leaves core's own typography intact.
-		// `:where()` keeps that exclusion at zero specificity, so these rules
-		// stay at their original weight and the `h1`–`h6` rule below still wins
-		// on source order.
+		// only applies when flag is off (MJML path). Editor chrome never reaches
+		// the email, so it is excluded here rather than overridden afterwards,
+		// leaving core's own typography intact. `:where()` holds the exclusion
+		// at zero specificity, so these rules keep their original weight.
 		*:where(:not(
 			.components-placeholder, .components-placeholder *,
 			.block-editor-warning, .block-editor-warning *,
-			.components-notice, .components-notice *
+			.components-notice, .components-notice *,
+			.newsletters-block__conditional-content__label,
+			.newsletters-block__conditional-content__label *,
+			.newsletters-block-visibility-label,
+			.newsletters-block-visibility-label *
 		)) {
 			line-height: 1.5;
 
@@ -76,14 +78,19 @@
 			}
 		}
 
-		// Chrome roots carry no font-family of their own, so they would inherit
-		// georgia from the block wrapper. Reset the root only: everything inside
-		// then follows core, which is why no line-height is set here — core's
-		// `line-height: initial` on placeholder text would be lost if it were.
+		// Core leaves the placeholder root's font-family unset, and sets no
+		// line-height on any chrome root, so both would otherwise be inherited
+		// from the block wrapper. Core's own declarations inside still win,
+		// an explicit value beating an inherited one. The Newspack labels above
+		// set their own typography and need no reset.
+		.components-placeholder {
+			font-family: wp-vars.$default-font;
+		}
+
 		.components-placeholder,
 		.block-editor-warning,
 		.components-notice {
-			font-family: wp-vars.$default-font;
+			line-height: wp-vars.$default-line-height;
 		}
 
 		h1,

--- a/plugins/newspack-newsletters/src/editor/legacy-block-styles/style.scss
+++ b/plugins/newspack-newsletters/src/editor/legacy-block-styles/style.scss
@@ -11,6 +11,8 @@
 // `.editor-styles-wrapper .block-editor-block-list__layout` in `style.scss`, so
 // when both stylesheets load (flag off) the result is identical to before.
 
+@use "~@wordpress/base-styles/variables" as wp-vars;
+
 // Font variable declarations and aliases — moved from `../style.scss` (Task 5).
 // Under flag-on these are absent so the theme's fonts flow through; under
 // flag-off this bundle restores them, keeping the MJML editor appearance intact.
@@ -65,9 +67,13 @@
 			}
 		}
 
-		.block-editor-block-list__block .components-placeholder,
-		.block-editor-block-list__block .components-placeholder div {
-			font-family: "Noto Serif", helvetica, arial, sans-serif;
+		// Block editor chrome — placeholders and variation pickers — is UI that
+		// never reaches the email, so exempt it from the blanket override above
+		// and leave it on the admin typography.
+		.components-placeholder,
+		.components-placeholder * {
+			font-family: wp-vars.$default-font;
+			line-height: wp-vars.$default-line-height;
 		}
 
 		h1,

--- a/plugins/newspack-newsletters/src/editor/legacy-block-styles/style.scss
+++ b/plugins/newspack-newsletters/src/editor/legacy-block-styles/style.scss
@@ -12,7 +12,31 @@
 // when both stylesheets load (flag off) the result is identical to before,
 // except for editor chrome (see the exclusion list below).
 
+@use "sass:list";
 @use "~@wordpress/base-styles/variables" as wp-vars;
+
+$canvas-scope: ".editor-styles-wrapper .block-editor-block-list__layout";
+
+$chrome-root-needing-font-reset: ".components-placeholder";
+
+$chrome-roots-needing-line-height-reset:
+	$chrome-root-needing-font-reset,
+	".block-editor-warning",
+	".components-notice",
+	".components-drop-zone";
+
+$chrome-roots-self-styled:
+	".block-editor-block-list__block-html-textarea",
+	".newsletters-block__conditional-content__label",
+	".newsletters-block-visibility-label",
+	".newspack-newsletters-ad-block-ad-label";
+
+$canvas-chrome: ();
+
+@each $root in list.join($chrome-roots-needing-line-height-reset, $chrome-roots-self-styled, $separator: comma) {
+	$canvas-chrome: list.append($canvas-chrome, #{$root}, $separator: comma);
+	$canvas-chrome: list.append($canvas-chrome, #{$root + " *"}, $separator: comma);
+}
 
 // Font variable declarations and aliases — moved from `../style.scss` (Task 5).
 // Under flag-on these are absent so the theme's fonts flow through; under
@@ -59,45 +83,13 @@
 
 		// Blanket font-family and line-height overrides — moved from
 		// `../style.scss` (Task 5). Forces georgia/arial regardless of theme;
-		// only applies when flag is off (MJML path). Editor chrome never reaches
-		// the email, so it is excluded here, leaving core's own typography
-		// intact. `:where()` holds the exclusion at zero specificity, so these
-		// rules keep their original weight.
-		//
-		// This is the registry of canvas chrome, not just the selectors that
-		// currently lose to the blanket — some already out-specify it, and
-		// listing them keeps that from being load-bearing.
-		*:where(:not(
-			.components-placeholder, .components-placeholder *,
-			.block-editor-warning, .block-editor-warning *,
-			.components-notice, .components-notice *,
-			.newsletters-block__conditional-content__label,
-			.newsletters-block__conditional-content__label *,
-			.newsletters-block-visibility-label,
-			.newsletters-block-visibility-label *,
-			.newspack-newsletters-ad-block-ad-label,
-			.newspack-newsletters-ad-block-ad-label *
-		)) {
+		// only applies when flag is off (MJML path).
+		*:not(:where(#{$canvas-chrome})) {
 			line-height: 1.5;
 
 			&:not(code) {
 				font-family: var(--newspack-newsletters-body-font);
 			}
-		}
-
-		// Core leaves the placeholder root's font-family unset, and sets no
-		// line-height on any chrome root, so both would otherwise be inherited
-		// from the block wrapper. Core's own declarations inside still win,
-		// an explicit value beating an inherited one. The Newspack labels above
-		// set their own typography and need no reset.
-		.components-placeholder {
-			font-family: wp-vars.$default-font;
-		}
-
-		.components-placeholder,
-		.block-editor-warning,
-		.components-notice {
-			line-height: wp-vars.$default-line-height;
 		}
 
 		h1,
@@ -393,4 +385,12 @@
 			}
 		}
 	}
+}
+
+:where(#{$canvas-scope}) :where(#{$chrome-roots-needing-line-height-reset}) {
+	line-height: wp-vars.$default-line-height;
+}
+
+:where(#{$canvas-scope}) :where(#{$chrome-root-needing-font-reset}) {
+	font-family: wp-vars.$default-font;
 }

--- a/plugins/newspack-newsletters/src/editor/legacy-block-styles/style.scss
+++ b/plugins/newspack-newsletters/src/editor/legacy-block-styles/style.scss
@@ -60,9 +60,9 @@
 		// Blanket font-family and line-height overrides — moved from
 		// `../style.scss` (Task 5). Forces georgia/arial regardless of theme;
 		// only applies when flag is off (MJML path). Editor chrome never reaches
-		// the email, so it is excluded here rather than overridden afterwards,
-		// leaving core's own typography intact. `:where()` holds the exclusion
-		// at zero specificity, so these rules keep their original weight.
+		// the email, so it is excluded here, leaving core's own typography
+		// intact. `:where()` holds the exclusion at zero specificity, so these
+		// rules keep their original weight.
 		//
 		// This is the registry of canvas chrome, not just the selectors that
 		// currently lose to the blanket — some already out-specify it, and

--- a/plugins/newspack-newsletters/src/editor/legacy-block-styles/style.scss
+++ b/plugins/newspack-newsletters/src/editor/legacy-block-styles/style.scss
@@ -58,8 +58,17 @@
 
 		// Blanket font-family and line-height overrides — moved from
 		// `../style.scss` (Task 5). Forces georgia/arial regardless of theme;
-		// only applies when flag is off (MJML path).
-		* {
+		// only applies when flag is off (MJML path). Block editor chrome is UI
+		// that never reaches the email, so it is excluded here rather than
+		// overridden afterwards, which leaves core's own typography intact.
+		// `:where()` keeps that exclusion at zero specificity, so these rules
+		// stay at their original weight and the `h1`–`h6` rule below still wins
+		// on source order.
+		*:where(:not(
+			.components-placeholder, .components-placeholder *,
+			.block-editor-warning, .block-editor-warning *,
+			.components-notice, .components-notice *
+		)) {
 			line-height: 1.5;
 
 			&:not(code) {
@@ -67,13 +76,14 @@
 			}
 		}
 
-		// Block editor chrome — placeholders and variation pickers — is UI that
-		// never reaches the email, so exempt it from the blanket override above
-		// and leave it on the admin typography.
+		// Chrome roots carry no font-family of their own, so they would inherit
+		// georgia from the block wrapper. Reset the root only: everything inside
+		// then follows core, which is why no line-height is set here — core's
+		// `line-height: initial` on placeholder text would be lost if it were.
 		.components-placeholder,
-		.components-placeholder * {
+		.block-editor-warning,
+		.components-notice {
 			font-family: wp-vars.$default-font;
-			line-height: wp-vars.$default-line-height;
 		}
 
 		h1,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

On the MJML path the newsletter editor forces email-safe fonts across the canvas so the editor resembles the sent email. That override also reached block editor chrome, which never appears in an email: placeholders, block warnings, notices and this plugin's own canvas labels all rendered in georgia at the email's leading.

Chrome is now **excluded** from the override rather than styled back on top of it. Core's own typography then applies unchanged, so placeholder text keeps `line-height: initial`, the embed placeholder's URL field keeps `line-height: normal`, and `<code>` keeps its monospace face. `:where()` holds the exclusion at zero specificity, so every other canvas rule keeps the weight it had.

The exclusion list is a registry of canvas chrome, not only the selectors that currently lose to the override. A chrome element that happens to out-specify the override today therefore stops depending on that.

What this covers:

* Every block's placeholder, so variation pickers are included without naming them.
* Block warnings and notices.
* Three Newspack labels: conditional content, block visibility, and the ad block label.

Two of those labels were already rendering in the email font. The conditional-content badge declared the admin font but lost at one class of specificity, and the ad block label declared no `font-family` at all. The ad label's declaration lives in the always-enqueued bundle, so it now reads the same under either renderer.

Rendered email output is untouched. MJML is generated server-side from block attributes and never consulted these rules.

Surfaced while fixing the Roundup block's placeholder in `newspack-manager`; that PR is linked from this one and depends on this change for its typography to take effect.

### How to test the changes in this Pull Request:

1. Confirm the WooCommerce email renderer flag is off. This is what loads the stylesheet, so the rest of the steps depend on it.
2. Edit a newsletter and insert a block with a placeholder state, for example Image or Embed. The placeholder's label, instructions and controls render in the admin sans-serif font, not a serif.
3. Paste nothing into the Embed placeholder and compare its URL field with the same block in the standard post editor. The leading matches, rather than sitting looser.
4. Add a Conditional Content block. The yellow badge and its inline Edit and Remove controls render in the admin font.
5. Add an Ad block. The label on the dashed mock renders in the admin font.
6. Confirm paragraphs and headings in the newsletter body still render in georgia and arial.
7. Turn the WooCommerce email renderer flag on. The ad block label still renders in the admin font; everything else here is inert in that state.
8. Send or preview the newsletter and confirm the email output is unchanged.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? Tests n/a: stylesheet only, no test surface.
* [x] Have you successfully run tests with your changes locally? Verified by the manual steps above, plus `lint:scss` on both changed files.

Left for follow-ups:

* `src/editor/style.scss` forces `color: inherit` on canvas links, which beats core's styling for `ExternalLink` inside placeholders, so chrome links render near-black instead of the admin accent. Colour is a separate axis, and that file is always enqueued, so a fix would reach the WooCommerce renderer path too. Best handled together with its `text-decoration: underline` counterpart.
* The conditional-content and visibility labels declare a local `--newspack-system-font` property rather than the base-styles variable used elsewhere. Same computed value today, so this is tidy-up rather than a behaviour change.
* The Roundup loading overlay renders as a sibling of `<Placeholder>`, so the exclusion does not reach it and its font workaround is still required on the `newspack-manager` side.
