### PR TITLE
fix(content-gate): keep Memberships-exempt posts public after migration

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-content-restriction-control.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-restriction-control.php
@@ -55,12 +55,21 @@ class Content_Restriction_Control {
 	const IS_EXEMPT_META_KEY = 'newspack_content_restriction_is_exempt';
 
 	/**
+	 * Post meta key WooCommerce Memberships uses to force a post public.
+	 *
+	 * @var string
+	 */
+	const WC_FORCE_PUBLIC_META_KEY = '_wc_memberships_force_public';
+
+	/**
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
 		add_action( 'init', [ __CLASS__, 'register_meta_guards' ] );
 		add_filter( 'newspack_is_post_restricted', [ __CLASS__, 'is_post_restricted' ], 10, 2 );
+		// Priority 20 so the fallback wins over the meta key's registered default.
+		add_filter( 'default_post_metadata', [ __CLASS__, 'default_exempt_from_force_public' ], 20, 4 );
 	}
 
 	/**
@@ -500,6 +509,46 @@ class Content_Restriction_Control {
 	 */
 	public static function current_user_can_edit_exemption() {
 		return current_user_can( 'edit_others_posts' );
+	}
+
+	/**
+	 * Treat a post WooCommerce Memberships forced public as exempt from access control,
+	 * when no exemption of our own is recorded for it.
+	 *
+	 * Keeps posts a publisher exempted under Memberships readable once a migrated
+	 * site's gates start enforcing. A recorded exemption always wins, including a falsy
+	 * one, so turning the toggle off is respected.
+	 *
+	 * @param mixed  $value     Default value to return.
+	 * @param int    $object_id Post ID.
+	 * @param string $meta_key  Meta key being read.
+	 * @param bool   $single    Whether a single value was requested.
+	 *
+	 * @return mixed
+	 */
+	public static function default_exempt_from_force_public( $value, $object_id, $meta_key, $single ) {
+		if ( self::IS_EXEMPT_META_KEY !== $meta_key || ! Content_Gate::is_newspack_feature_enabled() ) {
+			return $value;
+		}
+
+		/**
+		 * Filters whether a Memberships force-public flag stands in for a missing
+		 * exemption. Turn off on sites that have finished migrating.
+		 *
+		 * @param bool $respect   Whether to honor the Memberships flag. Default true.
+		 * @param int  $object_id Post ID.
+		 */
+		if ( ! apply_filters( 'newspack_content_gate_respect_memberships_force_public', true, $object_id ) ) {
+			return $value;
+		}
+
+		// Memberships stores 'yes' or 'no', and 'no' is a truthy string.
+		if ( 'yes' !== get_post_meta( $object_id, self::WC_FORCE_PUBLIC_META_KEY, true ) ) {
+			return $value;
+		}
+
+		// Non-single reads expect an array of values.
+		return $single ? true : [ true ];
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/content-gate/class-content-restriction-control.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-restriction-control.php
@@ -544,15 +544,16 @@ class Content_Restriction_Control {
 			return $value;
 		}
 
-		// Stay within the post types the exemption is registered and editable for.
-		if ( ! in_array( get_post_type( $post_id ), array_column( (array) self::get_available_post_types(), 'value' ), true ) ) {
+		// Only where the exemption is registered, so an inferred one always has a
+		// toggle to see it and the save guards behind it.
+		if ( ! registered_meta_key_exists( 'post', self::IS_EXEMPT_META_KEY, get_post_type( $post_id ) ) ) {
 			return $value;
 		}
 
 		/**
 		 * Filters whether a Memberships force-public flag stands in for a missing
-		 * exemption. Turn off on sites that have finished migrating, having first
-		 * recorded the exemptions the flag was standing in for.
+		 * exemption. Turning it off re-gates every post whose exemption was only
+		 * inferred, so record those exemptions first.
 		 *
 		 * @param bool $respect Whether to honor the Memberships flag. Default true.
 		 * @param int  $post_id Post ID.
@@ -574,11 +575,12 @@ class Content_Restriction_Control {
 	 * and ignore the opt-out filter, quietly making the exemption permanent.
 	 *
 	 * An explicit falsy value is left alone: that one is a decision, and recording
-	 * it is what makes turning the toggle off stick.
+	 * it is what makes turning the toggle off stick. A post being created has no
+	 * ID yet and nothing to inherit from, so it is skipped.
 	 *
-	 * @param stdClass        $prepared_post Prepared post object (returned unchanged).
-	 * @param WP_REST_Request $request       Incoming request.
-	 * @return stdClass
+	 * @param stdClass|WP_Error $prepared_post Prepared post object (returned unchanged).
+	 * @param WP_REST_Request   $request       Incoming request.
+	 * @return stdClass|WP_Error
 	 */
 	public static function strip_inherited_exempt_meta( $prepared_post, $request ) {
 		$meta = $request['meta'];
@@ -626,11 +628,12 @@ class Content_Restriction_Control {
 	}
 
 	/**
-	 * Register the REST guard that strips the exemption meta from unauthorized
-	 * saves. Registered unconditionally — independent of whether the meta itself
-	 * is registered — so its lifetime never depends on when the content-gate
-	 * feature flag resolves. It is a harmless no-op when the key is absent from
-	 * the request.
+	 * Register the REST guards that keep the exemption meta out of saves that
+	 * should not carry it: one for a user who cannot toggle it, one for a value
+	 * this class inferred rather than a person choosing it. Registered
+	 * unconditionally — independent of whether the meta itself is registered —
+	 * so their lifetime never depends on when the content-gate feature flag
+	 * resolves. Both are harmless no-ops when the key is absent from the request.
 	 */
 	public static function register_meta_guards() {
 		$post_types = array_column( (array) self::get_available_post_types(), 'value' );

--- a/plugins/newspack-plugin/includes/content-gate/class-content-restriction-control.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-restriction-control.php
@@ -69,7 +69,7 @@ class Content_Restriction_Control {
 		add_action( 'init', [ __CLASS__, 'register_meta_guards' ] );
 		add_filter( 'newspack_is_post_restricted', [ __CLASS__, 'is_post_restricted' ], 10, 2 );
 		// Priority 20 so the fallback wins over the meta key's registered default.
-		add_filter( 'default_post_metadata', [ __CLASS__, 'default_exempt_from_force_public' ], 20, 4 );
+		add_filter( 'default_post_metadata', [ __CLASS__, 'filter_default_exemption_meta' ], 20, 4 );
 	}
 
 	/**
@@ -516,39 +516,89 @@ class Content_Restriction_Control {
 	 * when no exemption of our own is recorded for it.
 	 *
 	 * Keeps posts a publisher exempted under Memberships readable once a migrated
-	 * site's gates start enforcing. A recorded exemption always wins, including a falsy
-	 * one, so turning the toggle off is respected.
+	 * site's gates start enforcing. An exemption recorded here wins for as long as it
+	 * is recorded, including a falsy one -- which is why this answers the default
+	 * rather than the read: the default is only consulted when no row exists.
 	 *
-	 * @param mixed  $value     Default value to return.
-	 * @param int    $object_id Post ID.
-	 * @param string $meta_key  Meta key being read.
-	 * @param bool   $single    Whether a single value was requested.
+	 * Answers keyed reads only, so a whole-object meta read will not carry the key.
+	 *
+	 * @param mixed  $value    Default value to return.
+	 * @param int    $post_id  Post ID.
+	 * @param string $meta_key Meta key being read.
+	 * @param bool   $single   Whether a single value was requested.
 	 *
 	 * @return mixed
 	 */
-	public static function default_exempt_from_force_public( $value, $object_id, $meta_key, $single ) {
+	public static function filter_default_exemption_meta( $value, $post_id, $meta_key, $single ) {
 		if ( self::IS_EXEMPT_META_KEY !== $meta_key || ! Content_Gate::is_newspack_feature_enabled() ) {
+			return $value;
+		}
+
+		// Matches core's own default-metadata guard.
+		if ( wp_installing() ) {
+			return $value;
+		}
+
+		// Memberships stores 'yes' or 'no', and 'no' is a truthy string.
+		if ( 'yes' !== get_post_meta( $post_id, self::WC_FORCE_PUBLIC_META_KEY, true ) ) {
+			return $value;
+		}
+
+		// Stay within the post types the exemption is registered and editable for.
+		if ( ! in_array( get_post_type( $post_id ), array_column( (array) self::get_available_post_types(), 'value' ), true ) ) {
 			return $value;
 		}
 
 		/**
 		 * Filters whether a Memberships force-public flag stands in for a missing
-		 * exemption. Turn off on sites that have finished migrating.
+		 * exemption. Turn off on sites that have finished migrating, having first
+		 * recorded the exemptions the flag was standing in for.
 		 *
-		 * @param bool $respect   Whether to honor the Memberships flag. Default true.
-		 * @param int  $object_id Post ID.
+		 * @param bool $respect Whether to honor the Memberships flag. Default true.
+		 * @param int  $post_id Post ID.
 		 */
-		if ( ! apply_filters( 'newspack_content_gate_respect_memberships_force_public', true, $object_id ) ) {
+		if ( ! apply_filters( 'newspack_content_gate_respect_memberships_force_public', true, $post_id ) ) {
 			return $value;
 		}
 
-		// Memberships stores 'yes' or 'no', and 'no' is a truthy string.
-		if ( 'yes' !== get_post_meta( $object_id, self::WC_FORCE_PUBLIC_META_KEY, true ) ) {
-			return $value;
-		}
-
-		// Non-single reads expect an array of values.
 		return $single ? true : [ true ];
+	}
+
+	/**
+	 * Drop an exemption the editor is only echoing back at us.
+	 *
+	 * The block editor reads every meta value from REST and returns the whole set
+	 * whenever any one of them is edited, so without this a value this class
+	 * synthesized would be saved as a real row by nothing more than opening a post
+	 * and saving it. That row would then outlive the Memberships flag it came from
+	 * and ignore the opt-out filter, quietly making the exemption permanent.
+	 *
+	 * An explicit falsy value is left alone: that one is a decision, and recording
+	 * it is what makes turning the toggle off stick.
+	 *
+	 * @param stdClass        $prepared_post Prepared post object (returned unchanged).
+	 * @param WP_REST_Request $request       Incoming request.
+	 * @return stdClass
+	 */
+	public static function strip_inherited_exempt_meta( $prepared_post, $request ) {
+		$meta = $request['meta'];
+		if ( ! is_array( $meta ) || empty( $meta[ self::IS_EXEMPT_META_KEY ] ) ) {
+			return $prepared_post;
+		}
+
+		$post_id = isset( $prepared_post->ID ) ? (int) $prepared_post->ID : 0;
+		if ( ! $post_id || metadata_exists( 'post', $post_id, self::IS_EXEMPT_META_KEY ) ) {
+			return $prepared_post;
+		}
+
+		// Ask the fallback itself, so the two can't drift apart.
+		if ( true !== self::filter_default_exemption_meta( false, $post_id, self::IS_EXEMPT_META_KEY, true ) ) {
+			return $prepared_post;
+		}
+
+		unset( $meta[ self::IS_EXEMPT_META_KEY ] );
+		$request['meta'] = $meta;
+		return $prepared_post;
 	}
 
 	/**
@@ -586,6 +636,7 @@ class Content_Restriction_Control {
 		$post_types = array_column( (array) self::get_available_post_types(), 'value' );
 		foreach ( $post_types as $post_type ) {
 			\add_filter( "rest_pre_insert_{$post_type}", [ __CLASS__, 'strip_unauthorized_exempt_meta' ], 10, 2 );
+			\add_filter( "rest_pre_insert_{$post_type}", [ __CLASS__, 'strip_inherited_exempt_meta' ], 10, 2 );
 		}
 	}
 

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-force-public-exemption.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-force-public-exemption.php
@@ -238,9 +238,26 @@ class Force_Public_Exemption_Test extends WP_UnitTestCase {
 		$meta = rest_do_request( $read )->get_data()['meta'];
 		$this->assertTrue( $meta[ Content_Restriction_Control::IS_EXEMPT_META_KEY ], 'Guard: the editor must be reading the synthesised value.' );
 
+		// The editor returns the whole set because some other value in it was edited.
+		register_post_meta(
+			'post',
+			'newspack_probe_meta',
+			[
+				'show_in_rest' => true,
+				'single'       => true,
+				'type'         => 'string',
+			] 
+		);
+		$meta['newspack_probe_meta'] = 'edited';
+
 		$save = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $post_id );
 		$save->set_body_params( [ 'meta' => $meta ] );
-		$this->assertSame( 200, rest_do_request( $save )->get_status() );
+		$saved = rest_do_request( $save );
+		$this->assertSame( 200, $saved->get_status() );
+		$this->assertTrue(
+			$saved->get_data()['meta'][ Content_Restriction_Control::IS_EXEMPT_META_KEY ],
+			'The post is still exempt, so the response must still say so.'
+		);
 
 		$this->assertFalse(
 			metadata_exists( 'post', $post_id, Content_Restriction_Control::IS_EXEMPT_META_KEY ),
@@ -255,10 +272,10 @@ class Force_Public_Exemption_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The fallback covers the post types the exemption itself covers, and no others.
-	 * Memberships writes its flag to products and attachments too, and a gate can
-	 * reach those through a specific-posts rule -- but nothing there offers a way to
-	 * see or undo an exemption.
+	 * The fallback covers the post types the exemption itself is registered for, and
+	 * no others. Memberships writes its flag to attachments too, and a gate can reach
+	 * one through a specific-posts rule -- but there is no toggle there to see or undo
+	 * an exemption, and neither save guard is registered for it.
 	 */
 	public function test_the_fallback_is_scoped_to_supported_post_types() {
 		$this->enable_gates_and_register();
@@ -266,7 +283,7 @@ class Force_Public_Exemption_Test extends WP_UnitTestCase {
 			[
 				'post_type'   => 'attachment',
 				'post_status' => 'inherit',
-			] 
+			]
 		);
 		update_post_meta( $attachment_id, Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY, 'yes' );
 
@@ -278,6 +295,32 @@ class Force_Public_Exemption_Test extends WP_UnitTestCase {
 		$this->assertFalse(
 			(bool) get_post_meta( $attachment_id, Content_Restriction_Control::IS_EXEMPT_META_KEY, true ),
 			'A post type the exemption is not registered for must not pick one up from the fallback.'
+		);
+	}
+
+	/**
+	 * Only keyed reads get the fallback. Whole-object meta reads must not carry it,
+	 * which is what stops an inferred exemption travelling to other posts and other
+	 * sites -- newspack-network distributes post meta with exactly such a read.
+	 */
+	public function test_a_whole_object_meta_read_does_not_carry_the_fallback() {
+		$this->enable_gates_and_register();
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY, 'yes' );
+
+		$this->assertTrue(
+			(bool) get_post_meta( $post_id, Content_Restriction_Control::IS_EXEMPT_META_KEY, true ),
+			'Guard: the keyed read must be answering with the fallback.'
+		);
+		$this->assertArrayNotHasKey(
+			Content_Restriction_Control::IS_EXEMPT_META_KEY,
+			get_post_meta( $post_id ),
+			'A whole-object read must not carry an exemption that was never recorded.'
+		);
+		$this->assertArrayNotHasKey(
+			Content_Restriction_Control::IS_EXEMPT_META_KEY,
+			get_post_custom( $post_id ),
+			'get_post_custom() must not carry it either.'
 		);
 	}
 

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-force-public-exemption.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-force-public-exemption.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * Tests for the WooCommerce Memberships force-public exemption fallback.
+ *
+ * A post Memberships forced public stays readable after a site migrates to
+ * Access Control. Both halves of that contract are covered here: an absent
+ * exemption defers to Memberships, and a recorded one wins even when falsy.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Content_Gate;
+use Newspack\Content_Restriction_Control;
+
+/**
+ * Tests that Memberships' force-public flag stands in for a missing exemption.
+ *
+ * @group content-gate
+ */
+class Force_Public_Exemption_Test extends WP_UnitTestCase {
+
+	/**
+	 * Reset per-request state and any filter a case added.
+	 */
+	public function tear_down() {
+		remove_all_filters( 'newspack_content_gate_respect_memberships_force_public' );
+		foreach ( array_column( (array) Content_Restriction_Control::get_available_post_types(), 'value' ) as $subtype ) {
+			unregister_meta_key( 'post', Content_Restriction_Control::IS_EXEMPT_META_KEY, $subtype );
+		}
+		parent::tear_down();
+	}
+
+	/**
+	 * Enable the feature and register the exemption meta for a case.
+	 *
+	 * Per-case so the disabled-feature case below can run without it.
+	 */
+	private function enable_gates_and_register() {
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+		Content_Restriction_Control::register_meta();
+		$this->reset_restriction_caches();
+	}
+
+	/**
+	 * Clear the per-request gate memoisation between cases.
+	 */
+	private function reset_restriction_caches() {
+		foreach ( [ 'post_gates_map', 'post_gate_id_map', 'post_gate_layout_id_map' ] as $property ) {
+			$reflected = new ReflectionProperty( Content_Restriction_Control::class, $property );
+			$reflected->setAccessible( true );
+			$reflected->setValue( null, [] );
+		}
+		Content_Gate::flush_gates_cache();
+	}
+
+	/**
+	 * Create a published gate that puts every post behind registration.
+	 *
+	 * @return int The gate post ID.
+	 */
+	private function create_registration_gate() {
+		$gate_id = Content_Gate::create_gate(
+			[
+				'title'         => 'Force public test gate',
+				'status'        => 'publish',
+				'content_rules' => [
+					[
+						'slug'  => 'post_types',
+						'value' => [ 'post' ],
+					],
+				],
+				'registration'  => [ 'active' => true ],
+			],
+			Content_Gate::GATE_CPT
+		);
+		$this->assertNotWPError( $gate_id, 'Gate fixture could not be created.' );
+		$this->reset_restriction_caches();
+		return $gate_id;
+	}
+
+	/**
+	 * The control: the gate fixture restricts, so the cases below that assert
+	 * otherwise are testing the fallback and not an inert gate.
+	 */
+	public function test_the_gate_fixture_restricts_an_unexempted_post() {
+		$this->enable_gates_and_register();
+		$this->create_registration_gate();
+		$post_id = self::factory()->post->create();
+
+		$this->assertTrue(
+			Content_Restriction_Control::is_post_restricted( false, $post_id, 0 ),
+			'Expected the registration gate to restrict an anonymous reader.'
+		);
+	}
+
+	/**
+	 * A post carrying only the Memberships flag reads as exempt and stays readable
+	 * once the migrated gates start enforcing.
+	 */
+	public function test_force_public_stands_in_for_a_missing_exemption() {
+		$this->enable_gates_and_register();
+		$this->create_registration_gate();
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY, 'yes' );
+
+		$this->assertTrue(
+			(bool) get_post_meta( $post_id, Content_Restriction_Control::IS_EXEMPT_META_KEY, true ),
+			'A force-public post with no exemption of its own should read as exempt.'
+		);
+		$this->assertFalse(
+			Content_Restriction_Control::is_post_restricted( false, $post_id, 0 ),
+			'A force-public post should not be restricted for an anonymous reader.'
+		);
+	}
+
+	/**
+	 * A post a publisher explicitly marked as not public must not become exempt.
+	 */
+	public function test_force_public_no_is_not_treated_as_truthy() {
+		$this->enable_gates_and_register();
+		$this->create_registration_gate();
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY, 'no' );
+
+		$this->assertFalse(
+			(bool) get_post_meta( $post_id, Content_Restriction_Control::IS_EXEMPT_META_KEY, true ),
+			'A post explicitly marked not-public must not read as exempt.'
+		);
+		$this->assertTrue(
+			Content_Restriction_Control::is_post_restricted( false, $post_id, 0 ),
+			'A post explicitly marked not-public must still be restricted.'
+		);
+	}
+
+	/**
+	 * A recorded falsy exemption is a decision rather than an absence, so it wins
+	 * over the Memberships flag.
+	 */
+	public function test_a_stored_falsy_exemption_ignores_force_public() {
+		$this->enable_gates_and_register();
+		$this->create_registration_gate();
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY, 'yes' );
+		update_post_meta( $post_id, Content_Restriction_Control::IS_EXEMPT_META_KEY, false );
+
+		$this->assertTrue(
+			metadata_exists( 'post', $post_id, Content_Restriction_Control::IS_EXEMPT_META_KEY ),
+			'Guard: a falsy exemption must be stored as a row for this case to mean anything.'
+		);
+		$this->assertFalse(
+			(bool) get_post_meta( $post_id, Content_Restriction_Control::IS_EXEMPT_META_KEY, true ),
+			'A stored falsy exemption must not be overridden by the Memberships flag.'
+		);
+		$this->assertTrue(
+			Content_Restriction_Control::is_post_restricted( false, $post_id, 0 ),
+			'A post whose exemption was turned off must still be restricted.'
+		);
+	}
+
+	/**
+	 * The editor sidebar toggle and the gate must agree about a post's exemption.
+	 */
+	public function test_rest_reflects_the_fallback_for_the_editor_toggle() {
+		$this->enable_gates_and_register();
+		$post_id = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		update_post_meta( $post_id, Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY, 'yes' );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'editor' ] ) );
+		rest_get_server();
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id );
+		$request->set_param( 'context', 'edit' );
+		$response = rest_do_request( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertTrue(
+			$data['meta'][ Content_Restriction_Control::IS_EXEMPT_META_KEY ],
+			'The editor toggle reads this value; it must reflect the fallback.'
+		);
+	}
+
+	/**
+	 * An exemption turned off in the editor stays off.
+	 */
+	public function test_toggling_the_exemption_off_persists_and_latches() {
+		$this->enable_gates_and_register();
+		$this->create_registration_gate();
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY, 'yes' );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'editor' ] ) );
+		rest_get_server();
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $post_id );
+		$request->set_body_params(
+			[ 'meta' => [ Content_Restriction_Control::IS_EXEMPT_META_KEY => false ] ]
+		);
+		$this->assertSame( 200, rest_do_request( $request )->get_status() );
+
+		$this->assertTrue(
+			metadata_exists( 'post', $post_id, Content_Restriction_Control::IS_EXEMPT_META_KEY ),
+			'Turning the toggle off must write a row rather than leaving the meta absent.'
+		);
+		$this->reset_restriction_caches();
+		$this->assertTrue(
+			Content_Restriction_Control::is_post_restricted( false, $post_id, 0 ),
+			'Once turned off, the exemption must stay off despite the Memberships flag.'
+		);
+	}
+
+	/**
+	 * The escape hatch for sites that finished migrating and would rather stale
+	 * Memberships meta stopped widening access.
+	 */
+	public function test_the_fallback_can_be_filtered_off() {
+		$this->enable_gates_and_register();
+		$this->create_registration_gate();
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY, 'yes' );
+		add_filter( 'newspack_content_gate_respect_memberships_force_public', '__return_false' );
+
+		$this->assertFalse(
+			(bool) get_post_meta( $post_id, Content_Restriction_Control::IS_EXEMPT_META_KEY, true ),
+			'The filter must suppress the fallback.'
+		);
+		$this->assertTrue(
+			Content_Restriction_Control::is_post_restricted( false, $post_id, 0 ),
+			'A suppressed fallback must leave the gate enforcing.'
+		);
+	}
+
+	/**
+	 * A site that never turned Access Control on gets no exemption at all.
+	 *
+	 * Separate process because the feature flag is a constant.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_the_fallback_is_inert_when_the_feature_is_disabled() {
+		// NEWSPACK_CONTENT_GATES is undefined in the default test env.
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY, 'yes' );
+
+		$this->assertEmpty(
+			get_post_meta( $post_id, Content_Restriction_Control::IS_EXEMPT_META_KEY, true ),
+			'With the feature off, the Memberships flag must not produce an exemption.'
+		);
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-force-public-exemption.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-force-public-exemption.php
@@ -11,6 +11,7 @@
 
 use Newspack\Content_Gate;
 use Newspack\Content_Restriction_Control;
+use Newspack\Tests\Content_Gate\Traits\Trait_Restriction_Cache_Test;
 
 /**
  * Tests that Memberships' force-public flag stands in for a missing exemption.
@@ -19,11 +20,12 @@ use Newspack\Content_Restriction_Control;
  */
 class Force_Public_Exemption_Test extends WP_UnitTestCase {
 
+	use Trait_Restriction_Cache_Test;
+
 	/**
-	 * Reset per-request state and any filter a case added.
+	 * Unregister the exemption meta between cases.
 	 */
 	public function tear_down() {
-		remove_all_filters( 'newspack_content_gate_respect_memberships_force_public' );
 		foreach ( array_column( (array) Content_Restriction_Control::get_available_post_types(), 'value' ) as $subtype ) {
 			unregister_meta_key( 'post', Content_Restriction_Control::IS_EXEMPT_META_KEY, $subtype );
 		}
@@ -40,25 +42,12 @@ class Force_Public_Exemption_Test extends WP_UnitTestCase {
 			define( 'NEWSPACK_CONTENT_GATES', true );
 		}
 		Content_Restriction_Control::register_meta();
-		$this->reset_restriction_caches();
-	}
-
-	/**
-	 * Clear the per-request gate memoisation between cases.
-	 */
-	private function reset_restriction_caches() {
-		foreach ( [ 'post_gates_map', 'post_gate_id_map', 'post_gate_layout_id_map' ] as $property ) {
-			$reflected = new ReflectionProperty( Content_Restriction_Control::class, $property );
-			$reflected->setAccessible( true );
-			$reflected->setValue( null, [] );
-		}
+		$this->reset_restriction_cache();
 		Content_Gate::flush_gates_cache();
 	}
 
 	/**
 	 * Create a published gate that puts every post behind registration.
-	 *
-	 * @return int The gate post ID.
 	 */
 	private function create_registration_gate() {
 		$gate_id = Content_Gate::create_gate(
@@ -72,12 +61,11 @@ class Force_Public_Exemption_Test extends WP_UnitTestCase {
 					],
 				],
 				'registration'  => [ 'active' => true ],
-			],
-			Content_Gate::GATE_CPT
+			]
 		);
 		$this->assertNotWPError( $gate_id, 'Gate fixture could not be created.' );
-		$this->reset_restriction_caches();
-		return $gate_id;
+		$this->reset_restriction_cache();
+		Content_Gate::flush_gates_cache();
 	}
 
 	/**
@@ -202,7 +190,8 @@ class Force_Public_Exemption_Test extends WP_UnitTestCase {
 			metadata_exists( 'post', $post_id, Content_Restriction_Control::IS_EXEMPT_META_KEY ),
 			'Turning the toggle off must write a row rather than leaving the meta absent.'
 		);
-		$this->reset_restriction_caches();
+		$this->reset_restriction_cache();
+		Content_Gate::flush_gates_cache();
 		$this->assertTrue(
 			Content_Restriction_Control::is_post_restricted( false, $post_id, 0 ),
 			'Once turned off, the exemption must stay off despite the Memberships flag.'
@@ -227,6 +216,68 @@ class Force_Public_Exemption_Test extends WP_UnitTestCase {
 		$this->assertTrue(
 			Content_Restriction_Control::is_post_restricted( false, $post_id, 0 ),
 			'A suppressed fallback must leave the gate enforcing.'
+		);
+	}
+
+	/**
+	 * The fallback must stay a fallback. The editor loads every meta value it reads
+	 * from REST and posts the whole set back whenever any one of them is edited, so
+	 * a synthesised exemption would otherwise be written to the database as a real
+	 * row -- silently decoupling the post from Memberships and from the opt-out
+	 * filter, on nothing more than someone opening the post and saving it.
+	 */
+	public function test_an_editor_save_does_not_persist_a_synthesised_exemption() {
+		$this->enable_gates_and_register();
+		$post_id = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		update_post_meta( $post_id, Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY, 'yes' );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'editor' ] ) );
+		rest_get_server();
+
+		$read = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id );
+		$read->set_param( 'context', 'edit' );
+		$meta = rest_do_request( $read )->get_data()['meta'];
+		$this->assertTrue( $meta[ Content_Restriction_Control::IS_EXEMPT_META_KEY ], 'Guard: the editor must be reading the synthesised value.' );
+
+		$save = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $post_id );
+		$save->set_body_params( [ 'meta' => $meta ] );
+		$this->assertSame( 200, rest_do_request( $save )->get_status() );
+
+		$this->assertFalse(
+			metadata_exists( 'post', $post_id, Content_Restriction_Control::IS_EXEMPT_META_KEY ),
+			'A synthesised exemption must not be written to the database by an ordinary save.'
+		);
+
+		delete_post_meta( $post_id, Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY );
+		$this->assertFalse(
+			(bool) get_post_meta( $post_id, Content_Restriction_Control::IS_EXEMPT_META_KEY, true ),
+			'Once Memberships no longer forces the post public, the exemption must go with it.'
+		);
+	}
+
+	/**
+	 * The fallback covers the post types the exemption itself covers, and no others.
+	 * Memberships writes its flag to products and attachments too, and a gate can
+	 * reach those through a specific-posts rule -- but nothing there offers a way to
+	 * see or undo an exemption.
+	 */
+	public function test_the_fallback_is_scoped_to_supported_post_types() {
+		$this->enable_gates_and_register();
+		$attachment_id = self::factory()->post->create(
+			[
+				'post_type'   => 'attachment',
+				'post_status' => 'inherit',
+			] 
+		);
+		update_post_meta( $attachment_id, Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY, 'yes' );
+
+		$this->assertNotContains(
+			'attachment',
+			array_column( (array) Content_Restriction_Control::get_available_post_types(), 'value' ),
+			'Guard: this case only means something while attachments are out of scope.'
+		);
+		$this->assertFalse(
+			(bool) get_post_meta( $attachment_id, Content_Restriction_Control::IS_EXEMPT_META_KEY, true ),
+			'A post type the exemption is not registered for must not pick one up from the fallback.'
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Posts that WooCommerce Memberships marked always-public lose that exemption when a site moves to Access Control. `wp newspack migrate-membership-gates` carries over plans, rules, and layouts, but per-post exemptions are stored as `_wc_memberships_force_public` and stay behind. Those posts start being gated the moment Memberships is deactivated and the migrated gates take effect.

A post with no Access Control exemption of its own now defers to the Memberships flag. That covers the gate check and the "Disable access control restrictions for this post" toggle alike, so the editor shows what the gate will do. **A recorded exemption always wins, even a falsy one**, so turning the toggle off sticks.

The inferred value stays inferred. The block editor returns every meta value it read whenever any one of them is edited, so the exemption is stripped back out of those saves — otherwise opening a post and saving it would write the inference to the database, outliving the Memberships flag it came from. Sites that have finished migrating can switch the fallback off with the `newspack_content_gate_respect_memberships_force_public` filter.

### How to test the changes in this Pull Request:

1. Define `NEWSPACK_CONTENT_GATES` as `true` and enable Audience Management. Both are required for gating.
2. Create a published gate that puts all posts behind registration.
3. Open any post while logged out. The gate appears.
4. Run `wp post meta update <id> _wc_memberships_force_public yes` for that post.
5. Reload while logged out. The post is readable and no gate appears.
6. Open the post in the editor. The "Disable access control restrictions" toggle reads ON.
7. Save the post without touching that toggle. `wp post meta list <id>` shows no `newspack_content_restriction_is_exempt` row.
8. Run `wp post meta delete <id> _wc_memberships_force_public`. The gate returns.
9. Restore the flag, then turn the toggle off and save. The gate returns and stays.
10. On a second post, set the same meta to `no`. The gate still applies.
11. Set the flag on an attachment. It stays gated — the fallback covers only post types the exemption is registered for.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally? Full `newspack-plugin` suite: 2934 tests, no failures.

* Follow-up worth its own issue: `migrate-membership-gates` still doesn't record these exemptions, so they exist only by inference. Turning the opt-out filter on before backfilling real `newspack_content_restriction_is_exempt` rows would re-gate that content.
* Rollout risk: on a site that used force-public long ago and has since stopped using Memberships, those posts become exempt again. The filter above is the opt-out.
* `newspack-manager` is the only other consumer of the content-gate contract and does not read this meta, so no coordinated change is needed.
