### PR TITLE
feat(themes): offer Header and Body fonts in the editor font picker

### DIFF
--- a/plugins/newspack-newsletters/tests/email-renderers/fixtures/theme-font-functions.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/fixtures/theme-font-functions.php
@@ -33,11 +33,15 @@ if ( ! function_exists( 'newspack_font_stack' ) ) {
 	 * @return string
 	 */
 	function newspack_font_stack( $primary, $fallback_id ) {
-		$stacks = newspack_get_font_stacks();
-		$fonts  = isset( $stacks[ $fallback_id ] ) ? $stacks[ $fallback_id ]['fonts'] : [];
+		$stacks   = newspack_get_font_stacks();
+		$fonts    = isset( $stacks[ $fallback_id ] ) ? $stacks[ $fallback_id ]['fonts'] : [];
+		$generics = [ 'serif', 'sans-serif', 'monospace', 'cursive', 'fantasy', 'system-ui' ];
 		array_unshift( $fonts, $primary );
 		foreach ( $fonts as &$font ) {
-			$font = '"' . $font . '"';
+			$font = str_replace( [ "\n", "\r", "\t", '<', '>' ], '', stripslashes( $font ) );
+			if ( ! in_array( strtolower( $font ), $generics, true ) ) {
+				$font = '"' . str_replace( [ '\\', '"' ], [ '\\\\', '\\"' ], $font ) . '"';
+			}
 		}
 		return implode( ',', $fonts );
 	}

--- a/plugins/newspack-newsletters/tests/email-renderers/fixtures/theme-font-functions.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/fixtures/theme-font-functions.php
@@ -34,11 +34,11 @@ if ( ! function_exists( 'newspack_font_stack' ) ) {
 	 */
 	function newspack_font_stack( $primary, $fallback_id ) {
 		$stacks   = newspack_get_font_stacks();
-		$fonts    = isset( $stacks[ $fallback_id ] ) ? $stacks[ $fallback_id ]['fonts'] : [];
+		$fonts    = isset( $stacks[ $fallback_id ] ) ? $stacks[ $fallback_id ]['fonts'] : $stacks['serif']['fonts'];
 		$generics = [ 'serif', 'sans-serif', 'monospace', 'cursive', 'fantasy', 'system-ui' ];
 		array_unshift( $fonts, $primary );
 		foreach ( $fonts as &$font ) {
-			$font = str_replace( [ "\n", "\r", "\t", '<', '>' ], '', stripslashes( $font ) );
+			$font = preg_replace( '/[\x00-\x1F\x7F<>]/', '', stripslashes( $font ) );
 			if ( ! in_array( strtolower( $font ), $generics, true ) ) {
 				$font = '"' . str_replace( [ '\\', '"' ], [ '\\\\', '\\"' ], $font ) . '"';
 			}

--- a/plugins/newspack-newsletters/tests/email-renderers/fixtures/theme-font-functions.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/fixtures/theme-font-functions.php
@@ -43,6 +43,7 @@ if ( ! function_exists( 'newspack_font_stack' ) ) {
 				$font = '"' . str_replace( [ '\\', '"' ], [ '\\\\', '\\"' ], $font ) . '"';
 			}
 		}
+		unset( $font );
 		return implode( ',', $fonts );
 	}
 }

--- a/themes/newspack-theme/newspack-joseph/sass/variables-style/_variables-style.scss
+++ b/themes/newspack-theme/newspack-joseph/sass/variables-style/_variables-style.scss
@@ -57,6 +57,7 @@
 
 // Now overlay our style-specific variables, so we're only overriding specific variables.
 :root {
+	// Header and Body changes must be mirrored in newspack_font_family_stacks(), newspack-theme/inc/typography.php.
 	--newspack-theme-font-heading: "Old Standard TT", georgia, serif;
 	--newspack-theme-font-body: "EB Garamond", georgia, serif;
 	--newspack-theme-color-text-light: #444;

--- a/themes/newspack-theme/newspack-katharine/sass/variables-style/_variables-style.scss
+++ b/themes/newspack-theme/newspack-katharine/sass/variables-style/_variables-style.scss
@@ -35,6 +35,7 @@
 
 // Now overlay our style-specific variable values, so we're only overriding specific variables.
 :root {
+	// Header and Body changes must be mirrored in newspack_font_family_stacks(), newspack-theme/inc/typography.php.
 	--newspack-theme-font-heading: "Barlow", "Helvetica", sans-serif;
 	--newspack-theme-font-body: "Barlow", "Helvetica", sans-serif;
 }

--- a/themes/newspack-theme/newspack-nelson/sass/variables-style/_variables-style.scss
+++ b/themes/newspack-theme/newspack-nelson/sass/variables-style/_variables-style.scss
@@ -34,6 +34,7 @@
 
 // Now overlay our style-specific variables, so we're only overriding specific variables.
 :root {
+	// Header and Body changes must be mirrored in newspack_font_family_stacks(), newspack-theme/inc/typography.php.
 	--newspack-theme-font-heading: "Montserrat", "Helvetica", sans-serif;
 	--newspack-theme-font-body:
 		-apple-system,

--- a/themes/newspack-theme/newspack-sacha/sass/variables-style/_variables-style.scss
+++ b/themes/newspack-theme/newspack-sacha/sass/variables-style/_variables-style.scss
@@ -35,5 +35,6 @@
 
 // Now overlay our style-specific variables, so we're only overriding specific variables.
 :root {
+	// Header and Body changes must be mirrored in newspack_font_family_stacks(), newspack-theme/inc/typography.php.
 	--newspack-theme-font-heading: "IBM Plex Serif", georgia, serif;
 }

--- a/themes/newspack-theme/newspack-scott/sass/variables-style/_variables-style.scss
+++ b/themes/newspack-theme/newspack-scott/sass/variables-style/_variables-style.scss
@@ -35,5 +35,6 @@
 
 // Now overlay our style-specific variables, so we're only overriding specific variables.
 :root {
+	// Header and Body changes must be mirrored in newspack_font_family_stacks(), newspack-theme/inc/typography.php.
 	--newspack-theme-font-heading: "Fira Sans Condensed", "Helvetica", sans-serif;
 }

--- a/themes/newspack-theme/newspack-theme/inc/typography.php
+++ b/themes/newspack-theme/newspack-theme/inc/typography.php
@@ -169,10 +169,11 @@ function newspack_get_font_stacks_as_select_choices() {
 /**
  * Prepare a font-family definition with a primary font and fallbacks.
  *
- * Font names are stripped of CSS string and function delimiters — these values
- * flow into inline styles and theme.json preset values, where the theme origin
- * is never passed through core's insecure-property filtering. Generic family
- * keywords stay unquoted so a stack always ends in a real generic.
+ * Values flow into inline styles and theme.json preset values, and core never
+ * passes the theme origin through its insecure-property filtering, so names
+ * are emitted as quoted CSS strings with string delimiters escaped and markup
+ * and control characters removed. Generic family keywords stay unquoted so a
+ * stack always ends in a real generic.
  */
 function newspack_font_stack( $primary_font, $fallback_id ) {
 	$stacks   = newspack_get_font_stacks();
@@ -180,9 +181,9 @@ function newspack_font_stack( $primary_font, $fallback_id ) {
 	$generics = array( 'serif', 'sans-serif', 'monospace', 'cursive', 'fantasy', 'system-ui' );
 	array_unshift( $fonts, $primary_font );
 	foreach ( $fonts as &$font ) {
-		$font = str_replace( array( '"', "'", ';', '{', '}', '(', ')', '\\' ), '', $font );
+		$font = str_replace( array( "\n", "\r", "\t", '<', '>' ), '', stripslashes( $font ) );
 		if ( ! in_array( strtolower( $font ), $generics, true ) ) {
-			$font = '"' . $font . '"';
+			$font = '"' . str_replace( array( '\\', '"' ), array( '\\\\', '\\"' ), $font ) . '"';
 		}
 	}
 	return implode( ',', $fonts );
@@ -222,9 +223,17 @@ function newspack_font_family_stacks() {
 			'heading' => '"Fira Sans Condensed","Helvetica",sans-serif',
 		),
 	);
-	if ( isset( $variations[ get_stylesheet() ] ) ) {
-		$defaults = array_merge( $defaults, $variations[ get_stylesheet() ] );
+	$slug = isset( $variations[ get_stylesheet() ] ) ? get_stylesheet() : get_template();
+	if ( isset( $variations[ $slug ] ) ) {
+		$defaults = array_merge( $defaults, $variations[ $slug ] );
 	}
+
+	/**
+	 * Filter the default Header and Body font stacks.
+	 *
+	 * @param array $defaults Stacks keyed heading/body.
+	 */
+	$defaults = apply_filters( 'newspack_font_family_default_stacks', $defaults );
 
 	$mods   = array(
 		'heading' => array( 'font_header', 'font_header_stack' ),
@@ -249,8 +258,8 @@ function newspack_font_family_stacks() {
  * the Gutenberg plugin active the resolver passes WP_Theme_JSON_Data_Gutenberg,
  * a sibling class rather than a subclass, so the parameter stays untyped.
  *
- * @param WP_Theme_JSON_Data $theme_json Theme JSON data.
- * @return WP_Theme_JSON_Data
+ * @param WP_Theme_JSON_Data|WP_Theme_JSON_Data_Gutenberg $theme_json Theme JSON data.
+ * @return WP_Theme_JSON_Data|WP_Theme_JSON_Data_Gutenberg
  */
 function newspack_font_family_presets( $theme_json ) {
 	$data     = $theme_json->get_data();

--- a/themes/newspack-theme/newspack-theme/inc/typography.php
+++ b/themes/newspack-theme/newspack-theme/inc/typography.php
@@ -7,6 +7,12 @@
 
 /**
  * Generate the CSS for custom typography.
+ *
+ * The editor override targets the root element as well as the wrapper: in the
+ * iframed canvas the font-family presets compute on the iframe's root element,
+ * which a wrapper-scoped rule cannot reach. html:root outweighs the compiled
+ * editor defaults, which land later in the canvas and would win a plain-:root
+ * tie on document order.
  */
 function newspack_custom_typography_css() {
 
@@ -24,6 +30,7 @@ function newspack_custom_typography_css() {
 		';
 
 		$editor_css_blocks .= '
+			html:root,
 			:root .editor-styles-wrapper {
 				--newspack-theme-font-heading: ' . wp_kses( $font_header, null ) . ';
 			}
@@ -38,6 +45,7 @@ function newspack_custom_typography_css() {
 		';
 
 		$editor_css_blocks .= '
+			html:root,
 			:root .editor-styles-wrapper {
 				--newspack-theme-font-body: ' . wp_kses( $font_body, null ) . ';
 			}
@@ -172,35 +180,89 @@ function newspack_font_stack( $primary_font, $fallback_id ) {
 }
 
 /**
+ * The theme's default font stacks, mirroring sass/variables-site/_fonts.scss.
+ *
+ * @return array Stacks keyed heading/body.
+ */
+function newspack_font_family_default_stacks() {
+	return array(
+		'heading' => '-apple-system,blinkmacsystemfont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif',
+		'body'    => 'georgia,garamond,"Times New Roman",serif',
+	);
+}
+
+/**
+ * Resolve the stack a Customizer font currently produces, falling back to the
+ * theme's default stack when no font is set.
+ *
+ * @param string $font_mod  Font theme mod name.
+ * @param string $stack_mod Fallback-stack theme mod name.
+ * @param string $default   Default stack when no font is set.
+ * @return string
+ */
+function newspack_font_family_resolved_stack( $font_mod, $stack_mod, $default ) {
+	$font = get_theme_mod( $font_mod, '' );
+	if ( ! $font ) {
+		return $default;
+	}
+	return newspack_font_stack( $font, get_theme_mod( $stack_mod, 'serif' ) );
+}
+
+/**
  * Register the Customizer fonts as editor font family presets.
  *
- * The values reference the theme's own CSS variables rather than resolved
- * stacks, so saved content tracks Customizer font changes with no re-save.
+ * The values reference the theme's own CSS variables so saved content tracks
+ * Customizer font changes with no re-save; the resolved stack rides along as
+ * the var() fallback for contexts that load no theme stylesheet (feeds, lite
+ * pages). Existing theme-origin presets are appended to, not replaced. With
+ * the Gutenberg plugin active the resolver passes WP_Theme_JSON_Data_Gutenberg,
+ * a sibling class rather than a subclass, so the parameter stays untyped.
  *
- * @param WP_Theme_JSON_Data|WP_Theme_JSON_Data_Gutenberg $theme_json Theme JSON data.
+ * @param WP_Theme_JSON_Data $theme_json Theme JSON data.
  * @return WP_Theme_JSON_Data
  */
 function newspack_font_family_presets( $theme_json ) {
+	$data     = $theme_json->get_data();
+	$families = $data['settings']['typography']['fontFamilies'] ?? array();
+	if ( isset( $families['theme'] ) ) {
+		$families = $families['theme'];
+	}
+
+	$defaults   = newspack_font_family_default_stacks();
+	$families[] = array(
+		'slug'       => 'newspack-header',
+		'name'       => _x( 'Header', 'font family name', 'newspack-theme' ),
+		'fontFamily' => 'var(--newspack-theme-font-heading,' . newspack_font_family_resolved_stack( 'font_header', 'font_header_stack', $defaults['heading'] ) . ')',
+	);
+	$families[] = array(
+		'slug'       => 'newspack-body',
+		'name'       => _x( 'Body', 'font family name', 'newspack-theme' ),
+		'fontFamily' => 'var(--newspack-theme-font-body,' . newspack_font_family_resolved_stack( 'font_body', 'font_body_stack', $defaults['body'] ) . ')',
+	);
+
 	return $theme_json->update_with(
 		array(
 			'version'  => 3,
 			'settings' => array(
 				'typography' => array(
-					'fontFamilies' => array(
-						array(
-							'slug'       => 'header',
-							'name'       => _x( 'Header', 'font family name', 'newspack-theme' ),
-							'fontFamily' => 'var(--newspack-theme-font-heading)',
-						),
-						array(
-							'slug'       => 'body',
-							'name'       => _x( 'Body', 'font family name', 'newspack-theme' ),
-							'fontFamily' => 'var(--newspack-theme-font-body)',
-						),
-					),
+					'fontFamilies' => $families,
 				),
 			),
 		)
 	);
 }
-add_filter( 'wp_theme_json_data_theme', 'newspack_font_family_presets' );
+add_filter( 'wp_theme_json_data_theme', 'newspack_font_family_presets', 10, 1 );
+
+/**
+ * Define the theme font variables in the editor's admin document, where the
+ * Font control renders its option previews; the canvas carries its own copy.
+ */
+function newspack_font_family_presets_editor_css() {
+	$defaults = newspack_font_family_default_stacks();
+	$css      = ':root{--newspack-theme-font-heading:' . wp_kses( newspack_font_family_resolved_stack( 'font_header', 'font_header_stack', $defaults['heading'] ), null ) . ';--newspack-theme-font-body:' . wp_kses( newspack_font_family_resolved_stack( 'font_body', 'font_body_stack', $defaults['body'] ), null ) . '}';
+
+	wp_register_style( 'newspack-font-family-presets', false, array(), wp_get_theme()->get( 'Version' ) );
+	wp_enqueue_style( 'newspack-font-family-presets' );
+	wp_add_inline_style( 'newspack-font-family-presets', $css );
+}
+add_action( 'enqueue_block_editor_assets', 'newspack_font_family_presets_editor_css' );

--- a/themes/newspack-theme/newspack-theme/inc/typography.php
+++ b/themes/newspack-theme/newspack-theme/inc/typography.php
@@ -168,44 +168,75 @@ function newspack_get_font_stacks_as_select_choices() {
 
 /**
  * Prepare a font-family definition with a primary font and fallbacks.
+ *
+ * Font names are stripped of CSS string and function delimiters — these values
+ * flow into inline styles and theme.json preset values, where the theme origin
+ * is never passed through core's insecure-property filtering. Generic family
+ * keywords stay unquoted so a stack always ends in a real generic.
  */
 function newspack_font_stack( $primary_font, $fallback_id ) {
-	$stacks = newspack_get_font_stacks();
-	$fonts  = isset( $stacks[ $fallback_id ] ) ? $stacks[ $fallback_id ]['fonts'] : array();
+	$stacks   = newspack_get_font_stacks();
+	$fonts    = isset( $stacks[ $fallback_id ] ) ? $stacks[ $fallback_id ]['fonts'] : array();
+	$generics = array( 'serif', 'sans-serif', 'monospace', 'cursive', 'fantasy', 'system-ui' );
 	array_unshift( $fonts, $primary_font );
 	foreach ( $fonts as &$font ) {
-		$font = '"' . $font . '"';
+		$font = str_replace( array( '"', "'", ';', '{', '}', '(', ')', '\\' ), '', $font );
+		if ( ! in_array( strtolower( $font ), $generics, true ) ) {
+			$font = '"' . $font . '"';
+		}
 	}
 	return implode( ',', $fonts );
 }
 
 /**
- * The theme's default font stacks, mirroring sass/variables-site/_fonts.scss.
+ * The current Header and Body font stacks: the Customizer font when set,
+ * otherwise the active theme's default, mirroring
+ * sass/variables-site/_fonts.scss and each style variation's overrides.
  *
  * @return array Stacks keyed heading/body.
  */
-function newspack_font_family_default_stacks() {
-	return array(
-		'heading' => '-apple-system,blinkmacsystemfont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif',
+function newspack_font_family_stacks() {
+	$system   = '-apple-system,blinkmacsystemfont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif';
+	$defaults = array(
+		'heading' => $system,
 		'body'    => 'georgia,garamond,"Times New Roman",serif',
 	);
-}
 
-/**
- * Resolve the stack a Customizer font currently produces, falling back to the
- * theme's default stack when no font is set.
- *
- * @param string $font_mod  Font theme mod name.
- * @param string $stack_mod Fallback-stack theme mod name.
- * @param string $default   Default stack when no font is set.
- * @return string
- */
-function newspack_font_family_resolved_stack( $font_mod, $stack_mod, $default ) {
-	$font = get_theme_mod( $font_mod, '' );
-	if ( ! $font ) {
-		return $default;
+	$variations = array(
+		'newspack-joseph'    => array(
+			'heading' => '"Old Standard TT",georgia,serif',
+			'body'    => '"EB Garamond",georgia,serif',
+		),
+		'newspack-katharine' => array(
+			'heading' => '"Barlow","Helvetica",sans-serif',
+			'body'    => '"Barlow","Helvetica",sans-serif',
+		),
+		'newspack-nelson'    => array(
+			'heading' => '"Montserrat","Helvetica",sans-serif',
+			'body'    => $system,
+		),
+		'newspack-sacha'     => array(
+			'heading' => '"IBM Plex Serif",georgia,serif',
+		),
+		'newspack-scott'     => array(
+			'heading' => '"Fira Sans Condensed","Helvetica",sans-serif',
+		),
+	);
+	if ( isset( $variations[ get_stylesheet() ] ) ) {
+		$defaults = array_merge( $defaults, $variations[ get_stylesheet() ] );
 	}
-	return newspack_font_stack( $font, get_theme_mod( $stack_mod, 'serif' ) );
+
+	$mods   = array(
+		'heading' => array( 'font_header', 'font_header_stack' ),
+		'body'    => array( 'font_body', 'font_body_stack' ),
+	);
+	$stacks = array();
+	foreach ( $mods as $key => $mod_names ) {
+		$font           = get_theme_mod( $mod_names[0], '' );
+		$stacks[ $key ] = $font ? newspack_font_stack( $font, get_theme_mod( $mod_names[1], 'serif' ) ) : $defaults[ $key ];
+	}
+
+	return $stacks;
 }
 
 /**
@@ -228,16 +259,16 @@ function newspack_font_family_presets( $theme_json ) {
 		$families = $families['theme'];
 	}
 
-	$defaults   = newspack_font_family_default_stacks();
+	$stacks     = newspack_font_family_stacks();
 	$families[] = array(
 		'slug'       => 'newspack-header',
 		'name'       => _x( 'Header', 'font family name', 'newspack-theme' ),
-		'fontFamily' => 'var(--newspack-theme-font-heading,' . newspack_font_family_resolved_stack( 'font_header', 'font_header_stack', $defaults['heading'] ) . ')',
+		'fontFamily' => 'var(--newspack-theme-font-heading,' . $stacks['heading'] . ')',
 	);
 	$families[] = array(
 		'slug'       => 'newspack-body',
 		'name'       => _x( 'Body', 'font family name', 'newspack-theme' ),
-		'fontFamily' => 'var(--newspack-theme-font-body,' . newspack_font_family_resolved_stack( 'font_body', 'font_body_stack', $defaults['body'] ) . ')',
+		'fontFamily' => 'var(--newspack-theme-font-body,' . $stacks['body'] . ')',
 	);
 
 	return $theme_json->update_with(
@@ -252,17 +283,3 @@ function newspack_font_family_presets( $theme_json ) {
 	);
 }
 add_filter( 'wp_theme_json_data_theme', 'newspack_font_family_presets', 10, 1 );
-
-/**
- * Define the theme font variables in the editor's admin document, where the
- * Font control renders its option previews; the canvas carries its own copy.
- */
-function newspack_font_family_presets_editor_css() {
-	$defaults = newspack_font_family_default_stacks();
-	$css      = ':root{--newspack-theme-font-heading:' . wp_kses( newspack_font_family_resolved_stack( 'font_header', 'font_header_stack', $defaults['heading'] ), null ) . ';--newspack-theme-font-body:' . wp_kses( newspack_font_family_resolved_stack( 'font_body', 'font_body_stack', $defaults['body'] ), null ) . '}';
-
-	wp_register_style( 'newspack-font-family-presets', false, array(), wp_get_theme()->get( 'Version' ) );
-	wp_enqueue_style( 'newspack-font-family-presets' );
-	wp_add_inline_style( 'newspack-font-family-presets', $css );
-}
-add_action( 'enqueue_block_editor_assets', 'newspack_font_family_presets_editor_css' );

--- a/themes/newspack-theme/newspack-theme/inc/typography.php
+++ b/themes/newspack-theme/newspack-theme/inc/typography.php
@@ -170,3 +170,37 @@ function newspack_font_stack( $primary_font, $fallback_id ) {
 	}
 	return implode( ',', $fonts );
 }
+
+/**
+ * Register the Customizer fonts as editor font family presets.
+ *
+ * The values reference the theme's own CSS variables rather than resolved
+ * stacks, so saved content tracks Customizer font changes with no re-save.
+ *
+ * @param WP_Theme_JSON_Data|WP_Theme_JSON_Data_Gutenberg $theme_json Theme JSON data.
+ * @return WP_Theme_JSON_Data
+ */
+function newspack_font_family_presets( $theme_json ) {
+	return $theme_json->update_with(
+		array(
+			'version'  => 3,
+			'settings' => array(
+				'typography' => array(
+					'fontFamilies' => array(
+						array(
+							'slug'       => 'header',
+							'name'       => _x( 'Header', 'font family name', 'newspack-theme' ),
+							'fontFamily' => 'var(--newspack-theme-font-heading)',
+						),
+						array(
+							'slug'       => 'body',
+							'name'       => _x( 'Body', 'font family name', 'newspack-theme' ),
+							'fontFamily' => 'var(--newspack-theme-font-body)',
+						),
+					),
+				),
+			),
+		)
+	);
+}
+add_filter( 'wp_theme_json_data_theme', 'newspack_font_family_presets' );

--- a/themes/newspack-theme/newspack-theme/inc/typography.php
+++ b/themes/newspack-theme/newspack-theme/inc/typography.php
@@ -25,14 +25,14 @@ function newspack_custom_typography_css() {
 	if ( get_theme_mod( 'font_header', '' ) ) {
 		$css_blocks .= '
 			:root {
-				--newspack-theme-font-heading: ' . wp_kses( $font_header, null ) . ';
+				--newspack-theme-font-heading: ' . $font_header . ';
 			}
 		';
 
 		$editor_css_blocks .= '
 			html:root,
 			:root .editor-styles-wrapper {
-				--newspack-theme-font-heading: ' . wp_kses( $font_header, null ) . ';
+				--newspack-theme-font-heading: ' . $font_header . ';
 			}
 		';
 	}
@@ -40,14 +40,14 @@ function newspack_custom_typography_css() {
 	if ( get_theme_mod( 'font_body', '' ) ) {
 		$css_blocks .= '
 			:root {
-				--newspack-theme-font-body: ' . wp_kses( $font_body, null ) . ';
+				--newspack-theme-font-body: ' . $font_body . ';
 			}
 		';
 
 		$editor_css_blocks .= '
 			html:root,
 			:root .editor-styles-wrapper {
-				--newspack-theme-font-body: ' . wp_kses( $font_body, null ) . ';
+				--newspack-theme-font-body: ' . $font_body . ';
 			}
 		';
 	}
@@ -174,14 +174,19 @@ function newspack_get_font_stacks_as_select_choices() {
  * are emitted as quoted CSS strings with string delimiters escaped and markup
  * and control characters removed. Generic family keywords stay unquoted so a
  * stack always ends in a real generic.
+ *
+ * @param string $primary_font Primary font name.
+ * @param string $fallback_id  Key of newspack_get_font_stacks(); unknown ids
+ *                             take the serif stack.
+ * @return string Comma-joined, pre-escaped CSS font-family list.
  */
 function newspack_font_stack( $primary_font, $fallback_id ) {
 	$stacks   = newspack_get_font_stacks();
-	$fonts    = isset( $stacks[ $fallback_id ] ) ? $stacks[ $fallback_id ]['fonts'] : array();
+	$fonts    = isset( $stacks[ $fallback_id ] ) ? $stacks[ $fallback_id ]['fonts'] : $stacks['serif']['fonts'];
 	$generics = array( 'serif', 'sans-serif', 'monospace', 'cursive', 'fantasy', 'system-ui' );
 	array_unshift( $fonts, $primary_font );
 	foreach ( $fonts as &$font ) {
-		$font = str_replace( array( "\n", "\r", "\t", '<', '>' ), '', stripslashes( $font ) );
+		$font = preg_replace( '/[\x00-\x1F\x7F<>]/', '', stripslashes( $font ) );
 		if ( ! in_array( strtolower( $font ), $generics, true ) ) {
 			$font = '"' . str_replace( array( '\\', '"' ), array( '\\\\', '\\"' ), $font ) . '"';
 		}
@@ -223,9 +228,8 @@ function newspack_font_family_stacks() {
 			'heading' => '"Fira Sans Condensed","Helvetica",sans-serif',
 		),
 	);
-	$slug = isset( $variations[ get_stylesheet() ] ) ? get_stylesheet() : get_template();
-	if ( isset( $variations[ $slug ] ) ) {
-		$defaults = array_merge( $defaults, $variations[ $slug ] );
+	if ( isset( $variations[ get_stylesheet() ] ) ) {
+		$defaults = array_merge( $defaults, $variations[ get_stylesheet() ] );
 	}
 
 	/**
@@ -233,7 +237,7 @@ function newspack_font_family_stacks() {
 	 *
 	 * @param array $defaults Stacks keyed heading/body.
 	 */
-	$defaults = apply_filters( 'newspack_font_family_default_stacks', $defaults );
+	$defaults = array_merge( $defaults, (array) apply_filters( 'newspack_font_family_default_stacks', $defaults ) );
 
 	$mods   = array(
 		'heading' => array( 'font_header', 'font_header_stack' ),

--- a/themes/newspack-theme/newspack-theme/inc/typography.php
+++ b/themes/newspack-theme/newspack-theme/inc/typography.php
@@ -175,6 +175,11 @@ function newspack_get_font_stacks_as_select_choices() {
  * and control characters removed. Generic family keywords stay unquoted so a
  * stack always ends in a real generic.
  *
+ * Mirrored by newspack-newsletters' test fixture at
+ * tests/email-renderers/fixtures/theme-font-functions.php, which stands in for
+ * this function when the theme is not loaded; changes to the escaping here need
+ * to be carried over there.
+ *
  * @param string $primary_font Primary font name.
  * @param string $fallback_id  Key of newspack_get_font_stacks(); unknown ids
  *                             take the serif stack.
@@ -191,6 +196,7 @@ function newspack_font_stack( $primary_font, $fallback_id ) {
 			$font = '"' . str_replace( array( '\\', '"' ), array( '\\\\', '\\"' ), $font ) . '"';
 		}
 	}
+	unset( $font );
 	return implode( ',', $fonts );
 }
 
@@ -258,10 +264,10 @@ function newspack_font_family_stacks() {
  * The values reference the theme's own CSS variables so saved content tracks
  * Customizer font changes with no re-save; the resolved stack rides along as
  * the var() fallback for feeds and other contexts that print global styles
- * without the theme stylesheet. Existing theme-origin presets are appended
- * to, not replaced. With
- * the Gutenberg plugin active the resolver passes WP_Theme_JSON_Data_Gutenberg,
- * a sibling class rather than a subclass, so the parameter stays untyped.
+ * without the theme stylesheet. Existing theme-origin presets are appended to,
+ * not replaced. With the Gutenberg plugin active the resolver passes
+ * WP_Theme_JSON_Data_Gutenberg, a sibling class rather than a subclass, so the
+ * parameter stays untyped.
  *
  * @param WP_Theme_JSON_Data|WP_Theme_JSON_Data_Gutenberg $theme_json Theme JSON data.
  * @return WP_Theme_JSON_Data|WP_Theme_JSON_Data_Gutenberg
@@ -269,6 +275,9 @@ function newspack_font_family_stacks() {
 function newspack_font_family_presets( $theme_json ) {
 	$data     = $theme_json->get_data();
 	$families = $data['settings']['typography']['fontFamilies'] ?? array();
+	// WP_Theme_JSON keys presets by origin internally, so a non-empty list comes
+	// back nested under 'theme'; appending to the nested array would double-nest
+	// it on the way back in and drop the existing presets.
 	if ( isset( $families['theme'] ) ) {
 		$families = $families['theme'];
 	}

--- a/themes/newspack-theme/newspack-theme/inc/typography.php
+++ b/themes/newspack-theme/newspack-theme/inc/typography.php
@@ -257,8 +257,9 @@ function newspack_font_family_stacks() {
  *
  * The values reference the theme's own CSS variables so saved content tracks
  * Customizer font changes with no re-save; the resolved stack rides along as
- * the var() fallback for contexts that load no theme stylesheet (feeds, lite
- * pages). Existing theme-origin presets are appended to, not replaced. With
+ * the var() fallback for feeds and other contexts that print global styles
+ * without the theme stylesheet. Existing theme-origin presets are appended
+ * to, not replaced. With
  * the Gutenberg plugin active the resolver passes WP_Theme_JSON_Data_Gutenberg,
  * a sibling class rather than a subclass, so the parameter stays untyped.
  *

--- a/themes/newspack-theme/newspack-theme/sass/variables-site/_fonts.scss
+++ b/themes/newspack-theme/newspack-theme/sass/variables-site/_fonts.scss
@@ -1,6 +1,7 @@
 // Font and typographic variables
 
 :root {
+	// Header and Body changes must be mirrored in newspack_font_family_stacks(), inc/typography.php.
 	--newspack-theme-font-body: georgia, garamond, "Times New Roman", serif;
 	--newspack-theme-font-heading:
 		-apple-system,

--- a/themes/newspack-theme/tests/functions-stubs.php
+++ b/themes/newspack-theme/tests/functions-stubs.php
@@ -93,7 +93,23 @@ function newspack_sanitize_svgs() {
 }
 /**
  * Gutenberg's sibling of WP_Theme_JSON_Data; only defined when the plugin is
- * active, so static analysis needs this stand-in.
+ * active, so static analysis needs this stand-in. Deliberately not extending
+ * the core class: the real one is a sibling, not a subclass.
  */
-class WP_Theme_JSON_Data_Gutenberg extends WP_Theme_JSON_Data {
+class WP_Theme_JSON_Data_Gutenberg {
+	/**
+	 * Return the underlying data.
+	 *
+	 * @return array
+	 */
+	public function get_data() {
+	}
+	/**
+	 * Merge new data into the object.
+	 *
+	 * @param array $new_data Data to merge.
+	 * @return WP_Theme_JSON_Data_Gutenberg
+	 */
+	public function update_with( $new_data ) {
+	}
 }

--- a/themes/newspack-theme/tests/functions-stubs.php
+++ b/themes/newspack-theme/tests/functions-stubs.php
@@ -91,3 +91,9 @@ function newspack_typography_css_wrap() {
  */
 function newspack_sanitize_svgs() {
 }
+/**
+ * Gutenberg's sibling of WP_Theme_JSON_Data; only defined when the plugin is
+ * active, so static analysis needs this stand-in.
+ */
+class WP_Theme_JSON_Data_Gutenberg extends WP_Theme_JSON_Data {
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The block editor's Font control never appears on the classic Newspack theme, so publishers cannot set a paragraph (or any other block) to the site's headline font without custom CSS. The control only shows when a theme registers font presets, and the classic theme has nowhere to do that without a `theme.json`.

This registers two presets, **Header** and **Body**, mirroring the Customizer's Header Font and Body Font settings. The Font control now offers them on every block that supports typography, in the base theme and all five style variations. The presets reference the theme's existing font variables rather than fixed font stacks, so changing a font in the Customizer updates any content using them, with no re-save.

![Before and after: the Typography panel without and with the Font control offering Header and Body](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/11/11enfpmx-font-families-before-after.png)

### How to test the changes in this Pull Request:

1. On a site running the Newspack classic theme, edit a post and select a paragraph.
2. Open the Typography panel's options menu and enable Font. A Font dropdown appears with Default, Header, and Body.
3. Choose Header. The paragraph switches to the header font in the editor.
4. Save and view the post. The paragraph renders in the header font on the front end.
5. In the Customizer, set a different Header Font. The paragraph follows it without editing the post.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? New tests n/a: the theme has no PHPUnit suite. Verified live on a dev site.
* [x] Have you successfully run tests with your changes locally? PHPCS clean; no test suite exists for the theme.

Core hides the Font control behind the Typography panel's options menu by default, on block themes too. Step 2 covers it here; worth a line in help docs when this ships.
