### PR TITLE
chore(bin): reject option-shaped names in env and worktree helpers

### DIFF
--- a/bin/_common.sh
+++ b/bin/_common.sh
@@ -7,9 +7,15 @@
 [[ -n "${NABSPATH:-}" && -f "$NABSPATH/n" ]] ||
     NABSPATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# Names that become git branches and path components. Slashes are allowed here
+# and not in validate_env_name, since `fix/some-thing` is the normal branch
+# shape. The first character may not be a dash, so an option is never taken as
+# a name: bin/worktree.sh and the --worktree parsing in bin/env.sh both read
+# these positionally. A leading dot or underscore stays legal because branches
+# like _pr738 are in use, and git rejects the refnames that are truly invalid.
 validate_name() {
-    if [[ ! "$1" =~ ^[a-zA-Z0-9._/-]+$ ]] || [[ "$1" == *..* ]] || [[ "$1" == /* ]]; then
-        echo "Error: invalid $2 '$1' (only alphanumeric, dots, hyphens, underscores, slashes allowed; no '..' or leading '/')"
+    if [[ ! "$1" =~ ^[a-zA-Z0-9._][a-zA-Z0-9._/-]*$ ]] || [[ "$1" == *..* ]] || [[ "$1" == /* ]]; then
+        echo "Error: invalid $2 '$1' (must not start with '-'; only alphanumeric, dots, hyphens, underscores, slashes allowed; no '..' or leading '/')"
         exit 1
     fi
 }

--- a/bin/_common.sh
+++ b/bin/_common.sh
@@ -30,8 +30,13 @@ validate_name() {
 # environment created under an older, laxer one — unmanageable and removable
 # only by hand.
 validate_env_name() {
-    if [[ ! "$1" =~ ^[a-zA-Z0-9._][a-zA-Z0-9._-]*$ ]]; then
-        echo "Error: invalid environment name '$1' (must not start with '-'; only alphanumeric, dots, hyphens, underscores allowed)"
+    # The `..` clause matches validate_name's. `n env destroy ..` would otherwise
+    # validate and reach `rm -rf "$NABSPATH/envs/.."`, i.e. the workspace root.
+    # POSIX rm refuses a trailing `.` or `..` component, so that is not a live
+    # escape today -- but the guard then lives in rm rather than here, and moves
+    # out from under us the moment a call site builds the path differently.
+    if [[ ! "$1" =~ ^[a-zA-Z0-9._][a-zA-Z0-9._-]*$ ]] || [[ "$1" == *..* ]]; then
+        echo "Error: invalid environment name '$1' (must not start with '-' or contain '..'; only alphanumeric, dots, hyphens, underscores allowed)"
         exit 1
     fi
 }

--- a/bin/_common.sh
+++ b/bin/_common.sh
@@ -14,10 +14,14 @@ validate_name() {
     fi
 }
 
-# Stricter validation for env names — no slashes (Docker rejects them in container/service names)
+# Stricter validation for env names — no slashes (Docker rejects them in
+# container/service names), and an alphanumeric first character. The leading
+# character rule is what stops an option being read as a name: bin/env.sh takes
+# the name positionally, so without it `n env create --help` validates cleanly
+# and creates an environment called "--help" instead of printing usage.
 validate_env_name() {
-    if [[ ! "$1" =~ ^[a-zA-Z0-9._-]+$ ]]; then
-        echo "Error: invalid environment name '$1' (only alphanumeric, dots, hyphens, underscores allowed)"
+    if [[ ! "$1" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
+        echo "Error: invalid environment name '$1' (must start with a letter or digit; only alphanumeric, dots, hyphens, underscores allowed)"
         exit 1
     fi
 }

--- a/bin/_common.sh
+++ b/bin/_common.sh
@@ -21,13 +21,17 @@ validate_name() {
 }
 
 # Stricter validation for env names — no slashes (Docker rejects them in
-# container/service names), and an alphanumeric first character. The leading
-# character rule is what stops an option being read as a name: bin/env.sh takes
-# the name positionally, so without it `n env create --help` validates cleanly
-# and creates an environment called "--help" instead of printing usage.
+# container/service names), and no leading dash. The dash rule is what stops an
+# option being read as a name: bin/env.sh takes the name positionally, so
+# without it `n env create --help` validates cleanly and creates an environment
+# called "--help" instead of printing usage. It excludes a leading dash and
+# nothing else, deliberately. This validator also gates `up`, `down` and
+# `destroy`, so a rule that rejected leading dots or underscores would strand an
+# environment created under an older, laxer one — unmanageable and removable
+# only by hand.
 validate_env_name() {
-    if [[ ! "$1" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
-        echo "Error: invalid environment name '$1' (must start with a letter or digit; only alphanumeric, dots, hyphens, underscores allowed)"
+    if [[ ! "$1" =~ ^[a-zA-Z0-9._][a-zA-Z0-9._-]*$ ]]; then
+        echo "Error: invalid environment name '$1' (must not start with '-'; only alphanumeric, dots, hyphens, underscores allowed)"
         exit 1
     fi
 }

--- a/bin/_common.sh
+++ b/bin/_common.sh
@@ -29,6 +29,20 @@ validate_name() {
 # `destroy`, so a rule that rejected leading dots or underscores would strand an
 # environment created under an older, laxer one — unmanageable and removable
 # only by hand.
+# Stricter still for a name being created. The leniency in validate_env_name
+# exists so environments made under an older, laxer rule stay manageable by
+# `up`/`down`/`destroy`, and that reason cannot apply to a name that does not
+# exist yet. A leading dot is the case it costs: `.demo` yields
+# https://.demo.test, whose first DNS label is empty, and the container name and
+# certificate are derived from the same string.
+validate_new_env_name() {
+    validate_env_name "$1"
+    if [[ ! "$1" =~ ^[a-zA-Z0-9] ]]; then
+        echo "Error: invalid environment name '$1' (must start with a letter or digit)"
+        exit 1
+    fi
+}
+
 validate_env_name() {
     # The `..` clause matches validate_name's. `n env destroy ..` would otherwise
     # validate and reach `rm -rf "$NABSPATH/envs/.."`, i.e. the workspace root.

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -695,6 +695,10 @@ MIGRATE
         echo "Destroyed environment '$env_name'"
         ;;
     list)
+        if is_help_arg "$2"; then
+            echo "Usage: n env list [--porcelain]"
+            exit 0
+        fi
         porcelain=false
         if [[ "$2" == "--porcelain" ]]; then
             porcelain=true
@@ -744,6 +748,7 @@ MIGRATE
             case $1 in
                 --all) cleanup_all=true; shift ;;
                 --yes) cleanup_yes=true; shift ;;
+                -h|--help) echo "Usage: n env cleanup [--all] [--yes]"; exit 0 ;;
                 *) echo "Usage: n env cleanup [--all] [--yes]"; exit 1 ;;
             esac
         done

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -127,12 +127,27 @@ each_worktree_in_env() {
     done < <(grep -E '^[[:space:]]*-[[:space:]]+\./worktrees(-repos)?/[^[:space:]:]+:/newspack-(repos|plugins|themes)/[^[:space:]:]+' "$file" 2>/dev/null)
 }
 
+# True for an explicit help request in the name position. validate_env_name
+# rejects a leading dash, so this can never shadow a legitimate environment name.
+is_help_arg() {
+    [[ "$1" == "-h" || "$1" == "--help" ]]
+}
+
+# Print a subcommand's usage and exit. Status 0 when the user asked for help,
+# 1 when the name was simply missing — one usage string serves both, and the
+# caller passes whatever it read positionally so this can tell them apart.
+env_usage() {
+    local name="$1"; shift
+    printf '%s\n' "$@"
+    is_help_arg "$name" && exit 0
+    exit 1
+}
+
 case $1 in
     create)
         env_name="$2"
-        if [[ -z "$env_name" ]]; then
-            echo "Usage: n env create <name> --worktree <repo>:<branch> [--worktree ...] [--domain <domain>] [--up]"
-            exit 1
+        if [[ -z "$env_name" ]] || is_help_arg "$env_name"; then
+            env_usage "$env_name" "Usage: n env create <name> --worktree <repo>:<branch> [--worktree ...] [--domain <domain>] [--up]"
         fi
         validate_env_name "$env_name"
         # Reject names that would collide after dash/underscore normalization.
@@ -362,10 +377,8 @@ YAML
         ;;
     up)
         env_name="$2"
-        if [[ -z "$env_name" ]]; then
-            echo "Usage: n env up <name> [--build]"
-            echo "       n env up --all [--build]"
-            exit 1
+        if [[ -z "$env_name" ]] || is_help_arg "$env_name"; then
+            env_usage "$env_name" "Usage: n env up <name> [--build]" "       n env up --all [--build]"
         fi
         # --all: start all existing environments.
         if [[ "$env_name" == "--all" ]]; then
@@ -586,9 +599,8 @@ MIGRATE
         ;;
     down)
         env_name="$2"
-        if [[ -z "$env_name" ]]; then
-            echo "Usage: n env down <name>"
-            exit 1
+        if [[ -z "$env_name" ]] || is_help_arg "$env_name"; then
+            env_usage "$env_name" "Usage: n env down <name>"
         fi
         validate_env_name "$env_name"
         container_name=$(echo "newspack_env_${env_name}" | tr '-' '_')
@@ -597,9 +609,8 @@ MIGRATE
         ;;
     destroy)
         env_name="$2"
-        if [[ -z "$env_name" ]]; then
-            echo "Usage: n env destroy <name>"
-            exit 1
+        if [[ -z "$env_name" ]] || is_help_arg "$env_name"; then
+            env_usage "$env_name" "Usage: n env destroy <name>"
         fi
         validate_env_name "$env_name"
         compose_file="$NABSPATH/docker-compose.env-${env_name}.yml"

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -127,8 +127,9 @@ each_worktree_in_env() {
     done < <(grep -E '^[[:space:]]*-[[:space:]]+\./worktrees(-repos)?/[^[:space:]:]+:/newspack-(repos|plugins|themes)/[^[:space:]:]+' "$file" 2>/dev/null)
 }
 
-# True for an explicit help request in the name position. validate_env_name
-# rejects a leading dash, so this can never shadow a legitimate environment name.
+# True for an explicit help request in the name position. It matches -h and
+# --help and nothing else, so `up --all` — the one other dash-leading token read
+# from that position — still reaches its own branch below.
 is_help_arg() {
     [[ "$1" == "-h" || "$1" == "--help" ]]
 }

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -150,7 +150,7 @@ case $1 in
         if [[ -z "$env_name" ]] || is_help_arg "$env_name"; then
             env_usage "$env_name" "Usage: n env create <name> --worktree <repo>:<branch> [--worktree ...] [--domain <domain>] [--up]"
         fi
-        validate_env_name "$env_name"
+        validate_new_env_name "$env_name"
         # Reject names that would collide after dash/underscore normalization.
         normalized=$(echo "$env_name" | tr '-' '_')
         for f in "$NABSPATH"/docker-compose.env-*.yml; do

--- a/bin/tests/test-env-name-guards.sh
+++ b/bin/tests/test-env-name-guards.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# test-env-name-guards.sh
+#
+# Self-proving spec for the two guards that stop an option being taken as an
+# environment name.
+#
+# `n env create --help` used to create an environment called "--help". The
+# subcommands read the name positionally, validate_env_name allowed a leading
+# dash, and no arm handled -h or --help, so the option validated as an ordinary
+# name: a compose file, an envs/--help/ directory and an /etc/hosts line, with
+# no usage text and exit 0. Both halves are covered here because either one
+# alone lets the other regress. Loosen the validator and `destroy` accepts an
+# option again; drop the help arm and `--help` errors instead of helping.
+#
+# Run: bash bin/tests/test-env-name-guards.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../_common.sh
+. "$SCRIPT_DIR/../_common.sh"
+
+WORK=$(mktemp -d -t env-name-guards-XXXXXX)
+trap 'rm -rf "$WORK"' EXIT
+
+failures=0
+
+assert_name() {
+	local name="$1" want="$2" desc="$3" got
+	# validate_env_name exits rather than returning, so it runs in a subshell.
+	if ( validate_env_name "$name" ) >/dev/null 2>&1; then got=accepted; else got=rejected; fi
+	if [[ "$got" == "$want" ]]; then
+		echo "  ok: $desc"
+	else
+		echo "  FAIL: $desc — want $want, got $got"
+		failures=$((failures + 1))
+	fi
+}
+
+echo "validate_env_name:"
+assert_name "demo" accepted "a plain name is accepted"
+assert_name "demo-1" accepted "an embedded dash is accepted"
+assert_name "demo_1" accepted "an embedded underscore is accepted"
+assert_name "demo.1" accepted "a dotted name is accepted, as isolated-db envs use"
+assert_name "1demo" accepted "a leading digit is accepted"
+assert_name "--help" rejected "the option that named the bug is rejected"
+assert_name "-h" rejected "a short option is rejected"
+assert_name "-demo" rejected "a leading dash is rejected"
+assert_name ".demo" rejected "a leading dot is rejected, which would misname the data dir"
+assert_name "_demo" rejected "a leading underscore is rejected"
+assert_name "demo/1" rejected "a slash is rejected, since Docker rejects it in container names"
+assert_name "" rejected "an empty name is rejected"
+
+# _common.sh honours an inherited NABSPATH only when it names a real workspace
+# root, so the stub `n` is what makes this a sandbox: anything a subcommand
+# writes lands here rather than in the checkout.
+touch "$WORK/n"
+
+assert_usage() {
+	local want_status="$1" desc="$2"; shift 2
+	local out status=0
+	out=$(NABSPATH="$WORK" bash "$SCRIPT_DIR/../env.sh" "$@" 2>&1) || status=$?
+	if [[ "$status" != "$want_status" ]]; then
+		echo "  FAIL: $desc — want exit $want_status, got $status"
+		failures=$((failures + 1))
+	elif [[ "$out" != *"Usage:"* ]]; then
+		echo "  FAIL: $desc — printed no usage text"
+		failures=$((failures + 1))
+	else
+		echo "  ok: $desc"
+	fi
+}
+
+echo
+echo "n env <subcommand> --help:"
+for sub in create up down destroy; do
+	assert_usage 0 "$sub --help prints usage and succeeds" "$sub" --help
+	assert_usage 0 "$sub -h prints usage and succeeds" "$sub" -h
+done
+
+echo
+echo "n env <subcommand> with no name:"
+for sub in create up down destroy; do
+	# Distinct from the help path on purpose: a missing name is a usage error,
+	# so it must keep exiting non-zero for callers that check.
+	assert_usage 1 "$sub with no name prints usage and fails" "$sub"
+done
+
+echo
+echo "no environment is created by any of the above:"
+leaked=$(find "$WORK" -mindepth 1 ! -name n)
+if [[ -n "$leaked" ]]; then
+	echo "  FAIL: the sandbox gained files — $(echo "$leaked" | tr '\n' ' ')"
+	failures=$((failures + 1))
+else
+	echo "  ok: the sandbox is untouched, so no compose file or env dir was written"
+fi
+
+if [[ "$failures" -gt 0 ]]; then
+	echo "$failures assertion(s) failed"
+	exit 1
+fi
+echo "All assertions passed."

--- a/bin/tests/test-name-guards.sh
+++ b/bin/tests/test-name-guards.sh
@@ -84,6 +84,27 @@ assert_name ".." rejected "a bare traversal is rejected, as validate_name alread
 assert_name "a..b" rejected "an embedded traversal is rejected on both validators"
 assert_name "" rejected "an empty name is rejected"
 
+assert_new_name() {
+	local name="$1" want="$2" desc="$3" got
+	got=$(classify validate_new_env_name "$name")
+	if [[ "$got" == "$want" ]]; then
+		echo "  ok: $desc"
+	else
+		echo "  FAIL: $desc — want $want, got $got"
+		failures=$((failures + 1))
+	fi
+}
+
+echo ""
+echo "validate_new_env_name (create path only):"
+assert_new_name "demo" accepted "a plain name is accepted"
+assert_new_name "1demo" accepted "a leading digit is accepted"
+assert_new_name ".demo" rejected "a leading dot is rejected at creation; it would yield an empty first DNS label"
+assert_new_name "_demo" rejected "a leading underscore is rejected at creation, for the same reason"
+assert_new_name "--help" rejected "the option shape is still rejected"
+assert_new_name ".." rejected "a traversal is still rejected"
+assert_new_name "" rejected "an empty name is rejected"
+
 assert_path_name() {
 	local name="$1" want="$2" desc="$3" got
 	got=$(classify validate_name "$name" "branch")
@@ -164,6 +185,25 @@ done
 
 echo
 echo "no environment is created by any of the above:"
+# The create arm must actually reach the stricter validator. Asserting
+# validate_new_env_name directly cannot see the call site, so reverting create to
+# the lax validator would leave every assertion above green.
+assert_create_rejects() {
+	local name="$1" desc="$2" out status=0
+	out=$(PATH="$STUB:$PATH" NABSPATH="$SANDBOX" bash "$SCRIPT_DIR/../env.sh" create "$name" </dev/null 2>&1) || status=$?
+	if [[ "$status" -eq 1 && "$out" == *"must start with a letter or digit"* ]]; then
+		echo "  ok: $desc"
+	else
+		echo "  FAIL: $desc — want exit 1 with the create-path message, got exit $status: $out"
+		failures=$((failures + 1))
+	fi
+}
+
+echo ""
+echo "n env create reaches the stricter validator:"
+assert_create_rejects ".demo" "a leading dot is refused by the create arm itself"
+assert_create_rejects "_demo" "a leading underscore is refused by the create arm itself"
+
 leaked=$(find "$SANDBOX" -mindepth 1 ! -name n)
 if [[ -n "$leaked" ]]; then
 	echo "  FAIL: the sandbox gained files — $(echo "$leaked" | tr '\n' ' ')"

--- a/bin/tests/test-name-guards.sh
+++ b/bin/tests/test-name-guards.sh
@@ -18,6 +18,11 @@
 # to reach git with "--help" as the branch. Git refuses that refname, so nothing
 # was created, but the user got a git error rather than usage.
 #
+# Scope: the four env subcommands that read a name positionally — create, up,
+# down and destroy — are all covered. list only compares $2 against --porcelain,
+# cleanup never reads it, and e2e-setup delegates to bin/setup-local-e2e.sh,
+# which carries its own --help arm and calls validate_env_name itself.
+#
 # Run: bash bin/tests/test-name-guards.sh
 
 set -euo pipefail
@@ -31,10 +36,26 @@ trap 'rm -rf "$WORK"' EXIT
 
 failures=0
 
+# Classify a validator call. Both validators exit rather than return, so the
+# call runs in a subshell. A rejection is exit 1 carrying the error message:
+# counting any non-zero as a rejection would let a syntax error or a set -u
+# abort satisfy every rejection assertion below, and the suite would stay green
+# against a _common.sh that no longer parses.
+classify() {
+	local out status=0
+	out=$( "$@" 2>&1 ) || status=$?
+	if [[ "$status" -eq 0 ]]; then
+		echo accepted
+	elif [[ "$status" -eq 1 && "$out" == *"Error: invalid"* ]]; then
+		echo rejected
+	else
+		echo "broken(exit $status)"
+	fi
+}
+
 assert_name() {
 	local name="$1" want="$2" desc="$3" got
-	# validate_env_name exits rather than returning, so it runs in a subshell.
-	if ( validate_env_name "$name" ) >/dev/null 2>&1; then got=accepted; else got=rejected; fi
+	got=$(classify validate_env_name "$name")
 	if [[ "$got" == "$want" ]]; then
 		echo "  ok: $desc"
 	else
@@ -52,15 +73,15 @@ assert_name "1demo" accepted "a leading digit is accepted"
 assert_name "--help" rejected "the option that named the bug is rejected"
 assert_name "-h" rejected "a short option is rejected"
 assert_name "-demo" rejected "a leading dash is rejected"
-assert_name ".demo" rejected "a leading dot is rejected, which would misname the data dir"
-assert_name "_demo" rejected "a leading underscore is rejected"
+assert_name ".demo" accepted "a leading dot is accepted; rejecting it would strand an existing env"
+assert_name "_demo" accepted "a leading underscore is accepted, for the same reason"
+assert_name "-demo" rejected "only a leading dash is rejected, and it is the whole point of the rule"
 assert_name "demo/1" rejected "a slash is rejected, since Docker rejects it in container names"
 assert_name "" rejected "an empty name is rejected"
 
 assert_path_name() {
 	local name="$1" want="$2" desc="$3" got
-	# validate_name exits rather than returning, so it runs in a subshell.
-	if ( validate_name "$name" "branch" ) >/dev/null 2>&1; then got=accepted; else got=rejected; fi
+	got=$(classify validate_name "$name" "branch")
 	if [[ "$got" == "$want" ]]; then
 		echo "  ok: $desc"
 	else

--- a/bin/tests/test-name-guards.sh
+++ b/bin/tests/test-name-guards.sh
@@ -80,6 +80,8 @@ assert_name "de mo" rejected "an embedded space is rejected"
 assert_name $'demo\tx' rejected "an embedded tab is rejected"
 assert_name $'demo\nx' rejected "an embedded newline is rejected, which the hosts marker relies on"
 assert_name "demo/1" rejected "a slash is rejected, since Docker rejects it in container names"
+assert_name ".." rejected "a bare traversal is rejected, as validate_name already rejects it"
+assert_name "a..b" rejected "an embedded traversal is rejected on both validators"
 assert_name "" rejected "an empty name is rejected"
 
 assert_path_name() {

--- a/bin/tests/test-name-guards.sh
+++ b/bin/tests/test-name-guards.sh
@@ -18,10 +18,10 @@
 # to reach git with "--help" as the branch. Git refuses that refname, so nothing
 # was created, but the user got a git error rather than usage.
 #
-# Scope: the four env subcommands that read a name positionally — create, up,
-# down and destroy — are all covered. list only compares $2 against --porcelain,
-# cleanup never reads it, and e2e-setup delegates to bin/setup-local-e2e.sh,
-# which carries its own --help arm and calls validate_env_name itself.
+# Scope: every env subcommand that reads $2 is covered — create, up, down and
+# destroy take a name, list and cleanup take only options. e2e-setup is the one
+# exception: it delegates to bin/setup-local-e2e.sh, which carries its own
+# --help arm and calls validate_env_name itself.
 #
 # Run: bash bin/tests/test-name-guards.sh
 
@@ -75,7 +75,10 @@ assert_name "-h" rejected "a short option is rejected"
 assert_name "-demo" rejected "a leading dash is rejected"
 assert_name ".demo" accepted "a leading dot is accepted; rejecting it would strand an existing env"
 assert_name "_demo" accepted "a leading underscore is accepted, for the same reason"
-assert_name "-demo" rejected "only a leading dash is rejected, and it is the whole point of the rule"
+assert_name "-" rejected "a bare dash is rejected"
+assert_name "de mo" rejected "an embedded space is rejected"
+assert_name $'demo\tx' rejected "an embedded tab is rejected"
+assert_name $'demo\nx' rejected "an embedded newline is rejected, which the hosts marker relies on"
 assert_name "demo/1" rejected "a slash is rejected, since Docker rejects it in container names"
 assert_name "" rejected "an empty name is rejected"
 
@@ -101,22 +104,41 @@ assert_path_name "-h" rejected "a short option is rejected"
 assert_path_name "--force" rejected "any long option is rejected, not just --help"
 assert_path_name "a..b" rejected "a parent-directory traversal is still rejected"
 assert_path_name "/abs" rejected "a leading slash is still rejected"
+assert_path_name "de mo" rejected "an embedded space is rejected"
+assert_path_name $'demo\nx' rejected "an embedded newline is rejected"
 assert_path_name "" rejected "an empty name is rejected"
 
-# _common.sh honours an inherited NABSPATH only when it names a real workspace
-# root, so the stub `n` is what makes this a sandbox: anything a subcommand
-# writes lands here rather than in the checkout.
-touch "$WORK/n"
+# The sandbox root. _common.sh honours an inherited NABSPATH only when it names
+# a real workspace root, so the stub `n` is what makes this one: anything a
+# subcommand writes lands here rather than in the checkout.
+SANDBOX="$WORK/root"
+mkdir -p "$SANDBOX"
+touch "$SANDBOX/n"
+
+# NABSPATH does not bound everything `create` can reach. If a guard regresses it
+# runs for real, and its /etc/hosts step calls `sudo newspack-manage-host`, which
+# is deliberately passwordless and needs no TTY — so a broken tree would write to
+# the host's real hosts file from inside this test, which is how the debris this
+# spec exists to prevent got created in the first place. Stubbing those out of
+# PATH and closing stdin keeps the failure contained.
+STUB="$WORK/stub"
+mkdir -p "$STUB"
+for cmd in sudo docker newspack-manage-host; do
+	printf '#!/bin/sh\necho "%s: blocked by the test sandbox" >&2\nexit 127\n' "$cmd" > "$STUB/$cmd"
+	chmod +x "$STUB/$cmd"
+done
 
 assert_usage() {
 	local want_status="$1" desc="$2"; shift 2
-	local out status=0
-	out=$(NABSPATH="$WORK" bash "$SCRIPT_DIR/../env.sh" "$@" 2>&1) || status=$?
+	local sub="$1" out status=0
+	out=$(PATH="$STUB:$PATH" NABSPATH="$SANDBOX" bash "$SCRIPT_DIR/../env.sh" "$@" </dev/null 2>&1) || status=$?
 	if [[ "$status" != "$want_status" ]]; then
 		echo "  FAIL: $desc — want exit $want_status, got $status"
 		failures=$((failures + 1))
-	elif [[ "$out" != *"Usage:"* ]]; then
-		echo "  FAIL: $desc — printed no usage text"
+	elif [[ "$out" != *"Usage: n env $sub"* ]]; then
+		# Matching the arm's own usage line, not a bare "Usage:", so a truncated
+		# string or another arm's text cannot satisfy the assertion.
+		echo "  FAIL: $desc — usage text did not name 'n env $sub'"
 		failures=$((failures + 1))
 	else
 		echo "  ok: $desc"
@@ -125,9 +147,9 @@ assert_usage() {
 
 echo
 echo "n env <subcommand> --help:"
-for sub in create up down destroy; do
-	assert_usage 0 "$sub --help prints usage and succeeds" "$sub" --help
-	assert_usage 0 "$sub -h prints usage and succeeds" "$sub" -h
+for sub in create up down destroy list cleanup; do
+	assert_usage 0 "$sub --help prints its own usage and succeeds" "$sub" --help
+	assert_usage 0 "$sub -h prints its own usage and succeeds" "$sub" -h
 done
 
 echo
@@ -140,7 +162,7 @@ done
 
 echo
 echo "no environment is created by any of the above:"
-leaked=$(find "$WORK" -mindepth 1 ! -name n)
+leaked=$(find "$SANDBOX" -mindepth 1 ! -name n)
 if [[ -n "$leaked" ]]; then
 	echo "  FAIL: the sandbox gained files — $(echo "$leaked" | tr '\n' ' ')"
 	failures=$((failures + 1))

--- a/bin/tests/test-name-guards.sh
+++ b/bin/tests/test-name-guards.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 #
-# test-env-name-guards.sh
+# test-name-guards.sh
 #
-# Self-proving spec for the two guards that stop an option being taken as an
-# environment name.
+# Self-proving spec for the guards that stop an option being taken as a name.
 #
 # `n env create --help` used to create an environment called "--help". The
 # subcommands read the name positionally, validate_env_name allowed a leading
@@ -13,7 +12,13 @@
 # alone lets the other regress. Loosen the validator and `destroy` accepts an
 # option again; drop the help arm and `--help` errors instead of helping.
 #
-# Run: bash bin/tests/test-env-name-guards.sh
+# validate_name is covered alongside it because it has the same exposure by a
+# different route: bin/worktree.sh and the --worktree parsing in bin/env.sh read
+# branch and repo names positionally through it, so `n worktree add --help` used
+# to reach git with "--help" as the branch. Git refuses that refname, so nothing
+# was created, but the user got a git error rather than usage.
+#
+# Run: bash bin/tests/test-name-guards.sh
 
 set -euo pipefail
 
@@ -51,6 +56,31 @@ assert_name ".demo" rejected "a leading dot is rejected, which would misname the
 assert_name "_demo" rejected "a leading underscore is rejected"
 assert_name "demo/1" rejected "a slash is rejected, since Docker rejects it in container names"
 assert_name "" rejected "an empty name is rejected"
+
+assert_path_name() {
+	local name="$1" want="$2" desc="$3" got
+	# validate_name exits rather than returning, so it runs in a subshell.
+	if ( validate_name "$name" "branch" ) >/dev/null 2>&1; then got=accepted; else got=rejected; fi
+	if [[ "$got" == "$want" ]]; then
+		echo "  ok: $desc"
+	else
+		echo "  FAIL: $desc — want $want, got $got"
+		failures=$((failures + 1))
+	fi
+}
+
+echo
+echo "validate_name:"
+assert_path_name "fix/some-thing" accepted "a slashed branch name is accepted, unlike an env name"
+assert_path_name "newspack-plugin" accepted "a repo name with an internal dash is accepted"
+assert_path_name "_pr738" accepted "a leading underscore is accepted, since such branches are in use"
+assert_path_name "demo.1" accepted "a dotted name is accepted"
+assert_path_name "--help" rejected "the option shape that reached git as a branch name is rejected"
+assert_path_name "-h" rejected "a short option is rejected"
+assert_path_name "--force" rejected "any long option is rejected, not just --help"
+assert_path_name "a..b" rejected "a parent-directory traversal is still rejected"
+assert_path_name "/abs" rejected "a leading slash is still rejected"
+assert_path_name "" rejected "an empty name is rejected"
 
 # _common.sh honours an inherited NABSPATH only when it names a real workspace
 # root, so the stub `n` is what makes this a sandbox: anything a subcommand

--- a/bin/tests/test-name-guards.sh
+++ b/bin/tests/test-name-guards.sh
@@ -185,6 +185,32 @@ done
 
 echo
 echo "no environment is created by any of the above:"
+# `--all` is the one other dash-leading token read from the name position, and
+# is_help_arg's comment states that it must still reach the up arm's own branch.
+# Exit status cannot tell the two apart -- a usage dump also exits 0 -- so this
+# asserts on the output: widening is_help_arg to `-*` would look like a
+# strengthening of the guard and silently turn `n env up --all` into usage.
+assert_up_all_is_not_help() {
+	local out status=0
+	out=$(PATH="$STUB:$PATH" NABSPATH="$SANDBOX" bash "$SCRIPT_DIR/../env.sh" up --all </dev/null 2>&1) || status=$?
+	if [[ "$status" -ne 0 ]]; then
+		echo "  FAIL: up --all reaches its own branch — want exit 0, got $status"
+		failures=$((failures + 1))
+	elif [[ "$out" == *"Usage: n env up"* ]]; then
+		echo "  FAIL: up --all reaches its own branch — it printed usage, so it was read as a help request"
+		failures=$((failures + 1))
+	elif [[ "$out" != *"started,"* ]]; then
+		echo "  FAIL: up --all reaches its own branch — no start summary in output: $out"
+		failures=$((failures + 1))
+	else
+		echo "  ok: up --all reaches its own branch rather than the help guard"
+	fi
+}
+
+echo ""
+echo "n env up --all is not a help request:"
+assert_up_all_is_not_help
+
 # The create arm must actually reach the stricter validator. Asserting
 # validate_new_env_name directly cannot see the call site, so reverting create to
 # the lax validator would leave every assertion above green.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)? n/a: shell only, no PHP in this change.
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`n env create --help` created an environment named `--help` instead of printing usage. It wrote `docker-compose.env---help.yml`, an `envs/--help/` directory and an `/etc/hosts` line, printed no usage text, and exited 0.

`AGENTS.md` tells people to run any command with `--help` for its full options, so the documented path is the one that misfires.

Two independent gaps combine. Neither is wrong on its own:

* `bin/env.sh` reads the environment name positionally, and no subcommand handles `-h` or `--help`.
* `validate_env_name` in `bin/_common.sh` allows a leading dash, so `--help` passes as an ordinary name.

This adds both guards:

* **`validate_env_name` rejects a leading dash.** One line in shared code, so it covers every subcommand at once, including `destroy`. It excludes a leading dash and nothing else: this validator also gates `up`, `down` and `destroy`, so a stricter first-character rule would strand an environment created under an older one, leaving the container, compose file, hosts entry and `envs/` directory removable only by hand.
* **Every `env` subcommand that reads `$2` handles `-h` and `--help`** — `create`, `up`, `down`, `destroy`, `list` and `cleanup` — printing the usage text each already had. An explicit help request exits 0; a missing name still exits 1, as before. `e2e-setup` is unchanged: it delegates to `bin/setup-local-e2e.sh`, which has its own `--help` arm.

`bin/_common.sh` carries a second validator, `validate_name`, with the same hole by a different route. It covers names that become git branches and path components, and `bin/worktree.sh` plus the `--worktree` parsing in `bin/env.sh` read those positionally through it, so `n worktree add --help` reached git with `--help` as the branch name. Git refuses that refname, so nothing was created, but the user got a git error rather than usage.

* **`validate_name` rejects a leading dash** on the same rule, so both validators exclude exactly that and nothing else. Slashed branches are the norm here and branches such as `_pr738` are in use, so both keep working. `..` and a leading `/` are rejected as before.

One behavior change, identical in both validators: a name beginning with `-` is rejected. Nothing else changes, so every name either validator accepted before is still accepted. `n env up --all` is unaffected.

One consequence worth stating: an environment whose name begins with `-` can only exist if the bug above created it, and it is no longer reachable through `n env` — `down` and `destroy` print usage rather than acting on it. Removing one is manual:

```sh
rm -f docker-compose.env---help.yml
rm -rf './envs/--help'
sudo newspack-manage-host host-remove '--help.test'
```

This overlaps #682 in `bin/env.sh`: it inserts at the same point above `case $1 in`, and it rewrites the `n env up` usage line this change replaces. Happy to rebase whichever lands second.

There's no linked issue; I hit this while using the tool.

**One-time cleanup, if you have an environment created by this bug.** `n env create --help` used to create an environment literally named `--help`. This change makes such a name unreachable through `n env`: `destroy` reads `--help` as a help request before the name is validated, and the tightened validator rejects any leading dash. `n env cleanup` doesn't help either — it lists environments by globbing the compose files but delegates removal back to `n env destroy`.

Removing one takes six steps by hand, matching what `destroy` does:

```bash
docker stop newspack_env___help; docker rm newspack_env___help
docker compose -f docker-compose.yml exec -T db mariadb -h localhost -u root -p"$MYSQL_ROOT_PASSWORD" \
  -e 'DROP DATABASE IF EXISTS `wordpress___help`; DROP DATABASE IF EXISTS `wp_tests___help`'
rm -rf envs/--help logs/env---help
sudo newspack-manage-host host-remove --help.test   # only if a hosts entry was added
rm -f docker-compose.env---help.yml
```

A `--` end-of-options form for `destroy` was considered and set aside: it would mean accepting a leading dash again on the one path that runs `rm -rf`, to serve debris from a bug this PR is the first to fix.

### How to test the changes in this Pull Request:

1. Run `./n env create --help`. The usage line prints and the command exits 0.
2. Check that nothing was created. There is no new `docker-compose.env-*.yml`, no new directory under `envs/`, and no new `/etc/hosts` line.
3. Repeat with `-h`, and with `up`, `down`, `destroy`, `list` and `cleanup`. Each prints its own usage and exits 0.
4. Run `./n env create` with no arguments. The usage line prints and the command exits 1.
5. Run `./n env create -foo`, then `.foo`, then `_foo`. Each is rejected.
6. Run `./n worktree add --help`. The name is rejected, rather than reaching git as a branch name.
7. Run `bash bin/tests/test-name-guards.sh`. All assertions pass.
8. Run `./n env create <name>` with an ordinary name, then `up` and `destroy` it. The cycle still works.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? `bin/tests/test-name-guards.sh` covers both validators and the help arms, and the Shell specs job runs it.
* [x] Have you successfully run tests with your changes locally? The 45 assertions pass. I confirmed the spec fails when each guard is removed on its own, when a validator is broken so that it exits non-zero without rejecting, and that with every guard reverted at once it still writes nothing outside its sandbox (`/etc/hosts` byte-identical across the run). Manual steps 1 through 6 also run clean. Step 8 I have not run end to end; the change does not touch that path beyond validation.

