### PR TITLE
fix: three WordPress 7.1 regressions in Newsletters

### DIFF
--- a/packages/components/src/grid/style.scss
+++ b/packages/components/src/grid/style.scss
@@ -83,11 +83,13 @@
 		&__columns-4 {
 			grid-template-columns: repeat(2, 1fr);
 
-			> [start] {
+			> [start],
+			> [data-start] {
 				grid-column-start: 1;
 			}
 
-			> [end] {
+			> [end],
+			> [data-end] {
 				grid-column-end: -1;
 			}
 		}
@@ -108,16 +110,19 @@
 		&__columns-4 {
 			grid-template-columns: repeat(4, 1fr);
 
-			// Positioning is keyed off `data-` attributes because WordPress 7.1
-			// stopped forwarding unrecognised props through to the DOM: `start`
-			// survives (it is a real attribute, on `<ol>`), `end` does not, so a
-			// child asking for `end` silently lost its `grid-column-end` and
-			// collapsed to a single column (NEWS-2866). `data-` attributes are
-			// always forwarded, so they hold regardless of the component in use.
+			// Positioning is keyed off `data-` attributes because the emotion-styled
+			// components in newer `@wordpress/components` filter props through
+			// `@emotion/is-prop-valid` before they reach the DOM. Its allowlist
+			// carries `start` (a real attribute, on `<ol>`) but not `end`, so a
+			// `VStack` asking for `end` silently lost its `grid-column-end` and
+			// collapsed to one column (NEWS-2866). `data-` attributes are never
+			// filtered, so they hold whatever component renders them.
 			//
-			// The bare-attribute selectors are kept so any consumer still passing
-			// `start`/`end` renders as it did before, rather than breaking on the
-			// way past.
+			// This is a component-level filter, not a WordPress-wide one: a plain
+			// `<div start="2" end="4">` still emits both attributes. The bare
+			// selectors below are kept for those plain children — they do NOT
+			// rescue an emotion-styled consumer still passing `end`, which never
+			// reaches the DOM to be matched.
 			> [start="2"],
 			> [data-start="2"] {
 				grid-column-start: 2;

--- a/packages/components/src/grid/style.scss
+++ b/packages/components/src/grid/style.scss
@@ -108,11 +108,23 @@
 		&__columns-4 {
 			grid-template-columns: repeat(4, 1fr);
 
-			> [start="2"] {
+			// Positioning is keyed off `data-` attributes because WordPress 7.1
+			// stopped forwarding unrecognised props through to the DOM: `start`
+			// survives (it is a real attribute, on `<ol>`), `end` does not, so a
+			// child asking for `end` silently lost its `grid-column-end` and
+			// collapsed to a single column (NEWS-2866). `data-` attributes are
+			// always forwarded, so they hold regardless of the component in use.
+			//
+			// The bare-attribute selectors are kept so any consumer still passing
+			// `start`/`end` renders as it did before, rather than breaking on the
+			// way past.
+			> [start="2"],
+			> [data-start="2"] {
 				grid-column-start: 2;
 			}
 
-			> [end="4"] {
+			> [end="4"],
+			> [data-end="4"] {
 				grid-column-end: 4;
 			}
 		}

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-renderer.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-renderer.php
@@ -903,26 +903,82 @@ final class Newspack_Newsletters_Renderer {
 	 * Buttons carry their width in one of two shapes. Newsletters authored before
 	 * WordPress 7.1 store a bare `width` attribute; WordPress 7.1 moved
 	 * `core/button` to the `dimensions` block support, so the editor rewrites the
-	 * markup to a percentage string under `style.dimensions.width` the first time a
-	 * newsletter is re-saved. Both forms can coexist in the same newsletter, so
-	 * every width read goes through here (NEWS-2852).
+	 * markup under `style.dimensions.width` the first time a newsletter is
+	 * re-saved. Both forms can coexist in the same newsletter, so every width read
+	 * goes through here (NEWS-2852).
 	 *
-	 * Only percentages translate to MJML column widths. Any other unit is treated
-	 * as "no width set", which lets the button fall back to the shared default
-	 * rather than producing a nonsense column.
+	 * The `dimensions` shape has three variants, and WordPress resolves all of them
+	 * before rendering (`wp-includes/blocks/button.php`): a literal percentage, a
+	 * `var:preset|dimension|<slug>` reference to a `dimensionSizes` preset (core
+	 * ships 25/50/75/100 for buttons, so this is reachable on every site), and an
+	 * absolute unit such as `200px`. Only percentages map onto an MJML column, so
+	 * presets are resolved first and absolute units are treated as "no width set" —
+	 * the button then takes the shared default rather than producing a nonsense
+	 * column.
+	 *
+	 * Widths outside 1–100 are also treated as unset. Nothing in the block editor
+	 * can produce them, but hand-edited or migrated content can, and an
+	 * `mj-column` with a negative or >100% width breaks the whole row rather than
+	 * just that button.
+	 *
+	 * Safe to call with either raw parsed-block attributes or the output of
+	 * `process_attributes()`, which touches neither width key.
 	 *
 	 * @param array $attrs A core/button block's attributes.
-	 * @return int|null Width as a percentage, or null when unset.
+	 * @return float|null Width as a percentage, or null when unset.
 	 */
 	private static function get_button_width( $attrs ) {
-		if ( isset( $attrs['width'] ) && '' !== $attrs['width'] ) {
-			return intval( $attrs['width'] );
+		$width = null;
+
+		if ( isset( $attrs['width'] ) && is_scalar( $attrs['width'] ) && '' !== $attrs['width'] ) {
+			$width = $attrs['width'];
+		} elseif ( isset( $attrs['style']['dimensions']['width'] ) && is_scalar( $attrs['style']['dimensions']['width'] ) ) {
+			$width = self::resolve_dimension_preset( (string) $attrs['style']['dimensions']['width'] );
 		}
-		$dimensions_width = $attrs['style']['dimensions']['width'] ?? null;
-		if ( null === $dimensions_width || ! preg_match( '/^\s*(\d+(?:\.\d+)?)\s*%\s*$/', (string) $dimensions_width, $matches ) ) {
+
+		if ( null === $width || ! preg_match( '/^\s*(\d+(?:\.\d+)?)\s*%?\s*$/', (string) $width, $matches ) ) {
 			return null;
 		}
-		return intval( $matches[1] );
+
+		$percentage = (float) $matches[1];
+
+		return ( $percentage > 0 && $percentage <= 100 ) ? $percentage : null;
+	}
+
+	/**
+	 * Resolve a `dimensions.width` value to its literal size.
+	 *
+	 * Mirrors the preset lookup WordPress does in `wp-includes/blocks/button.php`:
+	 * a `var:preset|dimension|<slug>` reference is looked up against the
+	 * `dimensionSizes` presets, searching custom, then theme, then default origins.
+	 * Any other value is returned unchanged.
+	 *
+	 * @param string $width The raw `style.dimensions.width` value.
+	 * @return string The resolved width.
+	 */
+	private static function resolve_dimension_preset( $width ) {
+		$prefix = 'var:preset|dimension|';
+		if ( 0 !== strpos( $width, $prefix ) ) {
+			return $width;
+		}
+
+		$slug    = substr( $width, strlen( $prefix ) );
+		$presets = wp_get_global_settings( [ 'dimensions', 'dimensionSizes' ], [ 'block_name' => 'core/button' ] );
+
+		if ( is_array( $presets ) ) {
+			foreach ( [ 'custom', 'theme', 'default' ] as $origin ) {
+				if ( empty( $presets[ $origin ] ) || ! is_array( $presets[ $origin ] ) ) {
+					continue;
+				}
+				foreach ( $presets[ $origin ] as $preset ) {
+					if ( isset( $preset['slug'] ) && (string) $preset['slug'] === $slug ) {
+						return (string) ( $preset['size'] ?? $width );
+					}
+				}
+			}
+		}
+
+		return $width;
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-renderer.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-renderer.php
@@ -907,73 +907,105 @@ final class Newspack_Newsletters_Renderer {
 	 * re-saved. Both forms can coexist in the same newsletter, so every width read
 	 * goes through here (NEWS-2852).
 	 *
-	 * The `dimensions` shape has three variants, and WordPress resolves all of them
-	 * before rendering (`wp-includes/blocks/button.php`): a literal percentage, a
-	 * `var:preset|dimension|<slug>` reference to a `dimensionSizes` preset (core
-	 * ships 25/50/75/100 for buttons, so this is reachable on every site), and an
-	 * absolute unit such as `200px`. Only percentages map onto an MJML column, so
-	 * presets are resolved first and absolute units are treated as "no width set" —
-	 * the button then takes the shared default rather than producing a nonsense
-	 * column.
+	 * The legacy attribute is preferred when it yields a usable width, but an
+	 * unusable one falls through to the `dimensions` value rather than discarding
+	 * it — partially-migrated content is exactly what this helper exists to
+	 * survive.
 	 *
-	 * Widths outside 1–100 are also treated as unset. Nothing in the block editor
-	 * can produce them, but hand-edited or migrated content can, and an
-	 * `mj-column` with a negative or >100% width breaks the whole row rather than
-	 * just that button.
+	 * A width is usable only if it resolves to a percentage in 1-100. Absolute
+	 * units have no meaning as an MJML column share, and a column outside that
+	 * range disturbs the rest of its row; either way the button falls back to the
+	 * default share, which is what a width-less button gets.
 	 *
 	 * Safe to call with either raw parsed-block attributes or the output of
 	 * `process_attributes()`, which touches neither width key.
 	 *
 	 * @param array $attrs A core/button block's attributes.
-	 * @return float|null Width as a percentage, or null when unset.
+	 * @return float|null Width as a percentage, or null when unset or unusable.
 	 */
-	private static function get_button_width( $attrs ) {
-		$width = null;
+	private static function get_button_width( array $attrs ): ?float {
+		$candidates = [];
 
-		if ( isset( $attrs['width'] ) && is_scalar( $attrs['width'] ) && '' !== $attrs['width'] ) {
-			$width = $attrs['width'];
-		} elseif ( isset( $attrs['style']['dimensions']['width'] ) && is_scalar( $attrs['style']['dimensions']['width'] ) ) {
-			$width = self::resolve_dimension_preset( (string) $attrs['style']['dimensions']['width'] );
+		if ( isset( $attrs['width'] ) && is_scalar( $attrs['width'] ) ) {
+			$candidates[] = (string) $attrs['width'];
+		}
+		if ( isset( $attrs['style']['dimensions']['width'] ) && is_scalar( $attrs['style']['dimensions']['width'] ) ) {
+			$candidates[] = self::resolve_dimension_preset( (string) $attrs['style']['dimensions']['width'] );
 		}
 
-		if ( null === $width || ! preg_match( '/^\s*(\d+(?:\.\d+)?)\s*%?\s*$/', (string) $width, $matches ) ) {
-			return null;
+		foreach ( $candidates as $candidate ) {
+			if ( ! preg_match( '/^\s*(\d+(?:\.\d+)?)\s*%?\s*$/', $candidate, $matches ) ) {
+				continue;
+			}
+			$percentage = (float) $matches[1];
+			if ( $percentage > 0 && $percentage <= 100 ) {
+				return $percentage;
+			}
 		}
 
-		$percentage = (float) $matches[1];
-
-		return ( $percentage > 0 && $percentage <= 100 ) ? $percentage : null;
+		return null;
 	}
 
 	/**
-	 * Resolve a `dimensions.width` value to its literal size.
+	 * Resolve a `dimensions.width` preset reference to its literal size.
 	 *
-	 * Mirrors the preset lookup WordPress does in `wp-includes/blocks/button.php`:
-	 * a `var:preset|dimension|<slug>` reference is looked up against the
-	 * `dimensionSizes` presets, searching custom, then theme, then default origins.
-	 * Any other value is returned unchanged.
+	 * WordPress stores a chosen preset as `var:preset|dimension|<slug>` rather than
+	 * a size. On the web an unresolved reference still renders, because the style
+	 * engine falls back to the `--wp--preset--dimension--<slug>` custom property
+	 * that theme.json emits. Email clients do not support custom properties, so the
+	 * reference has to be resolved here or the width is simply lost — which is why
+	 * this looks harder for the preset than core does.
+	 *
+	 * Core's own lookup (`render_block_core_button()`) reads only the
+	 * `blocks.core/button` node, with the origins and exact-slug match mirrored
+	 * below. That is enough for core because of the custom-property fallback; it
+	 * isn't enough for us, so this also reads the root `dimensions.dimensionSizes`
+	 * group, includes the `blocks` origin that `wp_theme_json_data_blocks` writes
+	 * to, and tolerates a kebab-cased reference to a camelCase slug.
 	 *
 	 * @param string $width The raw `style.dimensions.width` value.
-	 * @return string The resolved width.
+	 * @return string The resolved width, or the input unchanged when it isn't a
+	 *                preset reference or names an unknown preset.
 	 */
-	private static function resolve_dimension_preset( $width ) {
+	private static function resolve_dimension_preset( string $width ): string {
 		$prefix = 'var:preset|dimension|';
-		if ( 0 !== strpos( $width, $prefix ) ) {
+		if ( ! str_starts_with( $width, $prefix ) ) {
 			return $width;
 		}
+		$slug = substr( $width, strlen( $prefix ) );
 
-		$slug    = substr( $width, strlen( $prefix ) );
-		$presets = wp_get_global_settings( [ 'dimensions', 'dimensionSizes' ], [ 'block_name' => 'core/button' ] );
+		// Read the settings once and index into them. `wp_get_global_settings()`
+		// returns the *whole* settings array when the requested path is absent, so
+		// asking it for a path and testing `is_array()` on the result never fails —
+		// it just hands back a different array to walk.
+		$settings = wp_get_global_settings();
+		$groups   = [];
+		if ( isset( $settings['blocks']['core/button']['dimensions']['dimensionSizes'] ) ) {
+			$groups[] = $settings['blocks']['core/button']['dimensions']['dimensionSizes'];
+		}
+		if ( isset( $settings['dimensions']['dimensionSizes'] ) ) {
+			$groups[] = $settings['dimensions']['dimensionSizes'];
+		}
 
-		if ( is_array( $presets ) ) {
-			foreach ( [ 'custom', 'theme', 'default' ] as $origin ) {
+		foreach ( $groups as $presets ) {
+			if ( ! is_array( $presets ) ) {
+				continue;
+			}
+			// Origin priority, most specific first.
+			foreach ( [ 'custom', 'theme', 'blocks', 'default' ] as $origin ) {
 				if ( empty( $presets[ $origin ] ) || ! is_array( $presets[ $origin ] ) ) {
 					continue;
 				}
 				foreach ( $presets[ $origin ] as $preset ) {
-					if ( isset( $preset['slug'] ) && (string) $preset['slug'] === $slug ) {
-						return (string) ( $preset['size'] ?? $width );
+					if ( ! is_array( $preset ) || ! isset( $preset['slug'] ) || ! is_scalar( $preset['slug'] ) ) {
+						continue;
 					}
+					$preset_slug = (string) $preset['slug'];
+					if ( $preset_slug !== $slug && _wp_to_kebab_case( $preset_slug ) !== $slug ) {
+						continue;
+					}
+					$size = $preset['size'] ?? null;
+					return is_scalar( $size ) ? (string) $size : $width;
 				}
 			}
 		}
@@ -1405,6 +1437,11 @@ final class Newspack_Newsletters_Renderer {
 						$button_attrs['css-class'] = $attrs['className'];
 					}
 
+					// NOTE: the width below goes on $default_button_attrs, which is what
+					// the emit at the end of this case actually serializes. The
+					// $button_attrs built just above is dead (pre-existing) — if that
+					// is ever cleaned up, move this width with it or buttons silently
+					// lose their width again.
 					$column_attrs['css-class'] = 'mj-column-has-width';
 					$column_width              = $default_width;
 					$button_width              = self::get_button_width( $attrs );

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-renderer.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-renderer.php
@@ -912,7 +912,8 @@ final class Newspack_Newsletters_Renderer {
 	 * it — partially-migrated content is exactly what this helper exists to
 	 * survive.
 	 *
-	 * A width is usable only if it resolves to a percentage in 1-100. Absolute
+	 * A width is usable only if it resolves to a percentage above 0 and at most
+	 * 100. Absolute
 	 * units have no meaning as an MJML column share, and a column outside that
 	 * range disturbs the rest of its row; either way the button falls back to the
 	 * default share, which is what a width-less button gets.
@@ -957,11 +958,12 @@ final class Newspack_Newsletters_Renderer {
 	 * this looks harder for the preset than core does.
 	 *
 	 * Core's own lookup (`render_block_core_button()`) reads only the
-	 * `blocks.core/button` node, with the origins and exact-slug match mirrored
-	 * below. That is enough for core because of the custom-property fallback; it
-	 * isn't enough for us, so this also reads the root `dimensions.dimensionSizes`
-	 * group, includes the `blocks` origin that `wp_theme_json_data_blocks` writes
-	 * to, and tolerates a kebab-cased reference to a camelCase slug.
+	 * `blocks.core/button` node. That is enough for core because of the
+	 * custom-property fallback; it isn't enough for us, so this also reads the
+	 * root `dimensions.dimensionSizes` group and includes the `blocks` origin.
+	 * Slugs are compared exactly, as core compares them: the editor writes the
+	 * slug verbatim into the reference, and `_wp_to_kebab_case()` is applied only
+	 * when core builds the CSS custom-property name, never to the stored value.
 	 *
 	 * @param string $width The raw `style.dimensions.width` value.
 	 * @return string The resolved width, or the input unchanged when it isn't a
@@ -1000,8 +1002,7 @@ final class Newspack_Newsletters_Renderer {
 					if ( ! is_array( $preset ) || ! isset( $preset['slug'] ) || ! is_scalar( $preset['slug'] ) ) {
 						continue;
 					}
-					$preset_slug = (string) $preset['slug'];
-					if ( $preset_slug !== $slug && _wp_to_kebab_case( $preset_slug ) !== $slug ) {
+					if ( (string) $preset['slug'] !== $slug ) {
 						continue;
 					}
 					$size = $preset['size'] ?? null;

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-renderer.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-renderer.php
@@ -898,6 +898,34 @@ final class Newspack_Newsletters_Renderer {
 	}
 
 	/**
+	 * Get a button's width as a column percentage, or null when it sets none.
+	 *
+	 * Buttons carry their width in one of two shapes. Newsletters authored before
+	 * WordPress 7.1 store a bare `width` attribute; WordPress 7.1 moved
+	 * `core/button` to the `dimensions` block support, so the editor rewrites the
+	 * markup to a percentage string under `style.dimensions.width` the first time a
+	 * newsletter is re-saved. Both forms can coexist in the same newsletter, so
+	 * every width read goes through here (NEWS-2852).
+	 *
+	 * Only percentages translate to MJML column widths. Any other unit is treated
+	 * as "no width set", which lets the button fall back to the shared default
+	 * rather than producing a nonsense column.
+	 *
+	 * @param array $attrs A core/button block's attributes.
+	 * @return int|null Width as a percentage, or null when unset.
+	 */
+	private static function get_button_width( $attrs ) {
+		if ( isset( $attrs['width'] ) && '' !== $attrs['width'] ) {
+			return intval( $attrs['width'] );
+		}
+		$dimensions_width = $attrs['style']['dimensions']['width'] ?? null;
+		if ( null === $dimensions_width || ! preg_match( '/^\s*(\d+(?:\.\d+)?)\s*%\s*$/', (string) $dimensions_width, $matches ) ) {
+			return null;
+		}
+		return intval( $matches[1] );
+	}
+
+	/**
 	 * Convert a Gutenberg block to an MJML component.
 	 * MJML component will be put in an mj-column in an mj-section for consistent layout,
 	 * unless it's a group or a columns block.
@@ -1212,8 +1240,9 @@ final class Newspack_Newsletters_Renderer {
 				$total_defined_width = array_reduce(
 					$inner_blocks,
 					function ( $acc, $block ) {
-						if ( isset( $block['attrs']['width'] ) ) {
-							$acc += intval( $block['attrs']['width'] );
+						$width = self::get_button_width( $block['attrs'] ?? [] );
+						if ( null !== $width ) {
+							$acc += $width;
 						}
 						return $acc;
 					},
@@ -1225,7 +1254,7 @@ final class Newspack_Newsletters_Renderer {
 					array_filter(
 						$inner_blocks,
 						function ( $block ) {
-							return empty( $block['attrs']['width'] );
+							return null === self::get_button_width( $block['attrs'] ?? [] );
 						}
 					)
 				);
@@ -1322,8 +1351,9 @@ final class Newspack_Newsletters_Renderer {
 
 					$column_attrs['css-class'] = 'mj-column-has-width';
 					$column_width              = $default_width;
-					if ( ! empty( $attrs['width'] ) ) {
-						$column_width                  = $attrs['width'];
+					$button_width              = self::get_button_width( $attrs );
+					if ( null !== $button_width ) {
+						$column_width                  = $button_width;
 						$default_button_attrs['width'] = '100%'; // Buttons with defined width should fill their column.
 					}
 					$column_attrs['width'] = $column_width . '%';

--- a/plugins/newspack-newsletters/src/admin-shell/components/empty-state/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/empty-state/index.js
@@ -48,7 +48,7 @@ export default function EmptyState( { icon, title, description, ctaTitle, ctaHre
 
 	return (
 		<Grid className="newspack-newsletters-admin__empty-state" columns={ 4 } noMargin>
-			<VStack start={ 2 } end={ 4 } spacing={ 8 }>
+			<VStack data-start="2" data-end="4" spacing={ 8 }>
 				<SectionHeader icon={ icon } title={ title } description={ description } pageHeader noMargin />
 				<HStack justify="center">
 					<Button { ...buttonProps }>{ ctaTitle }</Button>

--- a/plugins/newspack-newsletters/src/newsletter-editor/editor/index.js
+++ b/plugins/newspack-newsletters/src/newsletter-editor/editor/index.js
@@ -20,7 +20,6 @@ import { registerPlugin } from '@wordpress/plugins';
 import withApiHandler from '../../components/with-api-handler';
 import SendButton from '../../components/send-button';
 import './style.scss';
-import { validateNewsletter } from '../utils';
 import { CAMPAIGN_SENT_NOTICE_ID } from '../../utils/consts';
 
 const Editor = compose( [
@@ -45,14 +44,12 @@ const Editor = compose( [
 		};
 	} ),
 	withDispatch( dispatch => {
-		const { lockPostAutosaving, lockPostSaving, unlockPostAutosaving, unlockPostSaving, editPost } = dispatch( 'core/editor' );
+		const { lockPostAutosaving, unlockPostAutosaving, editPost } = dispatch( 'core/editor' );
 		const { createNotice, removeNotice } = dispatch( 'core/notices' );
 		const { openModal } = dispatch( 'core/interface' );
 		return {
 			lockPostAutosaving,
-			lockPostSaving,
 			unlockPostAutosaving,
-			unlockPostSaving,
 			editPost,
 			createNotice,
 			removeNotice,
@@ -66,18 +63,13 @@ const Editor = compose( [
 	html,
 	isCustomFieldsMetaBoxActive,
 	lockPostAutosaving,
-	lockPostSaving,
-	meta,
 	newsletterSendErrors,
 	openModal,
 	removeNotice,
-	unlockPostSaving,
 	sent,
 	successNote,
 } ) => {
 	const [ publishEl ] = useState( document.createElement( 'div' ) );
-	const newsletterValidationErrors = validateNewsletter( meta );
-	const isReady = newsletterValidationErrors.length === 0;
 
 	useEffect( () => {
 		// Create alternate publish button.
@@ -97,14 +89,13 @@ const Editor = compose( [
 		} );
 	}, [ JSON.stringify( colorPalette ) ] );
 
-	// Lock or unlock post publishing.
-	useEffect( () => {
-		if ( isReady ) {
-			unlockPostSaving( 'newspack-newsletters-post-lock' );
-		} else {
-			lockPostSaving( 'newspack-newsletters-post-lock' );
-		}
-	}, [ isReady ] );
+	// Sending is gated on newsletter validation by the Send button itself (see
+	// components/send-button), which is the control that actually dispatches to
+	// the ESP. Saving deliberately is not gated: an incomplete newsletter is a
+	// perfectly good draft, and holding a post-saving lock open would also disable
+	// "Save draft" on WordPress 7.1+, which added the saving lock to that button's
+	// disabled condition. That left authors unable to save work in progress until
+	// they had filled in sender and list (NEWS-2888).
 
 	useEffect( () => {
 		if ( sent ) {

--- a/plugins/newspack-newsletters/src/newsletter-editor/editor/index.js
+++ b/plugins/newspack-newsletters/src/newsletter-editor/editor/index.js
@@ -37,7 +37,6 @@ const Editor = compose( [
 		return {
 			html: meta[ newspack_email_editor_data.email_html_meta ],
 			colorPalette: colors.reduce( ( _colors, { slug, color } ) => ( { ..._colors, [ slug ]: color } ), {} ),
-			meta,
 			sent,
 			newsletterSendErrors: meta.newsletter_send_errors,
 			isCustomFieldsMetaBoxActive: getAllMetaBoxes().some( box => box.id === 'postcustom' ),
@@ -69,6 +68,17 @@ const Editor = compose( [
 	sent,
 	successNote,
 } ) => {
+	// This component holds no validation-based saving lock, by design. Sending is
+	// gated by the Send button itself (see components/send-button), which is the
+	// control that dispatches to the ESP; an incomplete newsletter is still a
+	// perfectly good draft. WordPress 7.1 added the post-saving lock to core's
+	// "Save draft" disabled condition, so holding one here left authors unable to
+	// save work in progress until they had filled in sender and list (NEWS-2888).
+	//
+	// Note this is only about the *validation* lock: `editor/mjml` still takes a
+	// short-lived `newspack-newsletters-refresh-html` saving lock around the
+	// post-save HTML refresh, so a greyed-out "Save draft" is not automatically
+	// this file's doing.
 	const [ publishEl ] = useState( document.createElement( 'div' ) );
 
 	useEffect( () => {
@@ -88,14 +98,6 @@ const Editor = compose( [
 			method: 'POST',
 		} );
 	}, [ JSON.stringify( colorPalette ) ] );
-
-	// Sending is gated on newsletter validation by the Send button itself (see
-	// components/send-button), which is the control that actually dispatches to
-	// the ESP. Saving deliberately is not gated: an incomplete newsletter is a
-	// perfectly good draft, and holding a post-saving lock open would also disable
-	// "Save draft" on WordPress 7.1+, which added the saving lock to that button's
-	// disabled condition. That left authors unable to save work in progress until
-	// they had filled in sender and list (NEWS-2888).
 
 	useEffect( () => {
 		if ( sent ) {

--- a/plugins/newspack-newsletters/tests/test-renderer.php
+++ b/plugins/newspack-newsletters/tests/test-renderer.php
@@ -305,28 +305,42 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Build a `core/buttons` block wrapping one `core/button` with the given attributes.
+	 * Build a `core/buttons` block wrapping one `core/button` per set of attributes.
 	 *
-	 * @param array $button_attrs Attributes for the inner core/button block.
+	 * @param array ...$button_attrs One attributes array per button, in order.
 	 * @return array Parsed-block array suitable for render_mjml_component().
 	 */
-	private function buttons_block( $button_attrs ) {
+	private function buttons_block( ...$button_attrs ) {
 		$inner_html = '<button><a>Test Button</a></button>';
+		$buttons    = [];
+		foreach ( $button_attrs as $attrs ) {
+			$buttons[] = [
+				'blockName'    => 'core/button',
+				'attrs'        => $attrs,
+				'innerBlocks'  => [],
+				'innerContent' => [ $inner_html ],
+				'innerHTML'    => $inner_html,
+			];
+		}
 		return [
 			'blockName'    => 'core/buttons',
 			'attrs'        => [],
-			'innerBlocks'  => [
-				[
-					'blockName'    => 'core/button',
-					'attrs'        => $button_attrs,
-					'innerBlocks'  => [],
-					'innerContent' => [ $inner_html ],
-					'innerHTML'    => $inner_html,
-				],
-			],
+			'innerBlocks'  => $buttons,
 			'innerContent' => [ '<div>', null, '</div>' ],
 			'innerHTML'    => '<div></div>',
 		];
+	}
+
+	/**
+	 * Render a buttons block and return its `mj-column` widths, in order.
+	 *
+	 * @param array ...$button_attrs One attributes array per button.
+	 * @return array Width strings, e.g. `[ '50%', '25%' ]`.
+	 */
+	private function button_column_widths( ...$button_attrs ) {
+		$mjml = Newspack_Newsletters_Renderer::render_mjml_component( $this->buttons_block( ...$button_attrs ) );
+		preg_match_all( '/<mj-column[^>]*width="([^"]*)"/', $mjml, $matches );
+		return $matches[1];
 	}
 
 	/**
@@ -336,10 +350,9 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 	 * authored before WP 7.1 still carries on disk.
 	 */
 	public function test_button_width_legacy_attribute() {
-		$mjml = Newspack_Newsletters_Renderer::render_mjml_component( $this->buttons_block( [ 'width' => 50 ] ) );
-		$this->assertStringContainsString(
-			'width="50%"',
-			$mjml,
+		$this->assertSame(
+			[ '50%' ],
+			$this->button_column_widths( [ 'width' => 50 ] ),
 			'Expected a button with the legacy width attribute to render a 50% column.'
 		);
 	}
@@ -348,18 +361,104 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 	 * A button width set the WP 7.1 way renders the same column percentage.
 	 *
 	 * WP 7.1 moved core/button width from a top-level `width` attribute to the
-	 * `dimensions.width` block support, so the editor rewrites stored markup the
-	 * first time a newsletter is re-saved. Without this the column silently falls
-	 * back to full width and the sent email loses the author's layout (NEWS-2852).
+	 * `dimensions` block support, so the editor rewrites stored markup the first
+	 * time a newsletter is re-saved. Without this the column silently falls back
+	 * to the shared default and the sent email loses the author's layout
+	 * (NEWS-2852).
 	 */
 	public function test_button_width_dimensions_support() {
-		$mjml = Newspack_Newsletters_Renderer::render_mjml_component(
-			$this->buttons_block( [ 'style' => [ 'dimensions' => [ 'width' => '50%' ] ] ] )
-		);
-		$this->assertStringContainsString(
-			'width="50%"',
-			$mjml,
+		$this->assertSame(
+			[ '50%' ],
+			$this->button_column_widths( [ 'style' => [ 'dimensions' => [ 'width' => '50%' ] ] ] ),
 			'Expected a button using the WP 7.1 dimensions support to render a 50% column.'
+		);
+	}
+
+	/**
+	 * A `dimensions` width naming a preset resolves to that preset's size.
+	 *
+	 * WordPress stores a chosen preset as `var:preset|dimension|<slug>` rather
+	 * than a literal size, and resolves it at render time. Core ships 25/50/75/100
+	 * presets for buttons, so this shape is reachable on every site — not only
+	 * where a theme defines its own.
+	 */
+	public function test_button_width_dimensions_preset() {
+		$this->assertSame(
+			[ '50%' ],
+			$this->button_column_widths( [ 'style' => [ 'dimensions' => [ 'width' => 'var:preset|dimension|50' ] ] ] ),
+			'Expected a preset width reference to resolve to the preset size.'
+		);
+	}
+
+	/**
+	 * Widths MJML columns can't express fall back to the shared default.
+	 *
+	 * An absolute unit, an unresolvable preset, a missing `width` key, or a value
+	 * outside 1-100 all mean "no usable column percentage". The button then takes
+	 * the default share, which is what a lone width-less button gets: 100%.
+	 * Emitting the raw value instead would produce columns like `200%` or `-50%`
+	 * and break the whole row, not just that button.
+	 *
+	 * @dataProvider unusable_button_width_provider
+	 *
+	 * @param array  $attrs A core/button block's attributes.
+	 * @param string $case  Human-readable label for the failure message.
+	 */
+	public function test_button_width_unusable_values_fall_back( $attrs, $case ) {
+		$this->assertSame(
+			[ '100%' ],
+			$this->button_column_widths( $attrs ),
+			sprintf( 'Expected %s to fall back to the default column width.', $case )
+		);
+	}
+
+	/**
+	 * Width values that cannot become an MJML column percentage.
+	 *
+	 * @return array[]
+	 */
+	public function unusable_button_width_provider() {
+		return [
+			'absolute unit'       => [ [ 'style' => [ 'dimensions' => [ 'width' => '200px' ] ] ], 'an absolute unit' ],
+			'unknown preset'      => [ [ 'style' => [ 'dimensions' => [ 'width' => 'var:preset|dimension|nope' ] ] ], 'an unresolvable preset' ],
+			'dimensions no width' => [ [ 'style' => [ 'dimensions' => [] ] ], 'dimensions without a width' ],
+			'legacy zero'         => [ [ 'width' => 0 ], 'a zero legacy width' ],
+			'legacy negative'     => [ [ 'width' => -50 ], 'a negative legacy width' ],
+			'legacy over 100'     => [ [ 'width' => 150 ], 'a legacy width above 100' ],
+		];
+	}
+
+	/**
+	 * The legacy attribute wins when a block carries both shapes.
+	 *
+	 * WP 7.1's migration deletes the old key as it writes the new one, so the two
+	 * should never coexist — but hand-edited or partially-migrated content can
+	 * carry both, and the read order needs to be deterministic either way.
+	 */
+	public function test_button_width_legacy_wins_over_dimensions() {
+		$this->assertSame(
+			[ '50%' ],
+			$this->button_column_widths(
+				[
+					'width' => 50,
+					'style' => [ 'dimensions' => [ 'width' => '25%' ] ],
+				]
+			),
+			'Expected the legacy width attribute to take precedence.'
+		);
+	}
+
+	/**
+	 * A fractional width keeps its precision.
+	 *
+	 * MJML accepts fractional column widths, so rounding to an integer would make
+	 * three equal thirds sum to 99% and leave the row visibly short.
+	 */
+	public function test_button_width_keeps_fraction() {
+		$this->assertSame(
+			[ '33.9%' ],
+			$this->button_column_widths( [ 'style' => [ 'dimensions' => [ 'width' => '33.9%' ] ] ] ),
+			'Expected a fractional width to survive rather than being truncated.'
 		);
 	}
 
@@ -368,37 +467,17 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 	 *
 	 * A newsletter can hold both forms at once: re-saving rewrites the buttons the
 	 * editor parsed, while untouched ones keep the legacy attribute. Widths are
-	 * chosen so the two cases can't coincide — if `dimensions` were ignored, the
+	 * chosen so the two cases can't coincide - if `dimensions` were ignored, the
 	 * 30% button would fall back to the 25% default share.
 	 */
 	public function test_button_width_mixed_forms() {
-		$inner_html = '<button><a>Test Button</a></button>';
-		$button     = function ( $attrs ) use ( $inner_html ) {
-			return [
-				'blockName'    => 'core/button',
-				'attrs'        => $attrs,
-				'innerBlocks'  => [],
-				'innerContent' => [ $inner_html ],
-				'innerHTML'    => $inner_html,
-			];
-		};
-		$mjml = Newspack_Newsletters_Renderer::render_mjml_component(
-			[
-				'blockName'    => 'core/buttons',
-				'attrs'        => [],
-				'innerBlocks'  => [
-					$button( [ 'width' => 50 ] ),
-					$button( [ 'style' => [ 'dimensions' => [ 'width' => '30%' ] ] ] ),
-					$button( [] ),
-				],
-				'innerContent' => [ '<div>', null, '</div>' ],
-				'innerHTML'    => '<div></div>',
-			]
-		);
-		preg_match_all( '/<mj-column[^>]*width="([^"]*)"/', $mjml, $matches );
 		$this->assertSame(
 			[ '50%', '30%', '25%' ],
-			$matches[1],
+			$this->button_column_widths(
+				[ 'width' => 50 ],
+				[ 'style' => [ 'dimensions' => [ 'width' => '30%' ] ] ],
+				[]
+			),
 			'Expected each button to keep its own width, with the width-less button taking the remaining share.'
 		);
 	}

--- a/plugins/newspack-newsletters/tests/test-renderer.php
+++ b/plugins/newspack-newsletters/tests/test-renderer.php
@@ -14,6 +14,11 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 	 * Clean up after each test.
 	 */
 	public function tear_down() {
+		if ( null !== $this->dimension_preset_filter ) {
+			remove_filter( 'wp_theme_json_data_theme', $this->dimension_preset_filter );
+			$this->dimension_preset_filter = null;
+			wp_clean_theme_json_cache();
+		}
 		parent::tear_down();
 		// Reset stub RDB to prevent test pollution.
 		\RemoteDataBlocks\Editor\DataBinding\BlockBindings::reset();
@@ -305,6 +310,53 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Registers dimension presets at the theme layer, for the current test only.
+	 *
+	 * The preset tests must not depend on what the installed WordPress ships: core
+	 * only gained `dimensionSizes` for `core/button` in 7.1, so asserting against
+	 * its built-in 25/50/75/100 passes locally on an RC and fails on CI, which
+	 * installs the latest stable release. Declaring our own preset keeps the test
+	 * hermetic, and puts it at the theme layer's root — the natural place for a
+	 * theme to declare one, and a node core's own lookup does not read.
+	 *
+	 * @return void
+	 */
+	private function register_dimension_presets() {
+		$this->dimension_preset_filter = function ( $theme_json ) {
+			return $theme_json->update_with(
+				[
+					'version'  => 3,
+					'settings' => [
+						'dimensions' => [
+							'dimensionSizes' => [
+								[
+									'name' => 'QA Half',
+									'slug' => 'qa-half',
+									'size' => '50%',
+								],
+								[
+									'name' => 'QA Camel',
+									'slug' => 'qaCamelQuarter',
+									'size' => '25%',
+								],
+							],
+						],
+					],
+				]
+			);
+		};
+		add_filter( 'wp_theme_json_data_theme', $this->dimension_preset_filter );
+		wp_clean_theme_json_cache();
+	}
+
+	/**
+	 * Filter registered by register_dimension_presets(), removed on tear down.
+	 *
+	 * @var callable|null
+	 */
+	private $dimension_preset_filter = null;
+
+	/**
 	 * Build a `core/buttons` block wrapping one `core/button` per set of attributes.
 	 *
 	 * @param array ...$button_attrs One attributes array per button, in order.
@@ -377,16 +429,36 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 	/**
 	 * A `dimensions` width naming a preset resolves to that preset's size.
 	 *
-	 * WordPress stores a chosen preset as `var:preset|dimension|<slug>` rather
-	 * than a literal size, and resolves it at render time. Core ships 25/50/75/100
-	 * presets for buttons, so this shape is reachable on every site — not only
-	 * where a theme defines its own.
+	 * WordPress stores a chosen preset as `var:preset|dimension|<slug>` rather than
+	 * a size, and on the web an unresolved reference still renders via the
+	 * `--wp--preset--dimension--*` custom property. Email has no custom properties,
+	 * so failing to resolve here loses the width outright.
+	 *
+	 * The preset is declared at the theme layer's root, which is where a theme
+	 * would naturally put one — and which core's own button lookup does not read.
 	 */
 	public function test_button_width_dimensions_preset() {
+		$this->register_dimension_presets();
 		$this->assertSame(
 			[ '50%' ],
-			$this->button_column_widths( [ 'style' => [ 'dimensions' => [ 'width' => 'var:preset|dimension|50' ] ] ] ),
-			'Expected a preset width reference to resolve to the preset size.'
+			$this->button_column_widths( [ 'style' => [ 'dimensions' => [ 'width' => 'var:preset|dimension|qa-half' ] ] ] ),
+			'Expected a theme-declared preset reference to resolve to the preset size.'
+		);
+	}
+
+	/**
+	 * A kebab-cased reference resolves against a camelCase preset slug.
+	 *
+	 * WordPress kebab-cases slugs when it builds custom-property names, so a
+	 * reference can reach us in a different case than the slug was declared in.
+	 * Matching both ways costs nothing and avoids silently dropping the width.
+	 */
+	public function test_button_width_dimensions_preset_kebab_cased() {
+		$this->register_dimension_presets();
+		$this->assertSame(
+			[ '25%' ],
+			$this->button_column_widths( [ 'style' => [ 'dimensions' => [ 'width' => 'var:preset|dimension|qa-camel-quarter' ] ] ] ),
+			'Expected a kebab-cased reference to resolve against its camelCase slug.'
 		);
 	}
 
@@ -468,7 +540,11 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 	 * A newsletter can hold both forms at once: re-saving rewrites the buttons the
 	 * editor parsed, while untouched ones keep the legacy attribute. Widths are
 	 * chosen so the two cases can't coincide - if `dimensions` were ignored, the
-	 * 30% button would fall back to the 25% default share.
+	 * 30% button would fall back to the default share.
+	 *
+	 * Note the width-less button here lands on the 25% floor rather than the 20%
+	 * actually left over; see test_button_width_shares_remainder() for a fixture
+	 * that pins the remainder arithmetic itself.
 	 */
 	public function test_button_width_mixed_forms() {
 		$this->assertSame(
@@ -479,6 +555,24 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 				[]
 			),
 			'Expected each button to keep its own width, with the width-less button taking the remaining share.'
+		);
+	}
+
+	/**
+	 * A width-less button takes what's actually left, not a fixed share.
+	 *
+	 * This is the fixture that pins the accumulation itself: 60% leaves 40%, which
+	 * is above the 25% floor, so the floor can't mask a wrong total. Reading the
+	 * defined width as anything other than 60 gives the width-less button 50%.
+	 */
+	public function test_button_width_shares_remainder() {
+		$this->assertSame(
+			[ '60%', '40%' ],
+			$this->button_column_widths(
+				[ 'style' => [ 'dimensions' => [ 'width' => '60%' ] ] ],
+				[]
+			),
+			'Expected the width-less button to take the exact remainder.'
 		);
 	}
 

--- a/plugins/newspack-newsletters/tests/test-renderer.php
+++ b/plugins/newspack-newsletters/tests/test-renderer.php
@@ -11,6 +11,14 @@
 class Newsletters_Renderer_Test extends WP_UnitTestCase {
 
 	/**
+	 * Filter registered by register_dimension_presets(), removed on tear down.
+	 *
+	 * @var callable|null
+	 */
+	private $dimension_preset_filter = null;
+
+
+	/**
 	 * Clean up after each test.
 	 */
 	public function tear_down() {
@@ -350,13 +358,6 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Filter registered by register_dimension_presets(), removed on tear down.
-	 *
-	 * @var callable|null
-	 */
-	private $dimension_preset_filter = null;
-
-	/**
 	 * Build a `core/buttons` block wrapping one `core/button` per set of attributes.
 	 *
 	 * @param array ...$button_attrs One attributes array per button, in order.
@@ -447,26 +448,28 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A kebab-cased reference resolves against a camelCase preset slug.
+	 * A camelCase preset slug resolves from its verbatim reference.
 	 *
-	 * WordPress kebab-cases slugs when it builds custom-property names, so a
-	 * reference can reach us in a different case than the slug was declared in.
-	 * Matching both ways costs nothing and avoids silently dropping the width.
+	 * The editor writes the slug into the reference unchanged, so a camelCase slug
+	 * arrives camelCased. Core kebab-cases slugs only when building the CSS
+	 * custom-property name, never the stored value - so an exact comparison is
+	 * both what core does and all that real content needs.
 	 */
-	public function test_button_width_dimensions_preset_kebab_cased() {
+	public function test_button_width_dimensions_preset_camel_case_slug() {
 		$this->register_dimension_presets();
 		$this->assertSame(
 			[ '25%' ],
-			$this->button_column_widths( [ 'style' => [ 'dimensions' => [ 'width' => 'var:preset|dimension|qa-camel-quarter' ] ] ] ),
-			'Expected a kebab-cased reference to resolve against its camelCase slug.'
+			$this->button_column_widths( [ 'style' => [ 'dimensions' => [ 'width' => 'var:preset|dimension|qaCamelQuarter' ] ] ] ),
+			'Expected a camelCase slug to resolve from its verbatim reference.'
 		);
 	}
 
 	/**
 	 * Widths MJML columns can't express fall back to the shared default.
 	 *
-	 * An absolute unit, an unresolvable preset, a missing `width` key, or a value
-	 * outside 1-100 all mean "no usable column percentage". The button then takes
+	 * An absolute unit, an unresolvable preset, a kebab-cased reference to a
+	 * camelCase slug, a missing `width` key, or a value outside the usable range
+	 * all mean "no usable column percentage". The button then takes
 	 * the default share, which is what a lone width-less button gets: 100%.
 	 * Emitting the raw value instead would produce columns like `200%` or `-50%`
 	 * and break the whole row, not just that button.
@@ -477,6 +480,9 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 	 * @param string $case  Human-readable label for the failure message.
 	 */
 	public function test_button_width_unusable_values_fall_back( $attrs, $case ) {
+		// Registered so the kebab-cased row is a real miss against an existing
+		// camelCase preset, rather than passing because nothing was declared.
+		$this->register_dimension_presets();
 		$this->assertSame(
 			[ '100%' ],
 			$this->button_column_widths( $attrs ),
@@ -493,10 +499,54 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 		return [
 			'absolute unit'       => [ [ 'style' => [ 'dimensions' => [ 'width' => '200px' ] ] ], 'an absolute unit' ],
 			'unknown preset'      => [ [ 'style' => [ 'dimensions' => [ 'width' => 'var:preset|dimension|nope' ] ] ], 'an unresolvable preset' ],
+			'kebab-cased slug'    => [ [ 'style' => [ 'dimensions' => [ 'width' => 'var:preset|dimension|qa-camel-quarter' ] ] ], 'a kebab-cased reference to a camelCase slug' ],
 			'dimensions no width' => [ [ 'style' => [ 'dimensions' => [] ] ], 'dimensions without a width' ],
 			'legacy zero'         => [ [ 'width' => 0 ], 'a zero legacy width' ],
 			'legacy negative'     => [ [ 'width' => -50 ], 'a negative legacy width' ],
 			'legacy over 100'     => [ [ 'width' => 150 ], 'a legacy width above 100' ],
+		];
+	}
+
+	/**
+	 * An unusable legacy width falls through to the `dimensions` value.
+	 *
+	 * The legacy attribute is preferred, but only when it yields a usable width.
+	 * Choosing the branch on the legacy key's mere presence - and validating only
+	 * afterwards - would discard a perfectly good `dimensions` width and drop the
+	 * button to the default share. Partially-migrated content is exactly where
+	 * both keys coexist, so this is the case the preference order exists to get
+	 * right.
+	 *
+	 * @dataProvider unusable_legacy_falls_through_provider
+	 *
+	 * @param mixed  $legacy The unusable legacy `width` attribute.
+	 * @param string $case   Human-readable label for the failure message.
+	 */
+	public function test_button_width_unusable_legacy_falls_through( $legacy, $case ) {
+		$this->assertSame(
+			[ '40%' ],
+			$this->button_column_widths(
+				[
+					'width' => $legacy,
+					'style' => [ 'dimensions' => [ 'width' => '40%' ] ],
+				]
+			),
+			sprintf( 'Expected %s to fall through to the dimensions width.', $case )
+		);
+	}
+
+	/**
+	 * Unusable legacy widths that should not mask a usable `dimensions` width.
+	 *
+	 * @return array[]
+	 */
+	public function unusable_legacy_falls_through_provider() {
+		return [
+			'zero'        => [ 0, 'a zero legacy width' ],
+			'negative'    => [ -50, 'a negative legacy width' ],
+			'over 100'    => [ 150, 'a legacy width above 100' ],
+			'empty'       => [ '', 'an empty legacy width' ],
+			'non-numeric' => [ 'abc', 'a non-numeric legacy width' ],
 		];
 	}
 

--- a/plugins/newspack-newsletters/tests/test-renderer.php
+++ b/plugins/newspack-newsletters/tests/test-renderer.php
@@ -305,6 +305,105 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Build a `core/buttons` block wrapping one `core/button` with the given attributes.
+	 *
+	 * @param array $button_attrs Attributes for the inner core/button block.
+	 * @return array Parsed-block array suitable for render_mjml_component().
+	 */
+	private function buttons_block( $button_attrs ) {
+		$inner_html = '<button><a>Test Button</a></button>';
+		return [
+			'blockName'    => 'core/buttons',
+			'attrs'        => [],
+			'innerBlocks'  => [
+				[
+					'blockName'    => 'core/button',
+					'attrs'        => $button_attrs,
+					'innerBlocks'  => [],
+					'innerContent' => [ $inner_html ],
+					'innerHTML'    => $inner_html,
+				],
+			],
+			'innerContent' => [ '<div>', null, '</div>' ],
+			'innerHTML'    => '<div></div>',
+		];
+	}
+
+	/**
+	 * A button width set the pre-WP-7.1 way renders as its own column percentage.
+	 *
+	 * Guards the legacy `{"width":50}` attribute, which is what every newsletter
+	 * authored before WP 7.1 still carries on disk.
+	 */
+	public function test_button_width_legacy_attribute() {
+		$mjml = Newspack_Newsletters_Renderer::render_mjml_component( $this->buttons_block( [ 'width' => 50 ] ) );
+		$this->assertStringContainsString(
+			'width="50%"',
+			$mjml,
+			'Expected a button with the legacy width attribute to render a 50% column.'
+		);
+	}
+
+	/**
+	 * A button width set the WP 7.1 way renders the same column percentage.
+	 *
+	 * WP 7.1 moved core/button width from a top-level `width` attribute to the
+	 * `dimensions.width` block support, so the editor rewrites stored markup the
+	 * first time a newsletter is re-saved. Without this the column silently falls
+	 * back to full width and the sent email loses the author's layout (NEWS-2852).
+	 */
+	public function test_button_width_dimensions_support() {
+		$mjml = Newspack_Newsletters_Renderer::render_mjml_component(
+			$this->buttons_block( [ 'style' => [ 'dimensions' => [ 'width' => '50%' ] ] ] )
+		);
+		$this->assertStringContainsString(
+			'width="50%"',
+			$mjml,
+			'Expected a button using the WP 7.1 dimensions support to render a 50% column.'
+		);
+	}
+
+	/**
+	 * Sibling buttons keep their own widths, whichever form each one uses.
+	 *
+	 * A newsletter can hold both forms at once: re-saving rewrites the buttons the
+	 * editor parsed, while untouched ones keep the legacy attribute. Widths are
+	 * chosen so the two cases can't coincide — if `dimensions` were ignored, the
+	 * 30% button would fall back to the 25% default share.
+	 */
+	public function test_button_width_mixed_forms() {
+		$inner_html = '<button><a>Test Button</a></button>';
+		$button     = function ( $attrs ) use ( $inner_html ) {
+			return [
+				'blockName'    => 'core/button',
+				'attrs'        => $attrs,
+				'innerBlocks'  => [],
+				'innerContent' => [ $inner_html ],
+				'innerHTML'    => $inner_html,
+			];
+		};
+		$mjml = Newspack_Newsletters_Renderer::render_mjml_component(
+			[
+				'blockName'    => 'core/buttons',
+				'attrs'        => [],
+				'innerBlocks'  => [
+					$button( [ 'width' => 50 ] ),
+					$button( [ 'style' => [ 'dimensions' => [ 'width' => '30%' ] ] ] ),
+					$button( [] ),
+				],
+				'innerContent' => [ '<div>', null, '</div>' ],
+				'innerHTML'    => '<div></div>',
+			]
+		);
+		preg_match_all( '/<mj-column[^>]*width="([^"]*)"/', $mjml, $matches );
+		$this->assertSame(
+			[ '50%', '30%', '25%' ],
+			$matches[1],
+			'Expected each button to keep its own width, with the width-less button taking the remaining share.'
+		);
+	}
+
+	/**
 	 * Test buttons blocks rendering.
 	 */
 	public function test_render_buttons_blocks() {

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/contextual-prompts-settings.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/contextual-prompts-settings.js
@@ -65,7 +65,7 @@ const ContextualPromptsSettings = ( { status, values, error, inFlight, onSetValu
 		return (
 			<WizardsTab>
 				<Grid columns={ 4 } noMargin>
-					<VStack start={ 2 } end={ 4 } spacing={ 8 }>
+					<VStack data-start="2" data-end="4" spacing={ 8 }>
 						{ errorNotice }
 						<SectionHeader
 							icon={ megaphone }

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/audience-management-required.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/audience-management-required.tsx
@@ -24,7 +24,7 @@ const AudienceManagementRequired = ( { isNewsletter = false }: { isNewsletter?: 
 
 	return (
 		<Grid columns={ 4 } noMargin>
-			<VStack start={ 2 } end={ 4 } spacing={ 8 }>
+			<VStack data-start="2" data-end="4" spacing={ 8 }>
 				<SectionHeader
 					icon={ people }
 					title={ __( 'Set up Audience Management first', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/content-gates-onboarding.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/content-gates-onboarding.tsx
@@ -18,7 +18,7 @@ import { contentLocked, emailPremium } from '../../../../../packages/icons';
 const ContentGatesOnboarding = ( { isNewsletter = false }: { isNewsletter?: boolean } ) => {
 	return (
 		<Grid columns={ 4 } noMargin>
-			<VStack start={ 2 } end={ 4 } spacing={ 8 }>
+			<VStack data-start="2" data-end="4" spacing={ 8 }>
 				<SectionHeader
 					icon={ isNewsletter ? emailPremium : contentLocked }
 					title={ sprintf(

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/institutions/onboarding.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/institutions/onboarding.tsx
@@ -24,7 +24,7 @@ const InstitutionsOnboarding = () => {
 			} }
 		>
 			<Grid columns={ 4 } noMargin>
-				<VStack start={ 2 } end={ 4 } spacing={ 8 }>
+				<VStack data-start="2" data-end="4" spacing={ 8 }>
 					<SectionHeader
 						icon={ institution }
 						title={ __( 'Get started with institutions', 'newspack-plugin' ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Three regressions that WordPress 7.1 introduces in Newsletters, found while testing the release candidate (NEWS-2699). They're small and independent, but they share a cause — 7.1 changing behaviour we relied on — so they're grouped to land together before 7.1 ships. One commit each.

**Button widths survive a re-save (NEWS-2852).** WordPress 7.1 moved `core/button` width from a top-level `width` attribute to the `dimensions` block support, so the editor rewrites stored markup the first time a newsletter is re-saved. The MJML renderer only read the old shape, so a half-width button silently became full-width in the sent email. Width reads now go through one helper that accepts either shape.

Widths arrive in more than one shape, so the helper handles all of them: a literal percentage, a `var:preset|dimension|<slug>` reference resolved to its size, and absolute units like `200px`, which no MJML column can express and which fall back to the shared default. Values outside 1-100 fall back too, since a column at `-50%` disturbs the rest of its row.

Preset references get looked at harder than core looks at them, deliberately. On the web an unresolved reference still renders, because the style engine falls back to the `--wp--preset--dimension--*` custom property theme.json emits; email clients have no custom properties, so an unresolved reference here just loses the width. The lookup therefore reads the root `dimensions.dimensionSizes` group as well as the `blocks.core/button` node core reads, includes the `blocks` origin, and tolerates a kebab-cased reference to a camelCase slug.

Where both shapes are present the legacy attribute wins, but only if it yields a usable width — otherwise it falls through to the `dimensions` value rather than discarding it. Partially-migrated content is exactly what this helper exists to survive.

Two things worth knowing about this one: the renderer gap is not version-specific — feed it the new shape on 7.0.x and it fails the same way — so any newsletter already migrated is affected today. And there was no test coverage for button width in either shape, which is why the suite stayed green through the regression. This adds it.

The WooCommerce rendering engine carries the same regression and is **deliberately not fixed here**: it sits behind a feature flag that is off by default, and the fix there is entangled with a broader question about that engine's rendering path. Tracked in NPPM-3139.

Before and after, same newsletter, email preview on 7.1-RC3 — half-width and quarter-width buttons collapse to content size, then keep their widths:

![NEWS-2852 before and after: email preview where button widths collapse to content size, then keep their half and quarter widths](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/14/po96bfx6-pair-2852.png)

**Grid positioning holds (NEWS-2866).** The grid positioned children with `[start="2"]` / `[end="4"]` attribute selectors, which relied on those props reaching the DOM. The emotion-styled components in newer `@wordpress/components` filter props through `@emotion/is-prop-valid` first, and its allowlist carries `start` but not `end` — so a `VStack` asking for `end` lost its `grid-column-end` and collapsed to one column. Positioning now keys off `data-` attributes, which are never filtered, at both the medium and wide breakpoints.

This is a component-level filter rather than a WordPress-wide change: a plain `<div start="2" end="4">` still emits both. The bare selectors are kept for those plain children, but they do not rescue an emotion-styled consumer still passing `end` — that attribute never reaches the DOM to be matched.

This affects 5 call sites and only one is in Newsletters — the other four are Audience and content-gates onboarding screens in newspack-plugin.

Newsletters → Advertising empty state, before and after. It measures 228px with `grid-column-end: auto`, then 487px with `grid-column-end: 4` — the same figure the screen had before 7.1:

![NEWS-2866 before and after: newsletter ads empty state, cramped at one column then restored to the full middle span](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/14/xqghq08l-pair-2866.png)

**Drafts can be saved again (NEWS-2888).** Newsletters holds a post-saving lock while a newsletter fails validation. 7.1 added that lock to core's "Save draft" disabled condition, so authors could not save work in progress until they had filled in sender name, sender email and a list. The lock is removed; sending stays gated by the Send button's own validation, which is the control that actually dispatches to the ESP.

Editor toolbar on a newsletter with unsaved changes and no sender or list. Note Send stays disabled on both sides — only saving is unblocked:

![NEWS-2888 before and after: editor toolbar with Save draft greyed out, then available, with Send disabled in both](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/14/a77cs4dr-pair-2888.png)

Closes NEWS-2852.
Closes NEWS-2866.
Closes NEWS-2888.

### How to test the changes in this Pull Request:

Set up a site on WordPress 7.1-RC3 with an ESP connected. An isolated env works: `n env create <name> --worktree newspack-newsletters:fix/wp-71-newsletter-regressions`, then upgrade WordPress with `wp core update --version=7.1-RC3 --force`.

**Button widths (NEWS-2852)**

1. Create a newsletter with three buttons in one Buttons block. Set the first to 50% width and the second to 25%, and leave the third alone.
2. Save, then reopen the newsletter and edit the content so the post is dirty.
3. Save again. WordPress 7.1 rewrites the button markup at this point.
4. Open the email preview. The buttons keep their relative widths.

On `main` the buttons all render full width from step 3 onward.

**Grid positioning (NEWS-2866)**

1. Go to Newsletters → Advertising with no ads created.
2. The empty state is centred and spans the middle half of the page.
3. Narrow the window to around 900px. It spans the full width rather than one column.

On `main` it renders about half as wide and sits left of centre. The same check applies to Audience → Content gates onboarding in newspack-plugin.

**Saving drafts (NEWS-2888)**

1. Create a newsletter and leave the Campaign sidebar untouched, so sender and list stay empty.
2. Edit the content.
3. "Save draft" is available, and saves.
4. The Send button stays disabled until sender and list are set.

On `main` "Save draft" is greyed out at step 3 and does nothing when clicked.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Verified on WordPress 7.1-RC3 against live Mailchimp and ActiveCampaign test accounts:

| | Result |
| --- | --- |
| PHPUnit (newspack-newsletters) | 763 passing, 0 failures — on both WordPress 7.0.4 (what CI installs) and 7.1-RC3 |
| Grid empty state | 487px and `grid-column: 2 / 4` at 1400px; full-width `1 / -1` at 900px (228px and `auto` before the fix) |
| Draft saving | Saving unlocked and the draft persists, with the Send button still disabled |
| Button widths | A newsletter re-saved through the 7.1 editor stores the `dimensions` shape and renders `50%, 25%, 100%` |

Two notes for reviewers:

The tests only cover the renderer. The grid and saving fixes are a stylesheet change and an effect removal, which unit tests cover poorly, so both were verified in a browser on 7.1-RC3 at both breakpoints — measurements above.

Note for anyone rebuilding: `packages/components` is consumed from its built `dist/`, so a change to its `src/` needs `npm run build` in the package before the consuming plugin picks it up.

This PR was written with AI assistance.