### PR TITLE
build: keep agent files out of plugin release archives (NPPM-3111)

### DIFF
--- a/plugins/newspack-ads/.distignore
+++ b/plugins/newspack-ads/.distignore
@@ -32,6 +32,9 @@ phpcs.xml
 .phpcs.xml.dist
 phpcs.xml.dist
 README.md
+AGENTS.md
+CLAUDE.md
+.claude
 webpack.config.js
 wp-cli.local.yml
 yarn.lock

--- a/plugins/newspack-blocks/.distignore
+++ b/plugins/newspack-blocks/.distignore
@@ -44,3 +44,6 @@ node_modules
 /bin
 .cache
 coverage
+AGENTS.md
+CLAUDE.md
+.claude

--- a/plugins/newspack-listings/.distignore
+++ b/plugins/newspack-listings/.distignore
@@ -20,6 +20,9 @@ phpcs.xml
 .phpcs.xml.dist
 phpcs.xml.dist
 README.md
+AGENTS.md
+CLAUDE.md
+.claude
 PULL_REQUEST_TEMPLATE.md
 webpack.config.js
 *.sql

--- a/plugins/newspack-multibranded-site/.distignore
+++ b/plugins/newspack-multibranded-site/.distignore
@@ -22,6 +22,9 @@ phpcs.xml
 .phpcs.xml.dist
 phpcs.xml.dist
 README.md
+AGENTS.md
+CLAUDE.md
+.claude
 PULL_REQUEST_TEMPLATE.md
 webpack.config.js
 _.sql

--- a/plugins/newspack-newsletters/.distignore
+++ b/plugins/newspack-newsletters/.distignore
@@ -25,6 +25,9 @@ phpcs.xml
 .phpcs.xml.dist
 phpcs.xml.dist
 README.md
+AGENTS.md
+CLAUDE.md
+.claude
 PULL_REQUEST_TEMPLATE.md
 webpack.config.js
 wp-cli.local.yml

--- a/plugins/newspack-plugin/.distignore
+++ b/plugins/newspack-plugin/.distignore
@@ -26,6 +26,8 @@ phpcs.xml
 .phpcs.xml.dist
 phpcs.xml.dist
 README.md
+AGENTS.md
+CLAUDE.md
 PULL_REQUEST_TEMPLATE.md
 webpack.config.js
 wp-cli.local.yml
@@ -37,6 +39,7 @@ yarn.lock
 includes/plugins/google-site-kit/gtm-template/
 
 # directories
+.claude
 node_modules
 .cache
 .git

--- a/plugins/newspack-popups/.distignore
+++ b/plugins/newspack-popups/.distignore
@@ -31,6 +31,9 @@ phpcs.xml
 .phpcs.xml.dist
 phpcs.xml.dist
 README.md
+AGENTS.md
+CLAUDE.md
+.claude
 PULL_REQUEST_TEMPLATE.md
 webpack.config.js
 wp-cli.local.yml

--- a/plugins/newspack-sponsors/.distignore
+++ b/plugins/newspack-sponsors/.distignore
@@ -25,6 +25,9 @@ phpcs.xml
 .phpcs.xml.dist
 phpcs.xml.dist
 README.md
+AGENTS.md
+CLAUDE.md
+.claude
 PULL_REQUEST_TEMPLATE.md
 webpack.config.js
 wp-cli.local.yml

--- a/plugins/newspack-story-budget/.distignore
+++ b/plugins/newspack-story-budget/.distignore
@@ -26,6 +26,8 @@ phpcs.xml
 .phpcs.xml.dist
 phpcs.xml.dist
 README.md
+AGENTS.md
+CLAUDE.md
 PULL_REQUEST_TEMPLATE.md
 webpack.config.js
 wp-cli.local.yml
@@ -35,6 +37,7 @@ yarn.lock
 *.zip
 
 # directories
+.claude
 node_modules
 .cache
 .git

--- a/plugins/republication-tracker-tool/.distignore
+++ b/plugins/republication-tracker-tool/.distignore
@@ -22,6 +22,9 @@ multisite.xml.dist
 phpcs.xml
 phpcs.xml.dist
 README.md
+AGENTS.md
+CLAUDE.md
+.claude
 wp-cli.local.yml
 tests
 vendor

--- a/plugins/super-cool-ad-inserter/.distignore
+++ b/plugins/super-cool-ad-inserter/.distignore
@@ -21,6 +21,9 @@ multisite.xml.dist
 phpcs.xml
 phpcs.xml.dist
 README.md
+AGENTS.md
+CLAUDE.md
+.claude
 wp-cli.local.yml
 tests
 vendor

--- a/themes/newspack-block-theme/.distignore
+++ b/themes/newspack-block-theme/.distignore
@@ -25,6 +25,8 @@ phpcs.xml
 .phpcs.xml.dist
 phpcs.xml.dist
 README.md
+AGENTS.md
+CLAUDE.md
 PULL_REQUEST_TEMPLATE.md
 webpack.config.js
 wp-cli.local.yml
@@ -34,6 +36,7 @@ yarn.lock
 *.zip
 
 # directories
+.claude
 node_modules
 .cache
 .git


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`release:archive` copies `AGENTS.md` and `CLAUDE.md` into the plugin zip, so the AI agent instruction files ship to publisher sites and WordPress.org. Only `newspack-network` excluded them.

This adds the three lines it already carries to the other 12 `.distignore` files:

```
AGENTS.md
CLAUDE.md
.claude
```

Placement follows each file's existing structure, so the two files sit next to `README.md` and `.claude` goes in the directories section where there is one.

`newspack-theme` turned out not to need this. Its `release:archive` zips the inner theme directories, and the agent files sit at the project root one level above them.

Closes NPPM-3111.

### How to test the changes in this Pull Request:

Packaging only, so there's nothing to exercise in the product. This checks the archives no longer pick the files up.

1. From any plugin directory, run `rsync -rn --exclude-from=.distignore . /tmp/out --out-format='%n' | grep -i "agents\|claude"`. It returns nothing.
2. Repeat in `plugins/newspack-plugin`, which keeps `.claude` in its directories section. Same result.
3. Check `themes/newspack-theme`. None of the six directories its `release:archive` zips contain agent files, so it needs no exclusion.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (n/a, packaging config only)
* [x] Have you successfully run tests with your changes locally? (verified with the dry runs above, across all 14 projects that carry an `AGENTS.md`)
