### PR TITLE
feat(blocks): reorder the content picked in Static mode (NPPD-946)

### DIFF
--- a/plugins/newspack-blocks/package.json
+++ b/plugins/newspack-blocks/package.json
@@ -44,6 +44,7 @@
 		"extends @wordpress/browserslist-config"
 	],
 	"dependencies": {
+		"@wordpress/ui": "^0.16.0",
 		"classnames": "^2.5.1",
 		"lodash": "^4.17.21",
 		"newspack-colors": "workspace:*",

--- a/plugins/newspack-blocks/src/components/autocomplete-tokenfield.js
+++ b/plugins/newspack-blocks/src/components/autocomplete-tokenfield.js
@@ -45,15 +45,18 @@ class AutocompleteTokenField extends Component {
 		if ( this.isFetchingInfoOnLoad() ) {
 			const { tokens, fetchSavedInfo } = this.props;
 
-			fetchSavedInfo( tokens ).then( results => {
-				const { validValues } = this.state;
+			fetchSavedInfo( tokens )
+				.then( results => {
+					const { validValues } = this.state;
 
-				results.forEach( suggestion => {
-					validValues[ suggestion.value ] = suggestion.label;
-				} );
+					results.forEach( suggestion => {
+						validValues[ suggestion.value ] = suggestion.label;
+					} );
 
-				this.setState( { validValues, loading: false } );
-			} );
+					this.setState( { validValues, loading: false } );
+				} )
+				// Without this the field spins forever when the request fails.
+				.catch( () => this.setState( { loading: false } ) );
 		}
 	}
 

--- a/plugins/newspack-blocks/src/components/autocomplete-tokenfield.js
+++ b/plugins/newspack-blocks/src/components/autocomplete-tokenfield.js
@@ -55,8 +55,17 @@ class AutocompleteTokenField extends Component {
 
 					this.setState( { validValues, loading: false } );
 				} )
-				// Without this the field spins forever when the request fails.
-				.catch( () => this.setState( { loading: false } ) );
+				.catch( () => {
+					// Without labels the field would render no tokens, and the next
+					// selection would then write back a list missing every saved ID.
+					const { validValues } = this.state;
+
+					tokens.forEach( token => {
+						validValues[ token ] = String( token );
+					} );
+
+					this.setState( { validValues, loading: false } );
+				} );
 		}
 	}
 

--- a/plugins/newspack-blocks/src/components/autocomplete-tokenfield.js
+++ b/plugins/newspack-blocks/src/components/autocomplete-tokenfield.js
@@ -55,7 +55,9 @@ class AutocompleteTokenField extends Component {
 
 					this.setState( { validValues, loading: false } );
 				} )
-				.catch( () => {
+				.catch( error => {
+					// eslint-disable-next-line no-console
+					console.error( 'Newspack Blocks: could not load the titles for the saved selection.', error );
 					// Without labels the field would render no tokens, and the next
 					// selection would then write back a list missing every saved ID.
 					const { validValues } = this.state;

--- a/plugins/newspack-blocks/src/components/autocomplete-tokenfield.scss
+++ b/plugins/newspack-blocks/src/components/autocomplete-tokenfield.scss
@@ -22,6 +22,6 @@
 	.autocomplete-tokenfield__help {
 		color: wp-colors.$gray-700;
 		font-size: 12px;
-		margin: 8px 0;
+		margin: 8px 0 0;
 	}
 }

--- a/plugins/newspack-blocks/src/components/autocomplete-tokenfield.test.js
+++ b/plugins/newspack-blocks/src/components/autocomplete-tokenfield.test.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import AutocompleteTokenField from './autocomplete-tokenfield';
+
+const noop = () => {};
+
+describe( 'AutocompleteTokenField when the saved titles cannot be loaded', () => {
+	let errorSpy;
+
+	beforeEach( () => {
+		errorSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		errorSpy.mockRestore();
+	} );
+
+	const renderField = () => {
+		const onChange = jest.fn();
+		render(
+			<AutocompleteTokenField
+				tokens={ [ 11, 22 ] }
+				onChange={ onChange }
+				fetchSuggestions={ noop }
+				fetchSavedInfo={ () => Promise.reject( new Error( 'unreachable' ) ) }
+				label="Content"
+			/>
+		);
+		return { onChange };
+	};
+
+	it( 'shows the IDs rather than dropping the saved selection', async () => {
+		renderField();
+		expect( await screen.findByText( '11' ) ).toBeInTheDocument();
+		expect( screen.getByText( '22' ) ).toBeInTheDocument();
+	} );
+
+	// The field looks settled once the spinner goes, so the console is the only
+	// trace left of why the titles turned into numbers.
+	it( 'leaves the cause in the console', async () => {
+		renderField();
+		await screen.findByText( '11' );
+		expect( errorSpy ).toHaveBeenCalledWith( expect.stringContaining( 'could not load the titles' ), expect.any( Error ) );
+	} );
+
+	it( 'keeps the remaining IDs when one token is removed', async () => {
+		const { onChange } = renderField();
+		await screen.findByText( '11' );
+		fireEvent.click( document.querySelectorAll( '.components-form-token-field__remove-token' )[ 0 ] );
+		expect( onChange ).toHaveBeenCalledWith( [ '22' ] );
+	} );
+} );

--- a/plugins/newspack-blocks/src/components/query-controls.js
+++ b/plugins/newspack-blocks/src/components/query-controls.js
@@ -54,7 +54,7 @@ class QueryControls extends Component {
 		return apiFetch( {
 			url: addQueryArgs( restUrl, {
 				// These params use the block query parameters (see Newspack_Blocks::build_articles_query).
-				postsToShow: 100,
+				postsToShow: Math.max( postIDs.length, 1 ),
 				include: postIDs.join( ',' ),
 				_fields: 'id,title',
 				postType,

--- a/plugins/newspack-blocks/src/components/query-controls.js
+++ b/plugins/newspack-blocks/src/components/query-controls.js
@@ -51,10 +51,15 @@ class QueryControls extends Component {
 	fetchSavedPosts = postIDs => {
 		const { postType } = this.props;
 		const restUrl = window.newspack_blocks_data.posts_rest_url;
+		// An empty `include` is dropped server-side, which would answer with the
+		// most recent post rather than nothing.
+		if ( ! postIDs.length ) {
+			return Promise.resolve( [] );
+		}
 		return apiFetch( {
 			url: addQueryArgs( restUrl, {
 				// These params use the block query parameters (see Newspack_Blocks::build_articles_query).
-				postsToShow: Math.max( postIDs.length, 1 ),
+				postsToShow: postIDs.length,
 				include: postIDs.join( ',' ),
 				_fields: 'id,title',
 				postType,

--- a/plugins/newspack-blocks/src/components/query-controls.js
+++ b/plugins/newspack-blocks/src/components/query-controls.js
@@ -22,6 +22,7 @@ import { decodeEntities } from '@wordpress/html-entities';
  * Internal dependencies.
  */
 import AutocompleteTokenField from './autocomplete-tokenfield';
+import SpecificPostsControl from './specific-posts-control';
 
 const getCategoryTitle = category => decodeEntities( category.name ) || __( '(no title)', 'newspack-blocks' );
 
@@ -307,13 +308,11 @@ class QueryControls extends Component {
 					</ToggleGroupControl>
 				) }
 				{ specificMode ? (
-					<AutocompleteTokenField
-						tokens={ specificPosts || [] }
+					<SpecificPostsControl
+						postIds={ specificPosts || [] }
 						onChange={ onSpecificPostsChange }
 						fetchSuggestions={ this.fetchPostSuggestions }
 						fetchSavedInfo={ this.fetchSavedPosts }
-						label={ __( 'Content', 'newspack-blocks' ) }
-						help={ __( 'Begin typing any word in a title. Click on an autocomplete result to select it.', 'newspack-blocks' ) }
 					/>
 				) : (
 					<>

--- a/plugins/newspack-blocks/src/components/query-controls.js
+++ b/plugins/newspack-blocks/src/components/query-controls.js
@@ -65,10 +65,28 @@ class QueryControls extends Component {
 				postType,
 			} ),
 		} ).then( function ( posts ) {
-			return posts.map( post => ( {
+			const allPosts = posts.map( post => ( {
 				value: post.id,
 				label: decodeEntities( post.title.rendered ) || __( '(no title)', 'newspack-blocks' ),
 			} ) );
+			// An ID the endpoint did not return still needs an entry, or the token
+			// field drops it from the block on the next edit. The ID goes in the
+			// label because labels are matched back to IDs, and a shared label
+			// would collapse two items onto one.
+			postIDs.forEach( postID => {
+				const id = parseInt( postID );
+				if ( ! allPosts.find( post => post.value === id ) ) {
+					allPosts.push( {
+						value: id,
+						label: sprintf(
+							/* translators: %d: numeric ID of content that could not be found. */
+							__( 'Unavailable content (%d)', 'newspack-blocks' ),
+							id
+						),
+					} );
+				}
+			} );
+			return allPosts;
 		} );
 	};
 

--- a/plugins/newspack-blocks/src/components/query-controls.test.js
+++ b/plugins/newspack-blocks/src/components/query-controls.test.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import QueryControls from './query-controls';
+
+jest.mock( '@wordpress/api-fetch' );
+
+const fetchSavedPosts = ( postIDs, posts ) => {
+	apiFetch.mockResolvedValue( posts );
+	return new QueryControls( { postType: 'post' } ).fetchSavedPosts( postIDs );
+};
+
+describe( 'fetchSavedPosts', () => {
+	beforeAll( () => {
+		window.newspack_blocks_data = { posts_rest_url: 'https://example.test/wp-json/newspack-blocks/v1/newspack-blocks-posts' };
+	} );
+
+	beforeEach( () => {
+		apiFetch.mockClear();
+	} );
+
+	it( 'labels the content the endpoint returned', async () => {
+		await expect( fetchSavedPosts( [ 11 ], [ { id: 11, title: { rendered: 'Alpha' } } ] ) ).resolves.toEqual( [ { value: 11, label: 'Alpha' } ] );
+	} );
+
+	// Without an entry the token field renders no token for the ID, and the next
+	// selection writes the attribute back without it.
+	it( 'keeps an entry for an ID the endpoint did not return', async () => {
+		await expect( fetchSavedPosts( [ 11, 22 ], [ { id: 11, title: { rendered: 'Alpha' } } ] ) ).resolves.toEqual( [
+			{ value: 11, label: 'Alpha' },
+			{ value: 22, label: 'Unavailable content (22)' },
+		] );
+	} );
+
+	// A label is matched back to its ID, so two unavailable items sharing one
+	// would collapse onto a single ID.
+	it( 'tells two unavailable IDs apart', async () => {
+		const posts = await fetchSavedPosts( [ 22, 33 ], [] );
+		expect( posts.map( post => post.label ) ).toEqual( [ 'Unavailable content (22)', 'Unavailable content (33)' ] );
+	} );
+
+	it( 'still marks the content unavailable when the title is empty', async () => {
+		const posts = await fetchSavedPosts( [ 11, 22 ], [ { id: 11, title: { rendered: '' } } ] );
+		expect( posts.map( post => post.label ) ).toEqual( [ '(no title)', 'Unavailable content (22)' ] );
+	} );
+
+	it( 'asks for nothing when nothing is saved', async () => {
+		await expect( fetchSavedPosts( [], [] ) ).resolves.toEqual( [] );
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+} );

--- a/plugins/newspack-blocks/src/components/reorder-modal.js
+++ b/plugins/newspack-blocks/src/components/reorder-modal.js
@@ -38,7 +38,19 @@ export const moveItem = ( items, from, to ) => {
 // than the native attribute.
 const isAvailable = button => !! button && ! button.matches( ':disabled, [aria-disabled="true"]' );
 
+// Speech input matches on the visible label, so it has to open the accessible
+// name. Composing both from one translated string keeps that true in every locale.
+const nameWithTitle = ( label, title ) =>
+	sprintf(
+		/* translators: 1: the control's visible label. 2: title of the content being moved. */
+		__( '%1$s: %2$s', 'newspack-blocks' ),
+		label,
+		title
+	);
+
 const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
+	const moveUpLabel = __( 'Move Up', 'newspack-blocks' );
+	const moveDownLabel = __( 'Move Down', 'newspack-blocks' );
 	const [ items, setItems ] = useState( null );
 	const [ dragIndex, setDragIndex ] = useState( null );
 	const [ hasFetchError, setHasFetchError ] = useState( false );
@@ -48,6 +60,7 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 	const pendingFocus = useRef( null );
 	const closeRef = useRef( null );
 	const preDragItems = useRef( null );
+	const dragBlocked = useRef( false );
 
 	// The order the modal opened with. Snapshotted so a change to `ids` from
 	// elsewhere in the editor cannot desynchronise it from `items`.
@@ -200,18 +213,33 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 				size="medium"
 				className="newspack-blocks-reorder-modal"
 			>
-				<div className="newspack-blocks-reorder-modal__body">
-					{ ! items ? (
+				<div
+					className="newspack-blocks-reorder-modal__body"
+					aria-busy={ ! items }
+					// Rows are the only drop targets, so without this every gap between
+					// them reports a cancelled drag and would undo the reorder.
+					onDragOver={ event => event.preventDefault() }
+					onDrop={ event => event.preventDefault() }
+				>
+					{ ! items && (
 						<div className="newspack-blocks-reorder-modal__loading">
 							<Spinner />
 						</div>
-					) : (
+					) }
+					{ items && hasFetchError && (
 						<>
-							{ hasFetchError && (
-								<Notice status="error" isDismissible={ false } className="newspack-blocks-reorder-modal__notice">
-									{ __( 'The content could not be loaded, so the order cannot be saved.', 'newspack-blocks' ) }
-								</Notice>
-							) }
+							<Notice status="error" isDismissible={ false } className="newspack-blocks-reorder-modal__notice">
+								{ __( 'The content could not be loaded, so the order cannot be saved.', 'newspack-blocks' ) }
+							</Notice>
+							<div className="newspack-blocks-reorder-modal__footer">
+								<Button variant="tertiary" onClick={ requestClose }>
+									{ __( 'Cancel', 'newspack-blocks' ) }
+								</Button>
+							</div>
+						</>
+					) }
+					{ items && ! hasFetchError && (
+						<>
 							{ /* `list-style: none` drops list semantics in Safari, so the role is restated. */ }
 							{ /* eslint-disable-next-line jsx-a11y/no-redundant-roles */ }
 							<ul className="newspack-blocks-reorder-modal__list" role="list" ref={ listRef }>
@@ -224,10 +252,13 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 											'is-dragging': dragIndex === index,
 										} ) }
 										draggable
+										// `dragstart` always fires at the draggable row, never at the
+										// chevron inside it, so the grab point is recorded separately.
+										onPointerDown={ event => {
+											dragBlocked.current = !! event.target.closest?.( 'button' );
+										} }
 										onDragStart={ event => {
-											// The chevrons live inside the drag source, so a click that
-											// drifts would otherwise drag the row instead of stepping it.
-											if ( event.target.closest?.( 'button' ) ) {
+											if ( dragBlocked.current ) {
 												event.preventDefault();
 												return;
 											}
@@ -258,14 +289,8 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 												data-direction="up"
 												disabled={ 0 === index }
 												accessibleWhenDisabled
-												label={ __( 'Move Up', 'newspack-blocks' ) }
-												// The visible label has to stay a substring of the
-												// accessible name so speech input can reach it.
-												aria-label={ sprintf(
-													/* translators: %s: title of the content being moved. */
-													__( 'Move Up: %s', 'newspack-blocks' ),
-													item.label
-												) }
+												label={ moveUpLabel }
+												aria-label={ nameWithTitle( moveUpLabel, item.label ) }
 												onClick={ () => moveTo( index, index - 1, 'up' ) }
 											/>
 											<Button
@@ -274,12 +299,8 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 												data-direction="down"
 												disabled={ index === items.length - 1 }
 												accessibleWhenDisabled
-												label={ __( 'Move Down', 'newspack-blocks' ) }
-												aria-label={ sprintf(
-													/* translators: %s: title of the content being moved. */
-													__( 'Move Down: %s', 'newspack-blocks' ),
-													item.label
-												) }
+												label={ moveDownLabel }
+												aria-label={ nameWithTitle( moveDownLabel, item.label ) }
 												onClick={ () => moveTo( index, index + 1, 'down' ) }
 											/>
 										</span>

--- a/plugins/newspack-blocks/src/components/reorder-modal.js
+++ b/plugins/newspack-blocks/src/components/reorder-modal.js
@@ -1,0 +1,292 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
+import { useEffect, useRef, useState } from '@wordpress/element';
+import {
+	Button,
+	Modal,
+	Spinner,
+	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
+import { Icon, chevronDown, chevronUp, close, dragHandle } from '@wordpress/icons';
+import { Card } from '@wordpress/ui';
+
+/**
+ * Internal dependencies
+ */
+import './reorder-modal.scss';
+
+export const moveItem = ( items, from, to ) => {
+	if ( from === to || from < 0 || to < 0 || from >= items.length || to >= items.length ) {
+		return items;
+	}
+	const next = [ ...items ];
+	const [ moved ] = next.splice( from, 1 );
+	next.splice( to, 0, moved );
+	return next;
+};
+
+// Disabled controls stay focusable here, so they report `aria-disabled` rather
+// than the native attribute.
+const isAvailable = button => !! button && ! button.matches( ':disabled, [aria-disabled="true"]' );
+
+const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
+	const [ items, setItems ] = useState( null );
+	const [ dragIndex, setDragIndex ] = useState( null );
+	const [ isConfirmingDiscard, setIsConfirmingDiscard ] = useState( false );
+	const listRef = useRef( null );
+	const overlayRef = useRef( null );
+	const pendingFocus = useRef( null );
+	const closeRef = useRef( null );
+
+	// `ids` is the order the modal opened with: it remounts on every open.
+	const isDirty = !! items && items.some( ( item, index ) => item.id !== ids[ index ] );
+
+	useEffect( () => {
+		let cancelled = false;
+		const withLabels = labels => ids.map( id => ( { id, label: labels[ id ] || __( '(no title)', 'newspack-blocks' ) } ) );
+
+		fetchItems( ids )
+			.then( results => {
+				if ( cancelled ) {
+					return;
+				}
+				const labels = {};
+				results.forEach( ( { value, label } ) => {
+					labels[ value ] = label;
+				} );
+				setItems( withLabels( labels ) );
+			} )
+			.catch( error => {
+				// eslint-disable-next-line no-console
+				console.error( 'Newspack Blocks: could not prepare the content to reorder.', error );
+				if ( ! cancelled ) {
+					setItems( withLabels( {} ) );
+				}
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+	// A chevron that reaches an end of the list stops accepting moves, so send
+	// focus to the row's other chevron.
+	useEffect( () => {
+		const pending = pendingFocus.current;
+		pendingFocus.current = null;
+		if ( ! pending || ! listRef.current ) {
+			return;
+		}
+		const row = listRef.current.querySelector( `[data-item-id="${ pending.id }"]` );
+		if ( ! row ) {
+			return;
+		}
+		const preferred = row.querySelector( `[data-direction="${ pending.direction }"]` );
+		const fallback = row.querySelector( `[data-direction="${ 'up' === pending.direction ? 'down' : 'up' }"]` );
+		if ( isAvailable( preferred ) ) {
+			preferred.focus();
+		} else if ( isAvailable( fallback ) ) {
+			fallback.focus();
+		}
+	}, [ items ] );
+
+	const moveTo = ( from, to, direction ) => {
+		const next = moveItem( items, from, to );
+		if ( next === items ) {
+			return;
+		}
+		pendingFocus.current = { id: items[ from ].id, direction };
+		setItems( next );
+		speak(
+			sprintf(
+				/* translators: 1: new position of the moved item. 2: total number of items. */
+				__( 'Moved to position %1$d of %2$d.', 'newspack-blocks' ),
+				to + 1,
+				items.length
+			)
+		);
+	};
+
+	const requestClose = () => {
+		if ( isDirty ) {
+			setIsConfirmingDiscard( true );
+			return;
+		}
+		onClose();
+	};
+
+	useEffect( () => {
+		closeRef.current = requestClose;
+	}, [ requestClose ] );
+
+	const handleKeyDown = event => {
+		if ( 'Escape' !== event.key || event.defaultPrevented ) {
+			return;
+		}
+		event.preventDefault();
+		requestClose();
+	};
+
+	// `Modal` plays its exit animation before it reports a close request, which
+	// would fade the modal out and back in whenever the confirmation vetoes one.
+	// Its own dismissal handlers are off, so drive the overlay press here.
+	useEffect( () => {
+		const overlay = overlayRef.current;
+		if ( ! overlay ) {
+			return;
+		}
+		let pressedOverlay = false;
+		const onPointerDown = event => {
+			pressedOverlay = event.target === overlay;
+			if ( pressedOverlay ) {
+				event.preventDefault();
+			}
+		};
+		const onPointerUp = event => {
+			const dismisses = pressedOverlay && 0 === event.button && event.target === overlay;
+			pressedOverlay = false;
+			if ( dismisses ) {
+				closeRef.current();
+			}
+		};
+		overlay.addEventListener( 'pointerdown', onPointerDown );
+		overlay.addEventListener( 'pointerup', onPointerUp );
+		return () => {
+			overlay.removeEventListener( 'pointerdown', onPointerDown );
+			overlay.removeEventListener( 'pointerup', onPointerUp );
+		};
+	}, [] );
+
+	const handleDragOver = ( event, index ) => {
+		event.preventDefault();
+		if ( null === dragIndex ) {
+			return;
+		}
+		event.dataTransfer.dropEffect = 'move';
+		if ( dragIndex === index ) {
+			return;
+		}
+		setItems( moveItem( items, dragIndex, index ) );
+		setDragIndex( index );
+	};
+
+	return (
+		<>
+			<Modal
+				ref={ overlayRef }
+				title={ title }
+				onRequestClose={ requestClose }
+				onKeyDown={ handleKeyDown }
+				isDismissible={ false }
+				shouldCloseOnEsc={ false }
+				shouldCloseOnClickOutside={ false }
+				headerActions={ <Button size="compact" icon={ close } label={ __( 'Close', 'newspack-blocks' ) } onClick={ requestClose } /> }
+				size="medium"
+				className="newspack-blocks-reorder-modal"
+			>
+				<div className="newspack-blocks-reorder-modal__body">
+					{ ! items ? (
+						<div className="newspack-blocks-reorder-modal__loading">
+							<Spinner />
+						</div>
+					) : (
+						<>
+							<ul className="newspack-blocks-reorder-modal__list" ref={ listRef }>
+								{ items.map( ( item, index ) => (
+									<Card.Root
+										key={ item.id }
+										render={ <li /> }
+										data-item-id={ item.id }
+										className={ classnames( 'newspack-blocks-reorder-modal__item', {
+											'is-dragging': dragIndex === index,
+										} ) }
+										draggable
+										// Firefox and Safari will not start a drag until the payload is set.
+										onDragStart={ event => {
+											event.dataTransfer.setData( 'text/plain', String( item.id ) );
+											event.dataTransfer.effectAllowed = 'move';
+											setDragIndex( index );
+										} }
+										onDragOver={ event => handleDragOver( event, index ) }
+										onDragEnd={ () => setDragIndex( null ) }
+										onDrop={ event => event.preventDefault() }
+									>
+										<span className="newspack-blocks-reorder-modal__grip" aria-hidden="true">
+											<Icon icon={ dragHandle } />
+										</span>
+										<span className="newspack-blocks-reorder-modal__move">
+											<Button
+												icon={ chevronUp }
+												size="small"
+												data-direction="up"
+												disabled={ 0 === index }
+												accessibleWhenDisabled
+												label={ __( 'Move Up', 'newspack-blocks' ) }
+												aria-label={ sprintf(
+													/* translators: %s: title of the content being moved. */
+													__( 'Move "%s" up', 'newspack-blocks' ),
+													item.label
+												) }
+												onClick={ () => moveTo( index, index - 1, 'up' ) }
+											/>
+											<Button
+												icon={ chevronDown }
+												size="small"
+												data-direction="down"
+												disabled={ index === items.length - 1 }
+												accessibleWhenDisabled
+												label={ __( 'Move Down', 'newspack-blocks' ) }
+												aria-label={ sprintf(
+													/* translators: %s: title of the content being moved. */
+													__( 'Move "%s" down', 'newspack-blocks' ),
+													item.label
+												) }
+												onClick={ () => moveTo( index, index + 1, 'down' ) }
+											/>
+										</span>
+										<Card.Content className="newspack-blocks-reorder-modal__title">{ item.label }</Card.Content>
+									</Card.Root>
+								) ) }
+							</ul>
+							<div className="newspack-blocks-reorder-modal__footer">
+								<Button variant="tertiary" onClick={ requestClose }>
+									{ __( 'Cancel', 'newspack-blocks' ) }
+								</Button>
+								<Button
+									variant="primary"
+									disabled={ ! isDirty }
+									accessibleWhenDisabled
+									onClick={ () => onSave( items.map( item => item.id ) ) }
+								>
+									{ __( 'Save', 'newspack-blocks' ) }
+								</Button>
+							</div>
+						</>
+					) }
+				</div>
+			</Modal>
+			{ isConfirmingDiscard && (
+				<ConfirmDialog
+					isOpen
+					contentLabel={ __( 'Discard the new order?', 'newspack-blocks' ) }
+					confirmButtonText={ __( 'Discard', 'newspack-blocks' ) }
+					cancelButtonText={ __( 'Keep editing', 'newspack-blocks' ) }
+					onConfirm={ onClose }
+					onCancel={ () => setIsConfirmingDiscard( false ) }
+				>
+					{ __( 'Discard the new order?', 'newspack-blocks' ) }
+				</ConfirmDialog>
+			) }
+		</>
+	);
+};
+
+export default ReorderModal;

--- a/plugins/newspack-blocks/src/components/reorder-modal.js
+++ b/plugins/newspack-blocks/src/components/reorder-modal.js
@@ -89,7 +89,8 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 				console.error( 'Newspack Blocks: could not prepare the content to reorder.', error );
 				if ( ! cancelled ) {
 					setHasFetchError( true );
-					setItems( withLabels( {} ) );
+					// Only to leave the loading state: the error view lists nothing.
+					setItems( [] );
 				}
 			} );
 

--- a/plugins/newspack-blocks/src/components/reorder-modal.js
+++ b/plugins/newspack-blocks/src/components/reorder-modal.js
@@ -12,6 +12,7 @@ import { useEffect, useRef, useState } from '@wordpress/element';
 import {
 	Button,
 	Modal,
+	Notice,
 	Spinner,
 	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
@@ -40,20 +41,26 @@ const isAvailable = button => !! button && ! button.matches( ':disabled, [aria-d
 const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 	const [ items, setItems ] = useState( null );
 	const [ dragIndex, setDragIndex ] = useState( null );
+	const [ hasFetchError, setHasFetchError ] = useState( false );
 	const [ isConfirmingDiscard, setIsConfirmingDiscard ] = useState( false );
 	const listRef = useRef( null );
 	const overlayRef = useRef( null );
 	const pendingFocus = useRef( null );
 	const closeRef = useRef( null );
+	const preDragItems = useRef( null );
 
-	// `ids` is the order the modal opened with: it remounts on every open.
-	const isDirty = !! items && items.some( ( item, index ) => item.id !== ids[ index ] );
+	// The order the modal opened with. Snapshotted so a change to `ids` from
+	// elsewhere in the editor cannot desynchronise it from `items`.
+	const openedWith = useRef( ids );
+
+	const isDirty = !! items && items.some( ( item, index ) => item.id !== openedWith.current[ index ] );
 
 	useEffect( () => {
 		let cancelled = false;
-		const withLabels = labels => ids.map( id => ( { id, label: labels[ id ] || __( '(no title)', 'newspack-blocks' ) } ) );
+		const openIds = openedWith.current;
+		const withLabels = labels => openIds.map( id => ( { id, label: labels[ id ] || __( '(no title)', 'newspack-blocks' ) } ) );
 
-		fetchItems( ids )
+		fetchItems( openIds )
 			.then( results => {
 				if ( cancelled ) {
 					return;
@@ -68,6 +75,7 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 				// eslint-disable-next-line no-console
 				console.error( 'Newspack Blocks: could not prepare the content to reorder.', error );
 				if ( ! cancelled ) {
+					setHasFetchError( true );
 					setItems( withLabels( {} ) );
 				}
 			} );
@@ -199,7 +207,14 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 						</div>
 					) : (
 						<>
-							<ul className="newspack-blocks-reorder-modal__list" ref={ listRef }>
+							{ hasFetchError && (
+								<Notice status="error" isDismissible={ false } className="newspack-blocks-reorder-modal__notice">
+									{ __( 'The content could not be loaded, so the order cannot be saved.', 'newspack-blocks' ) }
+								</Notice>
+							) }
+							{ /* `list-style: none` drops list semantics in Safari, so the role is restated. */ }
+							{ /* eslint-disable-next-line jsx-a11y/no-redundant-roles */ }
+							<ul className="newspack-blocks-reorder-modal__list" role="list" ref={ listRef }>
 								{ items.map( ( item, index ) => (
 									<Card.Root
 										key={ item.id }
@@ -209,14 +224,28 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 											'is-dragging': dragIndex === index,
 										} ) }
 										draggable
-										// Firefox and Safari will not start a drag until the payload is set.
 										onDragStart={ event => {
+											// The chevrons live inside the drag source, so a click that
+											// drifts would otherwise drag the row instead of stepping it.
+											if ( event.target.closest?.( 'button' ) ) {
+												event.preventDefault();
+												return;
+											}
+											preDragItems.current = items;
+											// Firefox and Safari will not start a drag until the payload is set.
 											event.dataTransfer.setData( 'text/plain', String( item.id ) );
 											event.dataTransfer.effectAllowed = 'move';
 											setDragIndex( index );
 										} }
 										onDragOver={ event => handleDragOver( event, index ) }
-										onDragEnd={ () => setDragIndex( null ) }
+										onDragEnd={ event => {
+											// A cancelled drag reports no drop effect: put the order back.
+											if ( 'none' === event.dataTransfer.dropEffect && preDragItems.current ) {
+												setItems( preDragItems.current );
+											}
+											preDragItems.current = null;
+											setDragIndex( null );
+										} }
 										onDrop={ event => event.preventDefault() }
 									>
 										<span className="newspack-blocks-reorder-modal__grip" aria-hidden="true">
@@ -230,9 +259,11 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 												disabled={ 0 === index }
 												accessibleWhenDisabled
 												label={ __( 'Move Up', 'newspack-blocks' ) }
+												// The visible label has to stay a substring of the
+												// accessible name so speech input can reach it.
 												aria-label={ sprintf(
 													/* translators: %s: title of the content being moved. */
-													__( 'Move "%s" up', 'newspack-blocks' ),
+													__( 'Move Up: %s', 'newspack-blocks' ),
 													item.label
 												) }
 												onClick={ () => moveTo( index, index - 1, 'up' ) }
@@ -246,13 +277,15 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 												label={ __( 'Move Down', 'newspack-blocks' ) }
 												aria-label={ sprintf(
 													/* translators: %s: title of the content being moved. */
-													__( 'Move "%s" down', 'newspack-blocks' ),
+													__( 'Move Down: %s', 'newspack-blocks' ),
 													item.label
 												) }
 												onClick={ () => moveTo( index, index + 1, 'down' ) }
 											/>
 										</span>
-										<Card.Content className="newspack-blocks-reorder-modal__title">{ item.label }</Card.Content>
+										<Card.Content className="newspack-blocks-reorder-modal__title" title={ item.label }>
+											{ item.label }
+										</Card.Content>
 									</Card.Root>
 								) ) }
 							</ul>
@@ -262,7 +295,7 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 								</Button>
 								<Button
 									variant="primary"
-									disabled={ ! isDirty }
+									disabled={ ! isDirty || hasFetchError }
 									accessibleWhenDisabled
 									onClick={ () => onSave( items.map( item => item.id ) ) }
 								>

--- a/plugins/newspack-blocks/src/components/reorder-modal.js
+++ b/plugins/newspack-blocks/src/components/reorder-modal.js
@@ -42,7 +42,7 @@ const isAvailable = button => !! button && ! button.matches( ':disabled, [aria-d
 // name. Composing both from one translated string keeps that true in every locale.
 const nameWithTitle = ( label, title ) =>
 	sprintf(
-		/* translators: 1: the control's visible label. 2: title of the content being moved. */
+		/* translators: keep %1$s first: it repeats the button's visible label, which speech input matches on. 1: the control's visible label. 2: title of the content being moved. */
 		__( '%1$s: %2$s', 'newspack-blocks' ),
 		label,
 		title
@@ -186,6 +186,24 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 		};
 	}, [] );
 
+	// Rows are the only drop targets, and the frame's own padding is not one, so a
+	// release a few pixels wide of the list would report a cancelled drag and undo
+	// the reorder. Accepting the drop across the whole dialog leaves "cancelled"
+	// meaning only Escape or a release outside it.
+	useEffect( () => {
+		const frame = overlayRef.current?.querySelector( '.components-modal__frame' );
+		if ( ! frame ) {
+			return;
+		}
+		const accept = event => event.preventDefault();
+		frame.addEventListener( 'dragover', accept );
+		frame.addEventListener( 'drop', accept );
+		return () => {
+			frame.removeEventListener( 'dragover', accept );
+			frame.removeEventListener( 'drop', accept );
+		};
+	}, [] );
+
 	const handleDragOver = ( event, index ) => {
 		event.preventDefault();
 		if ( null === dragIndex ) {
@@ -213,14 +231,7 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 				size="medium"
 				className="newspack-blocks-reorder-modal"
 			>
-				<div
-					className="newspack-blocks-reorder-modal__body"
-					aria-busy={ ! items }
-					// Rows are the only drop targets, so without this every gap between
-					// them reports a cancelled drag and would undo the reorder.
-					onDragOver={ event => event.preventDefault() }
-					onDrop={ event => event.preventDefault() }
-				>
+				<div className="newspack-blocks-reorder-modal__body" aria-busy={ ! items }>
 					{ ! items && (
 						<div className="newspack-blocks-reorder-modal__loading">
 							<Spinner />

--- a/plugins/newspack-blocks/src/components/reorder-modal.js
+++ b/plugins/newspack-blocks/src/components/reorder-modal.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import {
@@ -96,7 +96,15 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 				results.forEach( ( { value, label } ) => {
 					labels[ value ] = label;
 				} );
-				setItems( withLabels( labels ) );
+				const loaded = withLabels( labels );
+				setItems( loaded );
+				speak(
+					sprintf(
+						/* translators: %d: number of items in the list. */
+						_n( '%d item ready to reorder.', '%d items ready to reorder.', loaded.length, 'newspack-blocks' ),
+						loaded.length
+					)
+				);
 			} )
 			.catch( error => {
 				// eslint-disable-next-line no-console
@@ -143,8 +151,9 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 		setItems( next );
 		speak(
 			sprintf(
-				/* translators: 1: new position of the moved item. 2: total number of items. */
-				__( 'Moved to position %1$d of %2$d.', 'newspack-blocks' ),
+				/* translators: 1: title of the moved item. 2: its new position. 3: total number of items. */
+				__( '%1$s moved to position %2$d of %3$d.', 'newspack-blocks' ),
+				items[ from ].label,
 				to + 1,
 				items.length
 			)
@@ -250,6 +259,7 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 					{ ! items && (
 						<div className="newspack-blocks-reorder-modal__loading">
 							<Spinner />
+							<span className="screen-reader-text">{ __( 'Loading content…', 'newspack-blocks' ) }</span>
 						</div>
 					) }
 					{ items && hasFetchError && (

--- a/plugins/newspack-blocks/src/components/reorder-modal.js
+++ b/plugins/newspack-blocks/src/components/reorder-modal.js
@@ -352,7 +352,7 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 								</Button>
 								<Button
 									variant="primary"
-									disabled={ ! isDirty || hasFetchError }
+									disabled={ ! isDirty }
 									accessibleWhenDisabled
 									onClick={ () => onSave( items.map( item => item.id ) ) }
 								>

--- a/plugins/newspack-blocks/src/components/reorder-modal.js
+++ b/plugins/newspack-blocks/src/components/reorder-modal.js
@@ -372,7 +372,7 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 					onConfirm={ onClose }
 					onCancel={ () => setIsConfirmingDiscard( false ) }
 				>
-					{ __( 'Discard the new order?', 'newspack-blocks' ) }
+					{ __( 'The order you set will be lost.', 'newspack-blocks' ) }
 				</ConfirmDialog>
 			) }
 		</>

--- a/plugins/newspack-blocks/src/components/reorder-modal.js
+++ b/plugins/newspack-blocks/src/components/reorder-modal.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import {
 	Button,
 	Modal,
@@ -33,6 +33,17 @@ export const moveItem = ( items, from, to ) => {
 	next.splice( to, 0, moved );
 	return next;
 };
+
+const OVERLAY_SELECTOR = '.components-modal__screen-overlay';
+
+// The overlay carries the dismissal handling and the drop target, and `Modal`
+// forwards its ref to it today. Deriving it from whatever node arrives keeps
+// both working if core ever forwards that ref somewhere else.
+export const findOverlay = node =>
+	node?.closest?.( OVERLAY_SELECTOR ) ||
+	node?.querySelector?.( OVERLAY_SELECTOR ) ||
+	node?.ownerDocument?.querySelector( OVERLAY_SELECTOR ) ||
+	null;
 
 // Disabled controls stay focusable here, so they report `aria-disabled` rather
 // than the native attribute.
@@ -61,6 +72,9 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 	const closeRef = useRef( null );
 	const preDragItems = useRef( null );
 	const dragBlocked = useRef( false );
+	const captureOverlay = useCallback( node => {
+		overlayRef.current = findOverlay( node );
+	}, [] );
 
 	// The order the modal opened with. Snapshotted so a change to `ids` from
 	// elsewhere in the editor cannot desynchronise it from `items`.
@@ -221,7 +235,7 @@ const ReorderModal = ( { title, ids, fetchItems, onSave, onClose } ) => {
 	return (
 		<>
 			<Modal
-				ref={ overlayRef }
+				ref={ captureOverlay }
 				title={ title }
 				onRequestClose={ requestClose }
 				onKeyDown={ handleKeyDown }

--- a/plugins/newspack-blocks/src/components/reorder-modal.scss
+++ b/plugins/newspack-blocks/src/components/reorder-modal.scss
@@ -1,0 +1,82 @@
+@use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/mixins" as wp-mixins;
+@use "~@wordpress/base-styles/variables" as wp-vars;
+
+.newspack-blocks-reorder-modal {
+	&__body {
+		display: flex;
+		flex-direction: column;
+		min-height: calc(#{wp-vars.$grid-unit} * 23);
+	}
+
+	&__loading {
+		align-items: center;
+		display: flex;
+		flex: 1;
+		justify-content: center;
+	}
+
+	&__list {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	&__item {
+		--newspack-blocks-reorder-divider: #{wp-colors.$gray-100};
+		--wp-ui-card-padding: 12px;
+
+		align-items: stretch;
+		cursor: grab;
+		flex-direction: row;
+		margin: 0;
+
+		&:focus-within,
+		&:hover {
+			--newspack-blocks-reorder-divider: #{wp-colors.$gray-300};
+
+			border-color: wp-colors.$gray-300;
+		}
+
+		&.is-dragging {
+			opacity: 0.5;
+		}
+	}
+
+	&__grip {
+		align-items: center;
+		color: wp-colors.$gray-700;
+		display: flex;
+		padding-left: 4px;
+	}
+
+	&__move {
+		align-items: center;
+		border-right: 1px solid var(--newspack-blocks-reorder-divider);
+		display: flex;
+		flex-direction: column;
+		padding: 4px;
+	}
+
+	&__title {
+		@include wp-mixins.heading-large();
+
+		align-self: center;
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&__footer {
+		display: flex;
+		gap: 8px;
+		justify-content: flex-end;
+		margin-top: auto;
+		padding-top: 24px;
+	}
+}

--- a/plugins/newspack-blocks/src/components/reorder-modal.scss
+++ b/plugins/newspack-blocks/src/components/reorder-modal.scss
@@ -16,10 +16,14 @@
 		justify-content: center;
 	}
 
+	&__notice {
+		margin: 0 0 wp-vars.$grid-unit-10;
+	}
+
 	&__list {
 		display: flex;
 		flex-direction: column;
-		gap: 8px;
+		gap: wp-vars.$grid-unit-10;
 		list-style: none;
 		margin: 0;
 		padding: 0;
@@ -27,7 +31,7 @@
 
 	&__item {
 		--newspack-blocks-reorder-divider: #{wp-colors.$gray-100};
-		--wp-ui-card-padding: 12px;
+		--wp-ui-card-padding: #{wp-vars.$grid-unit-15};
 
 		align-items: stretch;
 		cursor: grab;
@@ -42,6 +46,7 @@
 		}
 
 		&.is-dragging {
+			cursor: grabbing;
 			opacity: 0.5;
 		}
 	}
@@ -50,7 +55,7 @@
 		align-items: center;
 		color: wp-colors.$gray-700;
 		display: flex;
-		padding-left: 4px;
+		padding-left: wp-vars.$grid-unit-05;
 	}
 
 	&__move {
@@ -58,7 +63,7 @@
 		border-right: 1px solid var(--newspack-blocks-reorder-divider);
 		display: flex;
 		flex-direction: column;
-		padding: 4px;
+		padding: wp-vars.$grid-unit-05;
 	}
 
 	&__title {
@@ -74,9 +79,9 @@
 
 	&__footer {
 		display: flex;
-		gap: 8px;
+		gap: wp-vars.$grid-unit-10;
 		justify-content: flex-end;
 		margin-top: auto;
-		padding-top: 24px;
+		padding-top: wp-vars.$grid-unit-30;
 	}
 }

--- a/plugins/newspack-blocks/src/components/reorder-modal.test.js
+++ b/plugins/newspack-blocks/src/components/reorder-modal.test.js
@@ -1,0 +1,253 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import ReorderModal, { moveItem } from './reorder-modal';
+
+describe( 'moveItem', () => {
+	it( 'moves an item down', () => {
+		expect( moveItem( [ 'a', 'b', 'c' ], 0, 2 ) ).toEqual( [ 'b', 'c', 'a' ] );
+	} );
+
+	it( 'moves an item up', () => {
+		expect( moveItem( [ 'a', 'b', 'c' ], 2, 0 ) ).toEqual( [ 'c', 'a', 'b' ] );
+	} );
+
+	it( 'returns the original array when the indices match', () => {
+		const items = [ 'a', 'b' ];
+		expect( moveItem( items, 1, 1 ) ).toBe( items );
+	} );
+
+	it( 'returns the original array when an index is out of range', () => {
+		const items = [ 'a', 'b' ];
+		expect( moveItem( items, 0, 5 ) ).toBe( items );
+		expect( moveItem( items, -1, 0 ) ).toBe( items );
+	} );
+} );
+
+const ITEMS = [
+	{ value: 11, label: 'Alpha' },
+	{ value: 22, label: 'Beta' },
+	{ value: 33, label: 'Gamma' },
+];
+
+const renderModal = ( props = {} ) => {
+	const onSave = jest.fn();
+	const onClose = jest.fn();
+	render(
+		<ReorderModal
+			title="Reorder Content"
+			ids={ [ 11, 22, 33 ] }
+			fetchItems={ () => Promise.resolve( ITEMS ) }
+			onSave={ onSave }
+			onClose={ onClose }
+			{ ...props }
+		/>
+	);
+	return { onSave, onClose };
+};
+
+const titles = () => Array.from( document.querySelectorAll( '.newspack-blocks-reorder-modal__title' ) ).map( el => el.textContent );
+
+const overlay = () => document.querySelector( '.components-modal__screen-overlay' );
+
+// jsdom has no `PointerEvent`, and `fireEvent.pointerDown` would fall back to a
+// plain `Event` and drop `button`.
+const press = ( from, to, button = 0 ) => {
+	fireEvent( from, new MouseEvent( 'pointerdown', { bubbles: true, button } ) );
+	fireEvent( to, new MouseEvent( 'pointerup', { bubbles: true, button } ) );
+};
+
+describe( 'ReorderModal', () => {
+	it( 'lists the items in the order the IDs were given', async () => {
+		renderModal();
+		expect( await screen.findByText( 'Alpha' ) ).toBeInTheDocument();
+		expect( titles() ).toEqual( [ 'Alpha', 'Beta', 'Gamma' ] );
+	} );
+
+	it( 'falls back to (no title) for IDs the fetch does not resolve', async () => {
+		renderModal( { ids: [ 11, 99 ], fetchItems: () => Promise.resolve( [ ITEMS[ 0 ] ] ) } );
+		expect( await screen.findByText( 'Alpha' ) ).toBeInTheDocument();
+		expect( titles() ).toEqual( [ 'Alpha', '(no title)' ] );
+	} );
+
+	it( 'moves an item up with the chevron', async () => {
+		renderModal();
+		fireEvent.click( await screen.findByLabelText( 'Move "Gamma" up' ) );
+		expect( titles() ).toEqual( [ 'Alpha', 'Gamma', 'Beta' ] );
+	} );
+
+	it( 'moves an item down with the chevron', async () => {
+		renderModal();
+		fireEvent.click( await screen.findByLabelText( 'Move "Alpha" down' ) );
+		expect( titles() ).toEqual( [ 'Beta', 'Alpha', 'Gamma' ] );
+	} );
+
+	it( 'disables the chevrons at the ends of the list', async () => {
+		renderModal();
+		expect( await screen.findByLabelText( 'Move "Alpha" up' ) ).toHaveAttribute( 'aria-disabled', 'true' );
+		expect( screen.getByLabelText( 'Move "Gamma" down' ) ).toHaveAttribute( 'aria-disabled', 'true' );
+		expect( screen.getByLabelText( 'Move "Alpha" down' ) ).not.toHaveAttribute( 'aria-disabled' );
+	} );
+
+	it( 'keeps a disabled chevron focusable but inert', async () => {
+		renderModal();
+		const chevron = await screen.findByLabelText( 'Move "Alpha" up' );
+		chevron.focus();
+		expect( document.activeElement ).toBe( chevron );
+		fireEvent.click( chevron );
+		expect( titles() ).toEqual( [ 'Alpha', 'Beta', 'Gamma' ] );
+	} );
+
+	it( 'keeps the disabled Save button focusable but inert', async () => {
+		const { onSave } = renderModal();
+		const save = await screen.findByRole( 'button', { name: 'Save' } );
+		save.focus();
+		expect( document.activeElement ).toBe( save );
+		fireEvent.click( save );
+		expect( onSave ).not.toHaveBeenCalled();
+	} );
+
+	it( 'keeps the item title in the accessible name and out of the tooltip', async () => {
+		renderModal();
+		const chevron = await screen.findByLabelText( 'Move "Gamma" up' );
+		expect( screen.queryAllByLabelText( 'Move Up' ) ).toHaveLength( 0 );
+
+		chevron.focus();
+		const tooltip = await screen.findByRole( 'tooltip' );
+		expect( tooltip ).toHaveTextContent( 'Move Up' );
+		expect( tooltip ).not.toHaveTextContent( 'Gamma' );
+	} );
+
+	it( 'keeps focus on the pressed chevron while it stays enabled', async () => {
+		renderModal();
+		fireEvent.click( await screen.findByLabelText( 'Move "Gamma" up' ) );
+		expect( document.activeElement ).toBe( screen.getByLabelText( 'Move "Gamma" up' ) );
+	} );
+
+	it( 'moves focus to the other chevron when the pressed one disables', async () => {
+		renderModal();
+		fireEvent.click( await screen.findByLabelText( 'Move "Beta" up' ) );
+		expect( screen.getByLabelText( 'Move "Beta" up' ) ).toHaveAttribute( 'aria-disabled', 'true' );
+		expect( document.activeElement ).toBe( screen.getByLabelText( 'Move "Beta" down' ) );
+	} );
+
+	it( 'saves the reordered IDs', async () => {
+		const { onSave } = renderModal();
+		fireEvent.click( await screen.findByLabelText( 'Move "Gamma" up' ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Save' } ) );
+		expect( onSave ).toHaveBeenCalledWith( [ 11, 33, 22 ] );
+	} );
+
+	it( 'discards the new order once the discard is confirmed', async () => {
+		const { onSave, onClose } = renderModal();
+		fireEvent.click( await screen.findByLabelText( 'Move "Gamma" up' ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Discard' } ) );
+		expect( onSave ).not.toHaveBeenCalled();
+		expect( onClose ).toHaveBeenCalled();
+	} );
+
+	it( 'disables saving until the order changes', async () => {
+		renderModal();
+		expect( await screen.findByRole( 'button', { name: 'Save' } ) ).toHaveAttribute( 'aria-disabled', 'true' );
+		fireEvent.click( screen.getByLabelText( 'Move "Gamma" up' ) );
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).not.toHaveAttribute( 'aria-disabled' );
+	} );
+
+	it( 'disables saving again when the order is moved back', async () => {
+		renderModal();
+		fireEvent.click( await screen.findByLabelText( 'Move "Gamma" up' ) );
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).not.toHaveAttribute( 'aria-disabled' );
+		fireEvent.click( screen.getByLabelText( 'Move "Gamma" down' ) );
+		expect( titles() ).toEqual( [ 'Alpha', 'Beta', 'Gamma' ] );
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'closes without confirming when nothing was reordered', async () => {
+		const { onClose } = renderModal();
+		fireEvent.click( await screen.findByRole( 'button', { name: 'Cancel' } ) );
+		expect( onClose ).toHaveBeenCalled();
+		expect( screen.queryByText( 'Discard the new order?' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'asks before discarding and holds the modal open until answered', async () => {
+		const { onSave, onClose } = renderModal();
+		fireEvent.click( await screen.findByLabelText( 'Move "Gamma" up' ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+		expect( screen.getByText( 'Discard the new order?' ) ).toBeInTheDocument();
+		expect( onClose ).not.toHaveBeenCalled();
+		expect( onSave ).not.toHaveBeenCalled();
+	} );
+
+	// The modal takes Escape over from `Modal`, whose own handler defers the close
+	// request behind an exit animation, so the confirmation is up synchronously.
+	it( 'asks before discarding when Escape dismisses the modal', async () => {
+		const { onClose } = renderModal();
+		fireEvent.click( await screen.findByLabelText( 'Move "Gamma" up' ) );
+		fireEvent.keyDown( document.activeElement, { key: 'Escape' } );
+		expect( screen.getByText( 'Discard the new order?' ) ).toBeInTheDocument();
+		expect( onClose ).not.toHaveBeenCalled();
+	} );
+
+	it( 'closes on Escape without confirming when nothing was reordered', async () => {
+		const { onClose } = renderModal();
+		await screen.findByText( 'Alpha' );
+		fireEvent.keyDown( screen.getByRole( 'dialog' ), { key: 'Escape' } );
+		expect( onClose ).toHaveBeenCalled();
+		expect( screen.queryByText( 'Discard the new order?' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'asks before discarding when the header close button dismisses the modal', async () => {
+		const { onClose } = renderModal();
+		fireEvent.click( await screen.findByLabelText( 'Move "Gamma" up' ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Close' } ) );
+		expect( screen.getByText( 'Discard the new order?' ) ).toBeInTheDocument();
+		expect( onClose ).not.toHaveBeenCalled();
+	} );
+
+	it( 'closes when a press starts and ends on the overlay', async () => {
+		const { onClose } = renderModal();
+		await screen.findByText( 'Alpha' );
+		press( overlay(), overlay() );
+		expect( onClose ).toHaveBeenCalled();
+	} );
+
+	it( 'asks before discarding when an overlay press dismisses a reordered list', async () => {
+		const { onClose } = renderModal();
+		fireEvent.click( await screen.findByLabelText( 'Move "Gamma" up' ) );
+		press( overlay(), overlay() );
+		expect( screen.getByText( 'Discard the new order?' ) ).toBeInTheDocument();
+		expect( onClose ).not.toHaveBeenCalled();
+	} );
+
+	it( 'ignores a press that starts on a row and ends on the overlay', async () => {
+		const { onClose } = renderModal();
+		await screen.findByText( 'Alpha' );
+		press( document.querySelector( '.newspack-blocks-reorder-modal__item' ), overlay() );
+		expect( onClose ).not.toHaveBeenCalled();
+		expect( screen.queryByText( 'Discard the new order?' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'ignores a secondary-button press on the overlay', async () => {
+		const { onClose } = renderModal();
+		await screen.findByText( 'Alpha' );
+		press( overlay(), overlay(), 2 );
+		expect( onClose ).not.toHaveBeenCalled();
+	} );
+
+	it( 'keeps the reordered list when the discard is dismissed', async () => {
+		const { onSave, onClose } = renderModal();
+		fireEvent.click( await screen.findByLabelText( 'Move "Gamma" up' ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Keep editing' } ) );
+		expect( screen.queryByText( 'Discard the new order?' ) ).not.toBeInTheDocument();
+		expect( titles() ).toEqual( [ 'Alpha', 'Gamma', 'Beta' ] );
+		expect( onClose ).not.toHaveBeenCalled();
+		expect( onSave ).not.toHaveBeenCalled();
+	} );
+} );

--- a/plugins/newspack-blocks/src/components/reorder-modal.test.js
+++ b/plugins/newspack-blocks/src/components/reorder-modal.test.js
@@ -77,26 +77,26 @@ describe( 'ReorderModal', () => {
 
 	it( 'moves an item up with the chevron', async () => {
 		renderModal();
-		fireEvent.click( await screen.findByLabelText( 'Move "Gamma" up' ) );
+		fireEvent.click( await screen.findByLabelText( 'Move Up: Gamma' ) );
 		expect( titles() ).toEqual( [ 'Alpha', 'Gamma', 'Beta' ] );
 	} );
 
 	it( 'moves an item down with the chevron', async () => {
 		renderModal();
-		fireEvent.click( await screen.findByLabelText( 'Move "Alpha" down' ) );
+		fireEvent.click( await screen.findByLabelText( 'Move Down: Alpha' ) );
 		expect( titles() ).toEqual( [ 'Beta', 'Alpha', 'Gamma' ] );
 	} );
 
 	it( 'disables the chevrons at the ends of the list', async () => {
 		renderModal();
-		expect( await screen.findByLabelText( 'Move "Alpha" up' ) ).toHaveAttribute( 'aria-disabled', 'true' );
-		expect( screen.getByLabelText( 'Move "Gamma" down' ) ).toHaveAttribute( 'aria-disabled', 'true' );
-		expect( screen.getByLabelText( 'Move "Alpha" down' ) ).not.toHaveAttribute( 'aria-disabled' );
+		expect( await screen.findByLabelText( 'Move Up: Alpha' ) ).toHaveAttribute( 'aria-disabled', 'true' );
+		expect( screen.getByLabelText( 'Move Down: Gamma' ) ).toHaveAttribute( 'aria-disabled', 'true' );
+		expect( screen.getByLabelText( 'Move Down: Alpha' ) ).not.toHaveAttribute( 'aria-disabled' );
 	} );
 
 	it( 'keeps a disabled chevron focusable but inert', async () => {
 		renderModal();
-		const chevron = await screen.findByLabelText( 'Move "Alpha" up' );
+		const chevron = await screen.findByLabelText( 'Move Up: Alpha' );
 		chevron.focus();
 		expect( document.activeElement ).toBe( chevron );
 		fireEvent.click( chevron );
@@ -114,7 +114,7 @@ describe( 'ReorderModal', () => {
 
 	it( 'keeps the item title in the accessible name and out of the tooltip', async () => {
 		renderModal();
-		const chevron = await screen.findByLabelText( 'Move "Gamma" up' );
+		const chevron = await screen.findByLabelText( 'Move Up: Gamma' );
 		expect( screen.queryAllByLabelText( 'Move Up' ) ).toHaveLength( 0 );
 
 		chevron.focus();
@@ -123,29 +123,36 @@ describe( 'ReorderModal', () => {
 		expect( tooltip ).not.toHaveTextContent( 'Gamma' );
 	} );
 
+	it( 'starts the accessible name with the visible label', async () => {
+		renderModal();
+		const chevron = await screen.findByLabelText( 'Move Up: Gamma' );
+		expect( chevron.getAttribute( 'aria-label' ) ).toContain( 'Move Up' );
+		expect( screen.getByLabelText( 'Move Down: Alpha' ).getAttribute( 'aria-label' ) ).toContain( 'Move Down' );
+	} );
+
 	it( 'keeps focus on the pressed chevron while it stays enabled', async () => {
 		renderModal();
-		fireEvent.click( await screen.findByLabelText( 'Move "Gamma" up' ) );
-		expect( document.activeElement ).toBe( screen.getByLabelText( 'Move "Gamma" up' ) );
+		fireEvent.click( await screen.findByLabelText( 'Move Up: Gamma' ) );
+		expect( document.activeElement ).toBe( screen.getByLabelText( 'Move Up: Gamma' ) );
 	} );
 
 	it( 'moves focus to the other chevron when the pressed one disables', async () => {
 		renderModal();
-		fireEvent.click( await screen.findByLabelText( 'Move "Beta" up' ) );
-		expect( screen.getByLabelText( 'Move "Beta" up' ) ).toHaveAttribute( 'aria-disabled', 'true' );
-		expect( document.activeElement ).toBe( screen.getByLabelText( 'Move "Beta" down' ) );
+		fireEvent.click( await screen.findByLabelText( 'Move Up: Beta' ) );
+		expect( screen.getByLabelText( 'Move Up: Beta' ) ).toHaveAttribute( 'aria-disabled', 'true' );
+		expect( document.activeElement ).toBe( screen.getByLabelText( 'Move Down: Beta' ) );
 	} );
 
 	it( 'saves the reordered IDs', async () => {
 		const { onSave } = renderModal();
-		fireEvent.click( await screen.findByLabelText( 'Move "Gamma" up' ) );
+		fireEvent.click( await screen.findByLabelText( 'Move Up: Gamma' ) );
 		fireEvent.click( screen.getByRole( 'button', { name: 'Save' } ) );
 		expect( onSave ).toHaveBeenCalledWith( [ 11, 33, 22 ] );
 	} );
 
 	it( 'discards the new order once the discard is confirmed', async () => {
 		const { onSave, onClose } = renderModal();
-		fireEvent.click( await screen.findByLabelText( 'Move "Gamma" up' ) );
+		fireEvent.click( await screen.findByLabelText( 'Move Up: Gamma' ) );
 		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
 		fireEvent.click( screen.getByRole( 'button', { name: 'Discard' } ) );
 		expect( onSave ).not.toHaveBeenCalled();
@@ -155,15 +162,15 @@ describe( 'ReorderModal', () => {
 	it( 'disables saving until the order changes', async () => {
 		renderModal();
 		expect( await screen.findByRole( 'button', { name: 'Save' } ) ).toHaveAttribute( 'aria-disabled', 'true' );
-		fireEvent.click( screen.getByLabelText( 'Move "Gamma" up' ) );
+		fireEvent.click( screen.getByLabelText( 'Move Up: Gamma' ) );
 		expect( screen.getByRole( 'button', { name: 'Save' } ) ).not.toHaveAttribute( 'aria-disabled' );
 	} );
 
 	it( 'disables saving again when the order is moved back', async () => {
 		renderModal();
-		fireEvent.click( await screen.findByLabelText( 'Move "Gamma" up' ) );
+		fireEvent.click( await screen.findByLabelText( 'Move Up: Gamma' ) );
 		expect( screen.getByRole( 'button', { name: 'Save' } ) ).not.toHaveAttribute( 'aria-disabled' );
-		fireEvent.click( screen.getByLabelText( 'Move "Gamma" down' ) );
+		fireEvent.click( screen.getByLabelText( 'Move Down: Gamma' ) );
 		expect( titles() ).toEqual( [ 'Alpha', 'Beta', 'Gamma' ] );
 		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toHaveAttribute( 'aria-disabled', 'true' );
 	} );
@@ -177,7 +184,7 @@ describe( 'ReorderModal', () => {
 
 	it( 'asks before discarding and holds the modal open until answered', async () => {
 		const { onSave, onClose } = renderModal();
-		fireEvent.click( await screen.findByLabelText( 'Move "Gamma" up' ) );
+		fireEvent.click( await screen.findByLabelText( 'Move Up: Gamma' ) );
 		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
 		expect( screen.getByText( 'Discard the new order?' ) ).toBeInTheDocument();
 		expect( onClose ).not.toHaveBeenCalled();
@@ -188,7 +195,7 @@ describe( 'ReorderModal', () => {
 	// request behind an exit animation, so the confirmation is up synchronously.
 	it( 'asks before discarding when Escape dismisses the modal', async () => {
 		const { onClose } = renderModal();
-		fireEvent.click( await screen.findByLabelText( 'Move "Gamma" up' ) );
+		fireEvent.click( await screen.findByLabelText( 'Move Up: Gamma' ) );
 		fireEvent.keyDown( document.activeElement, { key: 'Escape' } );
 		expect( screen.getByText( 'Discard the new order?' ) ).toBeInTheDocument();
 		expect( onClose ).not.toHaveBeenCalled();
@@ -204,7 +211,7 @@ describe( 'ReorderModal', () => {
 
 	it( 'asks before discarding when the header close button dismisses the modal', async () => {
 		const { onClose } = renderModal();
-		fireEvent.click( await screen.findByLabelText( 'Move "Gamma" up' ) );
+		fireEvent.click( await screen.findByLabelText( 'Move Up: Gamma' ) );
 		fireEvent.click( screen.getByRole( 'button', { name: 'Close' } ) );
 		expect( screen.getByText( 'Discard the new order?' ) ).toBeInTheDocument();
 		expect( onClose ).not.toHaveBeenCalled();
@@ -219,7 +226,7 @@ describe( 'ReorderModal', () => {
 
 	it( 'asks before discarding when an overlay press dismisses a reordered list', async () => {
 		const { onClose } = renderModal();
-		fireEvent.click( await screen.findByLabelText( 'Move "Gamma" up' ) );
+		fireEvent.click( await screen.findByLabelText( 'Move Up: Gamma' ) );
 		press( overlay(), overlay() );
 		expect( screen.getByText( 'Discard the new order?' ) ).toBeInTheDocument();
 		expect( onClose ).not.toHaveBeenCalled();
@@ -242,12 +249,114 @@ describe( 'ReorderModal', () => {
 
 	it( 'keeps the reordered list when the discard is dismissed', async () => {
 		const { onSave, onClose } = renderModal();
-		fireEvent.click( await screen.findByLabelText( 'Move "Gamma" up' ) );
+		fireEvent.click( await screen.findByLabelText( 'Move Up: Gamma' ) );
 		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
 		fireEvent.click( screen.getByRole( 'button', { name: 'Keep editing' } ) );
 		expect( screen.queryByText( 'Discard the new order?' ) ).not.toBeInTheDocument();
 		expect( titles() ).toEqual( [ 'Alpha', 'Gamma', 'Beta' ] );
 		expect( onClose ).not.toHaveBeenCalled();
+		expect( onSave ).not.toHaveBeenCalled();
+	} );
+
+	it( 'exposes the rows as a list', async () => {
+		renderModal();
+		await screen.findByText( 'Alpha' );
+		expect( screen.getByRole( 'list' ) ).toBeInTheDocument();
+		expect( screen.getAllByRole( 'listitem' ) ).toHaveLength( 3 );
+	} );
+
+	it( 'carries the full title on a row whose text is clipped', async () => {
+		renderModal();
+		await screen.findByText( 'Alpha' );
+		expect( document.querySelector( '.newspack-blocks-reorder-modal__title' ) ).toHaveAttribute( 'title', 'Alpha' );
+	} );
+} );
+
+// jsdom ships no `DataTransfer`, so the drag payload is stubbed.
+const dataTransfer = () => ( {
+	data: {},
+	dropEffect: 'none',
+	effectAllowed: 'none',
+	setData( type, value ) {
+		this.data[ type ] = value;
+	},
+	getData( type ) {
+		return this.data[ type ];
+	},
+} );
+
+const rows = () => Array.from( document.querySelectorAll( '.newspack-blocks-reorder-modal__item' ) );
+
+describe( 'ReorderModal drag and drop', () => {
+	it( 'reorders as a row is dragged over another', async () => {
+		renderModal();
+		await screen.findByText( 'Alpha' );
+		const dt = dataTransfer();
+		fireEvent.dragStart( rows()[ 2 ], { dataTransfer: dt } );
+		expect( dt.getData( 'text/plain' ) ).toBe( '33' );
+		fireEvent.dragOver( rows()[ 0 ], { dataTransfer: dt } );
+		expect( titles() ).toEqual( [ 'Gamma', 'Alpha', 'Beta' ] );
+	} );
+
+	it( 'keeps the new order when the drag is dropped', async () => {
+		renderModal();
+		await screen.findByText( 'Alpha' );
+		const dt = dataTransfer();
+		fireEvent.dragStart( rows()[ 2 ], { dataTransfer: dt } );
+		fireEvent.dragOver( rows()[ 0 ], { dataTransfer: dt } );
+		dt.dropEffect = 'move';
+		fireEvent.dragEnd( rows()[ 0 ], { dataTransfer: dt } );
+		expect( titles() ).toEqual( [ 'Gamma', 'Alpha', 'Beta' ] );
+	} );
+
+	it( 'puts the order back when the drag is cancelled', async () => {
+		renderModal();
+		await screen.findByText( 'Alpha' );
+		const dt = dataTransfer();
+		fireEvent.dragStart( rows()[ 2 ], { dataTransfer: dt } );
+		fireEvent.dragOver( rows()[ 0 ], { dataTransfer: dt } );
+		expect( titles() ).toEqual( [ 'Gamma', 'Alpha', 'Beta' ] );
+		dt.dropEffect = 'none';
+		fireEvent.dragEnd( rows()[ 0 ], { dataTransfer: dt } );
+		expect( titles() ).toEqual( [ 'Alpha', 'Beta', 'Gamma' ] );
+	} );
+
+	it( 'does not start a drag from a chevron', async () => {
+		renderModal();
+		const chevron = await screen.findByLabelText( 'Move Up: Gamma' );
+		const dt = dataTransfer();
+		fireEvent.dragStart( chevron, { dataTransfer: dt } );
+		expect( dt.getData( 'text/plain' ) ).toBeUndefined();
+		fireEvent.dragOver( rows()[ 0 ], { dataTransfer: dt } );
+		expect( titles() ).toEqual( [ 'Alpha', 'Beta', 'Gamma' ] );
+	} );
+} );
+
+describe( 'ReorderModal when the titles cannot be loaded', () => {
+	let errorSpy;
+
+	beforeEach( () => {
+		errorSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		errorSpy.mockRestore();
+	} );
+
+	it( 'says so and refuses to save', async () => {
+		const { onSave } = renderModal( { fetchItems: () => Promise.reject( new Error( 'unreachable' ) ) } );
+		// The same wording also lands in the live region core announces it through.
+		expect(
+			await screen.findByText( 'The content could not be loaded, so the order cannot be saved.', {
+				selector: '.components-notice__content',
+			} )
+		).toBeInTheDocument();
+		expect( titles() ).toEqual( [ '(no title)', '(no title)', '(no title)' ] );
+
+		fireEvent.click( screen.getAllByLabelText( 'Move Up: (no title)' )[ 1 ] );
+		const save = screen.getByRole( 'button', { name: 'Save' } );
+		expect( save ).toHaveAttribute( 'aria-disabled', 'true' );
+		fireEvent.click( save );
 		expect( onSave ).not.toHaveBeenCalled();
 	} );
 } );

--- a/plugins/newspack-blocks/src/components/reorder-modal.test.js
+++ b/plugins/newspack-blocks/src/components/reorder-modal.test.js
@@ -346,20 +346,33 @@ describe( 'ReorderModal drag and drop', () => {
 		expect( dt.getData( 'text/plain' ) ).toBe( '33' );
 	} );
 
-	// Rows are the only drop targets, so the body has to accept the drop as well
-	// or releasing in the gap between two rows reads as a cancelled drag.
-	it( 'accepts a drop anywhere in the modal body', async () => {
+	// Rows are the only drop targets, so the dialog has to accept the drop as well:
+	// otherwise the gaps between rows, and the frame's own padding, read as a
+	// cancelled drag and undo the reorder.
+	it.each( [
+		[ 'frame', '.components-modal__frame' ],
+		[ 'body', '.newspack-blocks-reorder-modal__body' ],
+	] )( 'accepts a drop released on the %s', async ( _name, selector ) => {
 		renderModal();
 		await screen.findByText( 'Alpha' );
-		const body = document.querySelector( '.newspack-blocks-reorder-modal__body' );
+		const target = document.querySelector( selector );
 
-		const over = createEvent.dragOver( body, { dataTransfer: dataTransfer() } );
-		fireEvent( body, over );
+		const over = createEvent.dragOver( target, { dataTransfer: dataTransfer() } );
+		fireEvent( target, over );
 		expect( over.defaultPrevented ).toBe( true );
 
-		const drop = createEvent.drop( body, { dataTransfer: dataTransfer() } );
-		fireEvent( body, drop );
+		const drop = createEvent.drop( target, { dataTransfer: dataTransfer() } );
+		fireEvent( target, drop );
 		expect( drop.defaultPrevented ).toBe( true );
+	} );
+
+	it( 'leaves a drop released on the overlay cancelling the drag', async () => {
+		renderModal();
+		await screen.findByText( 'Alpha' );
+
+		const over = createEvent.dragOver( overlay(), { dataTransfer: dataTransfer() } );
+		fireEvent( overlay(), over );
+		expect( over.defaultPrevented ).toBe( false );
 	} );
 } );
 

--- a/plugins/newspack-blocks/src/components/reorder-modal.test.js
+++ b/plugins/newspack-blocks/src/components/reorder-modal.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { createEvent, fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -321,14 +321,45 @@ describe( 'ReorderModal drag and drop', () => {
 		expect( titles() ).toEqual( [ 'Alpha', 'Beta', 'Gamma' ] );
 	} );
 
-	it( 'does not start a drag from a chevron', async () => {
+	// `dragstart` fires at the draggable row even when the gesture began on a
+	// chevron inside it, so the guard keys off where the pointer went down.
+	it( 'does not start a drag that began on a chevron', async () => {
 		renderModal();
 		const chevron = await screen.findByLabelText( 'Move Up: Gamma' );
+		fireEvent( chevron, new MouseEvent( 'pointerdown', { bubbles: true } ) );
+
 		const dt = dataTransfer();
-		fireEvent.dragStart( chevron, { dataTransfer: dt } );
+		fireEvent.dragStart( rows()[ 2 ], { dataTransfer: dt } );
 		expect( dt.getData( 'text/plain' ) ).toBeUndefined();
+
 		fireEvent.dragOver( rows()[ 0 ], { dataTransfer: dt } );
 		expect( titles() ).toEqual( [ 'Alpha', 'Beta', 'Gamma' ] );
+	} );
+
+	it( 'starts a drag that began on the row itself', async () => {
+		renderModal();
+		await screen.findByText( 'Alpha' );
+		fireEvent( rows()[ 2 ], new MouseEvent( 'pointerdown', { bubbles: true } ) );
+
+		const dt = dataTransfer();
+		fireEvent.dragStart( rows()[ 2 ], { dataTransfer: dt } );
+		expect( dt.getData( 'text/plain' ) ).toBe( '33' );
+	} );
+
+	// Rows are the only drop targets, so the body has to accept the drop as well
+	// or releasing in the gap between two rows reads as a cancelled drag.
+	it( 'accepts a drop anywhere in the modal body', async () => {
+		renderModal();
+		await screen.findByText( 'Alpha' );
+		const body = document.querySelector( '.newspack-blocks-reorder-modal__body' );
+
+		const over = createEvent.dragOver( body, { dataTransfer: dataTransfer() } );
+		fireEvent( body, over );
+		expect( over.defaultPrevented ).toBe( true );
+
+		const drop = createEvent.drop( body, { dataTransfer: dataTransfer() } );
+		fireEvent( body, drop );
+		expect( drop.defaultPrevented ).toBe( true );
 	} );
 } );
 
@@ -343,20 +374,20 @@ describe( 'ReorderModal when the titles cannot be loaded', () => {
 		errorSpy.mockRestore();
 	} );
 
-	it( 'says so and refuses to save', async () => {
-		const { onSave } = renderModal( { fetchItems: () => Promise.reject( new Error( 'unreachable' ) ) } );
+	it( 'says so instead of offering rows nobody can tell apart', async () => {
+		const { onClose } = renderModal( { fetchItems: () => Promise.reject( new Error( 'unreachable' ) ) } );
 		// The same wording also lands in the live region core announces it through.
 		expect(
 			await screen.findByText( 'The content could not be loaded, so the order cannot be saved.', {
 				selector: '.components-notice__content',
 			} )
 		).toBeInTheDocument();
-		expect( titles() ).toEqual( [ '(no title)', '(no title)', '(no title)' ] );
 
-		fireEvent.click( screen.getAllByLabelText( 'Move Up: (no title)' )[ 1 ] );
-		const save = screen.getByRole( 'button', { name: 'Save' } );
-		expect( save ).toHaveAttribute( 'aria-disabled', 'true' );
-		fireEvent.click( save );
-		expect( onSave ).not.toHaveBeenCalled();
+		expect( titles() ).toEqual( [] );
+		expect( screen.queryByRole( 'list' ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Save' } ) ).not.toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+		expect( onClose ).toHaveBeenCalled();
 	} );
 } );

--- a/plugins/newspack-blocks/src/components/reorder-modal.test.js
+++ b/plugins/newspack-blocks/src/components/reorder-modal.test.js
@@ -6,7 +6,7 @@ import { createEvent, fireEvent, render, screen } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import ReorderModal, { moveItem } from './reorder-modal';
+import ReorderModal, { findOverlay, moveItem } from './reorder-modal';
 
 describe( 'moveItem', () => {
 	it( 'moves an item down', () => {
@@ -402,5 +402,32 @@ describe( 'ReorderModal when the titles cannot be loaded', () => {
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
 		expect( onClose ).toHaveBeenCalled();
+	} );
+} );
+
+describe( 'findOverlay', () => {
+	const markup = html => {
+		const root = document.createElement( 'div' );
+		root.innerHTML = html;
+		return root;
+	};
+
+	it( 'takes the node itself when it is the overlay', () => {
+		const overlayNode = markup( '<div class="components-modal__screen-overlay"></div>' ).firstChild;
+		expect( findOverlay( overlayNode ) ).toBe( overlayNode );
+	} );
+
+	it( 'finds the overlay from a node inside it', () => {
+		const root = markup( '<div class="components-modal__screen-overlay"><div class="components-modal__frame"></div></div>' );
+		expect( findOverlay( root.querySelector( '.components-modal__frame' ) ) ).toBe( root.firstChild );
+	} );
+
+	it( 'finds the overlay from a node wrapping it', () => {
+		const root = markup( '<div class="components-modal__screen-overlay"></div>' );
+		expect( findOverlay( root ) ).toBe( root.firstChild );
+	} );
+
+	it( 'reports nothing rather than guessing', () => {
+		expect( findOverlay( null ) ).toBe( null );
 	} );
 } );

--- a/plugins/newspack-blocks/src/components/reorder-modal.test.js
+++ b/plugins/newspack-blocks/src/components/reorder-modal.test.js
@@ -4,9 +4,20 @@
 import { createEvent, fireEvent, render, screen } from '@testing-library/react';
 
 /**
+ * WordPress dependencies
+ */
+import { speak } from '@wordpress/a11y';
+
+/**
  * Internal dependencies
  */
 import ReorderModal, { findOverlay, moveItem } from './reorder-modal';
+
+jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
+
+beforeEach( () => {
+	speak.mockClear();
+} );
 
 describe( 'moveItem', () => {
 	it( 'moves an item down', () => {
@@ -141,6 +152,20 @@ describe( 'ReorderModal', () => {
 		fireEvent.click( await screen.findByLabelText( 'Move Up: Beta' ) );
 		expect( screen.getByLabelText( 'Move Up: Beta' ) ).toHaveAttribute( 'aria-disabled', 'true' );
 		expect( document.activeElement ).toBe( screen.getByLabelText( 'Move Down: Beta' ) );
+	} );
+
+	it( 'names the loading state and announces the list once it arrives', async () => {
+		renderModal();
+		expect( screen.getByText( 'Loading content…' ) ).toBeInTheDocument();
+		await screen.findByText( 'Alpha' );
+		expect( screen.queryByText( 'Loading content…' ) ).not.toBeInTheDocument();
+		expect( speak ).toHaveBeenCalledWith( '3 items ready to reorder.' );
+	} );
+
+	it( 'names the row it moved, not just the position', async () => {
+		renderModal();
+		fireEvent.click( await screen.findByLabelText( 'Move Up: Gamma' ) );
+		expect( speak ).toHaveBeenCalledWith( 'Gamma moved to position 2 of 3.' );
 	} );
 
 	it( 'saves the reordered IDs', async () => {

--- a/plugins/newspack-blocks/src/components/reorder-modal.test.js
+++ b/plugins/newspack-blocks/src/components/reorder-modal.test.js
@@ -358,6 +358,23 @@ describe( 'ReorderModal drag and drop', () => {
 		expect( titles() ).toEqual( [ 'Alpha', 'Beta', 'Gamma' ] );
 	} );
 
+	it( 'reorders as a row is dragged down past the rows below it', async () => {
+		renderModal();
+		await screen.findByText( 'Alpha' );
+		const dt = dataTransfer();
+		fireEvent.dragStart( rows()[ 0 ], { dataTransfer: dt } );
+		fireEvent.dragOver( rows()[ 1 ], { dataTransfer: dt } );
+		expect( titles() ).toEqual( [ 'Beta', 'Alpha', 'Gamma' ] );
+
+		// The dragged row now sits under the cursor, so the next `dragover` reaches
+		// it rather than the row it swapped with: it has to leave the order alone.
+		fireEvent.dragOver( rows()[ 1 ], { dataTransfer: dt } );
+		expect( titles() ).toEqual( [ 'Beta', 'Alpha', 'Gamma' ] );
+
+		fireEvent.dragOver( rows()[ 2 ], { dataTransfer: dt } );
+		expect( titles() ).toEqual( [ 'Beta', 'Gamma', 'Alpha' ] );
+	} );
+
 	// `dragstart` fires at the draggable row even when the gesture began on a
 	// chevron inside it, so the guard keys off where the pointer went down.
 	it( 'does not start a drag that began on a chevron', async () => {

--- a/plugins/newspack-blocks/src/components/reorder-modal.test.js
+++ b/plugins/newspack-blocks/src/components/reorder-modal.test.js
@@ -66,6 +66,8 @@ const titles = () => Array.from( document.querySelectorAll( '.newspack-blocks-re
 
 const overlay = () => document.querySelector( '.components-modal__screen-overlay' );
 
+const discardPrompt = () => screen.queryByRole( 'dialog', { name: 'Discard the new order?' } );
+
 // jsdom has no `PointerEvent`, and `fireEvent.pointerDown` would fall back to a
 // plain `Event` and drop `button`.
 const press = ( from, to, button = 0 ) => {
@@ -204,14 +206,14 @@ describe( 'ReorderModal', () => {
 		const { onClose } = renderModal();
 		fireEvent.click( await screen.findByRole( 'button', { name: 'Cancel' } ) );
 		expect( onClose ).toHaveBeenCalled();
-		expect( screen.queryByText( 'Discard the new order?' ) ).not.toBeInTheDocument();
+		expect( discardPrompt() ).not.toBeInTheDocument();
 	} );
 
 	it( 'asks before discarding and holds the modal open until answered', async () => {
 		const { onSave, onClose } = renderModal();
 		fireEvent.click( await screen.findByLabelText( 'Move Up: Gamma' ) );
 		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
-		expect( screen.getByText( 'Discard the new order?' ) ).toBeInTheDocument();
+		expect( discardPrompt() ).toBeInTheDocument();
 		expect( onClose ).not.toHaveBeenCalled();
 		expect( onSave ).not.toHaveBeenCalled();
 	} );
@@ -222,7 +224,7 @@ describe( 'ReorderModal', () => {
 		const { onClose } = renderModal();
 		fireEvent.click( await screen.findByLabelText( 'Move Up: Gamma' ) );
 		fireEvent.keyDown( document.activeElement, { key: 'Escape' } );
-		expect( screen.getByText( 'Discard the new order?' ) ).toBeInTheDocument();
+		expect( discardPrompt() ).toBeInTheDocument();
 		expect( onClose ).not.toHaveBeenCalled();
 	} );
 
@@ -231,14 +233,14 @@ describe( 'ReorderModal', () => {
 		await screen.findByText( 'Alpha' );
 		fireEvent.keyDown( screen.getByRole( 'dialog' ), { key: 'Escape' } );
 		expect( onClose ).toHaveBeenCalled();
-		expect( screen.queryByText( 'Discard the new order?' ) ).not.toBeInTheDocument();
+		expect( discardPrompt() ).not.toBeInTheDocument();
 	} );
 
 	it( 'asks before discarding when the header close button dismisses the modal', async () => {
 		const { onClose } = renderModal();
 		fireEvent.click( await screen.findByLabelText( 'Move Up: Gamma' ) );
 		fireEvent.click( screen.getByRole( 'button', { name: 'Close' } ) );
-		expect( screen.getByText( 'Discard the new order?' ) ).toBeInTheDocument();
+		expect( discardPrompt() ).toBeInTheDocument();
 		expect( onClose ).not.toHaveBeenCalled();
 	} );
 
@@ -253,7 +255,7 @@ describe( 'ReorderModal', () => {
 		const { onClose } = renderModal();
 		fireEvent.click( await screen.findByLabelText( 'Move Up: Gamma' ) );
 		press( overlay(), overlay() );
-		expect( screen.getByText( 'Discard the new order?' ) ).toBeInTheDocument();
+		expect( discardPrompt() ).toBeInTheDocument();
 		expect( onClose ).not.toHaveBeenCalled();
 	} );
 
@@ -262,7 +264,7 @@ describe( 'ReorderModal', () => {
 		await screen.findByText( 'Alpha' );
 		press( document.querySelector( '.newspack-blocks-reorder-modal__item' ), overlay() );
 		expect( onClose ).not.toHaveBeenCalled();
-		expect( screen.queryByText( 'Discard the new order?' ) ).not.toBeInTheDocument();
+		expect( discardPrompt() ).not.toBeInTheDocument();
 	} );
 
 	it( 'ignores a secondary-button press on the overlay', async () => {
@@ -272,12 +274,22 @@ describe( 'ReorderModal', () => {
 		expect( onClose ).not.toHaveBeenCalled();
 	} );
 
+	// `ConfirmDialog` announces `contentLabel` as the dialog's name and hides its
+	// header, so repeating it in the body would have it read out twice.
+	it( 'states the consequence in the discard prompt rather than repeating its name', async () => {
+		renderModal();
+		fireEvent.click( await screen.findByLabelText( 'Move Up: Gamma' ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+		expect( discardPrompt() ).toHaveTextContent( 'The order you set will be lost.' );
+		expect( discardPrompt() ).not.toHaveTextContent( 'Discard the new order?' );
+	} );
+
 	it( 'keeps the reordered list when the discard is dismissed', async () => {
 		const { onSave, onClose } = renderModal();
 		fireEvent.click( await screen.findByLabelText( 'Move Up: Gamma' ) );
 		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
 		fireEvent.click( screen.getByRole( 'button', { name: 'Keep editing' } ) );
-		expect( screen.queryByText( 'Discard the new order?' ) ).not.toBeInTheDocument();
+		expect( discardPrompt() ).not.toBeInTheDocument();
 		expect( titles() ).toEqual( [ 'Alpha', 'Gamma', 'Beta' ] );
 		expect( onClose ).not.toHaveBeenCalled();
 		expect( onSave ).not.toHaveBeenCalled();

--- a/plugins/newspack-blocks/src/components/specific-posts-control.js
+++ b/plugins/newspack-blocks/src/components/specific-posts-control.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useCallback, useRef, useState } from '@wordpress/element';
 import {
 	Button,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -16,8 +16,29 @@ import AutocompleteTokenField from './autocomplete-tokenfield';
 import ReorderModal from './reorder-modal';
 import './specific-posts-control.scss';
 
-const SpecificPostsControl = ( { postIds, onChange, fetchSuggestions, fetchSavedInfo } ) => {
+const SpecificPostsControl = ( { postIds = [], onChange, fetchSuggestions, fetchSavedInfo } ) => {
 	const [ isReordering, setIsReordering ] = useState( false );
+	const savedInfo = useRef( { key: null, promise: null } );
+	const canReorder = 1 < postIds.length;
+
+	// The token field and the modal ask for the same titles, so the request is
+	// shared rather than made twice. A rejection clears the cache to allow a retry.
+	const fetchSavedInfoOnce = useCallback(
+		ids => {
+			const key = [ ...ids ].sort().join( ',' );
+			if ( savedInfo.current.key !== key ) {
+				savedInfo.current = {
+					key,
+					promise: fetchSavedInfo( ids ).catch( error => {
+						savedInfo.current = { key: null, promise: null };
+						throw error;
+					} ),
+				};
+			}
+			return savedInfo.current.promise;
+		},
+		[ fetchSavedInfo ]
+	);
 
 	return (
 		<>
@@ -26,7 +47,7 @@ const SpecificPostsControl = ( { postIds, onChange, fetchSuggestions, fetchSaved
 					tokens={ postIds }
 					onChange={ onChange }
 					fetchSuggestions={ fetchSuggestions }
-					fetchSavedInfo={ fetchSavedInfo }
+					fetchSavedInfo={ fetchSavedInfoOnce }
 					label={ __( 'Content', 'newspack-blocks' ) }
 					help={ __( 'Begin typing any word in a title. Click on an autocomplete result to select it.', 'newspack-blocks' ) }
 				/>
@@ -34,8 +55,9 @@ const SpecificPostsControl = ( { postIds, onChange, fetchSuggestions, fetchSaved
 					className="newspack-blocks-specific-posts-control__reorder"
 					variant="secondary"
 					__next40pxDefaultSize
-					disabled={ 2 > postIds.length }
+					disabled={ ! canReorder }
 					accessibleWhenDisabled
+					label={ canReorder ? undefined : __( 'Reorder Content: pick at least two items', 'newspack-blocks' ) }
 					onClick={ () => setIsReordering( true ) }
 				>
 					{ __( 'Reorder Content', 'newspack-blocks' ) }
@@ -45,7 +67,7 @@ const SpecificPostsControl = ( { postIds, onChange, fetchSuggestions, fetchSaved
 				<ReorderModal
 					title={ __( 'Reorder Content', 'newspack-blocks' ) }
 					ids={ postIds }
-					fetchItems={ fetchSavedInfo }
+					fetchItems={ fetchSavedInfoOnce }
 					onSave={ ids => {
 						onChange( ids );
 						setIsReordering( false );

--- a/plugins/newspack-blocks/src/components/specific-posts-control.js
+++ b/plugins/newspack-blocks/src/components/specific-posts-control.js
@@ -23,7 +23,7 @@ const SpecificPostsControl = ( { postIds = [], onChange, fetchSuggestions, fetch
 	const reorderLabel = __( 'Reorder Content', 'newspack-blocks' );
 
 	// The token field and the modal ask for the same titles, so the request is
-	// shared rather than made twice. A rejection clears the cache to allow a retry.
+	// shared rather than made twice, and a failure leaves the slot open to retry.
 	const fetchSavedInfoOnce = useCallback(
 		ids => {
 			const key = [ ...ids ].sort().join( ',' );

--- a/plugins/newspack-blocks/src/components/specific-posts-control.js
+++ b/plugins/newspack-blocks/src/components/specific-posts-control.js
@@ -1,0 +1,60 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import {
+	Button,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import AutocompleteTokenField from './autocomplete-tokenfield';
+import ReorderModal from './reorder-modal';
+import './specific-posts-control.scss';
+
+const SpecificPostsControl = ( { postIds, onChange, fetchSuggestions, fetchSavedInfo } ) => {
+	const [ isReordering, setIsReordering ] = useState( false );
+
+	return (
+		<>
+			<VStack spacing={ 2 }>
+				<AutocompleteTokenField
+					tokens={ postIds }
+					onChange={ onChange }
+					fetchSuggestions={ fetchSuggestions }
+					fetchSavedInfo={ fetchSavedInfo }
+					label={ __( 'Content', 'newspack-blocks' ) }
+					help={ __( 'Begin typing any word in a title. Click on an autocomplete result to select it.', 'newspack-blocks' ) }
+				/>
+				<Button
+					className="newspack-blocks-specific-posts-control__reorder"
+					variant="secondary"
+					__next40pxDefaultSize
+					disabled={ 2 > postIds.length }
+					accessibleWhenDisabled
+					onClick={ () => setIsReordering( true ) }
+				>
+					{ __( 'Reorder Content', 'newspack-blocks' ) }
+				</Button>
+			</VStack>
+			{ isReordering && (
+				<ReorderModal
+					title={ __( 'Reorder Content', 'newspack-blocks' ) }
+					ids={ postIds }
+					fetchItems={ fetchSavedInfo }
+					onSave={ ids => {
+						onChange( ids );
+						setIsReordering( false );
+					} }
+					onClose={ () => setIsReordering( false ) }
+				/>
+			) }
+		</>
+	);
+};
+
+export default SpecificPostsControl;

--- a/plugins/newspack-blocks/src/components/specific-posts-control.js
+++ b/plugins/newspack-blocks/src/components/specific-posts-control.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useRef, useState } from '@wordpress/element';
 import {
 	Button,
@@ -20,6 +20,7 @@ const SpecificPostsControl = ( { postIds = [], onChange, fetchSuggestions, fetch
 	const [ isReordering, setIsReordering ] = useState( false );
 	const savedInfo = useRef( { key: null, promise: null } );
 	const canReorder = 1 < postIds.length;
+	const reorderLabel = __( 'Reorder Content', 'newspack-blocks' );
 
 	// The token field and the modal ask for the same titles, so the request is
 	// shared rather than made twice. A rejection clears the cache to allow a retry.
@@ -30,7 +31,10 @@ const SpecificPostsControl = ( { postIds = [], onChange, fetchSuggestions, fetch
 				savedInfo.current = {
 					key,
 					promise: fetchSavedInfo( ids ).catch( error => {
-						savedInfo.current = { key: null, promise: null };
+						// A late rejection must not evict an entry a newer request owns.
+						if ( savedInfo.current.key === key ) {
+							savedInfo.current = { key: null, promise: null };
+						}
 						throw error;
 					} ),
 				};
@@ -57,15 +61,25 @@ const SpecificPostsControl = ( { postIds = [], onChange, fetchSuggestions, fetch
 					__next40pxDefaultSize
 					disabled={ ! canReorder }
 					accessibleWhenDisabled
-					label={ canReorder ? undefined : __( 'Reorder Content: pick at least two items', 'newspack-blocks' ) }
+					// A button with visible children shows no tooltip unless asked.
+					showTooltip={ ! canReorder }
+					label={
+						canReorder
+							? undefined
+							: sprintf(
+									/* translators: %s: the button's visible label. */
+									__( '%s: pick at least two items', 'newspack-blocks' ),
+									reorderLabel
+							  )
+					}
 					onClick={ () => setIsReordering( true ) }
 				>
-					{ __( 'Reorder Content', 'newspack-blocks' ) }
+					{ reorderLabel }
 				</Button>
 			</VStack>
 			{ isReordering && (
 				<ReorderModal
-					title={ __( 'Reorder Content', 'newspack-blocks' ) }
+					title={ reorderLabel }
 					ids={ postIds }
 					fetchItems={ fetchSavedInfoOnce }
 					onSave={ ids => {

--- a/plugins/newspack-blocks/src/components/specific-posts-control.js
+++ b/plugins/newspack-blocks/src/components/specific-posts-control.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useCallback, useRef, useState } from '@wordpress/element';
 import {
 	Button,
@@ -61,17 +61,12 @@ const SpecificPostsControl = ( { postIds = [], onChange, fetchSuggestions, fetch
 					__next40pxDefaultSize
 					disabled={ ! canReorder }
 					accessibleWhenDisabled
-					// A button with visible children shows no tooltip unless asked.
+					// A button with visible children shows no tooltip unless asked, and
+					// only shows one at all when it also carries a label. Matching the
+					// label to the visible text leaves the accessible name unchanged.
+					label={ reorderLabel }
 					showTooltip={ ! canReorder }
-					label={
-						canReorder
-							? undefined
-							: sprintf(
-									/* translators: %s: the button's visible label. */
-									__( '%s: pick at least two items', 'newspack-blocks' ),
-									reorderLabel
-							  )
-					}
+					description={ canReorder ? undefined : __( 'Pick at least two items to reorder them.', 'newspack-blocks' ) }
 					onClick={ () => setIsReordering( true ) }
 				>
 					{ reorderLabel }

--- a/plugins/newspack-blocks/src/components/specific-posts-control.scss
+++ b/plugins/newspack-blocks/src/components/specific-posts-control.scss
@@ -1,0 +1,5 @@
+.newspack-blocks-specific-posts-control {
+	&__reorder {
+		justify-content: center;
+	}
+}

--- a/plugins/newspack-blocks/src/components/specific-posts-control.test.js
+++ b/plugins/newspack-blocks/src/components/specific-posts-control.test.js
@@ -37,6 +37,27 @@ describe( 'SpecificPostsControl', () => {
 		expect( await screen.findByRole( 'button', { name: 'Reorder Content: pick at least two items' } ) ).toBeInTheDocument();
 	} );
 
+	// A button with visible children shows no tooltip by default, so the reason
+	// would otherwise reach assistive technology only.
+	it( 'shows the reason to sighted users too', async () => {
+		render( <SpecificPostsControl postIds={ [ 11 ] } onChange={ noop } fetchSuggestions={ noop } fetchSavedInfo={ noItems } /> );
+		( await screen.findByRole( 'button', { name: 'Reorder Content: pick at least two items' } ) ).focus();
+		expect( await screen.findByRole( 'tooltip' ) ).toHaveTextContent( 'pick at least two items' );
+	} );
+
+	it( 'shows no tooltip once the button is usable', async () => {
+		render(
+			<SpecificPostsControl
+				postIds={ [ 11, 22 ] }
+				onChange={ noop }
+				fetchSuggestions={ noop }
+				fetchSavedInfo={ () => Promise.resolve( ITEMS ) }
+			/>
+		);
+		( await screen.findByRole( 'button', { name: 'Reorder Content' } ) ).focus();
+		expect( screen.queryByRole( 'tooltip' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'enables the reorder button once two items are selected', async () => {
 		render(
 			<SpecificPostsControl

--- a/plugins/newspack-blocks/src/components/specific-posts-control.test.js
+++ b/plugins/newspack-blocks/src/components/specific-posts-control.test.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import SpecificPostsControl from './specific-posts-control';
+
+const noop = () => {};
+const noItems = () => Promise.resolve( [] );
+
+describe( 'SpecificPostsControl', () => {
+	it( 'exposes the token field to assistive technology as "Content"', () => {
+		render( <SpecificPostsControl postIds={ [] } onChange={ noop } fetchSuggestions={ noop } fetchSavedInfo={ noop } /> );
+		expect( screen.getByRole( 'combobox', { name: 'Content' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'keeps the reorder button focusable while too little content is selected', () => {
+		render( <SpecificPostsControl postIds={ [ 11 ] } onChange={ noop } fetchSuggestions={ noop } fetchSavedInfo={ noItems } /> );
+		const reorder = screen.getByRole( 'button', { name: 'Reorder Content' } );
+		expect( reorder ).toHaveAttribute( 'aria-disabled', 'true' );
+		reorder.focus();
+		expect( document.activeElement ).toBe( reorder );
+	} );
+
+	it( 'enables the reorder button once two items are selected', () => {
+		render( <SpecificPostsControl postIds={ [ 11, 22 ] } onChange={ noop } fetchSuggestions={ noop } fetchSavedInfo={ noItems } /> );
+		expect( screen.getByRole( 'button', { name: 'Reorder Content' } ) ).not.toHaveAttribute( 'aria-disabled' );
+	} );
+} );

--- a/plugins/newspack-blocks/src/components/specific-posts-control.test.js
+++ b/plugins/newspack-blocks/src/components/specific-posts-control.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -11,22 +11,92 @@ import SpecificPostsControl from './specific-posts-control';
 const noop = () => {};
 const noItems = () => Promise.resolve( [] );
 
+const ITEMS = [
+	{ value: 11, label: 'Alpha' },
+	{ value: 22, label: 'Beta' },
+];
+
+const titles = () => Array.from( document.querySelectorAll( '.newspack-blocks-reorder-modal__title' ) ).map( el => el.textContent );
+
 describe( 'SpecificPostsControl', () => {
 	it( 'exposes the token field to assistive technology as "Content"', () => {
 		render( <SpecificPostsControl postIds={ [] } onChange={ noop } fetchSuggestions={ noop } fetchSavedInfo={ noop } /> );
 		expect( screen.getByRole( 'combobox', { name: 'Content' } ) ).toBeInTheDocument();
 	} );
 
-	it( 'keeps the reorder button focusable while too little content is selected', () => {
+	it( 'keeps the reorder button focusable while too little content is selected', async () => {
 		render( <SpecificPostsControl postIds={ [ 11 ] } onChange={ noop } fetchSuggestions={ noop } fetchSavedInfo={ noItems } /> );
-		const reorder = screen.getByRole( 'button', { name: 'Reorder Content' } );
+		const reorder = await screen.findByRole( 'button', { name: /Reorder Content/ } );
 		expect( reorder ).toHaveAttribute( 'aria-disabled', 'true' );
 		reorder.focus();
 		expect( document.activeElement ).toBe( reorder );
 	} );
 
-	it( 'enables the reorder button once two items are selected', () => {
-		render( <SpecificPostsControl postIds={ [ 11, 22 ] } onChange={ noop } fetchSuggestions={ noop } fetchSavedInfo={ noItems } /> );
-		expect( screen.getByRole( 'button', { name: 'Reorder Content' } ) ).not.toHaveAttribute( 'aria-disabled' );
+	it( 'says why the reorder button is unavailable', async () => {
+		render( <SpecificPostsControl postIds={ [ 11 ] } onChange={ noop } fetchSuggestions={ noop } fetchSavedInfo={ noItems } /> );
+		expect( await screen.findByRole( 'button', { name: 'Reorder Content: pick at least two items' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'enables the reorder button once two items are selected', async () => {
+		render(
+			<SpecificPostsControl
+				postIds={ [ 11, 22 ] }
+				onChange={ noop }
+				fetchSuggestions={ noop }
+				fetchSavedInfo={ () => Promise.resolve( ITEMS ) }
+			/>
+		);
+		expect( await screen.findByRole( 'button', { name: 'Reorder Content' } ) ).not.toHaveAttribute( 'aria-disabled' );
+	} );
+
+	it( 'writes the reordered IDs back through onChange', async () => {
+		const onChange = jest.fn();
+		render(
+			<SpecificPostsControl
+				postIds={ [ 11, 22 ] }
+				onChange={ onChange }
+				fetchSuggestions={ noop }
+				fetchSavedInfo={ () => Promise.resolve( ITEMS ) }
+			/>
+		);
+
+		fireEvent.click( await screen.findByRole( 'button', { name: 'Reorder Content' } ) );
+		await screen.findByLabelText( 'Move Up: Beta' );
+		expect( titles() ).toEqual( [ 'Alpha', 'Beta' ] );
+
+		fireEvent.click( screen.getByLabelText( 'Move Up: Beta' ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Save' } ) );
+
+		expect( onChange ).toHaveBeenCalledWith( [ 22, 11 ] );
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'closes the modal without changing anything when the reorder is cancelled', async () => {
+		const onChange = jest.fn();
+		render(
+			<SpecificPostsControl
+				postIds={ [ 11, 22 ] }
+				onChange={ onChange }
+				fetchSuggestions={ noop }
+				fetchSavedInfo={ () => Promise.resolve( ITEMS ) }
+			/>
+		);
+
+		fireEvent.click( await screen.findByRole( 'button', { name: 'Reorder Content' } ) );
+		await screen.findByLabelText( 'Move Up: Beta' );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		expect( onChange ).not.toHaveBeenCalled();
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'asks for the titles once and shares them with the modal', async () => {
+		const fetchSavedInfo = jest.fn( () => Promise.resolve( ITEMS ) );
+		render( <SpecificPostsControl postIds={ [ 11, 22 ] } onChange={ noop } fetchSuggestions={ noop } fetchSavedInfo={ fetchSavedInfo } /> );
+
+		fireEvent.click( await screen.findByRole( 'button', { name: 'Reorder Content' } ) );
+		await screen.findByLabelText( 'Move Up: Beta' );
+
+		expect( fetchSavedInfo ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/plugins/newspack-blocks/src/components/specific-posts-control.test.js
+++ b/plugins/newspack-blocks/src/components/specific-posts-control.test.js
@@ -26,23 +26,25 @@ describe( 'SpecificPostsControl', () => {
 
 	it( 'keeps the reorder button focusable while too little content is selected', async () => {
 		render( <SpecificPostsControl postIds={ [ 11 ] } onChange={ noop } fetchSuggestions={ noop } fetchSavedInfo={ noItems } /> );
-		const reorder = await screen.findByRole( 'button', { name: /Reorder Content/ } );
+		const reorder = await screen.findByRole( 'button', { name: 'Reorder Content' } );
 		expect( reorder ).toHaveAttribute( 'aria-disabled', 'true' );
 		reorder.focus();
 		expect( document.activeElement ).toBe( reorder );
 	} );
 
-	it( 'says why the reorder button is unavailable', async () => {
+	it( 'describes why the reorder button is unavailable without renaming it', async () => {
 		render( <SpecificPostsControl postIds={ [ 11 ] } onChange={ noop } fetchSuggestions={ noop } fetchSavedInfo={ noItems } /> );
-		expect( await screen.findByRole( 'button', { name: 'Reorder Content: pick at least two items' } ) ).toBeInTheDocument();
+		const reorder = await screen.findByRole( 'button', { name: 'Reorder Content' } );
+		const description = document.getElementById( reorder.getAttribute( 'aria-describedby' ) );
+		expect( description ).toHaveTextContent( 'Pick at least two items to reorder them.' );
 	} );
 
 	// A button with visible children shows no tooltip by default, so the reason
 	// would otherwise reach assistive technology only.
 	it( 'shows the reason to sighted users too', async () => {
 		render( <SpecificPostsControl postIds={ [ 11 ] } onChange={ noop } fetchSuggestions={ noop } fetchSavedInfo={ noItems } /> );
-		( await screen.findByRole( 'button', { name: 'Reorder Content: pick at least two items' } ) ).focus();
-		expect( await screen.findByRole( 'tooltip' ) ).toHaveTextContent( 'pick at least two items' );
+		( await screen.findByRole( 'button', { name: 'Reorder Content' } ) ).focus();
+		expect( await screen.findByRole( 'tooltip' ) ).toHaveTextContent( 'Pick at least two items to reorder them.' );
 	} );
 
 	it( 'shows no tooltip once the button is usable', async () => {

--- a/plugins/newspack-blocks/src/components/specific-posts-control.test.js
+++ b/plugins/newspack-blocks/src/components/specific-posts-control.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -121,5 +121,53 @@ describe( 'SpecificPostsControl', () => {
 		await screen.findByLabelText( 'Move Up: Beta' );
 
 		expect( fetchSavedInfo ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	describe( 'when a request fails', () => {
+		let errorSpy;
+
+		beforeEach( () => {
+			errorSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+		} );
+
+		afterEach( () => {
+			errorSpy.mockRestore();
+		} );
+
+		it( 'asks again rather than sharing the failure', async () => {
+			const fetchSavedInfo = jest.fn().mockRejectedValueOnce( new Error( 'unreachable' ) ).mockResolvedValue( ITEMS );
+			render( <SpecificPostsControl postIds={ [ 11, 22 ] } onChange={ noop } fetchSuggestions={ noop } fetchSavedInfo={ fetchSavedInfo } /> );
+
+			// The token field falls back to the IDs, which is where the failure lands.
+			await screen.findByText( '11' );
+
+			fireEvent.click( screen.getByRole( 'button', { name: 'Reorder Content' } ) );
+			expect( await screen.findByLabelText( 'Move Up: Beta' ) ).toBeInTheDocument();
+			expect( fetchSavedInfo ).toHaveBeenCalledTimes( 2 );
+		} );
+
+		it( 'leaves a newer request in place when an older one fails late', async () => {
+			let failFirst;
+			const first = new Promise( ( resolve, reject ) => {
+				failFirst = reject;
+			} );
+			const fetchSavedInfo = jest.fn().mockReturnValueOnce( first ).mockResolvedValue( ITEMS );
+			const props = { onChange: noop, fetchSuggestions: noop, fetchSavedInfo };
+			const { rerender } = render( <SpecificPostsControl postIds={ [ 11 ] } { ...props } /> );
+
+			rerender( <SpecificPostsControl postIds={ [ 11, 22 ] } { ...props } /> );
+			fireEvent.click( screen.getByRole( 'button', { name: 'Reorder Content' } ) );
+			await screen.findByLabelText( 'Move Up: Beta' );
+
+			await act( async () => {
+				failFirst( new Error( 'too late' ) );
+			} );
+
+			fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+			fireEvent.click( screen.getByRole( 'button', { name: 'Reorder Content' } ) );
+			await screen.findByLabelText( 'Move Up: Beta' );
+
+			expect( fetchSavedInfo ).toHaveBeenCalledTimes( 2 );
+		} );
 	} );
 } );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -392,6 +392,9 @@ importers:
 
   plugins/newspack-blocks:
     dependencies:
+      '@wordpress/ui':
+        specifier: ^0.16.0
+        version: 0.16.0(@date-fns/tz@1.5.0)(@types/react@18.3.31)(date-fns@4.4.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))
       classnames:
         specifier: ^2.5.1
         version: 2.5.1


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A Homepage Posts or Carousel block set to Static mode lets a publisher pick specific posts, but there has been no way to reorder them. Moving one out-of-place story to the top means deleting every token after it and retyping them.

A **Reorder Content** button now sits below the Content field and opens a modal listing the selection in order. Rows move by dragging, or with per-row up and down chevrons, so the feature works with a mouse, a keyboard and on touch. Save writes the new order back; closing with unsaved changes asks before discarding.

![Reorder Content button in the block sidebar, highlighted in the post editor](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/11/k9axx0bd-final-01-editor-sidebar.png)

![Reorder Content modal open over the post editor, listing five posts in order](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/11/mrs5hjsa-final-02-editor-modal.png)

![Discard confirmation raised over the reorder modal after a row was moved](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/11/bn36xczy-final-03-editor-discard.png)

Both blocks gain the feature from one change, since they share `src/components/query-controls.js`.

**No PHP changes.** `Newspack_Blocks::build_articles_query()` already sets `post__in` with `orderby => post__in`, and the editor preview endpoint does the same, so the stored array order was honoured end to end already. The gap was only in the editor UI.

Notes for reviewers:

* Rows are `@wordpress/ui` Card components. The package is in the dependency-extraction plugin's `BUNDLED_PACKAGES` list, so it bundles rather than resolving a `wp.ui` global — which matters, because WordPress does not ship one. Card's compiled CSS carries hardcoded fallbacks for every design token it reads, so no token stylesheet is imported; importing one placed a `:root` block after newspack-components' brand remap and reset 15 `--wpds-*` properties to upstream values across the editor.
* The modal owns its own Escape, ✕ and backdrop handling rather than using `Modal`'s. Core defers `onRequestClose` behind `closeModal()`, which plays the exit animation first, so a close vetoed by the discard prompt made the modal visibly fade out and back in.
* IDs are never re-derived from labels. Every save is a permutation of the array the modal opened with, so no path can drop, duplicate or retype an ID. A post that is later trashed keeps its slot as a `(no title)` row rather than being silently dropped from the block.

NPPD-946

### How to test the changes in this Pull Request:

1. Add a **Homepage Posts** block to a page and set Mode to **Static**.
2. Pick one post. **Reorder Content** stays disabled. Pick a second and it enables.
3. Open it, drag the last row to the top, and Save. The block preview redraws in the new order.
4. Reopen it. **Save** is disabled until you move something, and moving a row back to where it started disables it again.
5. Move a row, then press Escape. The discard prompt appears over the modal, which should not move, fade or flicker. Repeat with the ✕ and with a click on the backdrop.
6. Choose **Keep editing** to return to the list, or **Discard** to close. Reopen and confirm the original order survived.
7. Reorder with the chevrons only. Walking a row to the top moves focus to that row's other chevron once the one you pressed disables.
8. Publish the page and check the front end renders in the saved order.
9. Repeat step 3 on a **Carousel** block.
10. With a post selected, trash it in another tab, reload the editor and reopen the modal. A `(no title)` row holds its place, and reordering does not drop it.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

101 tests across 6 suites. Coverage includes the array-move helper, the chevron reorder and focus handoff, the disabled thresholds, all four close paths, and the backdrop press-target logic that keeps a row drag released outside the modal from dismissing it.

