### PR TITLE
fix(icons): accept @wordpress/primitives 4.x as a peer

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -29,7 +29,7 @@
 	},
 	"dependencies": {},
 	"peerDependencies": {
-		"@wordpress/primitives": "^3.0.0",
+		"@wordpress/primitives": "^3.0.0 || ^4.0.0",
 		"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,7 +79,7 @@ importers:
         version: 6.21.0
       '@wordpress/icons':
         specifier: ^11.0.0
-        version: 11.8.0(react@18.3.1)
+        version: 11.8.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/keycodes':
         specifier: ^4.48.0
         version: 4.48.0
@@ -175,7 +175,7 @@ importers:
         version: 6.21.0
       '@wordpress/icons':
         specifier: ^11.0.0
-        version: 11.8.0(react@18.3.1)
+        version: 11.8.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/keycodes':
         specifier: ^4.48.0
         version: 4.48.0
@@ -238,7 +238,7 @@ importers:
   packages/icons:
     dependencies:
       '@wordpress/primitives':
-        specifier: ^3.0.0
+        specifier: ^3.0.0 || ^4.0.0
         version: 3.56.0
       react:
         specifier: 18.3.1
@@ -3932,12 +3932,6 @@ packages:
   '@wordpress/primitives@3.56.0':
     resolution: {integrity: sha512-NXBq1ODjl6inMWx/l7KCbATcjdoeIOqYeL9i9alqdAfWeKx1EH9PIvKWylIkqZk7erXxCxldiRkuyjTtwjNBxw==}
     engines: {node: '>=12'}
-
-  '@wordpress/primitives@4.48.0':
-    resolution: {integrity: sha512-dfF7IZotIqb6LUiGs7oPwKbSF8RPoC0JDSIrtxvgwFA/yvbc/pDIp/Zs0O8GvxZNxu4JIVnKskOhoLq7lAeziQ==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: 18.3.1
 
   '@wordpress/primitives@4.49.0':
     resolution: {integrity: sha512-mmyDQ6HLFdUhLCcdsJpPzzVjQ2H4wwS3MakMfeiKx39UUAdszoP50vjOohbcUL/7RGkNPvZ66AbpK45XMhlloA==, tarball: https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.49.0.tgz}
@@ -16255,10 +16249,10 @@ snapshots:
       '@wordpress/hooks': 4.48.0
       '@wordpress/html-entities': 4.48.0
       '@wordpress/i18n': 6.21.0
-      '@wordpress/icons': 11.8.0(react@18.3.1)
+      '@wordpress/icons': 11.8.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/is-shallow-equal': 5.48.0
       '@wordpress/keycodes': 4.48.0
-      '@wordpress/primitives': 4.48.0(react@18.3.1)
+      '@wordpress/primitives': 4.49.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/private-apis': 1.49.0
       '@wordpress/rich-text': 7.48.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/warning': 3.48.0
@@ -16550,9 +16544,9 @@ snapshots:
       '@wordpress/date': 5.48.0
       '@wordpress/element': 6.46.0
       '@wordpress/i18n': 6.21.0
-      '@wordpress/icons': 11.8.0(react@18.3.1)
+      '@wordpress/icons': 11.8.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/keycodes': 4.48.0
-      '@wordpress/primitives': 4.48.0(react@18.3.1)
+      '@wordpress/primitives': 4.49.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/private-apis': 1.49.0
       '@wordpress/url': 4.48.0
       '@wordpress/warning': 3.48.0
@@ -17009,12 +17003,14 @@ snapshots:
       memize: 2.1.1
       tannin: 1.2.0
 
-  '@wordpress/icons@11.8.0(react@18.3.1)':
+  '@wordpress/icons@11.8.0(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
       '@wordpress/element': 6.46.0
-      '@wordpress/primitives': 4.48.0(react@18.3.1)
+      '@wordpress/primitives': 4.49.0(@types/react@18.3.31)(react@18.3.1)
       change-case: 4.1.2
       react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@wordpress/icons@13.3.0(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
@@ -17335,12 +17331,6 @@ snapshots:
       '@babel/runtime': 7.29.7
       '@wordpress/element': 5.35.0
       clsx: 2.1.1
-
-  '@wordpress/primitives@4.48.0(react@18.3.1)':
-    dependencies:
-      '@wordpress/element': 8.1.0
-      clsx: 2.1.1
-      react: 18.3.1
 
   '@wordpress/primitives@4.49.0(@types/react@18.3.31)(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`newspack-icons` 1.1.0 added a peer dependency on `@wordpress/primitives` at `^3.0.0`. The package imports only `SVG` and `Path`, which are unchanged in primitives 4.x — but the range rejects 4.x, and standalone consumers install under npm's strict peer resolution. In newspack-manager, whose tree resolves primitives 4.44.0 through `newspack-scripts`, `npm ci` fails with `ERESOLVE` since the 1.1.0 bump merged (Automattic/newspack-manager#710), taking trunk and every open PR red there.

This widens the peer to `^3.0.0 || ^4.0.0`, matching the `||` style of the react peer beside it. The immediate unblock on the manager side is Automattic/newspack-manager#713, which reverts the two bumps until this ships. Releasing it as 1.1.1 clears the path for consumers: `newspack-components` depends on icons via `workspace:*`, so its next release picks the fixed version up, and newspack-manager can then take both bumps cleanly.

### How to test the changes in this Pull Request:

1. `npx semver 4.44.0 -r "^3.0.0 || ^4.0.0"` matches, and `npx semver 3.2.1 -r "^3.0.0 || ^4.0.0"` still matches.
2. The failing consumer shape: newspack-manager trunk (primitives 4.44.0 in-tree) raises `ERESOLVE` against icons 1.1.0's `^3.0.0` peer, and resolves once the peer accepts 4.x.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (Dependency metadata only — no code change.)
* [x] Have you successfully run tests with your changes locally?
