### PR TITLE
fix(content-gate): check both gate kinds in premium-list fast path

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-premium-newsletters.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-premium-newsletters.php
@@ -167,8 +167,9 @@ class Premium_Newsletters {
 		// than widening to both — the meta query is EXISTS vs NOT EXISTS — while the
 		// per-list check below runs through Content_Restriction_Control, which
 		// honours any gate whose content rules match the list. Testing only the
-		// newsletter half would skip lists an ordinary gate restricts. Both calls are
-		// statically cached, so the fast path stays cheap.
+		// newsletter half would skip lists an ordinary gate restricts. In non-test
+		// requests both gate lookups are cached (Content_Gate::get_gates cache is
+		// disabled under PHPUnit), so the fast path stays cheap.
 		if ( empty( self::get_gates() ) && empty( Content_Gate::get_gates( Content_Gate::GATE_CPT, 'publish' ) ) ) {
 			return $lists;
 		}

--- a/plugins/newspack-plugin/includes/content-gate/class-premium-newsletters.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-premium-newsletters.php
@@ -161,9 +161,15 @@ class Premium_Newsletters {
 			return $lists;
 		}
 
-		// If there are no premium newsletter gates, no list can be restricted, so
-		// skip the per-list check entirely. get_gates() is statically cached.
-		if ( empty( self::get_gates() ) ) {
+		// With no gates at all, no list can be restricted, so skip the per-list
+		// check entirely. Both kinds have to be absent: get_gates()'s $is_newsletter
+		// argument selects between premium newsletter gates and ordinary ones rather
+		// than widening to both — the meta query is EXISTS vs NOT EXISTS — while the
+		// per-list check below runs through Content_Restriction_Control, which
+		// honours any gate whose content rules match the list. Testing only the
+		// newsletter half would skip lists an ordinary gate restricts. Both calls are
+		// statically cached, so the fast path stays cheap.
+		if ( empty( self::get_gates() ) && empty( Content_Gate::get_gates( Content_Gate::GATE_CPT, 'publish' ) ) ) {
 			return $lists;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`main` is currently red: `Gating_Inertness_Test::test_premium_lists_reappear_in_signup_forms_while_inert` fails, so every PR's CI inherits the failure.

The cause is the fast path #769 added to `Premium_Newsletters::filter_subscription_lists()`:

```php
// If there are no premium newsletter gates, no list can be restricted, so
// skip the per-list check entirely.
if ( empty( self::get_gates() ) ) {
    return $lists;
}
```

`self::get_gates()` resolves to `Content_Gate::get_gates( GATE_CPT, 'publish', true )`, and that third argument **selects between** gate kinds rather than widening to both — the meta query is `EXISTS` vs `NOT EXISTS` on `is_newsletter`. So it returns premium newsletter gates only.

The per-list check it skips runs through `Content_Restriction_Control::is_post_restricted()`, which honours **any** gate whose content rules match the list. So on a site with ordinary content gates and no premium newsletter gates, the fast path returns early and lists that would have been filtered are handed back unfiltered. The premise in the comment — no premium newsletter gates means no list can be restricted — doesn't hold.

This makes the early return require both kinds to be absent. The optimization still fires for the common case of a site with no gates at all, and both calls are statically cached, so the fast path stays cheap.

Worth noting the failure direction is permissive: lists that should be hidden from signup forms are shown. How reachable that is in production depends on gate rules — real lists are the `newspack_nl_list` CPT, so a publisher needs a gate whose content rules match that post type, which is narrower than the test fixture (a plain `post`) suggests. The code paths genuinely diverge either way.

Not a flake, and not caused by #837: filtering CI runs to those that actually executed PHPUnit, `24c3870a3` was green and `00a9a791e` red, with #769 arriving between them via the release merge. Runs in between that look green never ran the job.

### How to test the changes in this Pull Request:

1. On `main`, run the failing test — it fails as a single isolated test, no ordering needed:
   ```
   vendor/bin/phpunit --filter test_premium_lists_reappear_in_signup_forms_while_inert
   ```
2. On this branch, run it again. It passes.
3. Run the full suite on both. `main` reports 1 failure; this branch is clean.
4. Sanity-check the fast path still short-circuits: on a site with no gates at all, `Premium_Newsletters::filter_subscription_lists()` returns its input without running the per-list check.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

No new test: `Gating_Inertness_Test::test_premium_lists_reappear_in_signup_forms_while_inert` already covers this exactly, and is the test that caught it.

Before, on `main` @ `51f9172f3`: `Gating_Inertness_Test` — 10 tests, 1 failure. After, on this branch: clean. Full suite on this branch: 2844 tests / 8363 assertions / 0 failures / 10 environment skips, matching CI's counts. PHPCS clean against the root ruleset.