### PR TITLE
feat(subscriptions): add a card to a manually created subscription

### DIFF
--- a/plugins/newspack-blocks/includes/class-modal-checkout.php
+++ b/plugins/newspack-blocks/includes/class-modal-checkout.php
@@ -761,6 +761,12 @@ final class Modal_Checkout {
 		if ( ! self::$has_modal ) {
 			return;
 		}
+		// Never inside the iframe this markup creates: the container would nest in
+		// itself, putting a second "Complete your transaction" dialog in the
+		// reader's checkout (NPPD-2170).
+		if ( self::is_modal_checkout() ) {
+			return;
+		}
 		/**
 		* Filters the header title for the modal checkout.
 		*

--- a/plugins/newspack-blocks/includes/modal-checkout/class-checkout-data.php
+++ b/plugins/newspack-blocks/includes/modal-checkout/class-checkout-data.php
@@ -327,12 +327,16 @@ final class Checkout_Data {
 			}
 			$order_items = $items_source->get_items();
 			$order_item  = reset( $order_items ); // Use only the first item in the order.
-			if ( $order_item ) {
-				$product_id   = $order_item->get_product_id();
-				$variation_id = $order_item->get_variation_id();
-				$amount       = $order_item->get_subtotal();
+			if ( ! $order_item ) {
+				// No line item means no purchase to summarise, and the product and
+				// name lookups below would fatal on the resulting null. Return empty,
+				// the same "nothing to checkout" signal as an empty source above.
+				return $data;
 			}
-			$referrer = $items_source->get_meta( '_newspack_referer' );
+			$product_id   = $order_item->get_product_id();
+			$variation_id = $order_item->get_variation_id();
+			$amount       = $order_item->get_subtotal();
+			$referrer     = $items_source->get_meta( '_newspack_referer' );
 		}
 
 		// If we have no referrer, set it to the current path.

--- a/plugins/newspack-blocks/includes/modal-checkout/class-checkout-data.php
+++ b/plugins/newspack-blocks/includes/modal-checkout/class-checkout-data.php
@@ -269,7 +269,10 @@ final class Checkout_Data {
 
 		$cart_item    = null;
 		$order        = null;
+		$subscription = null;
 		$referrer     = '';
+		$product_id   = null;
+		$amount       = 0;
 		$variation_id = null;
 		$is_variable  = false;
 		$is_grouped   = false;
@@ -303,18 +306,33 @@ final class Checkout_Data {
 			$amount       = $cart_item['data']->get_price();
 			$referrer     = $cart_item['referer'] ?? '';
 		} elseif ( $source instanceof \WC_Order ) {
-			// If order as actually a subscription object, we need to get the original order.
+			// A subscription's purchase details normally live on the order it was
+			// bought through. A subscription created by hand in wp-admin has no parent
+			// order, and its own line items describe the same purchase, so read those
+			// instead (NPPD-2170).
+			//
+			// The two identities stay separate on purpose. A subscription is not an
+			// order, and reporting its ID as an order ID sends the modal to a
+			// view-order URL built from a subscription ID: a page nothing links to,
+			// which renders the read-only receipt from WooCommerce Subscriptions
+			// rather than anything the reader can act on.
 			if ( $source instanceof \WC_Subscription ) {
-				$order = $source->get_parent();
+				$subscription = $source;
+				$parent       = $source->get_parent();
+				$order        = $parent ? $parent : null;
+				$items_source = $parent ? $parent : $source;
 			} else {
-				$order = $source;
+				$order        = $source;
+				$items_source = $source;
 			}
-			$order_items  = $order->get_items();
-			$order_item   = reset( $order_items ); // Use only the first item in the order.
-			$product_id   = $order_item->get_product_id();
-			$variation_id = $order_item->get_variation_id();
-			$amount       = $order_item->get_subtotal();
-			$referrer     = $order->get_meta( '_newspack_referer' );
+			$order_items = $items_source->get_items();
+			$order_item  = reset( $order_items ); // Use only the first item in the order.
+			if ( $order_item ) {
+				$product_id   = $order_item->get_product_id();
+				$variation_id = $order_item->get_variation_id();
+				$amount       = $order_item->get_subtotal();
+			}
+			$referrer = $items_source->get_meta( '_newspack_referer' );
 		}
 
 		// If we have no referrer, set it to the current path.
@@ -387,6 +405,13 @@ final class Checkout_Data {
 					}
 				}
 			}
+		}
+
+		// A subscription with no parent order has no order to identify itself by, so
+		// name the subscription directly. Without this the modal has nothing to
+		// return the reader to once checkout finishes (NPPD-2170).
+		if ( $subscription && empty( $data['subscription_ids'] ) ) {
+			$data['subscription_ids'] = [ $subscription->get_id() ];
 		}
 
 		/**

--- a/plugins/newspack-blocks/includes/modal-checkout/class-checkout-data.php
+++ b/plugins/newspack-blocks/includes/modal-checkout/class-checkout-data.php
@@ -414,7 +414,11 @@ final class Checkout_Data {
 		// A subscription with no parent order has no order to identify itself by, so
 		// name the subscription directly. Without this the modal has nothing to
 		// return the reader to once checkout finishes (NPPD-2170).
-		if ( $subscription && empty( $data['subscription_ids'] ) ) {
+		// Only when there is no parent order to identify the purchase by. With a
+		// parent present the block above owns the key, and widening this would set
+		// subscription_ids for product types it skips — a recurring donation resolves
+		// to `donation`, so it would silently change where those readers land.
+		if ( $subscription && ! $order && empty( $data['subscription_ids'] ) ) {
 			$data['subscription_ids'] = [ $subscription->get_id() ];
 		}
 

--- a/plugins/newspack-blocks/tests/test-modal-checkout-data.php
+++ b/plugins/newspack-blocks/tests/test-modal-checkout-data.php
@@ -364,6 +364,17 @@ class Newspack_Blocks_Modal_Checkout_Data_Test extends WP_UnitTestCase_Blocks {
 	}
 
 	/**
+	 * A subscription or order with no line items has no purchase to summarise.
+	 * It must return empty rather than fatalling on the null product the missing
+	 * line item would leave behind (NPPD-2170).
+	 */
+	public function test_source_with_no_line_items_returns_empty() {
+		$subscription = new WC_Subscription( [], false, 901 );
+
+		$this->assertSame( [], Checkout_Data::get_checkout_data( $subscription ) );
+	}
+
+	/**
 	 * The data-checkout attribute must escape values so a product name containing
 	 * an apostrophe can't break out of the single-quoted attribute.
 	 */

--- a/plugins/newspack-blocks/tests/test-modal-checkout-data.php
+++ b/plugins/newspack-blocks/tests/test-modal-checkout-data.php
@@ -149,6 +149,126 @@ if ( ! class_exists( 'WC_Product_Variation' ) ) {
 	}
 }
 
+if ( ! class_exists( 'WC_Order_Item_Product' ) ) {
+	/**
+	 * Minimal order line item stub.
+	 */
+	class WC_Order_Item_Product {
+		/**
+		 * Product ID.
+		 *
+		 * @var int
+		 */
+		private $product_id;
+
+		/**
+		 * Line subtotal.
+		 *
+		 * @var string
+		 */
+		private $subtotal;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param int    $product_id Product ID.
+		 * @param string $subtotal   Line subtotal.
+		 */
+		public function __construct( $product_id, $subtotal = '25' ) {
+			$this->product_id = $product_id;
+			$this->subtotal   = $subtotal;
+		}
+
+		public function get_product_id() {
+			return $this->product_id;
+		}
+
+		public function get_variation_id() {
+			return 0;
+		}
+
+		public function get_subtotal() {
+			return $this->subtotal;
+		}
+	}
+}
+
+if ( ! class_exists( 'WC_Order' ) ) {
+	/**
+	 * Minimal WooCommerce order stub.
+	 */
+	class WC_Order {
+		/**
+		 * Line items.
+		 *
+		 * @var array
+		 */
+		protected $items = [];
+
+		/**
+		 * Order ID.
+		 *
+		 * @var int
+		 */
+		protected $id;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param array $items Line items.
+		 * @param int   $id    Order ID.
+		 */
+		public function __construct( $items = [], $id = 900 ) {
+			$this->items = $items;
+			$this->id    = $id;
+		}
+
+		public function get_id() {
+			return $this->id;
+		}
+
+		public function get_items() {
+			return $this->items;
+		}
+
+		public function get_meta( $key ) {
+			unset( $key );
+			return '';
+		}
+	}
+}
+
+if ( ! class_exists( 'WC_Subscription' ) ) {
+	/**
+	 * Minimal subscription stub. A subscription created by hand in wp-admin has
+	 * no parent order, so get_parent() returning false is the case under test.
+	 */
+	class WC_Subscription extends WC_Order {
+		/**
+		 * Parent order, or false when there is none.
+		 *
+		 * @var WC_Order|false
+		 */
+		private $parent;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param array          $items  Line items.
+		 * @param WC_Order|false $parent Parent order, or false.
+		 * @param int            $id     Subscription ID.
+		 */
+		public function __construct( $items = [], $parent = false, $id = 901 ) {
+			parent::__construct( $items, $id );
+			$this->parent = $parent;
+		}
+
+		public function get_parent() {
+			return $this->parent;
+		}
+	}
+}
+
 if ( ! function_exists( 'wc_get_product' ) ) {
 	/**
 	 * Minimal wc_get_product stub.
@@ -196,6 +316,51 @@ class Newspack_Blocks_Modal_Checkout_Data_Test extends WP_UnitTestCase_Blocks {
 		$this->assertTrue( $data['is_variable'] );
 		$this->assertSame( [ 1407, 1408 ], $data['variation_ids'] );
 		$this->assertArrayNotHasKey( 'amount', $data );
+	}
+
+	/**
+	 * A subscription created by hand in wp-admin has no parent order. Reading its
+	 * purchase details must fall back to its own line items rather than calling
+	 * get_items() on the `false` that get_parent() returns, which took down the
+	 * modal's completion step with a fatal (NPPD-2170).
+	 */
+	public function test_subscription_without_a_parent_order_reads_its_own_items() {
+		$GLOBALS['newspack_blocks_test_products'] = [
+			2170 => new WC_Product( 2170, 'subscription', [], '25', 'Monthly Supporter' ),
+		];
+
+		$subscription = new WC_Subscription( [ new WC_Order_Item_Product( 2170, '25' ) ], false, 901 );
+
+		$data = Checkout_Data::get_checkout_data( $subscription );
+
+		$this->assertSame( '2170', $data['product_id'] );
+		$this->assertSame( '25', $data['amount'] );
+
+		// The subscription must identify itself as a subscription. Reporting its ID
+		// as order_id sends the modal to /view-order/<subscription id>, which nothing
+		// links to and which renders WCS's read-only receipt.
+		$this->assertArrayNotHasKey( 'order_id', $data );
+		$this->assertSame( [ 901 ], $data['subscription_ids'] );
+	}
+
+	/**
+	 * With a parent order present, its items remain the source of truth.
+	 */
+	public function test_subscription_with_a_parent_order_reads_the_parent() {
+		$GLOBALS['newspack_blocks_test_products'] = [
+			2171 => new WC_Product( 2171, 'subscription', [], '99', 'Annual Supporter' ),
+		];
+
+		$parent       = new WC_Order( [ new WC_Order_Item_Product( 2171, '99' ) ], 900 );
+		$subscription = new WC_Subscription( [ new WC_Order_Item_Product( 2170, '25' ) ], $parent, 901 );
+
+		$data = Checkout_Data::get_checkout_data( $subscription );
+
+		$this->assertSame( '2171', $data['product_id'] );
+		$this->assertSame( '99', $data['amount'] );
+
+		// The parent order is a real order, so it identifies the purchase.
+		$this->assertSame( 900, $data['order_id'] );
 	}
 
 	/**

--- a/plugins/newspack-blocks/tests/test-modal-checkout-data.php
+++ b/plugins/newspack-blocks/tests/test-modal-checkout-data.php
@@ -364,6 +364,26 @@ class Newspack_Blocks_Modal_Checkout_Data_Test extends WP_UnitTestCase_Blocks {
 	}
 
 	/**
+	 * A subscription that has a parent order keeps that order's identity, even when
+	 * its product type is one the subscription_ids branch skips. A recurring
+	 * donation resolves to `donation`, so widening the parentless fallback would
+	 * silently move those readers from /view-order/ to /view-subscription/.
+	 */
+	public function test_donation_subscription_with_a_parent_keeps_order_identity() {
+		$GLOBALS['newspack_blocks_test_products'] = [
+			2172 => new WC_Product( 2172, 'simple', [], '15', 'Monthly Donation' ),
+		];
+
+		$parent       = new WC_Order( [ new WC_Order_Item_Product( 2172, '15' ) ], 902 );
+		$subscription = new WC_Subscription( [ new WC_Order_Item_Product( 2172, '15' ) ], $parent, 903 );
+
+		$data = Checkout_Data::get_checkout_data( $subscription );
+
+		$this->assertSame( 902, $data['order_id'] );
+		$this->assertArrayNotHasKey( 'subscription_ids', $data );
+	}
+
+	/**
 	 * A subscription or order with no line items has no purchase to summarise.
 	 * It must return empty rather than fatalling on the null product the missing
 	 * line item would leave behind (NPPD-2170).

--- a/plugins/newspack-plugin/includes/content-gate/content-gifting/class-content-gifting.php
+++ b/plugins/newspack-plugin/includes/content-gate/content-gifting/class-content-gifting.php
@@ -581,6 +581,12 @@ class Content_Gifting {
 	 * Print the gift modal.
 	 */
 	public static function print_gift_modal() {
+		// Modal checkout renders in an iframe with its own modal. Emitting another
+		// modal's markup inside it puts unrelated content in the reader's checkout
+		// (NPPD-2170), so nothing is printed there.
+		if ( class_exists( '\Newspack_Blocks\Modal_Checkout' ) && \Newspack_Blocks\Modal_Checkout::is_modal_checkout() ) {
+			return;
+		}
 		?>
 		<div class="newspack-ui">
 			<div id="newspack-content-gifting-modal" class="newspack-ui__modal-container" data-state="closed">

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -421,18 +421,34 @@ class WooCommerce_Subscriptions {
 	 * Schedule the next payment once a card is attached to a subscription that
 	 * had none.
 	 *
-	 * The other half of {@see allow_add_payment_method_without_next_payment()}.
-	 * Eligibility alone would leave the reader with a card on file and still no
-	 * billing: the subscription reached this state precisely because nothing was
-	 * ever scheduled, and WCS only recalculates the date when a payment
-	 * completes. Calculating it here is what turns "card added" into "renewals
-	 * resume".
+	 * The other half of {@see allow_add_payment_method_without_next_payment()},
+	 * and deliberately narrower than it. Eligibility opens the form for four
+	 * statuses; only `active` gets a date written here.
+	 *
+	 * An active subscription with no next payment date is already giving the
+	 * reader access with nothing scheduled to bill, so calculating the date is
+	 * what turns "card added" into "renewals resume" — and it is also what makes
+	 * WCS's early renewal available, since `wcs_can_user_renew_early()` refuses
+	 * on `subscription_no_next_payment`. That matters for a hand-made
+	 * subscription with no orders at all, where early renewal is the reader's
+	 * only self-serve route to paying.
+	 *
+	 * The other statuses are left to WooCommerce, which already handles them
+	 * correctly: paying the pending or failed order is what activates the
+	 * subscription and sets its date. Writing a date for them would be wrong
+	 * twice over — it hands the reader a billing period they never paid for, and
+	 * it withdraws the "Add payment method" action (this pair steps back once a
+	 * date exists, while WCS's own rule still refuses a non-active subscription),
+	 * leaving them with a card on file and no way back to the form.
 	 *
 	 * `calculate_date( 'next_payment' )` derives the date from the last payment
 	 * or the start date plus one billing period, keeps it far enough in the
 	 * future to survive a daylight-saving shift, and returns `0` when the next
 	 * period would fall past the subscription's end date. A `0` is respected:
 	 * a subscription winding down to a fixed end has nothing further to bill.
+	 * A `pending-cancel` subscription therefore stays untouched even though it
+	 * is eligible for the form; resuming its auto-renewal means clearing the
+	 * cancelled and end dates, which is a separate change.
 	 *
 	 * @param \WC_Subscription $subscription       The subscription that was updated.
 	 * @param string           $new_payment_method The gateway ID now attached.
@@ -458,7 +474,9 @@ class WooCommerce_Subscriptions {
 			return;
 		}
 
-		if ( ! $subscription->has_status( [ 'pending', 'on-hold', 'active', 'pending-cancel' ] ) ) {
+		// Active only. See the note above on why the other eligible statuses are
+		// left to WooCommerce's own payment-completes-then-schedules flow.
+		if ( ! $subscription->has_status( 'active' ) ) {
 			return;
 		}
 

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -49,7 +49,11 @@ class WooCommerce_Subscriptions {
 		// allow_add_payment_method_without_next_payment() for the whole story.
 		// Priority 20: WCS registers its own answer at 10 and we only override a no.
 		add_filter( 'woocommerce_can_subscription_be_updated_to_new-payment-method', [ __CLASS__, 'allow_add_payment_method_without_next_payment' ], 20, 2 );
-		add_action( 'woocommerce_subscription_payment_method_updated', [ __CLASS__, 'schedule_next_payment_after_payment_method_added' ], 10, 2 );
+		// Not `woocommerce_subscription_payment_method_updated`: that fires before the
+		// card is validated or charged, so a declined card would still leave a
+		// schedule behind. This filter runs after process_payment() and carries its
+		// result, so the schedule can follow the payment instead of preceding it.
+		add_filter( 'woocommerce_subscriptions_process_payment_for_change_method_via_pay_shortcode', [ __CLASS__, 'schedule_next_payment_after_payment_method_added' ], 10, 2 );
 	}
 
 	/**
@@ -384,8 +388,9 @@ class WooCommerce_Subscriptions {
 			return $can_be_updated;
 		}
 
-		// Nothing recurring to charge, so nothing to add a card for. The 'edit'
-		// context reads the unfiltered total, as WCS's own check does.
+		// Nothing recurring to charge, so nothing to add a card for. WCS reads the
+		// filtered ('view') total here; 'edit' is deliberate, so a site filtering
+		// order totals cannot open the flow on a subscription with nothing to bill.
 		if ( (float) $subscription->get_total( 'edit' ) <= 0 ) {
 			return $can_be_updated;
 		}
@@ -494,42 +499,58 @@ class WooCommerce_Subscriptions {
 	 * owns the billing agreement and refuses them (PayPal Standard) never gets a
 	 * Woo-side schedule it would not honour.
 	 *
-	 * @param \WC_Subscription $subscription       The subscription that was updated.
-	 * @param string           $new_payment_method The gateway ID now attached.
+	 * Runs on `woocommerce_subscriptions_process_payment_for_change_method_via_pay_shortcode`,
+	 * which WCS applies after `process_payment()` and before it bails on a
+	 * non-success result. Scheduling from the earlier
+	 * `woocommerce_subscription_payment_method_updated` action would write a date
+	 * for a card that was later declined, leaving an automatic renewal queued
+	 * against a card the gateway never accepted.
 	 *
-	 * @return void
+	 * @param array            $result       The payment result, with a `result` key.
+	 * @param \WC_Subscription $subscription The subscription whose method changed.
+	 *
+	 * @return array The unmodified payment result.
 	 */
-	public static function schedule_next_payment_after_payment_method_added( $subscription, $new_payment_method ) {
+	public static function schedule_next_payment_after_payment_method_added( $result, $subscription ) {
 		if ( ! ( $subscription instanceof \WC_Subscription ) ) {
-			return;
+			return $result;
 		}
 
-		// No gateway attached means there is nothing to bill against.
-		if ( empty( $new_payment_method ) ) {
-			return;
+		// Only once the card has actually been accepted. WCS returns here after
+		// process_payment() and bails on anything but success, so a declined card
+		// must leave no schedule behind.
+		if ( ! is_array( $result ) || ! isset( $result['result'] ) || 'success' !== $result['result'] ) {
+			return $result;
+		}
+
+		// Ask the subscription whether a chargeable gateway is attached rather than
+		// trusting a method string: this runs for admin and bulk updates too, and
+		// has_payment_gateway() is the same predicate the My Account label uses.
+		if ( ! $subscription->has_payment_gateway() || $subscription->is_manual() ) {
+			return $result;
 		}
 
 		// Only the gap this pair exists to close. An already-scheduled payment is
 		// the reader's or WCS's, and is never rewritten.
 		if ( $subscription->get_time( 'next_payment' ) > 0 ) {
-			return;
+			return $result;
 		}
 
 		// Active only. See the note above on why pending / on-hold are left to
 		// WooCommerce's own payment-completes-then-schedules flow.
 		if ( ! $subscription->has_status( 'active' ) ) {
-			return;
+			return $result;
 		}
 
 		// Respect the same gate WCS applies to every date write: the gateway must
 		// support date changes, or its schedule and Woo's would silently diverge.
 		if ( ! $subscription->can_date_be_updated( 'next_payment' ) ) {
-			return;
+			return $result;
 		}
 
 		$next_payment = $subscription->calculate_date( 'next_payment' );
 		if ( empty( $next_payment ) ) {
-			return;
+			return $result;
 		}
 
 		// update_dates() validates the new date against the subscription's other
@@ -547,14 +568,20 @@ class WooCommerce_Subscriptions {
 				)
 			);
 		} catch ( \Exception $e ) {
-			Logger::error(
+			// An order note rather than Logger::error(): Logger::log() returns early
+			// unless NEWSPACK_LOG_LEVEL is defined and non-zero, which it is not on a
+			// stock site, so the one failure this method plans for would otherwise
+			// leave no trace anywhere the publisher looks.
+			$subscription->add_order_note(
 				sprintf(
-					'Could not schedule the next payment for subscription %1$d after a payment method was added: %2$s',
-					$subscription->get_id(),
+					/* translators: %s: the reason the date could not be set. */
+					__( 'A payment method was added, but the next payment date could not be scheduled: %s. The next payment date may need setting by hand.', 'newspack-plugin' ),
 					$e->getMessage()
 				)
 			);
 		}
+
+		return $result;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -43,6 +43,13 @@ class WooCommerce_Subscriptions {
 		add_action( 'woocommerce_store_api_checkout_order_processed', [ __CLASS__, 'maybe_reactivate_pending_cancel_switch' ], 40 );
 		add_action( 'woocommerce_order_status_failed', [ __CLASS__, 'maybe_revert_reactivation_on_failed_switch' ] );
 		add_action( 'woocommerce_order_status_cancelled', [ __CLASS__, 'maybe_revert_reactivation_on_failed_switch' ] );
+
+		// Adding a card to a subscription that has no next payment date: eligibility
+		// plus the follow-through that resumes billing. See
+		// allow_add_payment_method_without_next_payment() for the whole story.
+		// Priority 20: WCS registers its own answer at 10 and we only override a no.
+		add_filter( 'woocommerce_can_subscription_be_updated_to_new-payment-method', [ __CLASS__, 'allow_add_payment_method_without_next_payment' ], 20, 2 );
+		add_action( 'woocommerce_subscription_payment_method_updated', [ __CLASS__, 'schedule_next_payment_after_payment_method_added' ], 10, 3 );
 	}
 
 	/**
@@ -317,6 +324,172 @@ class WooCommerce_Subscriptions {
 		// reactivated on purpose in the meantime.
 		$order->delete_meta_data( self::REACTIVATED_FOR_SWITCH_META );
 		$order->save();
+	}
+
+	/**
+	 * Let a reader add a card to a subscription that has no next payment date.
+	 *
+	 * WCS withholds the "change payment method" action from any subscription
+	 * whose next payment date is unset, in
+	 * {@see \WC_Subscriptions_Change_Payment_Gateway::can_subscription_be_updated_to_new_payment_method()}.
+	 * That rule assumes a next payment date always exists once a subscription is
+	 * running, which holds for subscriptions bought at checkout but not for ones
+	 * a publisher creates by hand in wp-admin: those start with no payment method
+	 * and nothing scheduled, so the reader is offered no way to put a card on
+	 * file and the subscription can never be paid (NPPD-2170).
+	 *
+	 * The rule is enforced in exactly one place, and every part of the flow reads
+	 * it — the action button, the form, and the request validator all call
+	 * `can_be_updated_to( 'new-payment-method' )`. The POST handler applies no
+	 * status or date test of its own, so granting eligibility is sufficient to
+	 * open the flow end to end. WCS then labels the action "Add payment" rather
+	 * than "Change payment" whenever the subscription has no gateway yet, which
+	 * is the wording this case wants.
+	 *
+	 * Deliberately narrow: it only opens the case WCS closes, and only when a
+	 * card could actually be charged afterwards. Anything WCS already allows
+	 * passes straight through.
+	 *
+	 * Paired with {@see schedule_next_payment_after_payment_method_added()},
+	 * which schedules the payment the missing date would otherwise leave unset.
+	 *
+	 * @param bool             $can_be_updated Whether WCS allows the change.
+	 * @param \WC_Subscription $subscription   The subscription being checked.
+	 *
+	 * @return bool Whether the payment method can be changed.
+	 */
+	public static function allow_add_payment_method_without_next_payment( $can_be_updated, $subscription ) {
+		if ( $can_be_updated ) {
+			return $can_be_updated;
+		}
+
+		if ( ! ( $subscription instanceof \WC_Subscription ) ) {
+			return $can_be_updated;
+		}
+
+		// Statuses where putting a card on file still leads somewhere: awaiting a
+		// first payment, suspended, running, or winding down after the reader
+		// turned auto-renewal off. Terminal statuses are left to WCS.
+		if ( ! $subscription->has_status( [ 'pending', 'on-hold', 'active', 'pending-cancel' ] ) ) {
+			return $can_be_updated;
+		}
+
+		// A scheduled payment means WCS's own rule already applies.
+		if ( $subscription->get_time( 'next_payment' ) > 0 ) {
+			return $can_be_updated;
+		}
+
+		// Nothing recurring to charge, so nothing to add a card for. The 'edit'
+		// context reads the unfiltered total, matching WCS's own check.
+		if ( (float) $subscription->get_total( 'edit' ) <= 0 ) {
+			return $can_be_updated;
+		}
+
+		// Offering the action with no gateway able to take a card from the reader
+		// would lead them to a dead end.
+		if ( ! self::one_gateway_supports_customer_payment_method_change() ) {
+			return $can_be_updated;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Whether any gateway lets a reader change their own payment method.
+	 *
+	 * Routed through the WCS handler class rather than
+	 * `WC_Subscriptions_Payment_Gateways` directly, because WooPayments
+	 * substitutes its own handler and WCS resolves the capability through
+	 * whichever is active.
+	 *
+	 * @return bool
+	 */
+	private static function one_gateway_supports_customer_payment_method_change() {
+		if ( ! class_exists( 'WC_Subscriptions_Core_Plugin' ) ) {
+			return false;
+		}
+
+		$handler = \WC_Subscriptions_Core_Plugin::instance()->get_gateways_handler_class();
+		if ( ! is_callable( [ $handler, 'one_gateway_supports' ] ) ) {
+			return false;
+		}
+
+		return (bool) $handler::one_gateway_supports( 'subscription_payment_method_change_customer' );
+	}
+
+	/**
+	 * Schedule the next payment once a card is attached to a subscription that
+	 * had none.
+	 *
+	 * The other half of {@see allow_add_payment_method_without_next_payment()}.
+	 * Eligibility alone would leave the reader with a card on file and still no
+	 * billing: the subscription reached this state precisely because nothing was
+	 * ever scheduled, and WCS only recalculates the date when a payment
+	 * completes. Calculating it here is what turns "card added" into "renewals
+	 * resume".
+	 *
+	 * `calculate_date( 'next_payment' )` derives the date from the last payment
+	 * or the start date plus one billing period, keeps it far enough in the
+	 * future to survive a daylight-saving shift, and returns `0` when the next
+	 * period would fall past the subscription's end date. A `0` is respected:
+	 * a subscription winding down to a fixed end has nothing further to bill.
+	 *
+	 * @param \WC_Subscription $subscription       The subscription that was updated.
+	 * @param string           $new_payment_method The gateway ID now attached.
+	 * @param string           $old_payment_method The gateway ID previously attached.
+	 *
+	 * @return void
+	 */
+	public static function schedule_next_payment_after_payment_method_added( $subscription, $new_payment_method, $old_payment_method = '' ) {
+		unset( $old_payment_method );
+
+		if ( ! ( $subscription instanceof \WC_Subscription ) ) {
+			return;
+		}
+
+		// No gateway attached means there is nothing to bill against.
+		if ( empty( $new_payment_method ) ) {
+			return;
+		}
+
+		// Only the gap this pair exists to close. An already-scheduled payment is
+		// the reader's or WCS's, and is never rewritten.
+		if ( $subscription->get_time( 'next_payment' ) > 0 ) {
+			return;
+		}
+
+		if ( ! $subscription->has_status( [ 'pending', 'on-hold', 'active', 'pending-cancel' ] ) ) {
+			return;
+		}
+
+		$next_payment = $subscription->calculate_date( 'next_payment' );
+		if ( empty( $next_payment ) || '0' === (string) $next_payment ) {
+			return;
+		}
+
+		// update_dates() validates the new date against the subscription's other
+		// dates and throws when they disagree. A subscription we could not
+		// schedule is left as it was: the reader still has their card on file,
+		// and the publisher can set the date by hand.
+		try {
+			$subscription->update_dates( [ 'next_payment' => $next_payment ] );
+			$subscription->save();
+			$subscription->add_order_note(
+				sprintf(
+					/* translators: %s: the newly scheduled next payment date. */
+					__( 'Next payment scheduled for %s after the subscriber added a payment method.', 'newspack-plugin' ),
+					$next_payment
+				)
+			);
+		} catch ( \Exception $e ) {
+			Logger::error(
+				sprintf(
+					'Could not schedule the next payment for subscription %1$d after a payment method was added: %2$s',
+					$subscription->get_id(),
+					$e->getMessage()
+				)
+			);
+		}
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -49,7 +49,7 @@ class WooCommerce_Subscriptions {
 		// allow_add_payment_method_without_next_payment() for the whole story.
 		// Priority 20: WCS registers its own answer at 10 and we only override a no.
 		add_filter( 'woocommerce_can_subscription_be_updated_to_new-payment-method', [ __CLASS__, 'allow_add_payment_method_without_next_payment' ], 20, 2 );
-		add_action( 'woocommerce_subscription_payment_method_updated', [ __CLASS__, 'schedule_next_payment_after_payment_method_added' ], 10, 3 );
+		add_action( 'woocommerce_subscription_payment_method_updated', [ __CLASS__, 'schedule_next_payment_after_payment_method_added' ], 10, 2 );
 	}
 
 	/**
@@ -346,9 +346,14 @@ class WooCommerce_Subscriptions {
 	 * than "Change payment" whenever the subscription has no gateway yet, which
 	 * is the wording this case wants.
 	 *
-	 * Deliberately narrow: it only opens the case WCS closes, and only when a
-	 * card could actually be charged afterwards. Anything WCS already allows
-	 * passes straight through.
+	 * Deliberately narrow. WCS refuses the action for several distinct reasons;
+	 * this reproduces every one of them except the one it targets — the
+	 * missing-next-payment / not-active refusal. So the flow opens only for the
+	 * case this fixes and stays closed wherever WCS closed it for a different
+	 * reason: automatic payments switched off store-wide, no recurring charge, no
+	 * gateway that can take a customer card, or a gateway that cannot cancel.
+	 * Overriding just the one refusal, rather than returning a blanket `true`, is
+	 * what keeps a publisher's "no automatic renewals" choice intact.
 	 *
 	 * Paired with {@see schedule_next_payment_after_payment_method_added()},
 	 * which schedules the payment the missing date would otherwise leave unset.
@@ -367,31 +372,75 @@ class WooCommerce_Subscriptions {
 			return $can_be_updated;
 		}
 
-		// Statuses where putting a card on file still leads somewhere: awaiting a
-		// first payment, suspended, running, or winding down after the reader
-		// turned auto-renewal off. Terminal statuses are left to WCS.
-		if ( ! $subscription->has_status( [ 'pending', 'on-hold', 'active', 'pending-cancel' ] ) ) {
-			return $can_be_updated;
-		}
+		// Reproduce every WCS refusal except the missing-next-payment / not-active
+		// one this filter exists to override. See
+		// WC_Subscriptions_Change_Payment_Gateway::can_subscription_be_updated_to_new_payment_method().
 
-		// A scheduled payment means WCS's own rule already applies.
-		if ( $subscription->get_time( 'next_payment' ) > 0 ) {
+		// The store has turned automatic payments off entirely — a publisher
+		// configuration choice, not a per-subscription state.
+		if ( self::store_requires_manual_renewal() ) {
 			return $can_be_updated;
 		}
 
 		// Nothing recurring to charge, so nothing to add a card for. The 'edit'
-		// context reads the unfiltered total, matching WCS's own check.
+		// context reads the unfiltered total, as WCS's own check does.
 		if ( (float) $subscription->get_total( 'edit' ) <= 0 ) {
 			return $can_be_updated;
 		}
 
-		// Offering the action with no gateway able to take a card from the reader
-		// would lead them to a dead end.
+		// No gateway can take a card from the reader, so the flow would dead-end.
 		if ( ! self::one_gateway_supports_customer_payment_method_change() ) {
 			return $can_be_updated;
 		}
 
+		// The subscription's own gateway cannot cancel, which WCS requires before
+		// letting a reader swap payment method. A card-less subscription reads as
+		// manual here, so this passes for the hand-made case it targets.
+		if ( ! $subscription->payment_method_supports( 'subscription_cancellation' ) ) {
+			return $can_be_updated;
+		}
+
+		// The refusal we override, limited to statuses where putting a card on file
+		// leads somewhere: awaiting a first payment, suspended, or running.
+		// pending-cancel is excluded — its next payment is already cleared by
+		// design, so it would always match, and the action would do nothing for a
+		// subscription winding down (reactivating restores WCS's own flow).
+		if ( ! $subscription->has_status( [ 'pending', 'on-hold', 'active' ] ) ) {
+			return $can_be_updated;
+		}
+
+		if ( $subscription->get_time( 'next_payment' ) > 0 ) {
+			return $can_be_updated;
+		}
+
 		return true;
+	}
+
+	/**
+	 * Whether the store has switched automatic payments off — WCS's manual
+	 * renewals required with the reader-facing auto-renew toggle disabled. Under
+	 * that configuration WCS deliberately hides the payment-method change action,
+	 * and this filter must not re-open it.
+	 *
+	 * Wrapped in a method so the decision has a single seam: the
+	 * `newspack_add_payment_method_store_requires_manual_renewal` filter lets a
+	 * publisher override it, and lets the eligibility filter be unit tested
+	 * without loading WooCommerce Subscriptions. A missing toggle class fails
+	 * closed to "off", matching WCS's own guard.
+	 *
+	 * @return bool
+	 */
+	private static function store_requires_manual_renewal() {
+		$required       = function_exists( 'wcs_is_manual_renewal_required' ) && \wcs_is_manual_renewal_required();
+		$toggle_enabled = class_exists( 'WCS_My_Account_Auto_Renew_Toggle' ) && \WCS_My_Account_Auto_Renew_Toggle::is_enabled();
+
+		/**
+		 * Filters whether the store is configured for manual renewals only, which
+		 * keeps the add-payment-method flow closed.
+		 *
+		 * @param bool $manual_only Whether automatic payments are switched off store-wide.
+		 */
+		return (bool) apply_filters( 'newspack_add_payment_method_store_requires_manual_renewal', $required && ! $toggle_enabled );
 	}
 
 	/**
@@ -422,43 +471,39 @@ class WooCommerce_Subscriptions {
 	 * had none.
 	 *
 	 * The other half of {@see allow_add_payment_method_without_next_payment()},
-	 * and deliberately narrower than it. Eligibility opens the form for four
-	 * statuses; only `active` gets a date written here.
+	 * and deliberately narrower than it: eligibility opens the form for three
+	 * statuses, but only `active` gets a date written here.
 	 *
-	 * An active subscription with no next payment date is already giving the
-	 * reader access with nothing scheduled to bill, so calculating the date is
-	 * what turns "card added" into "renewals resume" — and it is also what makes
-	 * WCS's early renewal available, since `wcs_can_user_renew_early()` refuses
-	 * on `subscription_no_next_payment`. That matters for a hand-made
-	 * subscription with no orders at all, where early renewal is the reader's
-	 * only self-serve route to paying.
+	 * An `active` subscription is, by WCS's own model, currently inside a paid
+	 * period — the reader has access. For the subscriptions this targets, a human
+	 * granted that period on purpose (support setting a stuck subscription active
+	 * so the reader keeps access). Scheduling the first *future* charge one
+	 * billing period out is consistent with both facts, and it is what unlocks
+	 * WCS's early renewal — `wcs_can_user_renew_early()` refuses on
+	 * `subscription_no_next_payment`, so a reader who wants to pay sooner has no
+	 * self-serve route until a date exists. With a date set, "Renew now" appears
+	 * and takes payment immediately, resetting the cycle from that payment.
 	 *
-	 * The other statuses are left to WooCommerce, which already handles them
-	 * correctly: paying the pending or failed order is what activates the
-	 * subscription and sets its date. Writing a date for them would be wrong
-	 * twice over — it hands the reader a billing period they never paid for, and
-	 * it withdraws the "Add payment method" action (this pair steps back once a
-	 * date exists, while WCS's own rule still refuses a non-active subscription),
-	 * leaving them with a card on file and no way back to the form.
+	 * `pending` and `on-hold` are left to WooCommerce: they carry an unpaid order,
+	 * and paying it is what activates the subscription and sets its date. Writing
+	 * a date for them would also withdraw the "Add payment method" action (this
+	 * pair steps back once a date exists, while WCS still refuses a non-active
+	 * subscription), stranding the reader with a card on file and no way back.
 	 *
-	 * `calculate_date( 'next_payment' )` derives the date from the last payment
-	 * or the start date plus one billing period, keeps it far enough in the
-	 * future to survive a daylight-saving shift, and returns `0` when the next
-	 * period would fall past the subscription's end date. A `0` is respected:
-	 * a subscription winding down to a fixed end has nothing further to bill.
-	 * A `pending-cancel` subscription therefore stays untouched even though it
-	 * is eligible for the form; resuming its auto-renewal means clearing the
-	 * cancelled and end dates, which is a separate change.
+	 * `calculate_date( 'next_payment' )` derives the date from the last payment or
+	 * the start date plus one billing period, keeps it far enough out to survive a
+	 * daylight-saving shift, and returns `0` when the next period would fall past
+	 * the subscription's end date; a `0` is respected. `can_date_be_updated()`
+	 * additionally gates on the gateway supporting date changes, so a gateway that
+	 * owns the billing agreement and refuses them (PayPal Standard) never gets a
+	 * Woo-side schedule it would not honour.
 	 *
 	 * @param \WC_Subscription $subscription       The subscription that was updated.
 	 * @param string           $new_payment_method The gateway ID now attached.
-	 * @param string           $old_payment_method The gateway ID previously attached.
 	 *
 	 * @return void
 	 */
-	public static function schedule_next_payment_after_payment_method_added( $subscription, $new_payment_method, $old_payment_method = '' ) {
-		unset( $old_payment_method );
-
+	public static function schedule_next_payment_after_payment_method_added( $subscription, $new_payment_method ) {
 		if ( ! ( $subscription instanceof \WC_Subscription ) ) {
 			return;
 		}
@@ -474,14 +519,20 @@ class WooCommerce_Subscriptions {
 			return;
 		}
 
-		// Active only. See the note above on why the other eligible statuses are
-		// left to WooCommerce's own payment-completes-then-schedules flow.
+		// Active only. See the note above on why pending / on-hold are left to
+		// WooCommerce's own payment-completes-then-schedules flow.
 		if ( ! $subscription->has_status( 'active' ) ) {
 			return;
 		}
 
+		// Respect the same gate WCS applies to every date write: the gateway must
+		// support date changes, or its schedule and Woo's would silently diverge.
+		if ( ! $subscription->can_date_be_updated( 'next_payment' ) ) {
+			return;
+		}
+
 		$next_payment = $subscription->calculate_date( 'next_payment' );
-		if ( empty( $next_payment ) || '0' === (string) $next_payment ) {
+		if ( empty( $next_payment ) ) {
 			return;
 		}
 
@@ -494,9 +545,9 @@ class WooCommerce_Subscriptions {
 			$subscription->save();
 			$subscription->add_order_note(
 				sprintf(
-					/* translators: %s: the newly scheduled next payment date. */
+					/* translators: %s: the newly scheduled next payment date, localised. */
 					__( 'Next payment scheduled for %s after the subscriber added a payment method.', 'newspack-plugin' ),
-					$next_payment
+					$subscription->get_date_to_display( 'next_payment' )
 				)
 			);
 		} catch ( \Exception $e ) {

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -347,13 +347,14 @@ class WooCommerce_Subscriptions {
 	 * is the wording this case wants.
 	 *
 	 * Deliberately narrow. WCS refuses the action for several distinct reasons;
-	 * this reproduces every one of them except the one it targets — the
-	 * missing-next-payment / not-active refusal. So the flow opens only for the
-	 * case this fixes and stays closed wherever WCS closed it for a different
-	 * reason: automatic payments switched off store-wide, no recurring charge, no
-	 * gateway that can take a customer card, or a gateway that cannot cancel.
-	 * Overriding just the one refusal, rather than returning a blanket `true`, is
-	 * what keeps a publisher's "no automatic renewals" choice intact.
+	 * this reproduces the ones current WCS applies in
+	 * `can_subscription_be_updated_to_new_payment_method()` — automatic payments
+	 * switched off store-wide, no recurring charge, no gateway that can take a
+	 * customer card, a gateway that cannot cancel — and overrides only the
+	 * missing-next-payment / not-active refusal it targets. If a future WCS adds a
+	 * refusal, mirror it below. Overriding just the one refusal, rather than
+	 * returning a blanket `true`, is what keeps a publisher's "no automatic
+	 * renewals" choice intact.
 	 *
 	 * Paired with {@see schedule_next_payment_after_payment_method_added()},
 	 * which schedules the payment the missing date would otherwise leave unset.
@@ -377,8 +378,9 @@ class WooCommerce_Subscriptions {
 		// WC_Subscriptions_Change_Payment_Gateway::can_subscription_be_updated_to_new_payment_method().
 
 		// The store has turned automatic payments off entirely — a publisher
-		// configuration choice, not a per-subscription state.
-		if ( self::store_requires_manual_renewal() ) {
+		// configuration choice, not a per-subscription state. static:: so a test
+		// subclass can override the WCS-dependent read.
+		if ( static::store_requires_manual_renewal() ) {
 			return $can_be_updated;
 		}
 
@@ -420,27 +422,21 @@ class WooCommerce_Subscriptions {
 	 * Whether the store has switched automatic payments off — WCS's manual
 	 * renewals required with the reader-facing auto-renew toggle disabled. Under
 	 * that configuration WCS deliberately hides the payment-method change action,
-	 * and this filter must not re-open it.
+	 * and the eligibility filter must not re-open it.
 	 *
-	 * Wrapped in a method so the decision has a single seam: the
-	 * `newspack_add_payment_method_store_requires_manual_renewal` filter lets a
-	 * publisher override it, and lets the eligibility filter be unit tested
-	 * without loading WooCommerce Subscriptions. A missing toggle class fails
-	 * closed to "off", matching WCS's own guard.
+	 * `protected` rather than `private` and called through `static::` so a test
+	 * can override this WCS-dependent read with a subclass, without the eligibility
+	 * filter having to load WooCommerce Subscriptions or define its globals. A
+	 * missing toggle class leaves the manual-renewal setting to decide, matching
+	 * WCS's own guard.
 	 *
 	 * @return bool
 	 */
-	private static function store_requires_manual_renewal() {
+	protected static function store_requires_manual_renewal() {
 		$required       = function_exists( 'wcs_is_manual_renewal_required' ) && \wcs_is_manual_renewal_required();
 		$toggle_enabled = class_exists( 'WCS_My_Account_Auto_Renew_Toggle' ) && \WCS_My_Account_Auto_Renew_Toggle::is_enabled();
 
-		/**
-		 * Filters whether the store is configured for manual renewals only, which
-		 * keeps the add-payment-method flow closed.
-		 *
-		 * @param bool $manual_only Whether automatic payments are switched off store-wide.
-		 */
-		return (bool) apply_filters( 'newspack_add_payment_method_store_requires_manual_renewal', $required && ! $toggle_enabled );
+		return $required && ! $toggle_enabled;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/subscription-header.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/subscription-header.php
@@ -32,9 +32,14 @@ if ( ! empty( $actions['cancel'] ) ) {
 	$actions['cancel'] = $cancel_action;
 }
 
-// Rename 'Change payment' action.
+// Rename the 'Change payment' action, keeping the distinction WCS makes: a
+// subscription with no gateway yet needs a card added, not an existing one
+// updated. Telling a reader with nothing on file to "update" their payment
+// method is what sent them looking for a card they never had (NPPD-2170).
 if ( ! empty( $actions['change_payment_method']['name'] ) ) {
-	$actions['change_payment_method']['name'] = __( 'Update payment method', 'newspack-plugin' );
+	$actions['change_payment_method']['name'] = $subscription->has_payment_gateway()
+		? __( 'Update payment method', 'newspack-plugin' )
+		: __( 'Add payment method', 'newspack-plugin' );
 }
 
 \do_action( 'newspack_woocommerce_before_subscription_header', $subscription, $actions );

--- a/plugins/newspack-plugin/tests/mocks/wcs-add-payment-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wcs-add-payment-mocks.php
@@ -18,6 +18,15 @@
 // to the success path.
 if ( class_exists( 'WC_Subscription' ) && ! class_exists( 'WC_Subscription_Add_Payment_Double' ) ) {
 	class WC_Subscription_Add_Payment_Double extends WC_Subscription {
+		public function has_payment_gateway() {
+			return $this->data['has_payment_gateway'] ?? true;
+		}
+
+		public function is_manual() {
+			// A card-less subscription reads as manual, matching WCS.
+			return $this->data['is_manual'] ?? ! $this->has_payment_gateway();
+		}
+
 		public function can_date_be_updated( $date_type ) {
 			unset( $date_type );
 			return $this->data['can_date_be_updated'] ?? true;

--- a/plugins/newspack-plugin/tests/mocks/wcs-add-payment-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wcs-add-payment-mocks.php
@@ -1,0 +1,46 @@
+<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.VariableComment.Missing, Squiz.Commenting.FileComment.Missing, Generic.Files.OneObjectStructurePerFile.MultipleFound, Universal.Files.SeparateFunctionsFromOO.Mixed, Squiz.Commenting.FunctionCommentThrowTag.Missing
+
+// Scaffolding for the add-payment-method eligibility / follow-through tests
+// (woocommerce-subscriptions-add-payment.php). Requires wc-mocks.php (for
+// WC_Subscription) to be loaded first.
+//
+// Deliberately defines NO WooCommerce Subscriptions globals (wcs_* functions or
+// WCS_* classes): those persist for the whole PHPUnit process and would change
+// function_exists()/class_exists() results for every other test in the suite —
+// an order-dependent failure. The store-level manual-renewal check is exercised
+// through the `newspack_add_payment_method_store_requires_manual_renewal` filter
+// instead.
+
+// Subscription double that makes the follow-through's branches reachable. The
+// shared WC_Subscription mock cannot return `0` from calculate_date(), throws on
+// can_date_be_updated() / get_date_to_display(), and never fails update_dates() —
+// so the guard, the unschedulable-date branch and the catch path would all be
+// dead without these overrides. Each reads a staged value from $data, defaulting
+// to the success path.
+if ( class_exists( 'WC_Subscription' ) && ! class_exists( 'NPPD2170_Test_Subscription' ) ) {
+	class NPPD2170_Test_Subscription extends WC_Subscription {
+		public function can_date_be_updated( $date_type ) {
+			unset( $date_type );
+			return $this->data['can_date_be_updated'] ?? true;
+		}
+
+		public function get_date_to_display( $type ) {
+			return $this->data['dates'][ $type ] ?? '';
+		}
+
+		public function calculate_date( $date_type = 'next_payment' ) {
+			unset( $date_type );
+			if ( array_key_exists( 'calculate_date', $this->data ) ) {
+				return $this->data['calculate_date'];
+			}
+			return parent::calculate_date();
+		}
+
+		public function update_dates( $dates ) {
+			if ( ! empty( $this->data['update_dates_throws'] ) ) {
+				throw new \InvalidArgumentException( 'staged update_dates failure' );
+			}
+			parent::update_dates( $dates );
+		}
+	}
+}

--- a/plugins/newspack-plugin/tests/mocks/wcs-add-payment-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wcs-add-payment-mocks.php
@@ -8,8 +8,7 @@
 // WCS_* classes): those persist for the whole PHPUnit process and would change
 // function_exists()/class_exists() results for every other test in the suite —
 // an order-dependent failure. The store-level manual-renewal check is exercised
-// through the `newspack_add_payment_method_store_requires_manual_renewal` filter
-// instead.
+// through the WC_Subscriptions_Add_Payment_Store_Double subclass below instead.
 
 // Subscription double that makes the follow-through's branches reachable. The
 // shared WC_Subscription mock cannot return `0` from calculate_date(), throws on
@@ -17,8 +16,8 @@
 // so the guard, the unschedulable-date branch and the catch path would all be
 // dead without these overrides. Each reads a staged value from $data, defaulting
 // to the success path.
-if ( class_exists( 'WC_Subscription' ) && ! class_exists( 'NPPD2170_Test_Subscription' ) ) {
-	class NPPD2170_Test_Subscription extends WC_Subscription {
+if ( class_exists( 'WC_Subscription' ) && ! class_exists( 'WC_Subscription_Add_Payment_Double' ) ) {
+	class WC_Subscription_Add_Payment_Double extends WC_Subscription {
 		public function can_date_be_updated( $date_type ) {
 			unset( $date_type );
 			return $this->data['can_date_be_updated'] ?? true;
@@ -30,6 +29,8 @@ if ( class_exists( 'WC_Subscription' ) && ! class_exists( 'NPPD2170_Test_Subscri
 
 		public function calculate_date( $date_type = 'next_payment' ) {
 			unset( $date_type );
+			// Follow-through tests all stage a value; the parent fallback is a
+			// safety net for any that forget to.
 			if ( array_key_exists( 'calculate_date', $this->data ) ) {
 				return $this->data['calculate_date'];
 			}
@@ -41,6 +42,19 @@ if ( class_exists( 'WC_Subscription' ) && ! class_exists( 'NPPD2170_Test_Subscri
 				throw new \InvalidArgumentException( 'staged update_dates failure' );
 			}
 			parent::update_dates( $dates );
+		}
+	}
+}
+
+// Subclass of the production integration whose protected store_requires_manual_renewal()
+// is stageable, so the eligibility filter's manual-renewal branch can be tested
+// through late static binding without loading WooCommerce Subscriptions.
+if ( class_exists( 'Newspack\WooCommerce_Subscriptions' ) && ! class_exists( 'WC_Subscriptions_Add_Payment_Store_Double' ) ) {
+	class WC_Subscriptions_Add_Payment_Store_Double extends \Newspack\WooCommerce_Subscriptions {
+		public static $store_requires_manual_renewal = false;
+
+		protected static function store_requires_manual_renewal() {
+			return static::$store_requires_manual_renewal;
 		}
 	}
 }

--- a/plugins/newspack-plugin/tests/mocks/wcs-payment-gateways-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wcs-payment-gateways-mocks.php
@@ -1,0 +1,40 @@
+<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.VariableComment.Missing, Squiz.Commenting.FileComment.Missing, Generic.Files.OneObjectStructurePerFile.MultipleFound, Universal.Files.SeparateFunctionsFromOO.Mixed
+
+// Stand-ins for the WooCommerce Subscriptions gateway-capability lookup, used
+// when WooCommerce Subscriptions is not loaded in the test environment. WCS
+// routes the check through a handler class so WooPayments can substitute its
+// own, so both halves of that indirection are mocked here.
+
+/**
+ * Minimal mock for the WCS gateways handler.
+ */
+if ( ! class_exists( 'WC_Subscriptions_Payment_Gateways' ) ) {
+	class WC_Subscriptions_Payment_Gateways {
+		/**
+		 * Staged answer for one_gateway_supports(). Tests set this directly.
+		 *
+		 * @var bool
+		 */
+		public static $supports = true;
+
+		public static function one_gateway_supports( $feature ) {
+			unset( $feature );
+			return self::$supports;
+		}
+	}
+}
+
+/**
+ * Minimal mock for the WCS plugin singleton, which exposes the handler class.
+ */
+if ( ! class_exists( 'WC_Subscriptions_Core_Plugin' ) ) {
+	class WC_Subscriptions_Core_Plugin {
+		public static function instance() {
+			return new self();
+		}
+
+		public function get_gateways_handler_class() {
+			return 'WC_Subscriptions_Payment_Gateways';
+		}
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/woocommerce-subscriptions-add-payment.php
+++ b/plugins/newspack-plugin/tests/unit-tests/woocommerce-subscriptions-add-payment.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Tests adding a payment method to a subscription that has no next payment date.
+ *
+ * WooCommerce Subscriptions withholds the "change payment method" action from any
+ * subscription whose next payment date is unset, via
+ * WC_Subscriptions_Change_Payment_Gateway::can_subscription_be_updated_to_new_payment_method().
+ * A subscription created by hand in wp-admin never gets one, so the reader is left
+ * with no way to put a card on file — the subscription can never be paid or resumed.
+ *
+ * Coverage:
+ *   - Eligibility: the narrow set of subscriptions we open the flow for, and each
+ *     condition that keeps it closed.
+ *   - Follow-through: once a payment method is attached, the next payment date is
+ *     calculated and set, so auto-renewal resumes.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\WooCommerce_Subscriptions;
+
+require_once __DIR__ . '/../mocks/wcs-payment-gateways-mocks.php';
+
+/**
+ * Tests for opening the add-payment-method flow to subscriptions with no next payment.
+ *
+ * @group WooCommerce_Subscriptions_Integration
+ */
+class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
+
+	/**
+	 * Reset staged gateway support between tests.
+	 */
+	public function set_up() {
+		parent::set_up();
+		WC_Subscriptions_Payment_Gateways::$supports = true;
+	}
+
+	/**
+	 * Build a subscription double.
+	 *
+	 * @param array $data Overrides for the subscription data.
+	 *
+	 * @return WC_Subscription
+	 */
+	private function make_subscription( $data = [] ) {
+		return new WC_Subscription(
+			array_merge(
+				[
+					'id'               => 1,
+					'status'           => 'pending',
+					'total'            => '125.00',
+					'times'            => [ 'next_payment' => 0 ],
+					'dates'            => [ 'start' => gmdate( 'Y-m-d H:i:s', strtotime( '-2 days' ) ) ],
+					'billing_interval' => 1,
+					'billing_period'   => 'year',
+				],
+				$data
+			)
+		);
+	}
+
+	/**
+	 * The reported case: a subscription awaiting its first payment, with no next
+	 * payment date, gets the flow opened.
+	 */
+	public function test_grants_eligibility_when_no_next_payment_date() {
+		$subscription = $this->make_subscription();
+
+		$this->assertTrue(
+			WooCommerce_Subscriptions::allow_add_payment_method_without_next_payment( false, $subscription )
+		);
+	}
+
+	/**
+	 * Every status we deliberately cover.
+	 */
+	public function test_grants_eligibility_for_each_covered_status() {
+		foreach ( [ 'pending', 'on-hold', 'active', 'pending-cancel' ] as $status ) {
+			$subscription = $this->make_subscription( [ 'status' => $status ] );
+
+			$this->assertTrue(
+				WooCommerce_Subscriptions::allow_add_payment_method_without_next_payment( false, $subscription ),
+				sprintf( 'Expected the flow to be open for a "%s" subscription.', $status )
+			);
+		}
+	}
+
+	/**
+	 * A scheduled next payment means WCS's own rule already applies; leave it alone.
+	 */
+	public function test_leaves_subscriptions_with_a_next_payment_alone() {
+		$subscription = $this->make_subscription( [ 'times' => [ 'next_payment' => time() + DAY_IN_SECONDS ] ] );
+
+		$this->assertFalse(
+			WooCommerce_Subscriptions::allow_add_payment_method_without_next_payment( false, $subscription )
+		);
+	}
+
+	/**
+	 * Nothing recurring to charge means nothing to add a card for.
+	 */
+	public function test_leaves_zero_total_subscriptions_alone() {
+		$subscription = $this->make_subscription( [ 'total' => '0.00' ] );
+
+		$this->assertFalse(
+			WooCommerce_Subscriptions::allow_add_payment_method_without_next_payment( false, $subscription )
+		);
+	}
+
+	/**
+	 * Terminal statuses stay closed.
+	 */
+	public function test_leaves_terminal_statuses_alone() {
+		foreach ( [ 'cancelled', 'expired', 'switched' ] as $status ) {
+			$subscription = $this->make_subscription( [ 'status' => $status ] );
+
+			$this->assertFalse(
+				WooCommerce_Subscriptions::allow_add_payment_method_without_next_payment( false, $subscription ),
+				sprintf( 'Expected the flow to stay closed for a "%s" subscription.', $status )
+			);
+		}
+	}
+
+	/**
+	 * With no gateway able to take a card from the reader, offering the flow would
+	 * lead to a dead end.
+	 */
+	public function test_leaves_subscriptions_alone_when_no_gateway_supports_the_change() {
+		WC_Subscriptions_Payment_Gateways::$supports = false;
+		$subscription                                = $this->make_subscription();
+
+		$this->assertFalse(
+			WooCommerce_Subscriptions::allow_add_payment_method_without_next_payment( false, $subscription )
+		);
+	}
+
+	/**
+	 * When WCS already allows the change, pass its answer straight through.
+	 */
+	public function test_passes_through_an_existing_yes() {
+		$subscription = $this->make_subscription( [ 'status' => 'cancelled' ] );
+
+		$this->assertTrue(
+			WooCommerce_Subscriptions::allow_add_payment_method_without_next_payment( true, $subscription )
+		);
+	}
+
+	/**
+	 * Attaching a card to a subscription with no next payment date schedules one,
+	 * which is what resumes auto-renewal.
+	 */
+	public function test_sets_a_next_payment_date_once_a_card_is_attached() {
+		$subscription = $this->make_subscription();
+
+		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, 'stripe', '' );
+
+		$next_payment = $subscription->get_date( 'next_payment' );
+
+		$this->assertNotEmpty( $next_payment, 'Expected a next payment date to be scheduled.' );
+		$this->assertGreaterThan(
+			time(),
+			strtotime( $next_payment ),
+			'Expected the scheduled next payment to be in the future.'
+		);
+	}
+
+	/**
+	 * An already-scheduled next payment is never rewritten.
+	 */
+	public function test_does_not_reschedule_an_existing_next_payment() {
+		$existing     = gmdate( 'Y-m-d H:i:s', strtotime( '+30 days' ) );
+		$subscription = $this->make_subscription(
+			[
+				'times' => [ 'next_payment' => strtotime( '+30 days' ) ],
+				'dates' => [
+					'start'        => gmdate( 'Y-m-d H:i:s', strtotime( '-2 days' ) ),
+					'next_payment' => $existing,
+				],
+			]
+		);
+
+		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, 'stripe', '' );
+
+		$this->assertSame( $existing, $subscription->get_date( 'next_payment' ) );
+	}
+
+	/**
+	 * No gateway attached means nothing to schedule against.
+	 */
+	public function test_does_not_schedule_when_no_payment_method_was_attached() {
+		$subscription = $this->make_subscription();
+
+		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, '', '' );
+
+		$this->assertEmpty( $subscription->get_date( 'next_payment' ) );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/woocommerce-subscriptions-add-payment.php
+++ b/plugins/newspack-plugin/tests/unit-tests/woocommerce-subscriptions-add-payment.php
@@ -147,11 +147,12 @@ class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Attaching a card to a subscription with no next payment date schedules one,
-	 * which is what resumes auto-renewal.
+	 * Attaching a card to an active subscription with no next payment date
+	 * schedules one, which is what resumes auto-renewal and, for a subscription
+	 * with no orders, unlocks WCS's early renewal as a self-serve way to pay.
 	 */
 	public function test_sets_a_next_payment_date_once_a_card_is_attached() {
-		$subscription = $this->make_subscription();
+		$subscription = $this->make_subscription( [ 'status' => 'active' ] );
 
 		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, 'stripe', '' );
 
@@ -166,14 +167,34 @@ class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Statuses where WooCommerce sets the date itself when the outstanding order
+	 * is paid. Writing one here would grant a billing period nobody paid for, and
+	 * would withdraw the "Add payment method" action while the reader still has
+	 * no way to pay.
+	 */
+	public function test_does_not_schedule_for_statuses_where_payment_sets_the_date() {
+		foreach ( [ 'pending', 'on-hold', 'pending-cancel' ] as $status ) {
+			$subscription = $this->make_subscription( [ 'status' => $status ] );
+
+			WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, 'stripe', '' );
+
+			$this->assertEmpty(
+				$subscription->get_date( 'next_payment' ),
+				sprintf( 'Expected no next payment date to be written for a "%s" subscription.', $status )
+			);
+		}
+	}
+
+	/**
 	 * An already-scheduled next payment is never rewritten.
 	 */
 	public function test_does_not_reschedule_an_existing_next_payment() {
 		$existing     = gmdate( 'Y-m-d H:i:s', strtotime( '+30 days' ) );
 		$subscription = $this->make_subscription(
 			[
-				'times' => [ 'next_payment' => strtotime( '+30 days' ) ],
-				'dates' => [
+				'status' => 'active',
+				'times'  => [ 'next_payment' => strtotime( '+30 days' ) ],
+				'dates'  => [
 					'start'        => gmdate( 'Y-m-d H:i:s', strtotime( '-2 days' ) ),
 					'next_payment' => $existing,
 				],
@@ -189,7 +210,7 @@ class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 	 * No gateway attached means nothing to schedule against.
 	 */
 	public function test_does_not_schedule_when_no_payment_method_was_attached() {
-		$subscription = $this->make_subscription();
+		$subscription = $this->make_subscription( [ 'status' => 'active' ] );
 
 		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, '', '' );
 

--- a/plugins/newspack-plugin/tests/unit-tests/woocommerce-subscriptions-add-payment.php
+++ b/plugins/newspack-plugin/tests/unit-tests/woocommerce-subscriptions-add-payment.php
@@ -33,6 +33,16 @@ require_once __DIR__ . '/../mocks/wcs-add-payment-mocks.php';
 class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 
 	/**
+	 * The payment result WCS passes once the card has been accepted.
+	 */
+	const SUCCESS = [ 'result' => 'success' ];
+
+	/**
+	 * The payment result WCS passes when the card was declined.
+	 */
+	const FAILURE = [ 'result' => 'failure' ];
+
+	/**
 	 * Reset staged gateway support between tests.
 	 */
 	public function set_up() {
@@ -220,7 +230,7 @@ class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 			]
 		);
 
-		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, 'stripe' );
+		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( self::SUCCESS, $subscription );
 
 		$this->assertSame(
 			$scheduled,
@@ -242,7 +252,7 @@ class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 			]
 		);
 
-		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, 'stripe' );
+		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( self::SUCCESS, $subscription );
 
 		// Strict identity, not assertEmpty: the mock returns int 0 when the date was
 		// never written, but string '0' if the guard were removed and '0' written —
@@ -263,7 +273,7 @@ class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 			]
 		);
 
-		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, 'stripe' );
+		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( self::SUCCESS, $subscription );
 
 		$this->assertEmpty( $subscription->get_date( 'next_payment' ) );
 	}
@@ -281,7 +291,7 @@ class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 			]
 		);
 
-		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, 'stripe' );
+		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( self::SUCCESS, $subscription );
 
 		$this->assertEmpty( $subscription->get_date( 'next_payment' ) );
 	}
@@ -301,13 +311,48 @@ class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 				]
 			);
 
-			WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, 'stripe' );
+			WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( self::SUCCESS, $subscription );
 
 			$this->assertEmpty(
 				$subscription->get_date( 'next_payment' ),
 				sprintf( 'Expected no next payment date to be written for a "%s" subscription.', $status )
 			);
 		}
+	}
+
+	/**
+	 * A declined card writes nothing. WCS applies this filter after
+	 * process_payment() and bails on a non-success result, so scheduling here must
+	 * be conditional on that result — otherwise a reader whose card was refused
+	 * keeps access until a renewal runs against a card that was never accepted.
+	 */
+	public function test_does_not_schedule_when_the_payment_failed() {
+		$subscription = $this->make_subscription(
+			[
+				'status'         => 'active',
+				'calculate_date' => gmdate( 'Y-m-d H:i:s', strtotime( '+1 year' ) ),
+			]
+		);
+
+		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( self::FAILURE, $subscription );
+
+		$this->assertSame( 0, $subscription->get_date( 'next_payment' ) );
+	}
+
+	/**
+	 * The filter must hand back whatever WCS gave it, success or not.
+	 */
+	public function test_returns_the_payment_result_unchanged() {
+		$subscription = $this->make_subscription( [ 'status' => 'active' ] );
+
+		$this->assertSame(
+			self::SUCCESS,
+			WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( self::SUCCESS, $subscription )
+		);
+		$this->assertSame(
+			self::FAILURE,
+			WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( self::FAILURE, $subscription )
+		);
 	}
 
 	/**
@@ -326,18 +371,25 @@ class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 			]
 		);
 
-		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, 'stripe' );
+		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( self::SUCCESS, $subscription );
 
 		$this->assertSame( $existing, $subscription->get_date( 'next_payment' ) );
 	}
 
 	/**
-	 * No gateway attached means nothing to schedule against.
+	 * No chargeable gateway on the subscription means nothing to schedule against.
+	 * Asked of the subscription rather than inferred from a method string, since
+	 * this also runs for admin and bulk updates.
 	 */
-	public function test_does_not_schedule_when_no_payment_method_was_attached() {
-		$subscription = $this->make_subscription( [ 'status' => 'active' ] );
+	public function test_does_not_schedule_when_no_gateway_is_attached() {
+		$subscription = $this->make_subscription(
+			[
+				'status'              => 'active',
+				'has_payment_gateway' => false,
+			]
+		);
 
-		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, '' );
+		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( self::SUCCESS, $subscription );
 
 		$this->assertEmpty( $subscription->get_date( 'next_payment' ) );
 	}

--- a/plugins/newspack-plugin/tests/unit-tests/woocommerce-subscriptions-add-payment.php
+++ b/plugins/newspack-plugin/tests/unit-tests/woocommerce-subscriptions-add-payment.php
@@ -10,16 +10,20 @@
  *
  * Coverage:
  *   - Eligibility: the narrow set of subscriptions we open the flow for, and each
- *     condition that keeps it closed.
- *   - Follow-through: once a payment method is attached, the next payment date is
- *     calculated and set, so auto-renewal resumes.
+ *     WCS refusal we deliberately keep in place (manual-renewal store setting, zero
+ *     total, no capable gateway, gateway that cannot cancel).
+ *   - Follow-through: for an active subscription a next payment date is calculated
+ *     and set; every other status, an unschedulable date, a gateway that refuses
+ *     date changes, and a failing write are all left alone.
  *
  * @package Newspack\Tests
  */
 
 use Newspack\WooCommerce_Subscriptions;
 
+require_once __DIR__ . '/../mocks/wc-mocks.php';
 require_once __DIR__ . '/../mocks/wcs-payment-gateways-mocks.php';
+require_once __DIR__ . '/../mocks/wcs-add-payment-mocks.php';
 
 /**
  * Tests for opening the add-payment-method flow to subscriptions with no next payment.
@@ -37,14 +41,22 @@ class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Drop any filter a test added.
+	 */
+	public function tear_down() {
+		remove_all_filters( 'newspack_add_payment_method_store_requires_manual_renewal' );
+		parent::tear_down();
+	}
+
+	/**
 	 * Build a subscription double.
 	 *
 	 * @param array $data Overrides for the subscription data.
 	 *
-	 * @return WC_Subscription
+	 * @return NPPD2170_Test_Subscription
 	 */
 	private function make_subscription( $data = [] ) {
-		return new WC_Subscription(
+		return new NPPD2170_Test_Subscription(
 			array_merge(
 				[
 					'id'               => 1,
@@ -73,10 +85,10 @@ class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Every status we deliberately cover.
+	 * Every status we deliberately cover. pending-cancel is not among them.
 	 */
 	public function test_grants_eligibility_for_each_covered_status() {
-		foreach ( [ 'pending', 'on-hold', 'active', 'pending-cancel' ] as $status ) {
+		foreach ( [ 'pending', 'on-hold', 'active' ] as $status ) {
 			$subscription = $this->make_subscription( [ 'status' => $status ] );
 
 			$this->assertTrue(
@@ -84,6 +96,53 @@ class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 				sprintf( 'Expected the flow to be open for a "%s" subscription.', $status )
 			);
 		}
+	}
+
+	/**
+	 * A pending-cancel subscription always has next payment cleared, so it would
+	 * always match the override; it is excluded because the action does nothing for
+	 * a subscription winding down (reactivating restores WCS's own flow).
+	 */
+	public function test_leaves_pending_cancel_alone() {
+		$subscription = $this->make_subscription( [ 'status' => 'pending-cancel' ] );
+
+		$this->assertFalse(
+			WooCommerce_Subscriptions::allow_add_payment_method_without_next_payment( false, $subscription )
+		);
+	}
+
+	/**
+	 * A store that has switched automatic payments off — WCS manual renewals with
+	 * the auto-renew toggle disabled, surfaced here through the store-setting
+	 * filter — keeps the flow closed for a subscription that otherwise qualifies.
+	 */
+	public function test_respects_the_manual_renewal_store_setting() {
+		add_filter( 'newspack_add_payment_method_store_requires_manual_renewal', '__return_true' );
+		$subscription = $this->make_subscription();
+
+		$this->assertFalse(
+			WooCommerce_Subscriptions::allow_add_payment_method_without_next_payment( false, $subscription ),
+			'Expected the flow to stay closed when the store requires manual renewals.'
+		);
+
+		remove_all_filters( 'newspack_add_payment_method_store_requires_manual_renewal' );
+
+		$this->assertTrue(
+			WooCommerce_Subscriptions::allow_add_payment_method_without_next_payment( false, $subscription ),
+			'Expected the flow to open when automatic payments are available.'
+		);
+	}
+
+	/**
+	 * A gateway that cannot cancel keeps the flow closed, matching the WCS bail. A
+	 * card-less subscription reads as manual and so passes this check.
+	 */
+	public function test_leaves_subscriptions_alone_when_the_gateway_cannot_cancel() {
+		$subscription = $this->make_subscription( [ 'payment_method_supports' => [ 'subscription_amount_changes' ] ] );
+
+		$this->assertFalse(
+			WooCommerce_Subscriptions::allow_add_payment_method_without_next_payment( false, $subscription )
+		);
 	}
 
 	/**
@@ -148,22 +207,80 @@ class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 
 	/**
 	 * Attaching a card to an active subscription with no next payment date
-	 * schedules one, which is what resumes auto-renewal and, for a subscription
-	 * with no orders, unlocks WCS's early renewal as a self-serve way to pay.
+	 * schedules the exact date calculate_date() returns, and records it in an
+	 * order note — which is what unlocks WCS's early renewal as a self-serve way
+	 * to pay.
 	 */
 	public function test_sets_a_next_payment_date_once_a_card_is_attached() {
-		$subscription = $this->make_subscription( [ 'status' => 'active' ] );
-
-		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, 'stripe', '' );
-
-		$next_payment = $subscription->get_date( 'next_payment' );
-
-		$this->assertNotEmpty( $next_payment, 'Expected a next payment date to be scheduled.' );
-		$this->assertGreaterThan(
-			time(),
-			strtotime( $next_payment ),
-			'Expected the scheduled next payment to be in the future.'
+		$scheduled    = gmdate( 'Y-m-d H:i:s', strtotime( '+1 year' ) );
+		$subscription = $this->make_subscription(
+			[
+				'status'         => 'active',
+				'calculate_date' => $scheduled,
+			]
 		);
+
+		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, 'stripe' );
+
+		$this->assertSame(
+			$scheduled,
+			$subscription->get_date( 'next_payment' ),
+			'Expected the calculated date to be written verbatim.'
+		);
+	}
+
+	/**
+	 * When calculate_date() returns 0 — the next period would fall past the end
+	 * date — a subscription winding down to a fixed end has nothing further to
+	 * bill, so no date is written.
+	 */
+	public function test_does_not_schedule_when_the_calculated_date_is_zero() {
+		$subscription = $this->make_subscription(
+			[
+				'status'         => 'active',
+				'calculate_date' => '0',
+			]
+		);
+
+		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, 'stripe' );
+
+		$this->assertEmpty( $subscription->get_date( 'next_payment' ) );
+	}
+
+	/**
+	 * A gateway that refuses date changes gets no Woo-side schedule, so its dates
+	 * and Woo's never diverge.
+	 */
+	public function test_does_not_schedule_when_the_gateway_refuses_date_changes() {
+		$subscription = $this->make_subscription(
+			[
+				'status'              => 'active',
+				'can_date_be_updated' => false,
+				'calculate_date'      => gmdate( 'Y-m-d H:i:s', strtotime( '+1 year' ) ),
+			]
+		);
+
+		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, 'stripe' );
+
+		$this->assertEmpty( $subscription->get_date( 'next_payment' ) );
+	}
+
+	/**
+	 * A failing date write is caught, not fatal: the reader keeps the card they
+	 * just added, and no date is written.
+	 */
+	public function test_swallows_a_failing_date_write() {
+		$subscription = $this->make_subscription(
+			[
+				'status'              => 'active',
+				'update_dates_throws' => true,
+				'calculate_date'      => gmdate( 'Y-m-d H:i:s', strtotime( '+1 year' ) ),
+			]
+		);
+
+		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, 'stripe' );
+
+		$this->assertEmpty( $subscription->get_date( 'next_payment' ) );
 	}
 
 	/**
@@ -174,9 +291,14 @@ class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 	 */
 	public function test_does_not_schedule_for_statuses_where_payment_sets_the_date() {
 		foreach ( [ 'pending', 'on-hold', 'pending-cancel' ] as $status ) {
-			$subscription = $this->make_subscription( [ 'status' => $status ] );
+			$subscription = $this->make_subscription(
+				[
+					'status'         => $status,
+					'calculate_date' => gmdate( 'Y-m-d H:i:s', strtotime( '+1 year' ) ),
+				]
+			);
 
-			WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, 'stripe', '' );
+			WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, 'stripe' );
 
 			$this->assertEmpty(
 				$subscription->get_date( 'next_payment' ),
@@ -201,7 +323,7 @@ class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 			]
 		);
 
-		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, 'stripe', '' );
+		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, 'stripe' );
 
 		$this->assertSame( $existing, $subscription->get_date( 'next_payment' ) );
 	}
@@ -212,7 +334,7 @@ class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 	public function test_does_not_schedule_when_no_payment_method_was_attached() {
 		$subscription = $this->make_subscription( [ 'status' => 'active' ] );
 
-		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, '', '' );
+		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, '' );
 
 		$this->assertEmpty( $subscription->get_date( 'next_payment' ) );
 	}

--- a/plugins/newspack-plugin/tests/unit-tests/woocommerce-subscriptions-add-payment.php
+++ b/plugins/newspack-plugin/tests/unit-tests/woocommerce-subscriptions-add-payment.php
@@ -41,10 +41,10 @@ class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Drop any filter a test added.
+	 * Reset the staged store setting.
 	 */
 	public function tear_down() {
-		remove_all_filters( 'newspack_add_payment_method_store_requires_manual_renewal' );
+		WC_Subscriptions_Add_Payment_Store_Double::$store_requires_manual_renewal = false;
 		parent::tear_down();
 	}
 
@@ -53,10 +53,10 @@ class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 	 *
 	 * @param array $data Overrides for the subscription data.
 	 *
-	 * @return NPPD2170_Test_Subscription
+	 * @return WC_Subscription_Add_Payment_Double
 	 */
 	private function make_subscription( $data = [] ) {
-		return new NPPD2170_Test_Subscription(
+		return new WC_Subscription_Add_Payment_Double(
 			array_merge(
 				[
 					'id'               => 1,
@@ -113,22 +113,22 @@ class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 
 	/**
 	 * A store that has switched automatic payments off — WCS manual renewals with
-	 * the auto-renew toggle disabled, surfaced here through the store-setting
-	 * filter — keeps the flow closed for a subscription that otherwise qualifies.
+	 * the auto-renew toggle disabled — keeps the flow closed for a subscription
+	 * that otherwise qualifies. Exercised through a subclass that overrides the
+	 * store-setting read, via late static binding.
 	 */
 	public function test_respects_the_manual_renewal_store_setting() {
-		add_filter( 'newspack_add_payment_method_store_requires_manual_renewal', '__return_true' );
 		$subscription = $this->make_subscription();
 
+		WC_Subscriptions_Add_Payment_Store_Double::$store_requires_manual_renewal = true;
 		$this->assertFalse(
-			WooCommerce_Subscriptions::allow_add_payment_method_without_next_payment( false, $subscription ),
+			WC_Subscriptions_Add_Payment_Store_Double::allow_add_payment_method_without_next_payment( false, $subscription ),
 			'Expected the flow to stay closed when the store requires manual renewals.'
 		);
 
-		remove_all_filters( 'newspack_add_payment_method_store_requires_manual_renewal' );
-
+		WC_Subscriptions_Add_Payment_Store_Double::$store_requires_manual_renewal = false;
 		$this->assertTrue(
-			WooCommerce_Subscriptions::allow_add_payment_method_without_next_payment( false, $subscription ),
+			WC_Subscriptions_Add_Payment_Store_Double::allow_add_payment_method_without_next_payment( false, $subscription ),
 			'Expected the flow to open when automatic payments are available.'
 		);
 	}
@@ -244,7 +244,10 @@ class Newspack_Test_WC_Subscriptions_Add_Payment extends WP_UnitTestCase {
 
 		WooCommerce_Subscriptions::schedule_next_payment_after_payment_method_added( $subscription, 'stripe' );
 
-		$this->assertEmpty( $subscription->get_date( 'next_payment' ) );
+		// Strict identity, not assertEmpty: the mock returns int 0 when the date was
+		// never written, but string '0' if the guard were removed and '0' written —
+		// and assertEmpty() would pass on both, so it could not catch the regression.
+		$this->assertSame( 0, $subscription->get_date( 'next_payment' ) );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

WooCommerce Subscriptions only offers the "change payment method" action when a subscription has a next-payment date and is active (`WC_Subscriptions_Change_Payment_Gateway::can_subscription_be_updated_to_new_payment_method()`). A subscription created by hand in wp-admin never gets a next-payment date, so the reader is offered no way to put a card on file and the subscription can never be paid. Part of NPPD-2170.

This opens the payment-method flow for exactly that gap, and no wider.

- **Eligibility** — `WooCommerce_Subscriptions::allow_add_payment_method_without_next_payment()`, a priority-20 filter on `woocommerce_can_subscription_be_updated_to_new-payment-method`. It reproduces every refusal WCS applies except the missing-next-payment / not-active one it targets: store-wide manual renewals, zero recurring total, no gateway that can take a customer card, a gateway that cannot cancel. Limited to `pending` / `on-hold` / `active`. `pending-cancel` is excluded — its next-payment date is always cleared, so the action would be a no-op for a subscription winding down (reactivating restores WCS's own flow).
- **Follow-through** — `schedule_next_payment_after_payment_method_added()`, on `woocommerce_subscription_payment_method_updated`. For an `active` subscription with no next-payment date it schedules the next payment, which both resumes billing and unlocks WCS's early renewal ("Renew now"), since `wcs_can_user_renew_early()` refuses on `subscription_no_next_payment`. Gated on `can_date_be_updated( 'next_payment' )`, so a gateway that owns the billing agreement and refuses date changes never gets a Woo-side schedule it won't honour. `pending` / `on-hold` are left to WooCommerce, which sets the date when their outstanding order is paid.
- **Label** — `subscription-header.php` now reads "Add payment method" when the subscription has no gateway yet and "Update payment method" when it does, matching WCS's own add-vs-change wording instead of a hardcoded "Update payment method".
- **Modal checkout** — `Checkout_Data::get_checkout_data()`. A subscription with no parent order now reads its own line items instead of calling `get_items()` on the `false` that `get_parent()` returns (a fatal), and returns empty for an item-less order rather than fatalling on a null product. The subscription is identified by `subscription_ids`, never as an `order_id`, so the post-checkout redirect lands on the subscription page rather than a view-order URL.

### How to test the changes in this Pull Request:

1. With WooCommerce Subscriptions and a subscriptions-capable gateway (e.g. Stripe test mode) active, create a subscription in wp-admin for a subscriber, attach a subscription product, and leave it with no payment method.
2. As the subscriber, open the subscription under My Account. An **Add payment method** action appears. Before this change there is none.
3. Add a card. The modal completes and returns to the subscription page, not a view-order page.
4. For an **active** subscription with no orders: a next-payment date is set afterwards and a **Renew now** action appears; renewing takes payment immediately.
5. For a **pending** subscription: the button remains after adding a card and no next-payment date is written. Payment is collected by paying the pending order.
6. The action does **not** appear on a store configured for manual renewals with the auto-renew toggle disabled, nor on a `pending-cancel` subscription.

Tests: `n test-php` in `newspack-plugin` (`--group WooCommerce_Subscriptions_Integration`) and in `newspack-blocks`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<sub>🤖 Authored with [Claude Code](https://claude.com/claude-code).</sub>
