### PR TITLE
test(e2e): update campaigns spec for renamed wizard buttons

### DIFF
--- a/e2e/tests/campaigns.spec.ts
+++ b/e2e/tests/campaigns.spec.ts
@@ -11,12 +11,12 @@ test("Create and view a prompt",  {
   await goToAdminMenu("Audience", "Campaigns", page);
 
   await expect(page.getByRole("heading", { name: "Everyone" })).toBeVisible();
-  await page.getByRole("button", { name: "Add New Campaign" }).click();
+  await page.getByRole("button", { name: "Add Campaign" }).click();
   await page.getByPlaceholder("Campaign Name").fill("Basic");
   await page.getByRole("button", { name: "Add" }).click();
   await page.waitForURL("**/campaigns/**");
 
-  await page.getByRole("button", { name: "Add New Prompt" }).click();
+  await page.getByRole("button", { name: "Add Prompt" }).click();
   await page.getByRole("link", { name: "Center Overlay Fixed at the" }).click();
   await page.waitForURL(/post_type=newspack_popups_cpt/);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The nightly E2E suite has failed every run since Aug 5, always at `campaigns.spec.ts:14`.

#472 renamed two Campaigns wizard buttons — "Add New Campaign" to "Add Campaign", and "Add New Prompt" to "Add Prompt" — and moved campaign creation into the page header. It merged to `main` on Jul 16, but only reached the stable channel in newspack-plugin 6.47.1 on Aug 4. The nightly runs against a site pinned to stable, so Aug 5 was the first run to see the new labels.

This updates the two locators. No product code is touched.

Worth noting for future breaks of this shape: a spec can sit green on `main` for weeks and then fail the night its release ships to stable, because the target site tracks stable rather than the branch the spec merged with.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Set `SITE_URL` to the E2E staging site.
3. Set `ADMIN_PASSWORD` to the staging admin password from the secret store.
4. Run `npx playwright test --project="Vanilla in Desktop Chrome" tests/campaigns.spec.ts` in `e2e/`.
5. The test passes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Verified against the E2E staging site: `campaigns.spec.ts` passes, and the full vanilla set (Desktop + Mobile Chrome) is 4 passed / 0 failed. The `@with-woo` projects were not run — they need a destructive WooCommerce re-provision of the site — but they execute the same spec code.