### PR TITLE
fix(content-gate): return the institution name only on a matched check

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-ip-access-rule.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-ip-access-rule.php
@@ -189,7 +189,10 @@ class IP_Access_Rule {
 		}
 
 		$data = [ 'valid' => $valid ];
-		if ( $inst_name ) {
+		// Only disclose the institution name to a visitor who actually matched it;
+		// otherwise an unauthenticated caller could enumerate every institution's
+		// name by iterating institution_id.
+		if ( $valid && $inst_name ) {
 			$data['institution'] = $inst_name;
 		}
 

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-ip-access-rule.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-ip-access-rule.php
@@ -273,7 +273,7 @@ class Newspack_Test_IP_Access_Rule extends WP_UnitTestCase {
 		$data     = $response->get_data();
 
 		$this->assertFalse( $data['valid'] );
-		$this->assertSame( 'REST Test Library', $data['institution'], 'Institution name should be returned even on failure.' );
+		$this->assertArrayNotHasKey( 'institution', $data, 'Institution name must not be disclosed to a visitor who did not match it.' );
 
 		if ( null === $original_addr ) {
 			unset( $_SERVER['REMOTE_ADDR'] ); // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The institutional-access check endpoint returns an institution's name to label a visitor's match. Since the names are a publisher's institutional customer list, it should return that name only to a visitor who actually matches the institution.

This PR returns the `institution` name only when the check succeeds (`valid: true`). A non-matching or logged-out caller receives `{ valid: false }` with no name; a matching visitor still gets the name that labels their match. The non-matching and unknown-id responses are identical.

No first-party client reads `institution` on a non-matching response — the field has no consumer in the plugin or in newspack-manager — so legitimate behavior is unchanged.

Tracked in NPPM-3127.

### How to test the changes in this Pull Request:

Run `n test-php --filter Newspack_Test_IP_Access_Rule` from `plugins/newspack-plugin` — `test_rest_endpoint_institution_id_no_match` passes and fails without the change.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? This updates an existing test that had asserted the old behavior; the `Newspack_Test_IP_Access_Rule` suite passes.
* [x] Have you successfully run tests with your changes locally? Yes — the full `Newspack_Test_IP_Access_Rule` class and PHPCS pass.


