### PR TITLE
fix(newsletters): hide abandoned auto-drafts from lists (DSGNEWS-213)

### DIFF
--- a/plugins/newspack-newsletters/includes/admin/class-ads-list-rest.php
+++ b/plugins/newspack-newsletters/includes/admin/class-ads-list-rest.php
@@ -198,9 +198,12 @@ class Ads_List_REST {
 					$post_status_set[] = 'trash';
 					$bucket_clauses[]  = "{$wpdb->posts}.post_status = 'trash'";
 					break;
+				// `auto-draft` is deliberately absent: an abandoned "Add new" is
+				// empty by construction (any save promotes it to `draft`), and
+				// core's own lists hide it too.
 				case 'draft':
-					$post_status_set    = array_merge( $post_status_set, [ 'draft', 'pending', 'auto-draft' ] );
-					$bucket_clauses[]   = "{$wpdb->posts}.post_status IN ( 'draft', 'pending', 'auto-draft' )";
+					$post_status_set    = array_merge( $post_status_set, [ 'draft', 'pending' ] );
+					$bucket_clauses[]   = "{$wpdb->posts}.post_status IN ( 'draft', 'pending' )";
 					break;
 				case 'expired':
 					$post_status_set    = array_merge( $post_status_set, [ 'publish', 'private' ] );

--- a/plugins/newspack-newsletters/includes/admin/class-ads-list-rest.php
+++ b/plugins/newspack-newsletters/includes/admin/class-ads-list-rest.php
@@ -198,9 +198,6 @@ class Ads_List_REST {
 					$post_status_set[] = 'trash';
 					$bucket_clauses[]  = "{$wpdb->posts}.post_status = 'trash'";
 					break;
-				// `auto-draft` is deliberately absent: an abandoned "Add new" is
-				// empty by construction (any save promotes it to `draft`), and
-				// core's own lists hide it too.
 				case 'draft':
 					$post_status_set    = array_merge( $post_status_set, [ 'draft', 'pending' ] );
 					$bucket_clauses[]   = "{$wpdb->posts}.post_status IN ( 'draft', 'pending' )";

--- a/plugins/newspack-newsletters/includes/admin/class-newsletters-list-rest.php
+++ b/plugins/newspack-newsletters/includes/admin/class-newsletters-list-rest.php
@@ -118,6 +118,14 @@ class Newsletters_List_REST {
 	 */
 	public static function align_status_filter_with_scheduled_meta( $args, $request ) {
 		$values = self::parse_status_values( $request->get_param( 'status' ) );
+		// A legacy `auto-draft` selection resolves to the Draft bucket, as the
+		// list's own deep links do. Left as-is it would match no bucket, and the
+		// query would run unfiltered against `post_status = auto-draft`.
+		if ( in_array( 'auto-draft', $values, true ) ) {
+			$values   = array_diff( $values, [ 'auto-draft' ] );
+			$values[] = 'draft';
+			$values   = array_values( array_unique( $values ) );
+		}
 		if ( empty( $values ) ) {
 			return $args;
 		}
@@ -132,9 +140,6 @@ class Newsletters_List_REST {
 		if ( $wants_sent || $wants_draft || $wants_scheduled ) {
 			$widened = array_merge( $widened, [ 'publish', 'private' ] );
 		}
-		// `auto-draft` is deliberately absent: an abandoned "Add new" is empty
-		// by construction (any save promotes it to `draft`), and core's own
-		// lists hide it too.
 		if ( $wants_draft || $wants_scheduled ) {
 			$widened = array_merge( $widened, [ 'draft', 'pending' ] );
 		}

--- a/plugins/newspack-newsletters/includes/admin/class-newsletters-list-rest.php
+++ b/plugins/newspack-newsletters/includes/admin/class-newsletters-list-rest.php
@@ -123,7 +123,7 @@ class Newsletters_List_REST {
 		}
 
 		$wants_sent      = ! empty( array_intersect( $values, [ 'publish', 'private' ] ) );
-		$wants_draft     = ! empty( array_intersect( $values, [ 'draft', 'pending', 'auto-draft' ] ) );
+		$wants_draft     = ! empty( array_intersect( $values, [ 'draft', 'pending' ] ) );
 		$wants_scheduled = in_array( 'future', $values, true );
 		$wants_trash     = in_array( 'trash', $values, true );
 
@@ -132,8 +132,11 @@ class Newsletters_List_REST {
 		if ( $wants_sent || $wants_draft || $wants_scheduled ) {
 			$widened = array_merge( $widened, [ 'publish', 'private' ] );
 		}
+		// `auto-draft` is deliberately absent: an abandoned "Add new" is empty
+		// by construction (any save promotes it to `draft`), and core's own
+		// lists hide it too.
 		if ( $wants_draft || $wants_scheduled ) {
-			$widened = array_merge( $widened, [ 'draft', 'pending', 'auto-draft' ] );
+			$widened = array_merge( $widened, [ 'draft', 'pending' ] );
 		}
 		if ( $wants_scheduled ) {
 			$widened[] = 'future';
@@ -168,11 +171,10 @@ class Newsletters_List_REST {
 		}
 		if ( $wants_draft ) {
 			$bucket_clauses[] = $wpdb->prepare(
-				"( NOT EXISTS ( SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID AND meta_key = %s AND meta_value <> '' ) AND ( {$wpdb->posts}.post_status IN (%s, %s, %s) OR ( {$wpdb->posts}.post_status IN (%s, %s) AND EXISTS ( SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID AND meta_key = %s AND meta_value <> '' ) ) ) )",
+				"( NOT EXISTS ( SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID AND meta_key = %s AND meta_value <> '' ) AND ( {$wpdb->posts}.post_status IN (%s, %s) OR ( {$wpdb->posts}.post_status IN (%s, %s) AND EXISTS ( SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID AND meta_key = %s AND meta_value <> '' ) ) ) )",
 				'sending_scheduled',
 				'draft',
 				'pending',
-				'auto-draft',
 				'publish',
 				'private',
 				'scheduling_error'

--- a/plugins/newspack-newsletters/includes/admin/class-newsletters-list-rest.php
+++ b/plugins/newspack-newsletters/includes/admin/class-newsletters-list-rest.php
@@ -118,16 +118,15 @@ class Newsletters_List_REST {
 	 */
 	public static function align_status_filter_with_scheduled_meta( $args, $request ) {
 		$values = self::parse_status_values( $request->get_param( 'status' ) );
-		// A legacy `auto-draft` selection resolves to the Draft bucket, as the
-		// list's own deep links do. Left as-is it would match no bucket, and the
-		// query would run unfiltered against `post_status = auto-draft`.
-		if ( in_array( 'auto-draft', $values, true ) ) {
-			$values   = array_diff( $values, [ 'auto-draft' ] );
-			$values[] = 'draft';
-			$values   = array_values( array_unique( $values ) );
-		}
 		if ( empty( $values ) ) {
 			return $args;
+		}
+		$values = array_values( array_diff( $values, [ 'auto-draft' ] ) );
+		if ( empty( $values ) ) {
+			// Asked for auto-drafts and nothing else, so answer with nothing.
+			// Returning here instead would leave the posts controller's
+			// `post_status = auto-draft` running with no bucket clause.
+			return self::install_bucket_filter( $args, [ '1 = 0' ], '_newspack_nl_bucket_token' );
 		}
 
 		$wants_sent      = ! empty( array_intersect( $values, [ 'publish', 'private' ] ) );
@@ -146,10 +145,7 @@ class Newsletters_List_REST {
 		if ( $wants_scheduled ) {
 			$widened[] = 'future';
 		}
-		$widened = array_values( array_unique( $widened ) );
-		if ( $widened !== $values ) {
-			$args['post_status'] = $widened;
-		}
+		$args['post_status'] = array_values( array_unique( $widened ) );
 
 		global $wpdb;
 		$bucket_clauses = [];

--- a/plugins/newspack-newsletters/includes/ads/class-ads.php
+++ b/plugins/newspack-newsletters/includes/ads/class-ads.php
@@ -387,8 +387,6 @@ final class Ads {
 		global $wpdb;
 
 		$taxonomy_name = is_object( $taxonomy ) ? $taxonomy->name : $taxonomy;
-		// Include auto-draft to match the Ads list's draft bucket.
-		$statuses = [ 'publish', 'private', 'future', 'draft', 'pending', 'auto-draft' ];
 
 		foreach ( $terms as $tt_id ) {
 			$tt_id = (int) $tt_id;
@@ -398,15 +396,17 @@ final class Ads {
 					INNER JOIN {$wpdb->posts} p ON p.ID = tr.object_id
 					WHERE tr.term_taxonomy_id = %d
 					AND p.post_type = %s
-					AND p.post_status IN ( %s, %s, %s, %s, %s, %s )",
+					AND p.post_status IN ( %s, %s, %s, %s, %s )",
 					$tt_id,
 					self::CPT,
-					$statuses[0],
-					$statuses[1],
-					$statuses[2],
-					$statuses[3],
-					$statuses[4],
-					$statuses[5]
+					// `auto-draft` is absent to match the Ads list's draft
+					// bucket, which hides an abandoned "Add new" the way
+					// core's own lists do.
+					'publish',
+					'private',
+					'future',
+					'draft',
+					'pending'
 				)
 			);
 
@@ -420,10 +420,10 @@ final class Ads {
 	 * One-time recount of existing advertiser terms so counts predating
 	 * the custom count callback refresh without waiting for the next edit.
 	 * Bump the sentinel whenever the counted statuses change so already
-	 * recounted sites pick up the new semantics (v3: added auto-draft).
+	 * recounted sites pick up the new semantics (v4: dropped auto-draft).
 	 */
 	public static function maybe_recount_advertiser_terms() {
-		$option = 'newspack_nl_advertiser_count_recounted_v3';
+		$option = 'newspack_nl_advertiser_count_recounted_v4';
 		if ( get_option( $option ) ) {
 			return;
 		}

--- a/plugins/newspack-newsletters/includes/ads/class-ads.php
+++ b/plugins/newspack-newsletters/includes/ads/class-ads.php
@@ -26,6 +26,16 @@ final class Ads {
 	const ADVERTISER_TAX = 'newspack_nl_advertiser';
 
 	/**
+	 * Statuses an advertiser's term count covers. Must stay equal to the union
+	 * of the non-trash `post_status` sets in `Ads_List_REST::filter_rest_query`,
+	 * or the count disagrees with the list it describes. Bump the recount
+	 * sentinel in `maybe_recount_advertiser_terms` whenever this changes.
+	 *
+	 * @var string[]
+	 */
+	const COUNTED_STATUSES = [ 'publish', 'private', 'future', 'draft', 'pending' ];
+
+	/**
 	 * Ads already inserted in the newsletter.
 	 *
 	 * @var array[] Ad ids mapped by newsletter id.
@@ -399,14 +409,11 @@ final class Ads {
 					AND p.post_status IN ( %s, %s, %s, %s, %s )",
 					$tt_id,
 					self::CPT,
-					// `auto-draft` is absent to match the Ads list's draft
-					// bucket, which hides an abandoned "Add new" the way
-					// core's own lists do.
-					'publish',
-					'private',
-					'future',
-					'draft',
-					'pending'
+					self::COUNTED_STATUSES[0],
+					self::COUNTED_STATUSES[1],
+					self::COUNTED_STATUSES[2],
+					self::COUNTED_STATUSES[3],
+					self::COUNTED_STATUSES[4]
 				)
 			);
 
@@ -419,14 +426,22 @@ final class Ads {
 	/**
 	 * One-time recount of existing advertiser terms so counts predating
 	 * the custom count callback refresh without waiting for the next edit.
-	 * Bump the sentinel whenever the counted statuses change so already
-	 * recounted sites pick up the new semantics (v4: dropped auto-draft).
 	 */
 	public static function maybe_recount_advertiser_terms() {
 		$option = 'newspack_nl_advertiser_count_recounted_v4';
 		if ( get_option( $option ) ) {
 			return;
 		}
+		// `admin_init` also fires on admin-ajax.php, including for logged-out
+		// requests, so gate on the taxonomy's own management capability.
+		if ( ! current_user_can( 'manage_categories' ) ) {
+			return;
+		}
+		// Claim before the work. The recount is one `COUNT(*)` plus one `UPDATE`
+		// per term, so a concurrent burst would otherwise run it once each, and a
+		// pass that times out would re-arm it on every later request.
+		update_option( $option, 1 );
+		delete_option( 'newspack_nl_advertiser_count_recounted_v3' );
 
 		$term_ids = get_terms(
 			[
@@ -435,13 +450,10 @@ final class Ads {
 				'fields'     => 'tt_ids',
 			]
 		);
-		if ( is_wp_error( $term_ids ) ) {
+		if ( is_wp_error( $term_ids ) || empty( $term_ids ) ) {
 			return;
 		}
-		if ( ! empty( $term_ids ) ) {
-			wp_update_term_count_now( $term_ids, self::ADVERTISER_TAX );
-		}
-		update_option( $option, 1 );
+		wp_update_term_count_now( $term_ids, self::ADVERTISER_TAX );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/ads/class-ads.php
+++ b/plugins/newspack-newsletters/includes/ads/class-ads.php
@@ -434,7 +434,8 @@ final class Ads {
 		}
 		// `admin_init` also fires on admin-ajax.php, including for logged-out
 		// requests, so gate on the taxonomy's own management capability.
-		if ( ! current_user_can( 'manage_categories' ) ) {
+		$taxonomy = get_taxonomy( self::ADVERTISER_TAX );
+		if ( ! $taxonomy || ! current_user_can( $taxonomy->cap->manage_terms ) ) {
 			return;
 		}
 		// Claim before the work. The recount is one `COUNT(*)` plus one `UPDATE`

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/build-query.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/build-query.js
@@ -14,8 +14,9 @@ import { buildQueryParams as baseBuildQueryParams, toQueryString } from '../../u
 // these as `kind=scheduled` regardless of `start_date` meta. Without
 // `future` in the default set, WP-scheduled rows would silently
 // disappear from the list (the classic CPT list showed them).
-// `auto-draft` keeps an abandoned "Add new" visible.
-const DEFAULT_STATUSES = 'publish,private,future,draft,pending,auto-draft';
+// `auto-draft` is excluded, as core's own lists do — see the newsletters
+// list note; an `auto-draft` row is always an empty abandoned "Add new".
+const DEFAULT_STATUSES = 'publish,private,future,draft,pending';
 
 // Each value is the WP REST taxonomy filter param — i.e. the
 // taxonomy's `rest_base`, which defaults to the taxonomy slug when

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/build-query.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/build-query.js
@@ -14,8 +14,6 @@ import { buildQueryParams as baseBuildQueryParams, toQueryString } from '../../u
 // these as `kind=scheduled` regardless of `start_date` meta. Without
 // `future` in the default set, WP-scheduled rows would silently
 // disappear from the list (the classic CPT list showed them).
-// `auto-draft` is excluded, as core's own lists do — see the newsletters
-// list note; an `auto-draft` row is always an empty abandoned "Add new".
 const DEFAULT_STATUSES = 'publish,private,future,draft,pending';
 
 // Each value is the WP REST taxonomy filter param — i.e. the

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/build-query.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/build-query.test.js
@@ -47,9 +47,8 @@ describe( 'ads buildQueryParams', () => {
 		expect( status.split( ',' ) ).toContain( 'future' );
 	} );
 
-	it( 'includes auto-draft so a post-new + back row stays visible', () => {
-		const { status } = buildQueryParams( {} );
-		expect( status.split( ',' ) ).toContain( 'auto-draft' );
+	it( 'excludes auto-draft so an abandoned "Add new" never reaches the list', () => {
+		expect( buildQueryParams( {} ).status.split( ',' ) ).not.toContain( 'auto-draft' );
 	} );
 
 	it( 'maps a single kind filter to the kind-specific REST query param', () => {

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.js
@@ -49,8 +49,7 @@ const getTitle = item => item?.title?.raw ?? item?.title?.rendered ?? '';
 
 const renderTitle = ( { item } ) => {
 	const raw = getTitle( item );
-	// Auto-drafts carry WordPress's "Auto Draft" placeholder; show a friendly title instead.
-	const title = ! raw || 'auto-draft' === item?.status ? __( '(no title)', 'newspack-newsletters' ) : raw;
+	const title = raw || __( '(no title)', 'newspack-newsletters' );
 	return (
 		<a className="newspack-newsletters-list__title" href={ editUrl( item ) } onClickCapture={ event => event.stopPropagation() }>
 			<strong>{ title }</strong>

--- a/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/actions.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/actions.js
@@ -20,7 +20,7 @@ function buildEditUrl( item ) {
 const deleteOne = id => apiFetch( { path: `${ COLLECTION_PATH }/${ id }?force=true`, method: 'DELETE' } );
 
 function copyTitle( source ) {
-	// `??` would pick auto-drafts' empty `title.raw` and produce "Copy of ".
+	// `??` would keep an empty `title.raw` and produce "Copy of ".
 	const raw = ( source?.title?.raw ?? '' ).trim();
 	const rendered = ( source?.title?.rendered ?? '' ).trim();
 	const sourceTitle = raw || rendered || __( 'Untitled', 'newspack-newsletters' );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/fields.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/fields.js
@@ -117,8 +117,7 @@ export function getFields( { renamingId = null, onRenameCommit, onRenameCancel, 
 			return <RenamingTitle item={ item } onCommit={ next => onRenameCommit?.( item, next ) } onCancel={ () => onRenameCancel?.() } />;
 		}
 		const raw = getRawTitle( item );
-		// Auto-drafts carry WordPress's "Auto Draft" placeholder; show a friendly title instead.
-		const label = ! raw || 'auto-draft' === item?.status ? __( '(no title)', 'newspack-newsletters' ) : raw;
+		const label = raw || __( '(no title)', 'newspack-newsletters' );
 		// Prebuilts aren't editable; only user-owned layouts link to the editor.
 		if ( item?.is_prebuilt ) {
 			return <strong>{ label }</strong>;

--- a/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/use-layouts-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/use-layouts-data.js
@@ -6,8 +6,9 @@ import { buildQueryParams, toQueryString } from '../../utils/build-query';
 import { isFetchAllPerPage } from '../../utils/per-page';
 
 const COLLECTION_PATH = `/wp/v2/${ LAYOUT_CPT_SLUG }`;
-// `future` is excluded — layouts don't surface scheduling. `auto-draft` keeps "Add new" + back visible.
-const DEFAULT_STATUSES = 'publish,private,draft,pending,auto-draft';
+// `future` is excluded — layouts don't surface scheduling. `auto-draft` too,
+// as core's own lists do — see the newsletters list note.
+const DEFAULT_STATUSES = 'publish,private,draft,pending';
 
 function buildPath( view ) {
 	if ( ! view ) {

--- a/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/use-layouts-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/use-layouts-data.js
@@ -6,11 +6,10 @@ import { buildQueryParams, toQueryString } from '../../utils/build-query';
 import { isFetchAllPerPage } from '../../utils/per-page';
 
 const COLLECTION_PATH = `/wp/v2/${ LAYOUT_CPT_SLUG }`;
-// `future` is excluded — layouts don't surface scheduling. `auto-draft` too,
-// as core's own lists do — see the newsletters list note.
+// `future` is excluded: layouts don't surface scheduling.
 const DEFAULT_STATUSES = 'publish,private,draft,pending';
 
-function buildPath( view ) {
+export function buildPath( view ) {
 	if ( ! view ) {
 		return '';
 	}

--- a/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/use-layouts-data.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/use-layouts-data.test.js
@@ -1,0 +1,17 @@
+import { buildPath } from './use-layouts-data';
+
+const statusesFor = view => new URLSearchParams( buildPath( view ).split( '?' )[ 1 ] ).get( 'status' ).split( ',' );
+
+describe( 'layouts buildPath', () => {
+	it( 'returns an empty path when the view is not ready', () => {
+		expect( buildPath( null ) ).toBe( '' );
+	} );
+
+	it( 'excludes auto-draft so an abandoned "Add new" never reaches the list', () => {
+		expect( statusesFor( {} ) ).not.toContain( 'auto-draft' );
+	} );
+
+	it( 'lists the writable statuses layouts support', () => {
+		expect( statusesFor( {} ).sort() ).toEqual( [ 'draft', 'pending', 'private', 'publish' ] );
+	} );
+} );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.js
@@ -10,8 +10,10 @@
 
 import { buildQueryParams as baseBuildQueryParams, toQueryString } from '../../utils/build-query';
 
-// `auto-draft` so an abandoned "Add new" still shows in the list.
-const DEFAULT_STATUSES = 'publish,private,future,draft,pending,auto-draft';
+// `auto-draft` is excluded, as core's own lists do: WordPress inserts the
+// row when `post-new.php` loads, and any save promotes it to `draft`, so an
+// `auto-draft` here is always an abandoned "Add new" with nothing in it.
+const DEFAULT_STATUSES = 'publish,private,future,draft,pending';
 
 // `status` is handled separately by the shared util's status-filter branch, not here.
 const FIELD_TO_QUERY_PARAM = {

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.js
@@ -10,9 +10,8 @@
 
 import { buildQueryParams as baseBuildQueryParams, toQueryString } from '../../utils/build-query';
 
-// `auto-draft` is excluded, as core's own lists do: WordPress inserts the
-// row when `post-new.php` loads, and any save promotes it to `draft`, so an
-// `auto-draft` here is always an abandoned "Add new" with nothing in it.
+// `auto-draft` is excluded: any save promotes the row to `draft`, so one still
+// at `auto-draft` is always an abandoned "Add new" with nothing in it.
 const DEFAULT_STATUSES = 'publish,private,future,draft,pending';
 
 // `status` is handled separately by the shared util's status-filter branch, not here.

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.test.js
@@ -48,7 +48,6 @@ describe( 'buildQueryParams', () => {
 
 	it( 'excludes auto-draft so an abandoned "Add new" never reaches the list', () => {
 		expect( buildQueryParams( {} ).status.split( ',' ) ).not.toContain( 'auto-draft' );
-		// The Draft filter is the other way in — it must not widen the set back.
 		const filtered = buildQueryParams( {
 			filters: [ { field: 'status', operator: 'isAny', value: [ 'draft,pending' ] } ],
 		} );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.test.js
@@ -46,9 +46,13 @@ describe( 'buildQueryParams', () => {
 		expect( status.split( ',' ) ).not.toContain( 'trash' );
 	} );
 
-	it( 'includes auto-draft so a post-new + back row stays visible', () => {
-		const { status } = buildQueryParams( {} );
-		expect( status.split( ',' ) ).toContain( 'auto-draft' );
+	it( 'excludes auto-draft so an abandoned "Add new" never reaches the list', () => {
+		expect( buildQueryParams( {} ).status.split( ',' ) ).not.toContain( 'auto-draft' );
+		// The Draft filter is the other way in — it must not widen the set back.
+		const filtered = buildQueryParams( {
+			filters: [ { field: 'status', operator: 'isAny', value: [ 'draft,pending' ] } ],
+		} );
+		expect( filtered.status.split( ',' ) ).not.toContain( 'auto-draft' );
 	} );
 
 	it( 'replaces the default status set when the user filters by status', () => {

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/fields.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/fields.js
@@ -171,7 +171,7 @@ export function getFields( { authors = [], categories = [], tags = [], sendLists
 				{ value: 'publish,private', label: statusLabels.sent },
 				{ value: 'future', label: statusLabels.scheduled },
 				// Match `get_status_for_post`'s draft fallthrough.
-				{ value: 'draft,pending,auto-draft', label: statusLabels.draft },
+				{ value: 'draft,pending', label: statusLabels.draft },
 				{ value: 'trash', label: statusLabels.trash },
 			],
 			filterBy: { operators: [ 'isAny' ], isPrimary: true },

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/fields.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/fields.js
@@ -43,8 +43,7 @@ const getTitle = item => item?.title?.raw ?? item?.title?.rendered ?? '';
 
 const renderTitle = ( { item } ) => {
 	const raw = getTitle( item );
-	// New newsletters carry WordPress's "Auto Draft" placeholder title; show a friendly label instead.
-	const title = ! raw || 'auto-draft' === item?.status ? __( '(no subject)', 'newspack-newsletters' ) : raw;
+	const title = raw || __( '(no subject)', 'newspack-newsletters' );
 	return (
 		<a className="newspack-newsletters-list__title" href={ editUrl( item ) } onClickCapture={ event => event.stopPropagation() }>
 			<strong>{ title }</strong>

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/initial-filters.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/initial-filters.js
@@ -8,11 +8,13 @@
 
 import { makeGetInitialView } from '../../utils/initial-view';
 
+// The `auto-draft` key stays so a legacy deep link still lands on the Draft
+// chip, even though the list no longer queries that status.
 const POST_STATUS_TO_FILTER_VALUE = {
 	trash: 'trash',
-	draft: 'draft,pending,auto-draft',
-	pending: 'draft,pending,auto-draft',
-	'auto-draft': 'draft,pending,auto-draft',
+	draft: 'draft,pending',
+	pending: 'draft,pending',
+	'auto-draft': 'draft,pending',
 	future: 'future',
 	publish: 'publish,private',
 	private: 'publish,private',

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/initial-filters.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/initial-filters.js
@@ -8,8 +8,7 @@
 
 import { makeGetInitialView } from '../../utils/initial-view';
 
-// The `auto-draft` key stays so a legacy deep link still lands on the Draft
-// chip, even though the list no longer queries that status.
+// The `auto-draft` key stays so legacy deep links still land on the Draft chip.
 const POST_STATUS_TO_FILTER_VALUE = {
 	trash: 'trash',
 	draft: 'draft,pending',

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/initial-filters.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/initial-filters.test.js
@@ -11,7 +11,7 @@ describe( 'getInitialFilters', () => {
 	} );
 
 	it( 'maps post_status=draft, pending, and auto-draft to the combined draft filter', () => {
-		const expected = [ { field: 'status', operator: 'isAny', value: [ 'draft,pending,auto-draft' ] } ];
+		const expected = [ { field: 'status', operator: 'isAny', value: [ 'draft,pending' ] } ];
 		expect( getInitialFilters( '?post_status=draft' ) ).toEqual( expected );
 		expect( getInitialFilters( '?post_status=pending' ) ).toEqual( expected );
 		expect( getInitialFilters( '?post_status=auto-draft' ) ).toEqual( expected );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/initial-filters.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/initial-filters.test.js
@@ -10,7 +10,7 @@ describe( 'getInitialFilters', () => {
 		expect( getInitialFilters( '?post_status=trash' ) ).toEqual( [ { field: 'status', operator: 'isAny', value: [ 'trash' ] } ] );
 	} );
 
-	it( 'maps post_status=draft, pending, and auto-draft to the combined draft filter', () => {
+	it( 'maps post_status=draft, pending, and legacy auto-draft to the draft,pending filter', () => {
 		const expected = [ { field: 'status', operator: 'isAny', value: [ 'draft,pending' ] } ];
 		expect( getInitialFilters( '?post_status=draft' ) ).toEqual( expected );
 		expect( getInitialFilters( '?post_status=pending' ) ).toEqual( expected );

--- a/plugins/newspack-newsletters/tests/test-ads-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-ads-list-rest.php
@@ -409,9 +409,10 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * `kind=draft` covers `draft`, `pending`, and `auto-draft` — the
-	 * trio we resolve to the `draft` kind in the column. The filter
-	 * and the column have to agree on which rows belong in the bucket.
+	 * `kind=draft` covers `draft` and `pending` — the pair we resolve to
+	 * the `draft` kind in the column. The filter and the column have to
+	 * agree on which rows belong in the bucket. `auto-draft` is out: an
+	 * abandoned "Add new" is empty by construction (DSGNEWS-213).
 	 */
 	public function test_filter_rest_query_translates_draft_kind_to_full_draft_set() {
 		$args = Ads_List_REST::filter_rest_query(
@@ -422,7 +423,40 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 		$post_status = (array) $args['post_status'];
 		$this->assertContains( 'draft', $post_status );
 		$this->assertContains( 'pending', $post_status );
-		$this->assertContains( 'auto-draft', $post_status );
+		$this->assertNotContains( 'auto-draft', $post_status );
+	}
+
+	/**
+	 * An abandoned "Add new" must not reach the Draft bucket — neither
+	 * through `post_status` nor the bucket's `posts_where` (DSGNEWS-213).
+	 */
+	public function test_draft_kind_excludes_auto_draft_ads() {
+		$draft     = $this->make_ad( [ 'post_status' => 'draft' ] );
+		$abandoned = $this->make_ad(
+			[
+				'post_status' => 'auto-draft',
+				'post_title'  => 'Auto Draft',
+			]
+		);
+
+		$args = Ads_List_REST::filter_rest_query(
+			[],
+			$this->rest_request( [ Ads_List_REST::STATUS_QUERY_PARAM => 'draft' ] )
+		);
+
+		$query = new WP_Query(
+			array_merge(
+				$args,
+				[
+					'post_type'      => Ads::CPT,
+					'fields'         => 'ids',
+					'posts_per_page' => -1,
+				]
+			)
+		);
+
+		$this->assertContains( $draft, $query->posts, 'saved draft still surfaces' );
+		$this->assertNotContains( $abandoned, $query->posts, 'abandoned "Add new" never reaches the list' );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/tests/test-ads-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-ads-list-rest.php
@@ -409,10 +409,8 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * `kind=draft` covers `draft` and `pending` — the pair we resolve to
-	 * the `draft` kind in the column. The filter and the column have to
-	 * agree on which rows belong in the bucket. `auto-draft` is out: an
-	 * abandoned "Add new" is empty by construction (DSGNEWS-213).
+	 * The `draft` filter and the `draft` column must agree on which rows
+	 * belong in the bucket.
 	 */
 	public function test_filter_rest_query_translates_draft_kind_to_full_draft_set() {
 		$args = Ads_List_REST::filter_rest_query(
@@ -427,8 +425,8 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * An abandoned "Add new" must not reach the Draft bucket — neither
-	 * through `post_status` nor the bucket's `posts_where` (DSGNEWS-213).
+	 * An abandoned "Add new" must not reach the Draft bucket, through
+	 * either `post_status` or the bucket's `posts_where`.
 	 */
 	public function test_draft_kind_excludes_auto_draft_ads() {
 		$draft     = $this->make_ad( [ 'post_status' => 'draft' ] );
@@ -457,6 +455,28 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 
 		$this->assertContains( $draft, $query->posts, 'saved draft still surfaces' );
 		$this->assertNotContains( $abandoned, $query->posts, 'abandoned "Add new" never reaches the list' );
+	}
+
+	/**
+	 * The advertiser count covers whatever the list buckets show. If the two
+	 * drift apart the count describes a different set of rows than the list.
+	 */
+	public function test_counted_statuses_match_the_list_buckets() {
+		$listed = [];
+		foreach ( array_diff( Ads_List_REST::VALID_KINDS, [ 'trash' ] ) as $kind ) {
+			$args   = Ads_List_REST::filter_rest_query(
+				[],
+				$this->rest_request( [ Ads_List_REST::STATUS_QUERY_PARAM => $kind ] )
+			);
+			$listed = array_merge( $listed, (array) $args['post_status'] );
+		}
+
+		$listed = array_values( array_unique( $listed ) );
+		sort( $listed );
+		$counted = Ads::COUNTED_STATUSES;
+		sort( $counted );
+
+		$this->assertSame( $counted, $listed );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/tests/test-advertisers-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-advertisers-list-rest.php
@@ -130,11 +130,11 @@ class Advertisers_List_REST_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The Ads list `draft` bucket also surfaces `auto-draft` ads, so the
-	 * advertiser count must include them too — otherwise the count and the
-	 * list disagree by any auto-draft rows.
+	 * The Ads list `draft` bucket hides `auto-draft` ads (an abandoned
+	 * "Add new" is empty by construction — DSGNEWS-213), so the advertiser
+	 * count must skip them too, or the count and the list disagree.
 	 */
-	public function test_advertiser_count_includes_auto_draft_ads() {
+	public function test_advertiser_count_excludes_auto_draft_ads() {
 		$term = wp_insert_term( 'Auto-draft Advertiser', Ads::ADVERTISER_TAX );
 		$this->assertIsArray( $term );
 		$term_id = (int) $term['term_id'];
@@ -149,17 +149,17 @@ class Advertisers_List_REST_Test extends WP_UnitTestCase {
 
 		clean_term_cache( [ $term_id ], Ads::ADVERTISER_TAX );
 		$fresh = get_term( $term_id, Ads::ADVERTISER_TAX );
-		$this->assertSame( 1, (int) $fresh->count );
+		$this->assertSame( 0, (int) $fresh->count );
 	}
 
 	/**
 	 * A site that already ran the prior one-time recount must still pick up
-	 * the new auto-draft semantics: the bumped sentinel re-runs the recount
+	 * the new counted-status set: the bumped sentinel re-runs the recount
 	 * and refreshes stale term counts.
 	 */
 	public function test_recount_refreshes_stale_counts_after_sentinel_bump() {
-		update_option( 'newspack_nl_advertiser_count_recounted_v2', 1 );
-		delete_option( 'newspack_nl_advertiser_count_recounted_v3' );
+		update_option( 'newspack_nl_advertiser_count_recounted_v3', 1 );
+		delete_option( 'newspack_nl_advertiser_count_recounted_v4' );
 
 		$term = wp_insert_term( 'Stale-count Advertiser', Ads::ADVERTISER_TAX );
 		$this->assertIsArray( $term );
@@ -168,12 +168,12 @@ class Advertisers_List_REST_Test extends WP_UnitTestCase {
 		$ad = self::factory()->post->create(
 			[
 				'post_type'   => Ads::CPT,
-				'post_status' => 'auto-draft',
+				'post_status' => 'draft',
 			]
 		);
 		wp_set_object_terms( $ad, [ $term_id ], Ads::ADVERTISER_TAX );
 
-		// Force a stale count as if it predated the auto-draft semantics.
+		// Force a stale count as if it predated the current status set.
 		global $wpdb;
 		$tt_id = (int) get_term( $term_id, Ads::ADVERTISER_TAX )->term_taxonomy_id;
 		$wpdb->update( $wpdb->term_taxonomy, [ 'count' => 0 ], [ 'term_taxonomy_id' => $tt_id ] ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -184,7 +184,7 @@ class Advertisers_List_REST_Test extends WP_UnitTestCase {
 
 		clean_term_cache( [ $term_id ], Ads::ADVERTISER_TAX );
 		$this->assertSame( 1, (int) get_term( $term_id, Ads::ADVERTISER_TAX )->count );
-		$this->assertEquals( 1, get_option( 'newspack_nl_advertiser_count_recounted_v3' ) );
+		$this->assertEquals( 1, get_option( 'newspack_nl_advertiser_count_recounted_v4' ) );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/tests/test-advertisers-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-advertisers-list-rest.php
@@ -130,8 +130,7 @@ class Advertisers_List_REST_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The Ads list `draft` bucket hides `auto-draft` ads (an abandoned
-	 * "Add new" is empty by construction — DSGNEWS-213), so the advertiser
+	 * The Ads list `draft` bucket hides `auto-draft` ads, so the advertiser
 	 * count must skip them too, or the count and the list disagree.
 	 */
 	public function test_advertiser_count_excludes_auto_draft_ads() {
@@ -158,6 +157,7 @@ class Advertisers_List_REST_Test extends WP_UnitTestCase {
 	 * and refreshes stale term counts.
 	 */
 	public function test_recount_refreshes_stale_counts_after_sentinel_bump() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		update_option( 'newspack_nl_advertiser_count_recounted_v3', 1 );
 		delete_option( 'newspack_nl_advertiser_count_recounted_v4' );
 
@@ -185,6 +185,46 @@ class Advertisers_List_REST_Test extends WP_UnitTestCase {
 		clean_term_cache( [ $term_id ], Ads::ADVERTISER_TAX );
 		$this->assertSame( 1, (int) get_term( $term_id, Ads::ADVERTISER_TAX )->count );
 		$this->assertEquals( 1, get_option( 'newspack_nl_advertiser_count_recounted_v4' ) );
+		$this->assertFalse( get_option( 'newspack_nl_advertiser_count_recounted_v3' ), 'the superseded sentinel is cleaned up' );
+	}
+
+	/**
+	 * `admin_init` also fires on admin-ajax.php, including for logged-out
+	 * requests, so the recount must not run for them.
+	 */
+	public function test_recount_skips_requests_without_the_taxonomy_capability() {
+		wp_set_current_user( 0 );
+		delete_option( 'newspack_nl_advertiser_count_recounted_v4' );
+
+		Ads::maybe_recount_advertiser_terms();
+
+		$this->assertFalse( get_option( 'newspack_nl_advertiser_count_recounted_v4' ) );
+	}
+
+	/**
+	 * The sentinel is claimed before the recount runs, so a concurrent burst
+	 * does the work once rather than once each.
+	 */
+	public function test_recount_claims_the_sentinel_before_counting() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		delete_option( 'newspack_nl_advertiser_count_recounted_v4' );
+
+		$claimed_during_count = null;
+		add_filter(
+			'get_terms_args',
+			function ( $args, $taxonomies ) use ( &$claimed_during_count ) {
+				if ( in_array( Ads::ADVERTISER_TAX, (array) $taxonomies, true ) && null === $claimed_during_count ) {
+					$claimed_during_count = get_option( 'newspack_nl_advertiser_count_recounted_v4' );
+				}
+				return $args;
+			},
+			10,
+			2
+		);
+
+		Ads::maybe_recount_advertiser_terms();
+
+		$this->assertEquals( 1, $claimed_during_count );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/tests/test-newsletters-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-newsletters-list-rest.php
@@ -451,7 +451,7 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 			[ 'status' => 'publish' ],
 			[ 'status' => 'publish,private' ],
 			[ 'status' => [ 'publish', 'private' ] ],
-			[ 'status' => 'draft,pending,auto-draft' ],
+			[ 'status' => 'draft,pending' ],
 			[ 'status' => 'trash' ],
 		];
 
@@ -524,7 +524,7 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 	public function test_align_status_filter_widens_post_status_when_draft_selected() {
 		$args = Newsletters_List_REST::align_status_filter_with_scheduled_meta(
 			[],
-			$this->rest_request( [ 'status' => [ 'draft', 'pending', 'auto-draft' ] ] )
+			$this->rest_request( [ 'status' => [ 'draft', 'pending' ] ] )
 		);
 
 		$this->assertContains( 'publish', $args['post_status'] );
@@ -612,10 +612,17 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 				'post_date'   => '2026-04-20 10:00:00',
 			]
 		);
+		// Should NOT match: an abandoned "Add new" (DSGNEWS-213).
+		$abandoned = $this->make_newsletter(
+			[
+				'post_status' => 'auto-draft',
+				'post_title'  => 'Auto Draft',
+			]
+		);
 
 		$args = Newsletters_List_REST::align_status_filter_with_scheduled_meta(
 			[],
-			$this->rest_request( [ 'status' => [ 'draft', 'pending', 'auto-draft' ] ] )
+			$this->rest_request( [ 'status' => [ 'draft', 'pending' ] ] )
 		);
 
 		// `align_status_filter_with_scheduled_meta` widens `post_status`
@@ -628,6 +635,37 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 		$this->assertContains( $errored_draft, $query->posts, 'draft with scheduling_error surfaces' );
 		$this->assertContains( $errored_publish, $query->posts, 'publish row with scheduling_error surfaces — renders as Draft' );
 		$this->assertNotContains( $plain_publish, $query->posts, 'plain publish stays out — it renders as Sent, not Draft' );
+		$this->assertNotContains( $abandoned, $query->posts, 'auto-draft stays out — the Draft filter must not widen it back in' );
+	}
+
+	/**
+	 * The default status set the React list sends carries no `auto-draft`,
+	 * and the widening must not add one back (DSGNEWS-213).
+	 */
+	public function test_default_status_set_excludes_auto_draft() {
+		$plain_draft = $this->make_newsletter( [ 'post_status' => 'draft' ] );
+		$abandoned   = $this->make_newsletter(
+			[
+				'post_status' => 'auto-draft',
+				'post_title'  => 'Auto Draft',
+			]
+		);
+
+		$defaults = [ 'publish', 'private', 'future', 'draft', 'pending' ];
+		$args     = Newsletters_List_REST::align_status_filter_with_scheduled_meta(
+			[],
+			$this->rest_request( [ 'status' => $defaults ] )
+		);
+
+		// The widening only writes `post_status` when it actually changes the
+		// set; either way it must never reintroduce `auto-draft`.
+		$this->assertNotContains( 'auto-draft', (array) ( $args['post_status'] ?? [] ) );
+
+		// The posts controller applies the request's `status` as `post_status`,
+		// so drive the query with the same set the React list sends.
+		$query = $this->run_newsletter_query( array_merge( $args, [ 'post_status' => $defaults ] ) );
+		$this->assertContains( $plain_draft, $query->posts, 'saved draft still surfaces' );
+		$this->assertNotContains( $abandoned, $query->posts, 'abandoned "Add new" never reaches the list' );
 	}
 
 	/**
@@ -665,11 +703,11 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 
 		$args = Newsletters_List_REST::align_status_filter_with_scheduled_meta(
 			[],
-			$this->rest_request( [ 'status' => [ 'publish', 'private', 'draft', 'pending', 'auto-draft' ] ] )
+			$this->rest_request( [ 'status' => [ 'publish', 'private', 'draft', 'pending' ] ] )
 		);
 
 		$query = $this->run_newsletter_query(
-			array_merge( $args, [ 'post_status' => [ 'publish', 'private', 'draft', 'pending', 'auto-draft' ] ] )
+			array_merge( $args, [ 'post_status' => [ 'publish', 'private', 'draft', 'pending' ] ] )
 		);
 
 		$this->assertContains( $plain_publish, $query->posts, 'plain published row surfaces' );
@@ -725,7 +763,7 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 		// Scheduled+Draft: errored_publish renders as Draft → in.
 		$args  = Newsletters_List_REST::align_status_filter_with_scheduled_meta(
 			[],
-			$this->rest_request( [ 'status' => [ 'future', 'draft', 'pending', 'auto-draft' ] ] )
+			$this->rest_request( [ 'status' => [ 'future', 'draft', 'pending' ] ] )
 		);
 		$query = $this->run_newsletter_query( $args );
 		$this->assertContains( $future_post, $query->posts, 'Scheduled+Draft: future post surfaces' );

--- a/plugins/newspack-newsletters/tests/test-newsletters-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-newsletters-list-rest.php
@@ -612,7 +612,6 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 				'post_date'   => '2026-04-20 10:00:00',
 			]
 		);
-		// Should NOT match: an abandoned "Add new" (DSGNEWS-213).
 		$abandoned = $this->make_newsletter(
 			[
 				'post_status' => 'auto-draft',
@@ -639,8 +638,7 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The default status set the React list sends carries no `auto-draft`,
-	 * and the widening must not add one back (DSGNEWS-213).
+	 * The widening must not add `auto-draft` back to the default set.
 	 */
 	public function test_default_status_set_excludes_auto_draft() {
 		$plain_draft = $this->make_newsletter( [ 'post_status' => 'draft' ] );
@@ -652,19 +650,42 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 		);
 
 		$defaults = [ 'publish', 'private', 'future', 'draft', 'pending' ];
-		$args     = Newsletters_List_REST::align_status_filter_with_scheduled_meta(
-			[],
+		// Seed `post_status` the way the posts controller does, so the widening
+		// either leaves it or overwrites it, and the query runs on the result.
+		$args = Newsletters_List_REST::align_status_filter_with_scheduled_meta(
+			[ 'post_status' => $defaults ],
 			$this->rest_request( [ 'status' => $defaults ] )
 		);
 
-		// The widening only writes `post_status` when it actually changes the
-		// set; either way it must never reintroduce `auto-draft`.
-		$this->assertNotContains( 'auto-draft', (array) ( $args['post_status'] ?? [] ) );
+		$this->assertNotContains( 'auto-draft', (array) $args['post_status'] );
 
-		// The posts controller applies the request's `status` as `post_status`,
-		// so drive the query with the same set the React list sends.
-		$query = $this->run_newsletter_query( array_merge( $args, [ 'post_status' => $defaults ] ) );
+		$query = $this->run_newsletter_query( $args );
 		$this->assertContains( $plain_draft, $query->posts, 'saved draft still surfaces' );
+		$this->assertNotContains( $abandoned, $query->posts, 'abandoned "Add new" never reaches the list' );
+	}
+
+	/**
+	 * A legacy `auto-draft` deep link resolves to the Draft bucket rather
+	 * than querying the status directly.
+	 */
+	public function test_auto_draft_status_request_resolves_to_draft_bucket() {
+		$plain_draft = $this->make_newsletter( [ 'post_status' => 'draft' ] );
+		$abandoned   = $this->make_newsletter(
+			[
+				'post_status' => 'auto-draft',
+				'post_title'  => 'Auto Draft',
+			]
+		);
+
+		$args = Newsletters_List_REST::align_status_filter_with_scheduled_meta(
+			[ 'post_status' => [ 'auto-draft' ] ],
+			$this->rest_request( [ 'status' => [ 'auto-draft' ] ] )
+		);
+
+		$this->assertNotContains( 'auto-draft', (array) $args['post_status'] );
+
+		$query = $this->run_newsletter_query( $args );
+		$this->assertContains( $plain_draft, $query->posts, 'the Draft bucket answers instead' );
 		$this->assertNotContains( $abandoned, $query->posts, 'abandoned "Add new" never reaches the list' );
 	}
 

--- a/plugins/newspack-newsletters/tests/test-newsletters-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-newsletters-list-rest.php
@@ -518,8 +518,8 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 
 	/**
 	 * Draft selection widens `post_status` to include publish/private so
-	 * scheduling_error fallthrough rows are reachable. Other selections
-	 * don't need widening.
+	 * scheduling_error fallthrough rows are reachable. The selection always
+	 * drives `post_status`, so nothing the controller wrote survives it.
 	 */
 	public function test_align_status_filter_widens_post_status_when_draft_selected() {
 		$args = Newsletters_List_REST::align_status_filter_with_scheduled_meta(
@@ -531,12 +531,12 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 		$this->assertContains( 'private', $args['post_status'] );
 		$this->assertContains( 'draft', $args['post_status'] );
 
-		// Sent-only doesn't need widening.
+		// Sent-only needs no widening, and still replaces the incoming value.
 		$args = Newsletters_List_REST::align_status_filter_with_scheduled_meta(
-			[ 'post_status' => 'preserved' ],
+			[ 'post_status' => [ 'publish', 'private', 'auto-draft' ] ],
 			$this->rest_request( [ 'status' => [ 'publish', 'private' ] ] )
 		);
-		$this->assertSame( 'preserved', $args['post_status'] );
+		$this->assertSame( [ 'publish', 'private' ], $args['post_status'] );
 	}
 
 	/**
@@ -665,12 +665,13 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A legacy `auto-draft` deep link resolves to the Draft bucket rather
-	 * than querying the status directly.
+	 * A request for `auto-draft` and nothing else matches nothing. It must
+	 * neither answer with a different status nor fall through to an
+	 * unfiltered `post_status = auto-draft` query.
 	 */
-	public function test_auto_draft_status_request_resolves_to_draft_bucket() {
-		$plain_draft = $this->make_newsletter( [ 'post_status' => 'draft' ] );
-		$abandoned   = $this->make_newsletter(
+	public function test_auto_draft_only_status_request_matches_nothing() {
+		$this->make_newsletter( [ 'post_status' => 'draft' ] );
+		$this->make_newsletter(
 			[
 				'post_status' => 'auto-draft',
 				'post_title'  => 'Auto Draft',
@@ -682,10 +683,59 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 			$this->rest_request( [ 'status' => [ 'auto-draft' ] ] )
 		);
 
+		$query = $this->run_newsletter_query( $args );
+		$this->assertSame( [], $query->posts );
+	}
+
+	/**
+	 * `auto-draft` alongside a real status is dropped rather than answered,
+	 * leaving the remaining selection to bucket as it normally would.
+	 */
+	public function test_auto_draft_is_dropped_from_a_mixed_status_request() {
+		$plain_draft = $this->make_newsletter( [ 'post_status' => 'draft' ] );
+		$abandoned   = $this->make_newsletter(
+			[
+				'post_status' => 'auto-draft',
+				'post_title'  => 'Auto Draft',
+			]
+		);
+
+		$args = Newsletters_List_REST::align_status_filter_with_scheduled_meta(
+			[ 'post_status' => [ 'auto-draft', 'draft' ] ],
+			$this->rest_request( [ 'status' => [ 'auto-draft', 'draft' ] ] )
+		);
+
 		$this->assertNotContains( 'auto-draft', (array) $args['post_status'] );
 
 		$query = $this->run_newsletter_query( $args );
-		$this->assertContains( $plain_draft, $query->posts, 'the Draft bucket answers instead' );
+		$this->assertContains( $plain_draft, $query->posts, 'the Draft half of the selection still answers' );
+		$this->assertNotContains( $abandoned, $query->posts, 'abandoned "Add new" never reaches the list' );
+	}
+
+	/**
+	 * The pre-deploy default set, which a browser holding the previous
+	 * bundle still sends, carried `auto-draft`. The widening must strip it
+	 * from `post_status` even though it adds nothing else to the set.
+	 */
+	public function test_legacy_default_status_set_drops_auto_draft() {
+		$plain_draft = $this->make_newsletter( [ 'post_status' => 'draft' ] );
+		$abandoned   = $this->make_newsletter(
+			[
+				'post_status' => 'auto-draft',
+				'post_title'  => 'Auto Draft',
+			]
+		);
+
+		$legacy = [ 'publish', 'private', 'future', 'draft', 'pending', 'auto-draft' ];
+		$args   = Newsletters_List_REST::align_status_filter_with_scheduled_meta(
+			[ 'post_status' => $legacy ],
+			$this->rest_request( [ 'status' => $legacy ] )
+		);
+
+		$this->assertNotContains( 'auto-draft', (array) $args['post_status'] );
+
+		$query = $this->run_newsletter_query( $args );
+		$this->assertContains( $plain_draft, $query->posts, 'saved draft still surfaces' );
 		$this->assertNotContains( $abandoned, $query->posts, 'abandoned "Add new" never reaches the list' );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

"Add Newsletter" links to `post-new.php`, and WordPress inserts an auto-draft as soon as that page loads, before the layout picker opens. Leaving the picker without choosing a layout left that row in the Newsletters list as a `(no subject)` entry, because the list queried `auto-draft` alongside the writable statuses.

All three admin-shell lists (Newsletters, Newsletter Ads, Layouts) now exclude `auto-draft`, matching core's own Posts and Pages lists. Nothing is deleted here; core's daily cron force-deletes auto-drafts after 7 days.

**Any save promotes an auto-draft to `draft`** (core-data's `prePersistPostType` forces the status and clears the placeholder title), so a row still sitting in `auto-draft` has never been saved and its stored content is always empty. There is no in-progress newsletter to lose.

Two coupled pieces move with it. The REST draft buckets re-widened `auto-draft` back into `post_status`, so changing the JS alone would have done nothing. And advertiser term counts deliberately counted auto-draft ads to match the Ads draft bucket, so they drop it too, with the recount sentinel bumped so existing sites refresh.

The newsletters REST endpoint drops `auto-draft` from a `status` request rather than answering it. Asked for `auto-draft` and nothing else, it now returns an empty collection instead of the saved drafts a substituted status would have produced, and the selection always drives `post_status`, so the pre-deploy default set a cached bundle still sends no longer carries `auto-draft` through.

Closes DSGNEWS-213.

### How to test the changes in this Pull Request:

1. Note the count in the "All Newsletters" heading.
2. Go to Newsletters > Add New. The layout picker overlay opens.
3. Press the browser back button without choosing a layout.
4. Go to Newsletters > All Newsletters. No new `(no subject)` row appears and the count is unchanged.
5. Open the Status filter and choose Draft. Saved drafts appear; no auto-drafts do.
6. Save a newsletter with no subject. It still lists as `(no subject)`.
7. Repeat steps 2 to 4 for Newsletters > Advertising, then for Newsletters > Layouts.
8. Open Newsletters > Advertising and check the Advertiser filter. Each count matches the ads listed for that advertiser.
9. On a site with no newsletters, mis-click Add New, then return to the list. The empty state still shows.
10. Request `/wp-json/wp/v2/newspack_nl_cpt?status=auto-draft` as an administrator. The collection comes back empty.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

* No deletion path ships here. Existing stray rows stay in the database, invisible, until core's 7-day cron clears them.
* The advertiser recount is a one-time pass per site, on the first admin request after this deploys by a user who can manage advertisers. It is belt-and-braces: advertiser terms are only written on save, and every save promotes an ad out of `auto-draft`, so no stored count is expected to move. Deleting the `newspack_nl_advertiser_count_recounted_v4` option re-runs it, which is the one-step repair if a site's counts ever look stale.

