### PR TITLE
fix(cli): link migrate-teams line items to product variations (NPPD-1876)

### DIFF
--- a/plugins/newspack-plugin/includes/cli/class-teams-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-teams-migration.php
@@ -1737,6 +1737,33 @@ class Teams_Migration {
 	}
 
 	/**
+	 * Point a $0 migration line item at the product the operator chose.
+	 *
+	 * Assigning `product_id` directly cannot express a variation, and publishers
+	 * selling seat tiers hold them as variations of one variable subscription
+	 * product — so `--product-id` is routinely given a variation ID.
+	 * WC_Order_Item_Product::set_product_id() rejects any ID that is not a
+	 * `product` post by throwing, and set_props() swallows that into a return
+	 * value nobody reads, so the item is saved linked to nothing. From there the
+	 * subscription cannot be activated (WC Subscriptions refuses to activate a
+	 * subscription whose product is unavailable) and, on the reuse path where
+	 * nothing activates it, it silently grants access to nobody, since access is
+	 * matched by product ID. set_product() is the only setter that records a
+	 * variation correctly, splitting it into parent product ID + variation ID.
+	 *
+	 * @param \WC_Order_Item_Product $line_item The line item to populate.
+	 * @param \WC_Product            $product   The product or variation to link.
+	 *
+	 * @return void
+	 */
+	private static function link_migration_product( $line_item, $product ) {
+		$line_item->set_product( $product );
+		$line_item->set_quantity( 1 );
+		$line_item->set_subtotal( 0 );
+		$line_item->set_total( 0 );
+	}
+
+	/**
 	 * Create a new $0 migration subscription for a team owner and set its dates.
 	 *
 	 * @param int              $owner_id         The owner user ID.
@@ -1770,15 +1797,7 @@ class Teams_Migration {
 		}
 
 		$line_item = new \WC_Order_Item_Product();
-		$line_item->set_props(
-			[
-				'product_id' => $migration_product->get_id(),
-				'name'       => $migration_product->get_name(),
-				'quantity'   => 1,
-				'subtotal'   => 0,
-				'total'      => 0,
-			]
-		);
+		self::link_migration_product( $line_item, $migration_product );
 		$line_item->set_taxes( [] );
 		$new_sub->add_item( $line_item );
 
@@ -1832,15 +1851,7 @@ class Teams_Migration {
 			$subscription->remove_item( $item_id );
 		}
 		$line_item = new \WC_Order_Item_Product();
-		$line_item->set_props(
-			[
-				'product_id' => $migration_product->get_id(),
-				'name'       => $migration_product->get_name(),
-				'quantity'   => 1,
-				'subtotal'   => 0,
-				'total'      => 0,
-			]
-		);
+		self::link_migration_product( $line_item, $migration_product );
 
 		$subscription->set_billing_period( $billing_period );
 		$subscription->set_billing_interval( $billing_interval );

--- a/plugins/newspack-plugin/includes/cli/class-teams-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-teams-migration.php
@@ -118,6 +118,13 @@ class Teams_Migration {
 	 * such a subscription keeps its own schedule, the team's Teams end date is not
 	 * carried onto it, so the group can outlive the membership it came from.
 	 *
+	 * A subscription already cancelled but paid through the end of its term
+	 * (pending-cancel) is migrated in place for the same reason and keeps its
+	 * scheduled end date, whatever its total. Its members hold access for the rest
+	 * of the paid term and lose it when the subscription self-cancels, which is
+	 * what the reader asked for; re-aligning it onto the migration product would
+	 * overwrite that end date and extend their access indefinitely.
+	 *
 	 * Two cases are skipped rather than migrated, and reported as errors in the
 	 * summary: a paid team whose own product no published gate accepts, since
 	 * granting access would mean rewriting what the publisher charges; and a team
@@ -323,10 +330,18 @@ class Teams_Migration {
 			$members_added  = 0;
 			$recovering_sub = null;
 
-			// Attempt to reuse the team's linked subscription if it is active.
+			// Attempt to reuse the team's linked subscription if it still grants
+			// access. That is active *or* pending-cancel: a team riding out a period
+			// it has already paid for keeps its access until the subscription
+			// self-cancels, and both Access_Rules and Group_Subscription gate member
+			// access on WooCommerce_Connection::ACTIVE_SUBSCRIPTION_STATUSES. Reusing
+			// it in place carries that expiry across the migration, so the owner and
+			// the group's members lose access exactly when the subscription ends;
+			// creating a $0 group for such a team instead would hand them permanent
+			// access after they had cancelled.
 			if ( $raw_sub_id ) {
 				$existing_sub = \wcs_get_subscription( $raw_sub_id );
-				if ( $existing_sub && 'active' === $existing_sub->get_status() ) {
+				if ( $existing_sub && $existing_sub->has_status( WooCommerce_Connection::ACTIVE_SUBSCRIPTION_STATUSES ) ) {
 					$subscription = $existing_sub;
 					if ( 'yes' === $existing_sub->get_meta( '_newspack_group_subscription_enabled' ) ) {
 						WP_CLI::line( sprintf( 'Team %d: subscription %d is already a group subscription — re-updating.', $team_id, $raw_sub_id ) );
@@ -464,12 +479,20 @@ class Teams_Migration {
 			// billing schedule and gains only the group settings.
 			$reused_is_paid = ! $created_new && self::subscription_is_paid( $subscription );
 
+			// A pending-cancel subscription keeps its terms too, whatever its total.
+			// Its dates are the point: the scheduled end is what makes the owner and
+			// the group's members lose access when the subscription self-cancels, and
+			// re-aligning it would overwrite those dates with migration-derived ones
+			// and extend access past the cancellation the reader asked for.
+			$reused_is_ending  = ! $created_new && $subscription->has_status( 'pending-cancel' );
+			$reuse_keeps_terms = $reused_is_paid || $reused_is_ending;
+
 			// Access for a paid team therefore rests on its own product, since we no
 			// longer swap in --product-id. If no published gate accepts that product
 			// the migration cannot grant access without rewriting what the publisher
 			// charges — so leave the team untouched and let the operator decide,
 			// rather than silently converting a paying subscription to $0.
-			if ( $reused_is_paid && ! empty( $access_product_ids ) && ! self::subscription_covers_access_products( $subscription, $access_product_ids ) ) {
+			if ( $reuse_keeps_terms && ! empty( $access_product_ids ) && ! self::subscription_covers_access_products( $subscription, $access_product_ids ) ) {
 				$own_product_ids = self::subscription_product_ids( $subscription );
 				$own_list        = ! empty( $own_product_ids ) ? implode( ', ', $own_product_ids ) : 'none';
 				$errors[]        = sprintf( 'subscription %d is paid and holds product(s) %s, which no published gate accepts (accepted: %s) — migrating it would either grant no access or rewrite what the publisher charges', $subscription->get_id(), $own_list, implode( ', ', $access_product_ids ) );
@@ -511,8 +534,9 @@ class Teams_Migration {
 			// subscription with the product passed via --product-id. Paid
 			// subscriptions are exempt: rewriting their line items would replace what
 			// the publisher sells with a $0 product and overwrite the billing
-			// schedule (see $reused_is_paid above).
-			if ( ! $created_new && ! $reused_is_paid && $migration_product && ! $dry_run ) {
+			// schedule, and for a pending-cancel subscription would push its expiry
+			// out past the cancellation the reader asked for (see $reuse_keeps_terms).
+			if ( ! $created_new && ! $reuse_keeps_terms && $migration_product && ! $dry_run ) {
 				self::replace_subscription_product( $subscription, $migration_product, $billing_period, $billing_interval, $start_date, $end_date, $errors, $team_id );
 			}
 

--- a/plugins/newspack-plugin/includes/cli/class-teams-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-teams-migration.php
@@ -854,11 +854,21 @@ class Teams_Migration {
 			$access_products_source = 'derived from published gates';
 		}
 
+		$product = \wc_get_product( $product_id );
+		if ( ! $product ) {
+			WP_CLI::error( sprintf( 'Product %d could not be found.', $product_id ) );
+		}
+
 		// A $0 subscription for a product no gate accepts restores no access: the
 		// run would report "created" while the reader stays locked out. Only
 		// checkable when the accepted products are known — with none configured
 		// yet, the gates are presumably still to be built around this product.
-		if ( ! empty( $access_product_ids ) && ! in_array( $product_id, $access_product_ids, true ) ) {
+		// Matched through product_grants_gate_access() rather than a flat
+		// comparison because enforcement runs through has_product(), which accepts
+		// a line item's product ID or its variation ID: a gate naming a variable
+		// subscription's parent does accept a seat-tier variation, and refusing one
+		// here would block a --product-id that works.
+		if ( ! empty( $access_product_ids ) && ! self::product_grants_gate_access( $product, $access_product_ids ) ) {
 			WP_CLI::error(
 				sprintf(
 					'Product %d is not among the products that grant access (%s), so a subscription to it grants no access. Pass --product-id for a product the gates accept, or add %d to a gate\'s "Active subscription" rule first.',
@@ -867,11 +877,6 @@ class Teams_Migration {
 					$product_id
 				)
 			);
-		}
-
-		$product = \wc_get_product( $product_id );
-		if ( ! $product ) {
-			WP_CLI::error( sprintf( 'Product %d could not be found.', $product_id ) );
 		}
 
 		// Readers granted a $0 subscription to a limited product cannot purchase
@@ -2497,10 +2502,14 @@ class Teams_Migration {
 			if ( 'manual migration' !== $subscription->get_created_via() ) {
 				continue;
 			}
-			foreach ( $subscription->get_items() as $item ) {
-				if ( method_exists( $item, 'get_product_id' ) && (int) $item->get_product_id() === $product_id ) {
-					return true;
-				}
+			// has_product() matches a line item's product ID *or* its variation ID.
+			// Comparing get_product_id() alone would never recognise this command's
+			// own output for a variation --product-id, since create_individual_subscription()
+			// links through set_product() and so stores the parent in product_id —
+			// and an unrecognised prior run means every re-run grants another $0
+			// subscription rather than skipping the member.
+			if ( method_exists( $subscription, 'has_product' ) && $subscription->has_product( $product_id ) ) {
+				return true;
 			}
 		}
 		return false;

--- a/plugins/newspack-plugin/includes/cli/class-teams-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-teams-migration.php
@@ -116,7 +116,7 @@ class Teams_Migration {
 	 * ## OPTIONS
 	 *
 	 * [--product-id=<id>]
-	 * : Product ID to assign to newly-created subscriptions. When supplied, also overwrites the product on any existing subscription that is re-used. Required unless --skip-unlinked is passed.
+	 * : Product to assign to newly-created subscriptions. Accepts a product ID or a variation ID — pass the variation when a publisher sells seat tiers as variations of one variable subscription product. Must be published and accepted by a published gate's "Active subscription" rule. When supplied, also overwrites the product on any existing subscription that is re-used. Required unless --skip-unlinked is passed.
 	 *
 	 * [--live]
 	 * : Apply the changes. Without this flag the command runs as a dry-run and writes nothing.
@@ -162,7 +162,16 @@ class Teams_Migration {
 		}
 
 		if ( $migration_product ) {
-			WP_CLI::line( sprintf( 'Using product: "%s" (ID: %d)', $migration_product->get_name(), $migration_product->get_id() ) );
+			// Name which shape was passed: a variation and its parent read alike in
+			// the summary, and which one the operator meant is the crux of NPPD-1876.
+			WP_CLI::line(
+				sprintf(
+					'Using %s: "%s" (ID: %d)',
+					$migration_product->is_type( 'variation' ) ? sprintf( 'variation of product %d', $migration_product->get_parent_id() ) : 'product',
+					$migration_product->get_name(),
+					$migration_product->get_id()
+				)
+			);
 			// For a variable-subscription parent these meta live on the variation, not
 			// the parent, and come back empty; default them the same way
 			// create_group_subscription()/create_individual_subscription() do so an
@@ -171,6 +180,41 @@ class Teams_Migration {
 			$interval_meta    = \get_post_meta( $product_id, '_subscription_period_interval', true );
 			$billing_period   = '' !== $period_meta ? $period_meta : 'month';
 			$billing_interval = '' !== $interval_meta ? (int) $interval_meta : 1;
+
+			// An unpublished product fails the same way the migration used to fail on
+			// a variation: WC_Subscription::can_be_updated_to( 'active' ) rejects a
+			// line item whose product is unavailable, and unavailable includes any
+			// status other than publish. Checked here because a dry run cannot
+			// surface it — every write is behind ! $dry_run — so without this the
+			// first the operator hears of it is a fatal on team one of a live run.
+			if ( ! self::product_is_published( $migration_product ) ) {
+				WP_CLI::error(
+					sprintf(
+						'Product %d is not published, so subscriptions created against it cannot be activated. Publish it (or its parent product, for a variation) and re-run.',
+						$product_id
+					)
+				);
+			}
+
+			// A group subscription grants access only where a published gate lists
+			// its product: enforcement runs through WC_Subscription::has_product().
+			// Migrating against a product no gate accepts would report every team as
+			// migrated while granting access to nobody, and on the reuse path the
+			// subscription's original line items are replaced in the same pass, so
+			// there is nothing left to fall back on. Only checkable once the gates
+			// name some products; with none configured they are presumably still to
+			// be built around this product.
+			$access_product_ids = self::get_gate_access_product_ids();
+			if ( ! empty( $access_product_ids ) && ! self::product_grants_gate_access( $migration_product, $access_product_ids ) ) {
+				WP_CLI::error(
+					sprintf(
+						'Product %d is not among the products that grant access (%s), so migrating teams onto it would grant no access. Pass --product-id for a product the gates accept, or add %d to a gate\'s "Active subscription" rule first.',
+						$product_id,
+						implode( ', ', $access_product_ids ),
+						$product_id
+					)
+				);
+			}
 		}
 
 		if ( $dry_run ) {
@@ -1737,19 +1781,67 @@ class Teams_Migration {
 	}
 
 	/**
+	 * Whether a product is published, resolving a variation to its parent.
+	 *
+	 * WC_Subscription::contains_unavailable_product() checks the parent's status
+	 * for a variation, so the parent's status is what decides whether a migration
+	 * subscription can be activated.
+	 *
+	 * @param \WC_Product $product Product or variation.
+	 *
+	 * @return bool
+	 */
+	private static function product_is_published( $product ) {
+		$subject = $product;
+		if ( $product->is_type( 'variation' ) ) {
+			$parent = \wc_get_product( $product->get_parent_id() );
+			if ( ! $parent ) {
+				return false;
+			}
+			$subject = $parent;
+		}
+		return 'publish' === $subject->get_status();
+	}
+
+	/**
+	 * Whether the site's published gates would accept a subscription to a product.
+	 *
+	 * Enforcement runs through WC_Subscription::has_product(), which matches a
+	 * line item's product ID *or* its variation ID. So a gate naming a variable
+	 * subscription's parent accepts any of its variations, while a gate naming a
+	 * sibling variation accepts none of the others. Comparing the product's own
+	 * ID alone would refuse a variation the gates do in fact accept.
+	 *
+	 * @param \WC_Product $product            Product or variation.
+	 * @param int[]       $access_product_ids Product IDs the published gates accept.
+	 *
+	 * @return bool
+	 */
+	private static function product_grants_gate_access( $product, $access_product_ids ) {
+		$candidate_ids = [ (int) $product->get_id() ];
+		if ( $product->is_type( 'variation' ) ) {
+			$candidate_ids[] = (int) $product->get_parent_id();
+		}
+		foreach ( $candidate_ids as $candidate_id ) {
+			if ( $candidate_id && in_array( $candidate_id, $access_product_ids, true ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Point a $0 migration line item at the product the operator chose.
 	 *
-	 * Assigning `product_id` directly cannot express a variation, and publishers
-	 * selling seat tiers hold them as variations of one variable subscription
-	 * product — so `--product-id` is routinely given a variation ID.
-	 * WC_Order_Item_Product::set_product_id() rejects any ID that is not a
-	 * `product` post by throwing, and set_props() swallows that into a return
-	 * value nobody reads, so the item is saved linked to nothing. From there the
-	 * subscription cannot be activated (WC Subscriptions refuses to activate a
-	 * subscription whose product is unavailable) and, on the reuse path where
-	 * nothing activates it, it silently grants access to nobody, since access is
-	 * matched by product ID. set_product() is the only setter that records a
-	 * variation correctly, splitting it into parent product ID + variation ID.
+	 * `set_product()` is the only setter that records a variation correctly,
+	 * splitting it into parent product ID + variation ID; assigning the
+	 * variation's own ID to `product_id` is rejected outright. Publishers selling
+	 * seat tiers hold them as variations of one variable subscription product, so
+	 * `--product-id` is routinely given a variation ID (see NPPD-1876).
+	 *
+	 * `create_group_subscription()` and `create_individual_subscription()` link
+	 * their items the same way inline rather than through this helper: they were
+	 * already correct, and each builds a differently-shaped item.
 	 *
 	 * @param \WC_Order_Item_Product $line_item The line item to populate.
 	 * @param \WC_Product            $product   The product or variation to link.
@@ -1766,14 +1858,14 @@ class Teams_Migration {
 	/**
 	 * Create a new $0 migration subscription for a team owner and set its dates.
 	 *
-	 * @param int              $owner_id         The owner user ID.
-	 * @param \WC_Product|null $migration_product The migration product.
-	 * @param string           $billing_period   The billing period.
-	 * @param int              $billing_interval The billing interval.
-	 * @param string           $start_date       The subscription start date.
-	 * @param string           $end_date         The subscription end date, or ''.
-	 * @param array            $errors           Errors array, passed by reference.
-	 * @param int              $team_id          The team post ID (for error context).
+	 * @param int         $owner_id         The owner user ID.
+	 * @param \WC_Product $migration_product The migration product.
+	 * @param string      $billing_period   The billing period.
+	 * @param int         $billing_interval The billing interval.
+	 * @param string      $start_date       The subscription start date.
+	 * @param string      $end_date         The subscription end date, or ''.
+	 * @param array       $errors           Errors array, passed by reference.
+	 * @param int         $team_id          The team post ID (for error context).
 	 *
 	 * @return \WC_Subscription|null The subscription, or null on failure.
 	 */

--- a/plugins/newspack-plugin/includes/cli/class-teams-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-teams-migration.php
@@ -108,15 +108,22 @@ class Teams_Migration {
 	 * subscriptions in place rather than creating duplicates. Reuse keys on the
 	 * source team, so an owner who owns several teams migrates to one group
 	 * subscription per team rather than a single merged group. When --product-id is
-	 * supplied, every re-used subscription has its line items replaced with the
+	 * supplied, every re-used $0 subscription has its line items replaced with the
 	 * migration product.
+	 *
+	 * A team whose linked subscription is one the publisher actually bills is
+	 * migrated in place: it gains the group settings and keeps its own product,
+	 * price, taxes and billing schedule. Forcing a subscription to $0 is only
+	 * correct where the access being carried over was free in Memberships. Such a
+	 * team is skipped when no published gate accepts its product, since granting
+	 * access would otherwise mean rewriting what the publisher charges.
 	 *
 	 * Dry-run by default; pass --live to write.
 	 *
 	 * ## OPTIONS
 	 *
 	 * [--product-id=<id>]
-	 * : Product to assign to newly-created subscriptions. Accepts a product ID or a variation ID — pass the variation when a publisher sells seat tiers as variations of one variable subscription product. Must be published and accepted by a published gate's "Active subscription" rule. When supplied, also overwrites the product on any existing subscription that is re-used. Required unless --skip-unlinked is passed.
+	 * : Product to assign to newly-created subscriptions. Accepts a product ID or a variation ID — pass the variation when a publisher sells seat tiers as variations of one variable subscription product. Must be published and accepted by a published gate's "Active subscription" rule. Also re-aligns any re-used $0 subscription onto this product; a re-used subscription the team pays for keeps its own product, price, taxes and billing schedule. Required unless --skip-unlinked is passed.
 	 *
 	 * [--live]
 	 * : Apply the changes. Without this flag the command runs as a dry-run and writes nothing.
@@ -154,9 +161,10 @@ class Teams_Migration {
 			WP_CLI::error( 'WooCommerce Subscriptions is not active. Aborting.' );
 		}
 
-		$migration_product = $product_id ? \wc_get_product( $product_id ) : null;
-		$billing_period    = 'month';
-		$billing_interval  = 1;
+		$migration_product  = $product_id ? \wc_get_product( $product_id ) : null;
+		$billing_period     = 'month';
+		$billing_interval   = 1;
+		$access_product_ids = [];
 		if ( $product_id && ! $migration_product ) {
 			WP_CLI::error( sprintf( 'Product ID %d not found. Aborting.', $product_id ) );
 		}
@@ -403,6 +411,35 @@ class Teams_Migration {
 				$sub_owner_id    = (int) $subscription->get_user_id();
 			}
 
+			// A migration converts free Memberships access into a $0 subscription. A
+			// team that pays for its seats is a different case: the publisher still
+			// sells that subscription, so it keeps its product, price, taxes and
+			// billing schedule and gains only the group settings. Keyed on the
+			// recurring total rather than provenance so it holds for groups created
+			// by older migrator runs too — those are $0 and stay re-alignable.
+			$reused_is_paid = ! $created_new && (float) $subscription->get_total() > 0;
+
+			// Access for a paid team therefore rests on its own product, since we no
+			// longer swap in --product-id. If no published gate accepts that product
+			// the migration cannot grant access without rewriting what the publisher
+			// charges — so leave the team untouched and let the operator decide,
+			// rather than silently converting a paying subscription to $0.
+			if ( $reused_is_paid && ! empty( $access_product_ids ) && ! self::subscription_covers_access_products( $subscription, $access_product_ids ) ) {
+				$errors[]  = sprintf( 'subscription %d is a paid subscription whose product no published gate accepts (%s) — migrating it would either grant no access or rewrite what the publisher charges', $subscription->get_id(), implode( ', ', $access_product_ids ) );
+				$summary[] = self::summary_row( $team_id, 'ERROR', 0, 0, $group_limit, false, $errors );
+				WP_CLI::warning(
+					sprintf(
+						'Team %d ("%s"): linked subscription %d is a paid subscription (%s) whose product no published gate accepts — skipping so the migration does not zero out what the publisher bills. Add its product to a gate\'s "Active subscription" rule, then re-run.',
+						$team_id,
+						$team->post_title,
+						$subscription->get_id(),
+						\wc_price( $subscription->get_total() )
+					)
+				);
+				\WP_CLI\Utils\wp_clear_object_cache();
+				continue;
+			}
+
 			// Enable the group and set its name up front. The seat limit is deferred
 			// until after members are added (below) so update_members()' limit gate
 			// can't reject existing team members mid-migration — a new subscription
@@ -419,10 +456,13 @@ class Teams_Migration {
 				$subscription->save();
 			}
 
-			// When re-using an existing subscription with --product-id, overwrite its
-			// line items with the migration product so re-running aligns every
-			// subscription with the product passed via --product-id.
-			if ( ! $created_new && $migration_product && ! $dry_run ) {
+			// When re-using a $0 subscription with --product-id, overwrite its line
+			// items with the migration product so re-running aligns every migrated
+			// subscription with the product passed via --product-id. Paid
+			// subscriptions are exempt: rewriting their line items would replace what
+			// the publisher sells with a $0 product and overwrite the billing
+			// schedule (see $reused_is_paid above).
+			if ( ! $created_new && ! $reused_is_paid && $migration_product && ! $dry_run ) {
 				self::replace_subscription_product( $subscription, $migration_product, $billing_period, $billing_interval, $start_date, $end_date, $errors, $team_id );
 			}
 

--- a/plugins/newspack-plugin/includes/cli/class-teams-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-teams-migration.php
@@ -114,9 +114,16 @@ class Teams_Migration {
 	 * A team whose linked subscription is one the publisher actually bills is
 	 * migrated in place: it gains the group settings and keeps its own product,
 	 * price, taxes and billing schedule. Forcing a subscription to $0 is only
-	 * correct where the access being carried over was free in Memberships. Such a
-	 * team is skipped when no published gate accepts its product, since granting
-	 * access would otherwise mean rewriting what the publisher charges.
+	 * correct where the access being carried over was free in Memberships. Because
+	 * such a subscription keeps its own schedule, the team's Teams end date is not
+	 * carried onto it, so the group can outlive the membership it came from.
+	 *
+	 * Two cases are skipped rather than migrated, and reported as errors in the
+	 * summary: a paid team whose own product no published gate accepts, since
+	 * granting access would mean rewriting what the publisher charges; and a team
+	 * whose paid subscription is on hold for payment recovery and which has no
+	 * migrated group to update, since creating one would hand the owner permanent
+	 * free access and remove their reason to fix their payment method.
 	 *
 	 * Dry-run by default; pass --live to write.
 	 *
@@ -161,10 +168,16 @@ class Teams_Migration {
 			WP_CLI::error( 'WooCommerce Subscriptions is not active. Aborting.' );
 		}
 
-		$migration_product  = $product_id ? \wc_get_product( $product_id ) : null;
-		$billing_period     = 'month';
-		$billing_interval   = 1;
-		$access_product_ids = [];
+		$migration_product = $product_id ? \wc_get_product( $product_id ) : null;
+		$billing_period    = 'month';
+		$billing_interval  = 1;
+
+		// Derived independently of --product-id: the paid-team guard below needs it
+		// in --skip-unlinked runs, which take no --product-id and process only
+		// linked teams — exactly the teams that can be paid ones. Deriving it inside
+		// the migration-product block would leave that guard dead in the one mode
+		// where every team it protects is in scope.
+		$access_product_ids = self::get_gate_access_product_ids();
 		if ( $product_id && ! $migration_product ) {
 			WP_CLI::error( sprintf( 'Product ID %d not found. Aborting.', $product_id ) );
 		}
@@ -212,7 +225,6 @@ class Teams_Migration {
 			// there is nothing left to fall back on. Only checkable once the gates
 			// name some products; with none configured they are presumably still to
 			// be built around this product.
-			$access_product_ids = self::get_gate_access_product_ids();
 			if ( ! empty( $access_product_ids ) && ! self::product_grants_gate_access( $migration_product, $access_product_ids ) ) {
 				WP_CLI::error(
 					sprintf(
@@ -305,10 +317,11 @@ class Teams_Migration {
 				continue;
 			}
 
-			$subscription  = null;
-			$created_new   = false;
-			$errors        = [];
-			$members_added = 0;
+			$subscription   = null;
+			$created_new    = false;
+			$errors         = [];
+			$members_added  = 0;
+			$recovering_sub = null;
 
 			// Attempt to reuse the team's linked subscription if it is active.
 			if ( $raw_sub_id ) {
@@ -319,6 +332,14 @@ class Teams_Migration {
 						WP_CLI::line( sprintf( 'Team %d: subscription %d is already a group subscription — re-updating.', $team_id, $raw_sub_id ) );
 					}
 				} else {
+					// A paid subscription in payment recovery is not reusable, since reuse
+					// requires active. Remember it so the create branch can refuse to mint
+					// a free replacement; that decision has to wait until after the reuse
+					// lookup below, because a team already migrated on an earlier run has
+					// a group to re-update and the harm cannot arise for it.
+					if ( $existing_sub && 'on-hold' === $existing_sub->get_status() && self::subscription_is_paid( $existing_sub ) ) {
+						$recovering_sub = $existing_sub;
+					}
 					$status_label = $existing_sub ? $existing_sub->get_status() : 'not found';
 					WP_CLI::warning( sprintf( 'Team %d: linked subscription %d is not active (status: %s) — searching for the group subscription this team was previously migrated to.', $team_id, $raw_sub_id, $status_label ) );
 				}
@@ -340,7 +361,7 @@ class Teams_Migration {
 				if ( $reuse['disabled_marked_group_ids'] ) {
 					$disabled_list = implode( ', ', $reuse['disabled_marked_group_ids'] );
 					$errors[]      = sprintf( 'group subscription(s) %s migrated from this team have group subscriptions disabled — re-enable one or clear its %s meta, then re-run', $disabled_list, self::MIGRATED_TEAM_ID_META_KEY );
-					$summary[]     = self::summary_row( $team_id, 'ERROR', 0, 0, $seat_count, false, $errors );
+					$summary[]     = self::summary_row( $team_id, 'ERROR', 0, 0, $group_limit, false, $errors );
 					WP_CLI::warning( sprintf( 'Team %d ("%s"): group subscription(s) %s migrated from this team have group subscriptions disabled — skipping so the migration does not re-enable them or create a duplicate. Re-enable one, or clear the %s meta to let a fresh group be created, then re-run.', $team_id, $team->post_title, $disabled_list, self::MIGRATED_TEAM_ID_META_KEY ) );
 					// This path has just loaded every subscription of the owner's, which is what
 					// the per-team cache clear exists to bound.
@@ -377,6 +398,32 @@ class Teams_Migration {
 				}
 			}
 
+			// Nothing was reusable and the team's own subscription is a paid one in
+			// payment recovery, so creating here would mint a new, active, $0 group
+			// subscription alongside it: the owner would get permanent free access
+			// and no reason to fix their card, turning a recoverable paying customer
+			// into a permanently free one. That is the harm LIVE_SUBSCRIPTION_STATUSES
+			// records as deliberately out of scope for migrate-manual-members
+			// (NPPD-2052 owns the dunning cohort). On_Hold_Duration expires an
+			// unrecovered subscription on its own, and a re-run picks the team up
+			// once it is active again or gone. Checked here rather than at the reuse
+			// lookup so a team that already has a group to re-update is unaffected.
+			if ( ! $subscription && $recovering_sub ) {
+				$errors[]  = sprintf( 'linked subscription %d is a paid subscription in payment recovery ("on-hold") and no migrated group exists for this team — skipped so the migration does not mint a free parallel subscription', $recovering_sub->get_id() );
+				$summary[] = self::summary_row( $team_id, 'ERROR', 0, 0, $group_limit, false, $errors );
+				WP_CLI::warning(
+					sprintf(
+						'Team %d ("%s"): linked subscription %d is a paid subscription (%s) on hold for payment recovery, and this team has no migrated group to update — skipping so the owner is not granted a free subscription mid-recovery. Re-run once it is active again, or once it has expired.',
+						$team_id,
+						$team->post_title,
+						$recovering_sub->get_id(),
+						self::format_subscription_total( $recovering_sub )
+					)
+				);
+				\WP_CLI\Utils\wp_clear_object_cache();
+				continue;
+			}
+
 			// Create a new subscription when none resolved above. This needs a
 			// migration product; with --skip-unlinked and no --product-id a team
 			// whose linked subscription is inactive/missing (so it is not skipped)
@@ -386,7 +433,7 @@ class Teams_Migration {
 			if ( ! $subscription && ! $migration_product ) {
 				$errors[] = 'no reusable subscription and no --product-id supplied to create one';
 				WP_CLI::warning( sprintf( 'Team %d: linked subscription is inactive/missing and no --product-id was supplied to create a replacement — skipping. Re-run with --product-id to migrate these teams.', $team_id ) );
-				$summary[] = self::summary_row( $team_id, 'ERROR', 0, 0, $seat_count, false, $errors );
+				$summary[] = self::summary_row( $team_id, 'ERROR', 0, 0, $group_limit, false, $errors );
 				continue;
 			}
 
@@ -396,7 +443,7 @@ class Teams_Migration {
 				if ( ! $dry_run ) {
 					$new_sub = self::create_migration_subscription( $owner_id, $migration_product, $billing_period, $billing_interval, $start_date, $end_date, $errors, $team_id );
 					if ( ! $new_sub ) {
-						$summary[] = self::summary_row( $team_id, 'ERROR', 0, 0, $seat_count, true, $errors );
+						$summary[] = self::summary_row( $team_id, 'ERROR', 0, 0, $group_limit, true, $errors );
 						continue;
 					}
 					$subscription = $new_sub;
@@ -414,10 +461,8 @@ class Teams_Migration {
 			// A migration converts free Memberships access into a $0 subscription. A
 			// team that pays for its seats is a different case: the publisher still
 			// sells that subscription, so it keeps its product, price, taxes and
-			// billing schedule and gains only the group settings. Keyed on the
-			// recurring total rather than provenance so it holds for groups created
-			// by older migrator runs too — those are $0 and stay re-alignable.
-			$reused_is_paid = ! $created_new && (float) $subscription->get_total() > 0;
+			// billing schedule and gains only the group settings.
+			$reused_is_paid = ! $created_new && self::subscription_is_paid( $subscription );
 
 			// Access for a paid team therefore rests on its own product, since we no
 			// longer swap in --product-id. If no published gate accepts that product
@@ -425,15 +470,20 @@ class Teams_Migration {
 			// charges — so leave the team untouched and let the operator decide,
 			// rather than silently converting a paying subscription to $0.
 			if ( $reused_is_paid && ! empty( $access_product_ids ) && ! self::subscription_covers_access_products( $subscription, $access_product_ids ) ) {
-				$errors[]  = sprintf( 'subscription %d is a paid subscription whose product no published gate accepts (%s) — migrating it would either grant no access or rewrite what the publisher charges', $subscription->get_id(), implode( ', ', $access_product_ids ) );
-				$summary[] = self::summary_row( $team_id, 'ERROR', 0, 0, $group_limit, false, $errors );
+				$own_product_ids = self::subscription_product_ids( $subscription );
+				$own_list        = ! empty( $own_product_ids ) ? implode( ', ', $own_product_ids ) : 'none';
+				$errors[]        = sprintf( 'subscription %d is paid and holds product(s) %s, which no published gate accepts (accepted: %s) — migrating it would either grant no access or rewrite what the publisher charges', $subscription->get_id(), $own_list, implode( ', ', $access_product_ids ) );
+				$summary[]       = self::summary_row( $team_id, 'ERROR', 0, 0, $group_limit, false, $errors );
 				WP_CLI::warning(
 					sprintf(
-						'Team %d ("%s"): linked subscription %d is a paid subscription (%s) whose product no published gate accepts — skipping so the migration does not zero out what the publisher bills. Add its product to a gate\'s "Active subscription" rule, then re-run.',
+						'Team %d ("%s"): linked subscription %d is a paid subscription (%s) holding product(s) %s, which no published gate accepts (accepted: %s) — skipping so the migration does not zero out what the publisher bills. Add %s to a gate\'s "Active subscription" rule, then re-run.',
 						$team_id,
 						$team->post_title,
 						$subscription->get_id(),
-						\wc_price( $subscription->get_total() )
+						self::format_subscription_total( $subscription ),
+						$own_list,
+						implode( ', ', $access_product_ids ),
+						$own_list
 					)
 				);
 				\WP_CLI\Utils\wp_clear_object_cache();
@@ -1823,6 +1873,79 @@ class Teams_Migration {
 			]
 		);
 		return ! empty( $team_ids ) ? (int) $team_ids[0] : 0;
+	}
+
+	/**
+	 * Product and variation IDs a subscription's line items hold.
+	 *
+	 * Named in the skip messages so the operator can act without opening the
+	 * subscription: these are the IDs that would have to appear in a gate's
+	 * "Active subscription" rule for the team's own subscription to grant access.
+	 *
+	 * @param \WC_Subscription $subscription Subscription to read.
+	 *
+	 * @return int[]
+	 */
+	private static function subscription_product_ids( $subscription ) {
+		$ids = [];
+		foreach ( $subscription->get_items() as $item ) {
+			if ( ! method_exists( $item, 'get_product_id' ) ) {
+				continue;
+			}
+			$ids[] = (int) $item->get_product_id();
+			if ( method_exists( $item, 'get_variation_id' ) && $item->get_variation_id() ) {
+				$ids[] = (int) $item->get_variation_id();
+			}
+		}
+		return array_values( array_unique( array_filter( $ids ) ) );
+	}
+
+	/**
+	 * Whether the publisher bills this subscription.
+	 *
+	 * Decides whether a reused subscription keeps its commercial terms through
+	 * the migration or is re-aligned onto --product-id as a $0 group subscription.
+	 * Erring toward "paid" is the safe direction: the cost of a false positive is
+	 * a subscription that keeps the product it already had, while a false negative
+	 * deletes the product line the publisher sells and rewrites the schedule.
+	 *
+	 * `WC_Subscription::get_total()` is the recurring total, so a free trial, a
+	 * sign-up fee, a synced first payment and a pending-cancel all still report
+	 * the per-period amount. It is discounted, though: a 100% recurring coupon
+	 * stores a total of 0 on a subscription the publisher does intend to bill
+	 * again once the coupon's payment count runs out. The pre-discount subtotal is
+	 * immune to that, and is 0 on every subscription this migration creates
+	 * (link_migration_product() and create_group_subscription() both set it), so
+	 * checking both keeps old $0 groups re-alignable without reading a fully
+	 * discounted subscription as free.
+	 *
+	 * @param \WC_Subscription $subscription Subscription to test.
+	 *
+	 * @return bool
+	 */
+	private static function subscription_is_paid( $subscription ) {
+		$total = method_exists( $subscription, 'get_total' ) ? (float) $subscription->get_total() : 0.0;
+		if ( $total > 0 ) {
+			return true;
+		}
+		$subtotal = method_exists( $subscription, 'get_subtotal' ) ? (float) $subscription->get_subtotal() : 0.0;
+		return $subtotal > 0;
+	}
+
+	/**
+	 * A subscription's recurring total as plain text for CLI output.
+	 *
+	 * Formatted here rather than with wc_price(), which returns markup and renders
+	 * the USD symbol as the HTML entity `&#36;` — both land literally in a
+	 * terminal, in the one message whose job is to make the amount at risk legible.
+	 *
+	 * @param \WC_Subscription $subscription Subscription to format.
+	 *
+	 * @return string
+	 */
+	private static function format_subscription_total( $subscription ) {
+		$decimals = function_exists( 'wc_get_price_decimals' ) ? \wc_get_price_decimals() : 2;
+		return trim( sprintf( '%s %s', \number_format( (float) $subscription->get_total(), $decimals ), $subscription->get_currency() ) );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -569,8 +569,15 @@ class WC_Order {
 	public function get_date_completed() {
 		return new WC_DateTime( $this->data['date_completed'] );
 	}
+	/**
+	 * Real WC_Abstract_Order returns '0' for an order with no total set; without
+	 * a default a fixture that omits it raises an undefined-key warning instead.
+	 */
 	public function get_total() {
-		return $this->data['total'];
+		return $this->data['total'] ?? 0;
+	}
+	public function get_subtotal() {
+		return $this->data['subtotal'] ?? 0;
 	}
 	public function get_status() {
 		return $this->data['status'];
@@ -697,8 +704,20 @@ class WC_Subscription {
 	public function get_date_paid() {
 		return new WC_DateTime( $this->data['date_paid'] );
 	}
+	/**
+	 * Real WC_Abstract_Order returns '0' when no total is set; without a default
+	 * a fixture that omits it raises an undefined-key warning instead. Production
+	 * code now reads this for every reused subscription.
+	 */
 	public function get_total() {
-		return $this->data['total'];
+		return $this->data['total'] ?? 0;
+	}
+	/**
+	 * Pre-discount total. Distinguishes a fully-discounted subscription, which
+	 * still carries a subtotal, from a $0 migration subscription, which does not.
+	 */
+	public function get_subtotal() {
+		return $this->data['subtotal'] ?? 0;
 	}
 	public function get_status() {
 		return $this->data['status'];

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -308,7 +308,7 @@ class WC_Order_Item_Product implements ArrayAccess {
 	public function set_product_id( $product_id ) {
 		global $products_database;
 		$product = $products_database[ (int) $product_id ] ?? null;
-		if ( $product_id > 0 && $product && $product->is_type( [ 'variation', 'subscription_variation' ] ) ) {
+		if ( $product_id > 0 && $product && $product->is_type( 'variation' ) ) {
 			throw new WC_Data_Exception( 'order_item_product_invalid_product_id', 'Invalid product ID' );
 		}
 		$this->data['product_id'] = (int) $product_id;
@@ -383,13 +383,13 @@ class WC_Order_Item_Product implements ArrayAccess {
 	 * @param WC_Product $product Product or variation.
 	 */
 	public function set_product( $product ) {
-		if ( $product->is_type( [ 'variation', 'subscription_variation' ] ) ) {
+		if ( $product->is_type( 'variation' ) ) {
 			$this->set_product_id( $product->get_parent_id() );
 			$this->set_variation_id( $product->get_id() );
 		} else {
 			$this->set_product_id( $product->get_id() );
 		}
-		$this->data['name'] = $product->get_name();
+		$this->set_name( $product->get_name() );
 	}
 	public function set_quantity( $quantity ) {
 		$this->data['quantity'] = $quantity;
@@ -426,8 +426,22 @@ class WC_Product {
 	public function get_type() {
 		return $this->data['type'] ?? 'simple';
 	}
+	/**
+	 * WC_Product_Subscription_Variation overrides is_type() so a
+	 * `subscription_variation` answers true to `is_type( 'variation' )`. Production
+	 * code relies on that alias — WC_Order_Item_Product::set_product() branches on
+	 * `is_type( 'variation' )` alone — so the mock has to model it, or a test would
+	 * take a different branch than the real code does.
+	 *
+	 * @param string|string[] $types Type or types to test.
+	 *
+	 * @return bool
+	 */
 	public function is_type( $types ) {
 		$types = (array) $types;
+		if ( 'subscription_variation' === $this->get_type() && in_array( 'variation', $types, true ) ) {
+			return true;
+		}
 		return in_array( $this->get_type(), $types, true );
 	}
 	public function get_parent_id() {
@@ -677,7 +691,20 @@ class WC_Subscription {
 	public function set_total( $total ) {
 		$this->data['total'] = $total;
 	}
+	/**
+	 * Real WC_Abstract_Order keys its items by order-item ID, which is what makes
+	 * `remove_item( $item->get_id() )` work. Preserve that when the fixture gave
+	 * the item an ID; fall back to appending for the many fixtures that don't, so
+	 * their positional keys keep working.
+	 *
+	 * @param WC_Order_Item_Product $item Line item.
+	 */
 	public function add_item( $item ) {
+		$item_id = method_exists( $item, 'get_id' ) ? (int) $item->get_id() : 0;
+		if ( $item_id ) {
+			$this->data['items'][ $item_id ] = $item;
+			return;
+		}
 		$this->data['items'][] = $item;
 	}
 	/**

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -182,6 +182,39 @@ function wc_mocks_reset_notices() {
 	$wc_mock_notices = [];
 }
 
+/**
+ * Stand-in for WooCommerce's WC_Data_Exception, thrown by data setters that
+ * reject their input.
+ */
+class WC_Data_Exception extends Exception {
+	/**
+	 * Machine-readable error code.
+	 *
+	 * @var string
+	 */
+	private $error_code;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $code    Machine-readable error code.
+	 * @param string $message Human-readable message.
+	 */
+	public function __construct( $code, $message ) {
+		$this->error_code = $code;
+		parent::__construct( $message );
+	}
+
+	/**
+	 * Machine-readable error code.
+	 *
+	 * @return string
+	 */
+	public function getErrorCode() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		return $this->error_code;
+	}
+}
+
 class WC_Order_Item_Product implements ArrayAccess {
 	private $data = [];
 	private $meta = [];
@@ -257,11 +290,65 @@ class WC_Order_Item_Product implements ArrayAccess {
 	public function get_variation_id() {
 		return $this->data['variation_id'] ?? 0;
 	}
+	/**
+	 * Real WC_Order_Item_Product::set_product_id() rejects any ID that is not a
+	 * `product` post — a variation is `product_variation` — by throwing
+	 * WC_Data_Exception *before* assigning the prop, so the ID is silently
+	 * dropped rather than stored. Modelling that here is what lets a test catch
+	 * a variation ID being passed where a parent product ID belongs (NPPD-1876);
+	 * a mock that accepted anything made the bug invisible to the suite.
+	 *
+	 * IDs with no registered mock product are left alone, so fixtures that use
+	 * arbitrary product IDs keep working.
+	 *
+	 * @param int $product_id Product ID.
+	 *
+	 * @throws WC_Data_Exception If the ID belongs to a variation.
+	 */
 	public function set_product_id( $product_id ) {
+		global $products_database;
+		$product = $products_database[ (int) $product_id ] ?? null;
+		if ( $product_id > 0 && $product && $product->is_type( [ 'variation', 'subscription_variation' ] ) ) {
+			throw new WC_Data_Exception( 'order_item_product_invalid_product_id', 'Invalid product ID' );
+		}
 		$this->data['product_id'] = (int) $product_id;
 	}
 	public function set_variation_id( $variation_id ) {
 		$this->data['variation_id'] = (int) $variation_id;
+	}
+	public function set_name( $name ) {
+		$this->data['name'] = $name;
+	}
+	public function set_taxes( $taxes ) {
+		$this->data['taxes'] = $taxes;
+	}
+	/**
+	 * Mirror of WC_Data::set_props(): call each matching setter, collect any
+	 * WC_Data_Exception into a returned WP_Error rather than letting it bubble.
+	 * That swallowing is exactly how an invalid product ID reaches the database
+	 * as 0 without the caller noticing.
+	 *
+	 * @param array $props Property => value pairs.
+	 *
+	 * @return true|WP_Error
+	 */
+	public function set_props( $props ) {
+		$errors = false;
+		foreach ( $props as $prop => $value ) {
+			$setter = "set_$prop";
+			if ( ! is_callable( [ $this, $setter ] ) ) {
+				continue;
+			}
+			try {
+				$this->{$setter}( $value );
+			} catch ( WC_Data_Exception $e ) {
+				if ( ! $errors ) {
+					$errors = new WP_Error();
+				}
+				$errors->add( $e->getErrorCode(), $e->getMessage(), [ 'property_name' => $prop ] );
+			}
+		}
+		return $errors ? $errors : true;
 	}
 	public function save() {
 		return true;
@@ -278,14 +365,31 @@ class WC_Order_Item_Product implements ArrayAccess {
 	public function get_total() {
 		return $this->data['total'] ?? 0;
 	}
+	/**
+	 * Like the real getter, resolve the variation first and fall back to the
+	 * parent product, so an item linked to a variation returns the variation.
+	 */
 	public function get_product() {
 		global $products_database;
-		$product_id = $this->data['product_id'] ?? 0;
+		$product_id = $this->get_variation_id() ? $this->get_variation_id() : $this->get_product_id();
 		return $products_database[ $product_id ] ?? false;
 	}
+	/**
+	 * Real WC_Order_Item_Product::set_product() splits a variation into parent
+	 * product ID + variation ID; anything else sets the product ID alone. This
+	 * is the only setter that handles a variation correctly, which is why the
+	 * migration CLI uses it rather than assigning `product_id` directly.
+	 *
+	 * @param WC_Product $product Product or variation.
+	 */
 	public function set_product( $product ) {
-		$this->data['product_id'] = $product->get_id();
-		$this->data['name']       = $product->get_name();
+		if ( $product->is_type( [ 'variation', 'subscription_variation' ] ) ) {
+			$this->set_product_id( $product->get_parent_id() );
+			$this->set_variation_id( $product->get_id() );
+		} else {
+			$this->set_product_id( $product->get_id() );
+		}
+		$this->data['name'] = $product->get_name();
 	}
 	public function set_quantity( $quantity ) {
 		$this->data['quantity'] = $quantity;
@@ -670,6 +774,43 @@ class WC_Subscription {
 	}
 	public function get_items() {
 		return $this->data['items'] ?? [];
+	}
+	/**
+	 * Keyed by item ID like WC_Abstract_Order::remove_item().
+	 *
+	 * @param int $item_id Order item ID.
+	 */
+	public function remove_item( $item_id ) {
+		unset( $this->data['items'][ $item_id ] );
+	}
+	/**
+	 * Sum the line items into the order total, like WC_Abstract_Order does.
+	 */
+	public function calculate_totals() {
+		$total = 0;
+		foreach ( $this->get_items() as $item ) {
+			$total += (float) $item->get_total();
+		}
+		$this->data['total'] = $total;
+		return $total;
+	}
+	/**
+	 * Address setter. The mock stores address fields flat, matching how the
+	 * address getters in __call() read them.
+	 *
+	 * @param array  $address Address fields.
+	 * @param string $type    'billing' or 'shipping'.
+	 */
+	public function set_address( $address, $type = 'billing' ) {
+		foreach ( $address as $field => $value ) {
+			$this->data[ $type . '_' . $field ] = $value;
+		}
+	}
+	public function set_billing_period( $period ) {
+		$this->data['billing_period'] = $period;
+	}
+	public function set_billing_interval( $interval ) {
+		$this->data['billing_interval'] = $interval;
 	}
 	public function get_item( $item_id, $load_from_db = true ) {
 		// Faithful to WC_Abstract_Order::get_item(): the default delegates to

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -646,7 +646,28 @@ class WC_Subscription {
 		}
 		return true;
 	}
+	/**
+	 * Real WC_Subscription::has_product() walks the line items and matches either
+	 * the product ID or the variation ID — which is what lets a rule naming a
+	 * variable subscription's parent accept any of its variations. Check the items
+	 * first so code depending on that matching behaves as it does in production,
+	 * then fall back to the fixture-supplied `products` list, which many tests use
+	 * to declare coverage without building line items.
+	 *
+	 * @param int $product_id Product or variation ID.
+	 *
+	 * @return bool
+	 */
 	public function has_product( $product_id ) {
+		$product_id = (int) $product_id;
+		foreach ( $this->get_items() as $item ) {
+			if ( ! method_exists( $item, 'get_product_id' ) ) {
+				continue;
+			}
+			if ( (int) $item->get_product_id() === $product_id || (int) $item->get_variation_id() === $product_id ) {
+				return true;
+			}
+		}
 		return in_array( $product_id, $this->products, true );
 	}
 	public function get_meta( $field_name ) {

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-teams-migration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-teams-migration.php
@@ -1188,6 +1188,59 @@ class Test_Teams_Migration extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A pending-cancel subscription still grants access, so it is reusable.
+	 *
+	 * A team riding out a term it already paid for keeps access until the
+	 * subscription self-cancels. Both Access_Rules and Group_Subscription gate
+	 * member access on WooCommerce_Connection::ACTIVE_SUBSCRIPTION_STATUSES, so
+	 * reusing such a subscription in place carries that expiry across the
+	 * migration; creating a $0 group for the team instead would grant its members
+	 * access forever, after the owner had cancelled.
+	 */
+	public function test_pending_cancel_counts_as_access_granting_for_reuse() {
+		$this->assertContains(
+			'pending-cancel',
+			\Newspack\WooCommerce_Connection::ACTIVE_SUBSCRIPTION_STATUSES,
+			'Reuse keys on this constant; if pending-cancel leaves it, a cancelled-but-paid team would be given a permanent free group instead.'
+		);
+
+		$pending_cancel = wcs_create_subscription(
+			[
+				'customer_id'    => $this->create_reader(),
+				'status'         => 'pending-cancel',
+				'billing_period' => 'month',
+				'total'          => 599,
+			]
+		);
+		$this->assertTrue(
+			$pending_cancel->has_status( \Newspack\WooCommerce_Connection::ACTIVE_SUBSCRIPTION_STATUSES ),
+			'A pending-cancel subscription is reusable, so the migration updates it in place rather than minting a $0 replacement.'
+		);
+		$this->assertTrue(
+			$this->invoke_private( 'subscription_is_paid', [ $pending_cancel ] ),
+			'It is also paid, so its product and price are left alone.'
+		);
+
+		// Even with no total recorded, a pending-cancel subscription must keep its
+		// terms: its scheduled end date is what ends group access on time.
+		$free_pending_cancel = wcs_create_subscription(
+			[
+				'customer_id'    => $this->create_reader(),
+				'status'         => 'pending-cancel',
+				'billing_period' => 'month',
+			]
+		);
+		$this->assertFalse(
+			$this->invoke_private( 'subscription_is_paid', [ $free_pending_cancel ] ),
+			'A $0 pending-cancel subscription is not paid — it is exempted from re-alignment by its status, not its total.'
+		);
+		$this->assertTrue(
+			$free_pending_cancel->has_status( 'pending-cancel' ),
+			'Status is the signal that preserves its end date.'
+		);
+	}
+
+	/**
 	 * Gate coverage for a paid team's own subscription follows has_product().
 	 *
 	 * A team the publisher bills keeps its own product rather than being rewritten

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-teams-migration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-teams-migration.php
@@ -875,4 +875,135 @@ class Test_Teams_Migration extends WP_UnitTestCase {
 		);
 		$this->assertFalse( $reuse['used_owner_fallback'], 'No eligible fallback exists here.' );
 	}
+
+	/**
+	 * Register a variable subscription parent and one variation, as a publisher
+	 * selling seat tiers would have (NPPD-1876).
+	 *
+	 * @return array{parent: WC_Product, variation: WC_Product}
+	 */
+	private function create_variable_subscription_product() {
+		$parent = wc_create_mock_product(
+			[
+				'id'   => 109742,
+				'name' => 'Corporate Self Checkout',
+				'type' => 'variable-subscription',
+			]
+		);
+		$variation = wc_create_mock_product(
+			[
+				'id'        => 109751,
+				'name'      => 'Corporate Self Checkout - Unlimited',
+				'type'      => 'subscription_variation',
+				'parent_id' => 109742,
+			]
+		);
+		return [
+			'parent'    => $parent,
+			'variation' => $variation,
+		];
+	}
+
+	/**
+	 * Call one of the migration's private static creators.
+	 *
+	 * @param string $method Method name.
+	 * @param array  $args   Positional arguments.
+	 *
+	 * @return mixed
+	 */
+	private function invoke_private( $method, $args ) {
+		$reflection = new ReflectionMethod( Teams_Migration::class, $method );
+		$reflection->setAccessible( true );
+		return $reflection->invokeArgs( null, $args );
+	}
+
+	/**
+	 * A team migrated against a variation must end up linked to that variation.
+	 *
+	 * Publishers selling seat tiers hold them as variations of one variable
+	 * subscription product, so `--product-id` is routinely given a variation ID.
+	 * Assigning that ID straight to the line item's `product_id` is rejected by
+	 * WooCommerce and silently dropped, leaving an item linked to nothing — which
+	 * then makes WC Subscriptions refuse to activate the subscription (NPPD-1876).
+	 */
+	public function test_create_migration_subscription_links_a_variation() {
+		$owner    = $this->create_reader();
+		$products = $this->create_variable_subscription_product();
+		$errors   = [];
+
+		$subscription = $this->invoke_private(
+			'create_migration_subscription',
+			[ $owner, $products['variation'], 'month', 1, '2026-01-01 00:00:00', '', &$errors, 94782 ]
+		);
+
+		$this->assertNotNull( $subscription, 'The subscription should be created.' );
+		$items = $subscription->get_items();
+		$this->assertCount( 1, $items, 'The subscription should carry one line item.' );
+		$item = array_shift( $items );
+
+		$this->assertSame( 109742, $item->get_product_id(), 'A variation must be recorded against its parent product ID.' );
+		$this->assertSame( 109751, $item->get_variation_id(), 'The variation ID must be recorded on the line item.' );
+		$this->assertNotFalse( $item->get_product(), 'The line item must resolve to a product; an unresolvable item blocks activation.' );
+		$this->assertSame( [], $errors, 'Linking a variation should not record an error.' );
+	}
+
+	/**
+	 * The same linkage is required when re-using a team's existing subscription.
+	 *
+	 * This path never calls update_status(), so a dropped product ID raises no
+	 * exception — the subscription stays active and reports as migrated while
+	 * granting access to nobody, because access is matched by product ID.
+	 */
+	public function test_replace_subscription_product_links_a_variation() {
+		$owner        = $this->create_reader();
+		$products     = $this->create_variable_subscription_product();
+		$errors       = [];
+		$subscription = wcs_create_subscription(
+			[
+				'customer_id'    => $owner,
+				'status'         => 'active',
+				'billing_period' => 'month',
+			]
+		);
+
+		$this->invoke_private(
+			'replace_subscription_product',
+			[ $subscription, $products['variation'], 'month', 1, '2026-01-01 00:00:00', '', &$errors, 94782 ]
+		);
+
+		$items = $subscription->get_items();
+		$this->assertCount( 1, $items, 'The reused subscription should carry exactly the migration line item.' );
+		$item = array_shift( $items );
+
+		$this->assertSame( 109742, $item->get_product_id(), 'A variation must be recorded against its parent product ID.' );
+		$this->assertSame( 109751, $item->get_variation_id(), 'The variation ID must be recorded on the line item.' );
+		$this->assertNotFalse( $item->get_product(), 'The line item must resolve to a product, or the group grants no access.' );
+	}
+
+	/**
+	 * A plain (non-variation) product still links as before.
+	 */
+	public function test_create_migration_subscription_links_a_simple_product() {
+		$owner   = $this->create_reader();
+		$product = wc_create_mock_product(
+			[
+				'id'   => 500,
+				'name' => 'Group Subscription',
+				'type' => 'subscription',
+			]
+		);
+		$errors = [];
+
+		$subscription = $this->invoke_private(
+			'create_migration_subscription',
+			[ $owner, $product, 'month', 1, '2026-01-01 00:00:00', '', &$errors, 94783 ]
+		);
+
+		$items = $subscription->get_items();
+		$item  = array_shift( $items );
+
+		$this->assertSame( 500, $item->get_product_id(), 'A non-variation product links by product ID.' );
+		$this->assertSame( 0, $item->get_variation_id(), 'A non-variation product has no variation ID.' );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-teams-migration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-teams-migration.php
@@ -1085,6 +1085,44 @@ class Test_Teams_Migration extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The re-run guard must recognise a subscription linked to a variation.
+	 *
+	 * The migrate-manual-members command skips members who already hold a
+	 * migration subscription. Since a variation is stored as parent product ID plus
+	 * variation ID, matching on the product ID alone never recognised the
+	 * command's own output — so each re-run granted every member another $0
+	 * subscription instead of skipping them.
+	 */
+	public function test_member_has_migration_subscription_recognises_a_variation() {
+		$user         = $this->create_reader();
+		$products     = $this->create_variable_subscription_product();
+		$subscription = wcs_create_subscription(
+			[
+				'customer_id'    => $user,
+				'status'         => 'active',
+				'billing_period' => 'month',
+				'created_via'    => 'manual migration',
+			]
+		);
+		$item = new WC_Order_Item_Product();
+		$item->set_product( $products['variation'] );
+		$subscription->add_item( $item );
+
+		$this->assertTrue(
+			$this->invoke_private( 'member_has_migration_subscription', [ $user, 109751 ] ),
+			'A member holding a subscription linked to this variation must be recognised, or a re-run duplicates it.'
+		);
+		$this->assertTrue(
+			$this->invoke_private( 'member_has_migration_subscription', [ $user, 109742 ] ),
+			'The parent product ID must match too, since the line item records it.'
+		);
+		$this->assertFalse(
+			$this->invoke_private( 'member_has_migration_subscription', [ $user, 109999 ] ),
+			'An unrelated product must not match.'
+		);
+	}
+
+	/**
 	 * A plain (non-variation) product still links as before.
 	 */
 	public function test_create_migration_subscription_links_a_simple_product() {

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-teams-migration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-teams-migration.php
@@ -51,8 +51,13 @@ class Test_Teams_Migration extends WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
-		global $subscriptions_database;
+		global $subscriptions_database, $products_database;
 		$subscriptions_database = [];
+		// Products registered by one test are visible to every later one, and the
+		// mock's set_product_id() guard now reads this store to decide whether an ID
+		// is a variation — so a leaked registration could change another test's
+		// outcome. Every sibling test class resets it here for the same reason.
+		$products_database = [];
 		Group_Subscription::reset_cache();
 	}
 
@@ -945,6 +950,9 @@ class Test_Teams_Migration extends WP_UnitTestCase {
 		$this->assertSame( 109742, $item->get_product_id(), 'A variation must be recorded against its parent product ID.' );
 		$this->assertSame( 109751, $item->get_variation_id(), 'The variation ID must be recorded on the line item.' );
 		$this->assertNotFalse( $item->get_product(), 'The line item must resolve to a product; an unresolvable item blocks activation.' );
+		// The name is no longer set explicitly — set_product() carries it over — so
+		// hold that behavior in place rather than leaving it implicit.
+		$this->assertSame( 'Corporate Self Checkout - Unlimited', $item->get_name(), 'The line item should take its name from the linked product.' );
 		$this->assertSame( [], $errors, 'Linking a variation should not record an error.' );
 	}
 
@@ -967,6 +975,22 @@ class Test_Teams_Migration extends WP_UnitTestCase {
 			]
 		);
 
+		// Seed the team's original line item. This method leads with a removal loop,
+		// so without a pre-existing item the count assertion below would prove only
+		// that one item was added, not that the old one was cleared — and clearing
+		// it is the half that decides whether the group grants access.
+		$old_product = wc_create_mock_product(
+			[
+				'id'   => 500,
+				'name' => 'Legacy Teams product',
+				'type' => 'subscription',
+			]
+		);
+		$old_item = new WC_Order_Item_Product( [ 'id' => 4242 ] );
+		$old_item->set_product( $old_product );
+		$subscription->add_item( $old_item );
+		$this->assertCount( 1, $subscription->get_items(), 'Fixture check: the subscription starts with the legacy item.' );
+
 		$this->invoke_private(
 			'replace_subscription_product',
 			[ $subscription, $products['variation'], 'month', 1, '2026-01-01 00:00:00', '', &$errors, 94782 ]
@@ -979,6 +1003,85 @@ class Test_Teams_Migration extends WP_UnitTestCase {
 		$this->assertSame( 109742, $item->get_product_id(), 'A variation must be recorded against its parent product ID.' );
 		$this->assertSame( 109751, $item->get_variation_id(), 'The variation ID must be recorded on the line item.' );
 		$this->assertNotFalse( $item->get_product(), 'The line item must resolve to a product, or the group grants no access.' );
+		$this->assertNotSame( 500, $item->get_product_id(), 'The legacy line item should have been removed, not kept alongside.' );
+	}
+
+	/**
+	 * A migration product's availability is decided by the parent's status.
+	 *
+	 * An unpublished product fails activation the same way an unlinked line item
+	 * does, so the pre-flight has to resolve a variation to its parent before
+	 * judging it.
+	 */
+	public function test_product_is_published_resolves_a_variation_to_its_parent() {
+		$products = $this->create_variable_subscription_product();
+
+		$this->assertTrue(
+			$this->invoke_private( 'product_is_published', [ $products['variation'] ] ),
+			'A variation under a published parent counts as published.'
+		);
+		$this->assertTrue(
+			$this->invoke_private( 'product_is_published', [ $products['parent'] ] ),
+			'A published parent counts as published.'
+		);
+
+		$draft_parent = wc_create_mock_product(
+			[
+				'id'     => 700,
+				'name'   => 'Draft parent',
+				'type'   => 'variable-subscription',
+				'status' => 'draft',
+			]
+		);
+		$draft_child  = wc_create_mock_product(
+			[
+				'id'        => 701,
+				'name'      => 'Variation of a draft parent',
+				'type'      => 'subscription_variation',
+				'parent_id' => 700,
+			]
+		);
+
+		$this->assertFalse(
+			$this->invoke_private( 'product_is_published', [ $draft_child ] ),
+			'A variation whose parent is unpublished must not pass pre-flight — it cannot be activated.'
+		);
+		$this->assertFalse(
+			$this->invoke_private( 'product_is_published', [ $draft_parent ] ),
+			'An unpublished product must not pass pre-flight.'
+		);
+	}
+
+	/**
+	 * Gate matching follows has_product(), which accepts a product or its parent.
+	 *
+	 * A flat comparison against the product's own ID would refuse a seat-tier
+	 * variation on a site whose gate names the parent variable product — a
+	 * configuration that works perfectly at runtime.
+	 */
+	public function test_product_grants_gate_access_accepts_a_parent_rule() {
+		$products = $this->create_variable_subscription_product();
+
+		$this->assertTrue(
+			$this->invoke_private( 'product_grants_gate_access', [ $products['variation'], [ 109742 ] ] ),
+			'A gate naming the parent product accepts any of its variations.'
+		);
+		$this->assertTrue(
+			$this->invoke_private( 'product_grants_gate_access', [ $products['variation'], [ 109751 ] ] ),
+			'A gate naming the variation itself accepts it.'
+		);
+		$this->assertTrue(
+			$this->invoke_private( 'product_grants_gate_access', [ $products['parent'], [ 109742 ] ] ),
+			'A gate naming a plain product accepts it.'
+		);
+		$this->assertFalse(
+			$this->invoke_private( 'product_grants_gate_access', [ $products['variation'], [ 109999 ] ] ),
+			'A gate naming only a sibling variation accepts nothing.'
+		);
+		$this->assertFalse(
+			$this->invoke_private( 'product_grants_gate_access', [ $products['parent'], [ 109751 ] ] ),
+			'A gate naming a variation does not accept the bare parent product.'
+		);
 	}
 
 	/**
@@ -1000,10 +1103,15 @@ class Test_Teams_Migration extends WP_UnitTestCase {
 			[ $owner, $product, 'month', 1, '2026-01-01 00:00:00', '', &$errors, 94783 ]
 		);
 
+		$this->assertNotNull( $subscription, 'The subscription should be created.' );
+		$this->assertSame( [], $errors, 'Linking a plain product should not record an error.' );
+
 		$items = $subscription->get_items();
-		$item  = array_shift( $items );
+		$this->assertCount( 1, $items, 'The subscription should carry one line item.' );
+		$item = array_shift( $items );
 
 		$this->assertSame( 500, $item->get_product_id(), 'A non-variation product links by product ID.' );
 		$this->assertSame( 0, $item->get_variation_id(), 'A non-variation product has no variation ID.' );
+		$this->assertNotFalse( $item->get_product(), 'The line item must resolve to a product.' );
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-teams-migration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-teams-migration.php
@@ -1123,6 +1123,47 @@ class Test_Teams_Migration extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Gate coverage for a paid team's own subscription follows has_product().
+	 *
+	 * A team the publisher bills keeps its own product rather than being rewritten
+	 * onto --product-id, so whether its access survives the migration is decided
+	 * by whether a gate accepts the product it already holds. A subscription
+	 * linked to a seat-tier variation is covered by a gate naming either that
+	 * variation or its parent.
+	 */
+	public function test_subscription_covers_access_products_matches_parent_or_variation() {
+		$owner        = $this->create_reader();
+		$products     = $this->create_variable_subscription_product();
+		$subscription = wcs_create_subscription(
+			[
+				'customer_id'    => $owner,
+				'status'         => 'active',
+				'billing_period' => 'month',
+			]
+		);
+		$item = new WC_Order_Item_Product();
+		$item->set_product( $products['variation'] );
+		$subscription->add_item( $item );
+
+		$this->assertTrue(
+			$this->invoke_private( 'subscription_covers_access_products', [ $subscription, [ 109742 ] ] ),
+			'A gate naming the parent product covers a subscription linked to one of its variations.'
+		);
+		$this->assertTrue(
+			$this->invoke_private( 'subscription_covers_access_products', [ $subscription, [ 109751 ] ] ),
+			'A gate naming the variation covers it.'
+		);
+		$this->assertFalse(
+			$this->invoke_private( 'subscription_covers_access_products', [ $subscription, [ 109999 ] ] ),
+			'A gate naming an unrelated product covers nothing — this is what makes a paid team skip rather than migrate.'
+		);
+		$this->assertTrue(
+			$this->invoke_private( 'subscription_covers_access_products', [ $subscription, [] ] ),
+			'With no gate products configured there is nothing to check against.'
+		);
+	}
+
+	/**
 	 * A plain (non-variation) product still links as before.
 	 */
 	public function test_create_migration_subscription_links_a_simple_product() {

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-teams-migration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-teams-migration.php
@@ -1123,6 +1123,71 @@ class Test_Teams_Migration extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Whether a reused subscription counts as one the publisher bills.
+	 *
+	 * This predicate decides whether a team's subscription keeps its commercial
+	 * terms or is rewritten to $0 on the migration product, so a false negative
+	 * deletes the product line the publisher sells. It errs toward "paid".
+	 */
+	public function test_subscription_is_paid_errs_toward_paid() {
+		$paid = wcs_create_subscription(
+			[
+				'customer_id'    => $this->create_reader(),
+				'status'         => 'active',
+				'billing_period' => 'month',
+				'total'          => 599,
+			]
+		);
+		$this->assertTrue(
+			$this->invoke_private( 'subscription_is_paid', [ $paid ] ),
+			'A subscription with a recurring total is one the publisher bills.'
+		);
+
+		// A fully-discounted subscription stores a total of 0 but is still sold —
+		// the pre-discount subtotal is what distinguishes it from a $0 migration
+		// subscription, which has neither.
+		$fully_discounted = wcs_create_subscription(
+			[
+				'customer_id'    => $this->create_reader(),
+				'status'         => 'active',
+				'billing_period' => 'month',
+				'total'          => 0,
+				'subtotal'       => 599,
+			]
+		);
+		$this->assertTrue(
+			$this->invoke_private( 'subscription_is_paid', [ $fully_discounted ] ),
+			'A 100% recurring coupon must not read as free, or migration deletes the product being sold.'
+		);
+
+		$migration_created = wcs_create_subscription(
+			[
+				'customer_id'    => $this->create_reader(),
+				'status'         => 'active',
+				'billing_period' => 'month',
+				'total'          => 0,
+				'subtotal'       => 0,
+			]
+		);
+		$this->assertFalse(
+			$this->invoke_private( 'subscription_is_paid', [ $migration_created ] ),
+			'A $0 subscription with no pre-discount value is a migration subscription and stays re-alignable.'
+		);
+
+		$no_total_set = wcs_create_subscription(
+			[
+				'customer_id'    => $this->create_reader(),
+				'status'         => 'active',
+				'billing_period' => 'month',
+			]
+		);
+		$this->assertFalse(
+			$this->invoke_private( 'subscription_is_paid', [ $no_total_set ] ),
+			'A subscription with no total recorded is not treated as paid.'
+		);
+	}
+
+	/**
 	 * Gate coverage for a paid team's own subscription follows has_product().
 	 *
 	 * A team the publisher bills keeps its own product rather than being rewritten


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`wp newspack migrate-teams --product-id=<id> --live` aborted on the first team with:

```
Uncaught Exception: Unable to change subscription status to "active".
```

The ID passed was a product **variation**. Publishers selling seat tiers hold them as variations of one variable subscription product, so a variation ID is a normal thing to pass — and `wc_get_product()` accepts one, so pre-flight waved it through.

Both subscription-writing paths then assigned that ID straight to the line item:

```php
$line_item->set_props( [ 'product_id' => $migration_product->get_id(), ... ] );
```

`WC_Order_Item_Product::set_product_id()` rejects any ID that is not a `product` post — a variation is `product_variation` — by throwing `WC_Data_Exception` *before* it assigns the prop. `WC_Data::set_props()` catches that into a returned `WP_Error` that nothing here reads, so the item was saved with `product_id = 0` and no `variation_id`, while still carrying the product's name.

From there `WC_Subscription::can_be_updated_to( 'active' )` short-circuits on `contains_unavailable_product()`, since the item resolves to no product. Under WP-CLI `is_admin()` is false, so the admin escape hatch in that check doesn't apply, and `update_status()` throws.

This replaces both call sites with `set_product()`, the only setter that records a variation correctly (parent product ID + variation ID), via a shared `link_migration_product()` helper. It is what the two other creators in the same file already do.

**The reuse path was the quieter half.** `replace_subscription_product()` builds its line item the same way but never calls `update_status()`, so it raised no exception — it saved an active subscription whose line item pointed at nothing. Group access is matched by product ID, so such a subscription reports as migrated in the run summary while granting access to nobody. Only sites whose teams are already linked to a subscription reach that path.

**Two pre-flight guards come with it.** Fixing the linkage means the run now proceeds where it used to abort, and that abort was incidentally protecting operators from a quieter failure. So pre-flight now refuses a `--product-id` that:

- **no published gate accepts.** A group subscription grants access only where a gate lists its product, so migrating onto the wrong one would report every team as migrated while granting access to nobody — and the reuse path replaces the original line items in the same pass. `migrate-manual-members` already refuses to run in this situation. The comparison accepts the product **or its parent**, since `has_product()` matches either; a flat comparison would reject a variation the gates do accept.
- **isn't published**, resolving a variation to its parent. A draft product fails at exactly the same point as the bug being fixed here, and a dry run can't surface it because every write is behind `! $dry_run`.

**Reusing a team's own subscription no longer rewrites what the publisher sells.** It previously deleted the purchased product line, installed a $0 line, and overwrote the billing schedule — so a team paying for its seats came out of "migration" at $0. Converting to $0 is only right where the access being carried over was free in Memberships. Where each cohort now lands:

| Linked subscription | Outcome |
| --- | --- |
| Active, paid | Migrated in place — keeps product, price, taxes, billing schedule |
| Active, $0 | Re-aligned onto `--product-id`, as before |
| `pending-cancel` | Migrated in place, keeping its end date — members lose access when it self-cancels |
| `on-hold`, paid, no group from a prior run | Skipped with a warning — no free parallel subscription mid-recovery |

Two independent reasons keep a reused subscription's terms. `subscription_is_paid()` checks the recurring total **or** the pre-discount subtotal, since the total alone reads a 100%-recurring-coupon subscription as free and would delete the product being sold; the subtotal is 0 on every subscription this migration creates, so old $0 groups stay re-alignable. Separately, a `pending-cancel` subscription keeps its terms whatever its total, because `replace_subscription_product()` calls `update_dates()` — re-aligning it would overwrite the scheduled end and extend access past the cancellation the reader asked for.

Reuse now keys on `WooCommerce_Connection::ACTIVE_SUBSCRIPTION_STATUSES`, the same constant `Access_Rules` and `Group_Subscription` gate member access on, so a migrated group's access ends exactly when its subscription does.

A team whose own product no published gate accepts is skipped with the product IDs named, rather than granted access by rewriting what the publisher charges. The on-hold guard sits in the create branch rather than at the reuse lookup, so a team that already has a migrated group to update is unaffected.

**Two sibling-command fixes** in `migrate-manual-members`, both the same variation blind spot: its re-run guard compared `get_product_id()` and so could never recognise its own output for a variation (each re-run granted another $0 subscription), and its access check used a flat comparison that would reject a variation the gates accept. Both now go through `has_product()` / `product_grants_gate_access()`.

**Test mocks.** `WC_Order_Item_Product` in `tests/mocks/` accepted any product ID, which is why no test could catch either instance. It now models the real setter's rejection, `set_props()`'s swallowing of it, and `set_product()`'s parent/variation split. `WC_Product::is_type()` models WooCommerce Subscriptions' aliasing of `subscription_variation` to `variation`, and `add_item()`/`remove_item()` key by order-item ID like `WC_Abstract_Order`.

Closes NPPD-1876.

### How to test the changes in this Pull Request:

1. On a site with WooCommerce Teams memberships, create a variable subscription product with at least one variation, and note the **variation** ID.
2. Create a team membership with no linked subscription.
3. On `main`, run `wp newspack migrate-teams --product-id=<variation-id> --live`. It aborts with `Unable to change subscription status to "active"`, and leaves a `pending` subscription whose line item has `_product_id = 0`.
   - On a site with HPOS enabled, look in `wp_wc_orders`, not `wp_posts` — `wp post list --post_type=shop_subscription` shows nothing there.
4. On this branch, run the same command. The subscription is created and activated, and its line item carries the parent product ID plus the variation ID.
5. Repeat with a plain (non-variation) subscription product to confirm no change in behavior.
6. Check the new pre-flight guards. Set the variation's parent product to draft and re-run: the command refuses it by name instead of fataling on team one. Publish it again, then point `--product-id` at a product no published gate lists: the command names the products the gates do accept and stops before writing anything.
7. Check the paid-team path. Link a team to a subscription with a non-zero recurring total, on a product a published gate accepts, and run with `--live`. The subscription gains the group settings and keeps its product, price and billing schedule. Point that team's subscription at a product no gate accepts and re-run: the team is skipped with a warning naming the product IDs, and nothing is written for it.
8. Check the remaining cohorts. Set a linked paid subscription to `pending-cancel` and run: it is migrated in place and keeps its scheduled end date. Set one to `on-hold` on a team with no previously-migrated group and run: the team is skipped rather than given a new $0 group subscription.
9. `n test-php --group WooCommerce_Subscriptions_Integration`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Verified against real WooCommerce (10.9.4) and WC Subscriptions with a throwaway variable product: before the change `can_be_updated_to( 'active' )` returns `false`, after it returns `true`. `has_product()` then matches both the parent and the variation ID, so a content gate keyed on either grants access.

Full suite: 2843 tests / 8361 assertions, against a 2834 / 8306 baseline on `origin/main` with an identical set of 10 environment skips. PHPCS clean against the root ruleset.

The regression guards were checked by reverting the production fix with the new mocks and tests kept — both variation tests fail on `0 is identical to 109742`, so they catch a revert rather than merely passing alongside the change.

Known coverage gap: the per-team routing in `migrate_teams()` has no unit coverage — the helpers underneath it are tested, but which cohort a team lands in is decided by inline logic the test mocks can't reach. Deferred deliberately in favour of verification on a staging site with seeded teams in each state.
