### PR TITLE
fix(listings): pin expiration dates to site-local midnight (NPPM-3129)

### DIFF
--- a/plugins/newspack-listings/src/editor/featured-listings/index.js
+++ b/plugins/newspack-listings/src/editor/featured-listings/index.js
@@ -6,7 +6,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { BaseControl, Button, DatePicker, PanelRow, RangeControl, ToggleControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { dateI18n } from '@wordpress/date';
+import { dateI18n, getDate } from '@wordpress/date';
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import { useEffect, useState } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
@@ -125,13 +125,18 @@ const FeaturedListingsComponent = ( { createNotice, isSavingPost, meta, postId, 
 					<PanelRow>
 						<BaseControl id="newspack-listings__featured-listing-expiration" label={ __( 'Expiration Date', 'newspack-listings' ) }>
 							<DatePicker
-								currentDate={ newspack_listings_featured_expires ? new Date( newspack_listings_featured_expires ) : null }
+								currentDate={ newspack_listings_featured_expires || null }
 								onMonthPreviewed={ () => {} }
 								onChange={ value => {
-									// Convert value to midnight in the local timezone.
-									const date = new Date( value );
-									const midnight = new Date( date.getFullYear(), date.getMonth(), date.getDate() );
-									updateMetaValue( 'newspack_listings_featured_expires', dateI18n( 'Y-m-d\\TH:i:s', midnight ) );
+									// Pin midnight in the *site* timezone, which is how
+									// Featured::unset_featured_status parses this value when it decides
+									// whether the listing has expired. Taking the calendar date from the
+									// browser instead lands on the wrong day for any editor far enough
+									// from the site timezone, expiring the listing a day early or late.
+									updateMetaValue(
+										'newspack_listings_featured_expires',
+										value ? `${ dateI18n( 'Y-m-d', getDate( value ) ) }T00:00:00` : ''
+									);
 								} }
 							/>
 							{ newspack_listings_featured_expires && (

--- a/plugins/newspack-listings/src/editor/featured-listings/index.js
+++ b/plugins/newspack-listings/src/editor/featured-listings/index.js
@@ -128,11 +128,13 @@ const FeaturedListingsComponent = ( { createNotice, isSavingPost, meta, postId, 
 								currentDate={ newspack_listings_featured_expires || null }
 								onMonthPreviewed={ () => {} }
 								onChange={ value => {
-									// Pin midnight in the *site* timezone, which is how
-									// Featured::unset_featured_status parses this value when it decides
-									// whether the listing has expired. Taking the calendar date from the
-									// browser instead lands on the wrong day for any editor far enough
-									// from the site timezone, expiring the listing a day early or late.
+									// Pin midnight in the site timezone, not the browser's. The stored
+									// value is a naive, offset-less datetime, and
+									// Featured::unset_featured_status parses it as site-local when deciding
+									// whether the listing has expired, so attaching an offset here (via
+									// toISOString or similar) would change its meaning rather than clarify
+									// it. Taking the calendar date from the browser lands on the wrong day
+									// for a distant editor, expiring the listing a day early or late.
 									updateMetaValue(
 										'newspack_listings_featured_expires',
 										value ? `${ dateI18n( 'Y-m-d', getDate( value ) ) }T00:00:00` : ''

--- a/plugins/newspack-listings/src/editor/sidebar/index.js
+++ b/plugins/newspack-listings/src/editor/sidebar/index.js
@@ -87,7 +87,7 @@ const SidebarComponent = ( { createNotice, meta, publishDate, updateMetaValue } 
 							currentDate={ expirationDate || null }
 							onChange={ value => {
 								/**
-								 * If the current user is a listings customer, don't allow them to set the expiraiton date beyond the
+								 * If the current user is a listings customer, don't allow them to set the expiration date beyond the
 								 * last saved expiration date or `expirationPeriod` days from the publish date, whichever is later.
 								 */
 								if ( isListingCustomer ) {

--- a/plugins/newspack-listings/src/editor/sidebar/index.js
+++ b/plugins/newspack-listings/src/editor/sidebar/index.js
@@ -84,7 +84,7 @@ const SidebarComponent = ( { createNotice, meta, publishDate, updateMetaValue } 
 						label={ __( 'Expiration Date', 'newspack-listings' ) }
 					>
 						<DateTimePicker
-							currentDate={ expirationDate ? new Date( expirationDate ) : null }
+							currentDate={ expirationDate || null }
 							onChange={ value => {
 								/**
 								 * If the current user is a listings customer, don't allow them to set the expiraiton date beyond the


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Listing expiration dates now mean the same thing to the editor who sets them and to the code that acts on them.

Both expiration pickers in this plugin worked in the editor's browser timezone rather than the site's. A featured listing set to expire on January 15 by an editor in Sydney was stored as January 14, and stopped being featured a day early. Editors west of the site timezone kept the right day but the wrong hour.

The featured picker is the more serious of the two, because it wrote the wrong value rather than only displaying one. Its `onChange` built midnight in the browser's timezone and then formatted that instant in site time, so the two halves disagreed about which day it was. The listing sidebar picker had the display-side defect alone, the same one fixed for the Event Dates block in #863.

Both now resolve against the site timezone, which is what reads them: `Featured::unset_featured_status` parses the stored string with `new \DateTime( $value, new \DateTimeZone( $site_timezone ) )`.

**Why the sidebar picker changes on one side only.** It hands core's `onChange` output straight to the meta value, and core emits through `@wordpress/date`'s `date()` with `TIMEZONELESS_FORMAT`, which already formats in site time. Its write path was correct before this change; only the display was wrong. The featured picker needed both halves because it did its own date arithmetic on top of that output, and that arithmetic ran in the browser's timezone.

Existing stored values are left alone. A value saved by an affected editor is wrong, and a correct-looking `T00:00:00` cannot be told apart from a coincidentally-correct one, so a migration would be guessing. Re-saving a listing corrects its value.

Addresses NPPM-3129. Same family as NPPM-3125 (#863), found while fixing it, and not new in WordPress 7.1.

### How to test the changes in this Pull Request:

1. In Settings > General, set Timezone to a zone east of the machine you are testing from. UTC works from anywhere in the Americas. This offset is required; with matching timezones there is nothing to reproduce.
2. Open a listing and turn on **Featured Listing** in the document sidebar.
3. Set an **Expiration Date** of January 15, 2027.
4. Check the `newspack_listings_featured_expires` post meta. It reads `2027-01-15T00:00:00`. Before this change it read `2027-01-14T13:00:00` from Sydney.
5. Reload the editor. The picker still shows January 15. Before this change it showed the 14th.
6. Set an **Expiration Date** in the listing sidebar and reload. That field holds its day too.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? Tests n/a: `newspack-listings` has no JS test setup, so a unit test means adding that infrastructure first. Verified by the matrix below.
* [x] Have you successfully run tests with your changes locally? Ten editor timezones against a pre-fix baseline, plus fractional and extreme offsets, a non-UTC site, and a day where local midnight does not exist. Details below. ESLint clean.

<details>
<summary>Verification: 10 timezones, both pickers, measured against a failing baseline</summary>

Every row was measured on the pre-fix build first, so these are not assertions that could pass regardless.

Featured picker, site at UTC. Seed the meta to `2027-01-20T00:00:00`, click January 15, expect exactly `2027-01-15T00:00:00`:

| Editor timezone | Offset | Before | After |
| --- | --- | --- | --- |
| UTC | 0 | `2027-01-15T00:00:00` | correct |
| America/New_York | −5 | `2027-01-15T05:00:00` | correct |
| Asia/Tokyo | +9 | `2027-01-14T15:00:00` | correct |
| Australia/Sydney | +11 | `2027-01-14T13:00:00` | correct |
| Asia/Kolkata | +5:30 | `2027-01-14T18:30:00` | correct |
| Asia/Kathmandu | +5:45 | `2027-01-14T18:15:00` | correct |
| Pacific/Chatham | +13:45 | `2027-01-14T10:15:00` | correct |
| Pacific/Kiritimati | +14 | `2027-01-14T10:00:00` | correct |
| Pacific/Midway | −11 | `2027-01-15T11:00:00` | correct |
| America/Anchorage | −9 | `2027-01-15T09:00:00` | correct |

Nine of ten wrong before, all ten correct after. Editors east of the site lost a whole day; editors west kept the day and gained hours. The picker also displayed the wrong day for every eastern editor.

Seams beyond the plain matrix:

- **Fractional and extreme offsets** (+5:30, +5:45, +13:45, +14, −11) all pass, and the pre-fix values land exactly where the arithmetic predicts.
- **Non-UTC, DST-observing site** (`America/New_York`) passes. This class of error stays hidden while the site sits at UTC.
- **A day where local midnight does not exist.** Real transitions were located rather than assumed: `America/Havana` 2027-03-14 and `America/Santiago` 2026-09-06 jump from 23:59:59 to 01:00. PHP normalizes `T00:00:00` forward to 01:00 on the same calendar day, so the expiry day survives. Confirmed end to end with the site on Havana and that date, from four editor timezones.
- **Listing sidebar picker** passes. Before the fix it showed the 19th instead of the 20th and stored `15:00`, `13:00` and `10:00` for Tokyo, Sydney and Kiritimati.

</details>

<details>
<summary>Why site-local midnight, and not something else</summary>

The consumer decides this, so it is not a matter of preference. `Featured::unset_featured_status` (`includes/class-featured.php:474`):

```php
$parsed_date = new \DateTime( $expiration_date, new \DateTimeZone( $timezone ) );
$unset_featured = 0 > $parsed_date->getTimestamp() - time();
```

The stored offset-less string is parsed in the site timezone. `Utils\convert_string_to_date_time` does the same, and the plugin's own helper is named "the next occurrence of midnight in the site's local timezone". The importer already writes with `wp_date()`, which is site time, so this brings the editor into line with everything else that touches the value.

The removed comment read "Convert value to midnight in the local timezone", which is the defect in one word: it built midnight in the browser's zone, then rendered that instant in the site's. Two different meanings of "local" in three lines.

One note for reviewers of #863: `@wordpress/components` is externalized, so `DateTimePicker` and `DatePicker` behavior comes from WordPress core, not from the copy in `node_modules`. The installed copy is a different implementation and reading it suggests these changes are no-ops.

</details>
