### PR TITLE
fix(experimental-tools): keep template placeholders through sanitizing

### DIFF
--- a/plugins/newspack-plugin/includes/experimental-tools/class-experimental-tools.php
+++ b/plugins/newspack-plugin/includes/experimental-tools/class-experimental-tools.php
@@ -199,12 +199,6 @@ class Experimental_Tools {
 	/**
 	 * Get registered tools from the filter (raw, without saved state).
 	 *
-	 * Each tool declares `slug`, `label` and optionally `fields`. A field carries
-	 * `key`, `type` and `label`; a `type` of `display` is read-only and never
-	 * stored. A field may also declare `sanitize_callback`, which
-	 * save_tool_fields() applies instead of the default sanitizer — see
-	 * sanitize_field_value() for when a tool needs that.
-	 *
 	 * @return array Keyed by slug.
 	 */
 	private static function get_registered_tools() {
@@ -250,10 +244,6 @@ class Experimental_Tools {
 				} elseif ( ! isset( $field['value'] ) && isset( $field['default'] ) ) {
 					$field['value'] = $field['default'];
 				}
-
-				// Server-side only: a callable would serialize into the response as
-				// an object's public properties, or as an opaque {} for a closure.
-				unset( $field['sanitize_callback'] );
 			}
 			unset( $field );
 
@@ -363,31 +353,20 @@ class Experimental_Tools {
 			];
 		}
 
-		// Only accept keys declared in the tool registration, keeping each field's
-		// definition so its own sanitizer can be applied below.
-		$declared_fields = [];
+		// Only accept keys declared in the tool registration.
+		$valid_keys = [];
 		if ( isset( $registered[ $slug ]['fields'] ) ) {
 			foreach ( $registered[ $slug ]['fields'] as $field ) {
 				if ( ! empty( $field['key'] ) && ( $field['type'] ?? '' ) !== 'display' ) {
-					$declared_fields[ $field['key'] ] = $field;
+					$valid_keys[] = $field['key'];
 				}
 			}
 		}
 
 		foreach ( $fields as $key => $value ) {
-			if ( ! isset( $declared_fields[ $key ] ) ) {
-				continue;
+			if ( in_array( $key, $valid_keys, true ) ) {
+				$all_settings[ $slug ]['fields'][ $key ] = self::sanitize_field_value( $value );
 			}
-
-			// The route validates that `fields` is an object but says nothing about
-			// the values inside it. A non-scalar has no meaningful sanitized form,
-			// and writing one through would replace a saved value with an empty
-			// string on a malformed request; leave the stored value alone instead.
-			if ( ! is_scalar( $value ) ) {
-				continue;
-			}
-
-			$all_settings[ $slug ]['fields'][ $key ] = self::sanitize_field_value( $declared_fields[ $key ], $value );
 		}
 
 		update_option( self::OPTION_NAME, $all_settings );
@@ -402,47 +381,44 @@ class Experimental_Tools {
 	}
 
 	/**
-	 * Sanitize one submitted field value.
+	 * Sanitize a field value without destroying its placeholders.
 	 *
-	 * The default, sanitize_textarea_field(), deletes a percent sign followed by
-	 * two hex digits as a URL-encoded octet, which destroys a value carrying
-	 * placeholders of its own. A field may declare `sanitize_callback` to keep the
-	 * rules its format needs; an uncallable one falls back to the default.
+	 * WordPress deletes a percent sign followed by two hex digits, reading it as a
+	 * URL-encoded octet. A field holding a template therefore loses any
+	 * placeholder whose name opens with two hex characters — %CACHE_KEY% is stored
+	 * as CHE_KEY% — and the tool that owns it has no way to tell, because the
+	 * saved-fields action carries the sanitized value. Hold the placeholders out
+	 * of the sanitizer and put them back.
 	 *
-	 * The callback is handed a string and must return a scalar. It is a literal in
-	 * the registration, never read from the option or the request.
-	 *
-	 * @param array $field The registered field definition.
-	 * @param mixed $value The submitted value, already known to be scalar.
-	 * @return string|int|float|bool The sanitized value.
+	 * @param mixed $value The submitted value.
+	 * @return string The sanitized value.
 	 */
-	private static function sanitize_field_value( array $field, mixed $value ): string|int|float|bool {
-		$callback = $field['sanitize_callback'] ?? null;
-
-		if ( null === $callback ) {
+	private static function sanitize_field_value( $value ) {
+		if ( ! is_scalar( $value ) ) {
 			return sanitize_textarea_field( $value );
 		}
 
-		if ( ! is_callable( $callback ) ) {
-			$message = sprintf(
-				/* translators: %1$s: the sanitize_callback registration key. %2$s: field key. */
-				__( 'The %1$s declared for the %2$s field is not callable. Falling back to the default sanitizer, which strips percent-encoded sequences.', 'newspack-plugin' ),
-				'<code>sanitize_callback</code>',
-				'<code>' . ( $field['key'] ?? '' ) . '</code>'
-			);
+		// Random per call: the restore is a blind strtr, so a fixed token that the
+		// value itself contained would come back as a placeholder nobody wrote.
+		$prefix       = 'npeaPlaceholder' . wp_generate_password( 12, false );
+		$placeholders = [];
 
-			_doing_it_wrong(
-				__METHOD__,
-				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- _doing_it_wrong expects a translated string.
-				$message,
-				'6.47.9'
-			);
+		$held = preg_replace_callback(
+			'/%[A-Z][A-Z0-9_]*%/',
+			function ( $matches ) use ( &$placeholders, $prefix ) {
+				$token                  = $prefix . count( $placeholders );
+				$placeholders[ $token ] = $matches[0];
+				return $token;
+			},
+			(string) $value
+		);
+
+		// PCRE returns null on failure; sanitizing that would silently store ''.
+		if ( null === $held ) {
 			return sanitize_textarea_field( $value );
 		}
 
-		$sanitized = $callback( (string) $value );
-
-		return is_scalar( $sanitized ) ? $sanitized : '';
+		return strtr( sanitize_textarea_field( $held ), $placeholders );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/experimental-tools/class-experimental-tools.php
+++ b/plugins/newspack-plugin/includes/experimental-tools/class-experimental-tools.php
@@ -404,26 +404,13 @@ class Experimental_Tools {
 	/**
 	 * Sanitize one submitted field value.
 	 *
-	 * Defaults to sanitize_textarea_field(), which suits free text but destroys a
-	 * value carrying syntax of its own: it deletes a percent sign followed by two
-	 * hex digits, reading it as a URL-encoded octet, so a template placeholder
-	 * such as %CATEGORIES% is stored as TEGORIES%. A field may therefore declare
-	 * `sanitize_callback` in its registration and keep the rules its own format
-	 * needs. The callback is registration data, not user input, and an
-	 * uncallable one falls back to the default rather than storing raw input.
+	 * The default, sanitize_textarea_field(), deletes a percent sign followed by
+	 * two hex digits as a URL-encoded octet, which destroys a value carrying
+	 * placeholders of its own. A field may declare `sanitize_callback` to keep the
+	 * rules its format needs; an uncallable one falls back to the default.
 	 *
-	 * The callback is always handed a string, so it can declare `string` without
-	 * risking a TypeError on a hand-crafted request, and must return a scalar,
-	 * since the stored value is merged back into the field definition and sent
-	 * over REST. A non-scalar return is stored as an empty string, which is what
-	 * the default does with one. Anything narrower than scalar would rule out
-	 * `rest_sanitize_boolean` and friends on a toggle field.
-	 *
-	 * `sanitize_callback` is a literal in the registration — PHP from a loaded
-	 * plugin, never read from the option or the request — so applying it is no
-	 * wider a trust boundary than the registration itself. A tool that ever
-	 * derived the callback from stored data would change that. Deriving field
-	 * keys or values that way is fine and already done.
+	 * The callback is handed a string and must return a scalar. It is a literal in
+	 * the registration, never read from the option or the request.
 	 *
 	 * @param array $field The registered field definition.
 	 * @param mixed $value The submitted value, already known to be scalar.

--- a/plugins/newspack-plugin/includes/experimental-tools/class-experimental-tools.php
+++ b/plugins/newspack-plugin/includes/experimental-tools/class-experimental-tools.php
@@ -199,6 +199,12 @@ class Experimental_Tools {
 	/**
 	 * Get registered tools from the filter (raw, without saved state).
 	 *
+	 * Each tool declares `slug`, `label` and optionally `fields`. A field carries
+	 * `key`, `type` and `label`; a `type` of `display` is read-only and never
+	 * stored. A field may also declare `sanitize_callback`, which
+	 * save_tool_fields() applies instead of the default sanitizer — see
+	 * sanitize_field_value() for when a tool needs that.
+	 *
 	 * @return array Keyed by slug.
 	 */
 	private static function get_registered_tools() {
@@ -353,19 +359,20 @@ class Experimental_Tools {
 			];
 		}
 
-		// Only accept keys declared in the tool registration.
-		$valid_keys = [];
+		// Only accept keys declared in the tool registration, keeping each field's
+		// definition so its own sanitizer can be applied below.
+		$declared_fields = [];
 		if ( isset( $registered[ $slug ]['fields'] ) ) {
 			foreach ( $registered[ $slug ]['fields'] as $field ) {
 				if ( ! empty( $field['key'] ) && ( $field['type'] ?? '' ) !== 'display' ) {
-					$valid_keys[] = $field['key'];
+					$declared_fields[ $field['key'] ] = $field;
 				}
 			}
 		}
 
 		foreach ( $fields as $key => $value ) {
-			if ( in_array( $key, $valid_keys, true ) ) {
-				$all_settings[ $slug ]['fields'][ $key ] = sanitize_textarea_field( $value );
+			if ( isset( $declared_fields[ $key ] ) ) {
+				$all_settings[ $slug ]['fields'][ $key ] = self::sanitize_field_value( $declared_fields[ $key ], $value );
 			}
 		}
 
@@ -378,6 +385,31 @@ class Experimental_Tools {
 		 * @param array  $fields Saved key-value pairs.
 		 */
 		do_action( 'newspack_experimental_tool_fields_saved', $slug, $all_settings[ $slug ]['fields'] );
+	}
+
+	/**
+	 * Sanitize one submitted field value.
+	 *
+	 * Defaults to sanitize_textarea_field(), which suits free text but destroys a
+	 * value carrying syntax of its own: it deletes a percent sign followed by two
+	 * hex digits, reading it as a URL-encoded octet, so a template placeholder
+	 * such as %CATEGORIES% is stored as TEGORIES%. A field may therefore declare
+	 * `sanitize_callback` in its registration and keep the rules its own format
+	 * needs. The callback is registration data, not user input, and an
+	 * uncallable one falls back to the default rather than storing raw input.
+	 *
+	 * @param array $field The registered field definition.
+	 * @param mixed $value The submitted value.
+	 * @return mixed The sanitized value.
+	 */
+	private static function sanitize_field_value( $field, $value ) {
+		$callback = $field['sanitize_callback'] ?? null;
+
+		if ( null !== $callback && is_callable( $callback ) ) {
+			return call_user_func( $callback, $value );
+		}
+
+		return sanitize_textarea_field( $value );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/experimental-tools/class-experimental-tools.php
+++ b/plugins/newspack-plugin/includes/experimental-tools/class-experimental-tools.php
@@ -250,6 +250,10 @@ class Experimental_Tools {
 				} elseif ( ! isset( $field['value'] ) && isset( $field['default'] ) ) {
 					$field['value'] = $field['default'];
 				}
+
+				// Server-side only: a callable would serialize into the response as
+				// an object's public properties, or as an opaque {} for a closure.
+				unset( $field['sanitize_callback'] );
 			}
 			unset( $field );
 
@@ -371,9 +375,19 @@ class Experimental_Tools {
 		}
 
 		foreach ( $fields as $key => $value ) {
-			if ( isset( $declared_fields[ $key ] ) ) {
-				$all_settings[ $slug ]['fields'][ $key ] = self::sanitize_field_value( $declared_fields[ $key ], $value );
+			if ( ! isset( $declared_fields[ $key ] ) ) {
+				continue;
 			}
+
+			// The route validates that `fields` is an object but says nothing about
+			// the values inside it. A non-scalar has no meaningful sanitized form,
+			// and writing one through would replace a saved value with an empty
+			// string on a malformed request; leave the stored value alone instead.
+			if ( ! is_scalar( $value ) ) {
+				continue;
+			}
+
+			$all_settings[ $slug ]['fields'][ $key ] = self::sanitize_field_value( $declared_fields[ $key ], $value );
 		}
 
 		update_option( self::OPTION_NAME, $all_settings );
@@ -398,18 +412,50 @@ class Experimental_Tools {
 	 * needs. The callback is registration data, not user input, and an
 	 * uncallable one falls back to the default rather than storing raw input.
 	 *
+	 * The callback is always handed a string, so it can declare `string` without
+	 * risking a TypeError on a hand-crafted request, and must return a scalar,
+	 * since the stored value is merged back into the field definition and sent
+	 * over REST. A non-scalar return is stored as an empty string, which is what
+	 * the default does with one. Anything narrower than scalar would rule out
+	 * `rest_sanitize_boolean` and friends on a toggle field.
+	 *
+	 * `sanitize_callback` is a literal in the registration — PHP from a loaded
+	 * plugin, never read from the option or the request — so applying it is no
+	 * wider a trust boundary than the registration itself. A tool that ever
+	 * derived the callback from stored data would change that. Deriving field
+	 * keys or values that way is fine and already done.
+	 *
 	 * @param array $field The registered field definition.
-	 * @param mixed $value The submitted value.
-	 * @return mixed The sanitized value.
+	 * @param mixed $value The submitted value, already known to be scalar.
+	 * @return string|int|float|bool The sanitized value.
 	 */
-	private static function sanitize_field_value( $field, $value ) {
+	private static function sanitize_field_value( array $field, mixed $value ): string|int|float|bool {
 		$callback = $field['sanitize_callback'] ?? null;
 
-		if ( null !== $callback && is_callable( $callback ) ) {
-			return call_user_func( $callback, $value );
+		if ( null === $callback ) {
+			return sanitize_textarea_field( $value );
 		}
 
-		return sanitize_textarea_field( $value );
+		if ( ! is_callable( $callback ) ) {
+			$message = sprintf(
+				/* translators: %1$s: the sanitize_callback registration key. %2$s: field key. */
+				__( 'The %1$s declared for the %2$s field is not callable. Falling back to the default sanitizer, which strips percent-encoded sequences.', 'newspack-plugin' ),
+				'<code>sanitize_callback</code>',
+				'<code>' . ( $field['key'] ?? '' ) . '</code>'
+			);
+
+			_doing_it_wrong(
+				__METHOD__,
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- _doing_it_wrong expects a translated string.
+				$message,
+				'6.47.9'
+			);
+			return sanitize_textarea_field( $value );
+		}
+
+		$sanitized = $callback( (string) $value );
+
+		return is_scalar( $sanitized ) ? $sanitized : '';
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/experimental-tools.php
+++ b/plugins/newspack-plugin/tests/unit-tests/experimental-tools.php
@@ -137,125 +137,37 @@ class Newspack_Test_Experimental_Tools extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Register a tool with one plain field and one declaring its own sanitizer.
+	 * A template placeholder survives being saved.
 	 *
-	 * @param callable|string $callback The sanitize_callback to declare.
-	 * @return string The tool slug.
+	 * WordPress deletes a percent sign followed by two hex digits as a URL-encoded
+	 * octet, so %CACHE_KEY% used to be stored as CHE_KEY% — and the surrounding
+	 * spacing has to survive with it.
 	 */
-	private function register_tool_with_callback( $callback ) {
-		return $this->register_test_tool(
-			[
-				'fields' => [
-					[
-						'type' => 'textarea',
-						'key'  => 'plain',
-					],
-					[
-						'type'              => 'textarea',
-						'key'               => 'declared',
-						'sanitize_callback' => $callback,
-					],
-				],
-			]
-		);
-	}
+	public function test_placeholders_survive_saving() {
+		$slug = $this->register_test_tool();
 
-	/**
-	 * A field's own sanitizer replaces the default, and only for that field.
-	 *
-	 * The default reads a percent sign followed by two hex digits as a URL-encoded
-	 * octet and deletes it, so %CACHE_KEY% is stored as CHE_KEY%. That is what a
-	 * tool storing placeholders needs to escape, and what every other field keeps.
-	 */
-	public function test_a_declared_callback_replaces_the_default_for_that_field_only() {
-		$slug = $this->register_tool_with_callback( 'wp_kses_post' );
-
-		Experimental_Tools::save_tool_fields(
-			$slug,
-			[
-				'plain'    => 'Use %CACHE_KEY% here',
-				'declared' => 'Use %CACHE_KEY% here',
-			]
-		);
-
-		$fields = Experimental_Tools::get_tool_settings( $slug )['fields'];
-
-		$this->assertSame( 'Use CHE_KEY% here', $fields['plain'], 'An undeclared field keeps the default.' );
-		$this->assertSame( 'Use %CACHE_KEY% here', $fields['declared'], "The field's own sanitizer runs instead." );
-	}
-
-	/**
-	 * A callback that cannot be called falls back to the default rather than
-	 * fataling or storing raw input. Silent would hide a registration typo behind
-	 * the very sanitizer the callback was declared to escape.
-	 */
-	public function test_an_uncallable_callback_falls_back_to_the_default() {
-		$this->setExpectedIncorrectUsage( 'Newspack\\Experimental_Tools::sanitize_field_value' );
-
-		$slug = $this->register_tool_with_callback( 'newspack_no_such_sanitizer' );
-
-		Experimental_Tools::save_tool_fields( $slug, [ 'declared' => 'Use %CACHE_KEY% here' ] );
+		Experimental_Tools::save_tool_fields( $slug, [ 'api_key' => "Use %CACHE_KEY% here.\nAnd %CONTENT% there." ] );
 
 		$this->assertSame(
-			'Use CHE_KEY% here',
-			Experimental_Tools::get_tool_settings( $slug )['fields']['declared'],
-			"The default sanitizer's fingerprint proves which one ran."
+			"Use %CACHE_KEY% here.\nAnd %CONTENT% there.",
+			Experimental_Tools::get_tool_settings( $slug )['fields']['api_key']
 		);
 	}
 
 	/**
-	 * A non-scalar value is not storable, and a malformed request must not wipe
-	 * what was saved. The route validates that `fields` is an object but nothing
-	 * about the values inside it, so this is reachable. The typed callback also
-	 * pins that it is never handed one.
+	 * Everything that is not a placeholder is still sanitized: markup goes, and a
+	 * bare percent-encoded octet is still an octet rather than a placeholder.
 	 */
-	public function test_a_non_scalar_value_leaves_the_stored_value_alone() {
-		$slug = $this->register_tool_with_callback(
-			function ( string $value ) {
-				return $value;
-			}
-		);
+	public function test_non_placeholder_content_is_still_sanitized() {
+		$slug = $this->register_test_tool();
 
-		Experimental_Tools::save_tool_fields( $slug, [ 'declared' => 'what was written' ] );
-		Experimental_Tools::save_tool_fields( $slug, [ 'declared' => [ 'an', 'array' ] ] );
+		Experimental_Tools::save_tool_fields( $slug, [ 'api_key' => "a <script>alert('x')</script> %CA b" ] );
 
-		$this->assertSame(
-			'what was written',
-			Experimental_Tools::get_tool_settings( $slug )['fields']['declared'],
-			'A malformed request must not overwrite a saved value.'
-		);
+		$stored = Experimental_Tools::get_tool_settings( $slug )['fields']['api_key'];
+
+		$this->assertStringNotContainsString( '<script>', $stored );
+		$this->assertStringNotContainsString( '%CA', $stored );
 	}
-
-	/**
-	 * A non-scalar return cannot reach the option either: the stored value is
-	 * merged back into the field definition and sent over REST.
-	 */
-	public function test_a_non_scalar_return_is_stored_as_an_empty_string() {
-		$slug = $this->register_tool_with_callback(
-			function () {
-				return [ 'not', 'a', 'scalar' ];
-			}
-		);
-
-		Experimental_Tools::save_tool_fields( $slug, [ 'declared' => 'anything' ] );
-
-		$this->assertSame( '', Experimental_Tools::get_tool_settings( $slug )['fields']['declared'] );
-	}
-
-	/**
-	 * The callback is server-side only. A callable would serialize into the REST
-	 * response as an object's public properties, or as an opaque object for a
-	 * closure, and the UI has no use for either.
-	 */
-	public function test_the_callback_is_not_exposed_in_the_rest_payload() {
-		$this->register_tool_with_callback( 'wp_kses_post' );
-
-		$fields = Experimental_Tools::get_tools()[0]['fields'];
-
-		$this->assertArrayNotHasKey( 'sanitize_callback', $fields[1] );
-		$this->assertSame( 'declared', $fields[1]['key'], 'The rest of the definition still travels.' );
-	}
-
 
 	/**
 	 * Saved field values are merged into the tool's fields in get_tools().

--- a/plugins/newspack-plugin/tests/unit-tests/experimental-tools.php
+++ b/plugins/newspack-plugin/tests/unit-tests/experimental-tools.php
@@ -137,226 +137,125 @@ class Newspack_Test_Experimental_Tools extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Field values are sanitized on the way in.
+	 * Register a tool with one plain field and one declaring its own sanitizer.
+	 *
+	 * @param callable|string $callback The sanitize_callback to declare.
+	 * @return string The tool slug.
 	 */
-	public function test_save_fields_sanitizes_by_default() {
-		$slug = $this->register_test_tool();
-
-		Experimental_Tools::save_tool_fields( $slug, [ 'api_key' => "key <script>alert('x')</script>" ] );
-
-		$settings = Experimental_Tools::get_tool_settings( $slug );
-
-		$this->assertStringNotContainsString( '<script>', $settings['fields']['api_key'] );
-		$this->assertStringContainsString( 'key', $settings['fields']['api_key'] );
-	}
-
-	/**
-	 * A field can declare its own sanitizer. Some tools store values with syntax
-	 * of their own — a template carrying %PLACEHOLDER% tokens, say — that
-	 * the default sanitizer destroys, and only the owning tool knows the rules.
-	 */
-	public function test_field_sanitize_callback_is_used_when_declared() {
-		$slug = $this->register_test_tool(
+	private function register_tool_with_callback( $callback ) {
+		return $this->register_test_tool(
 			[
 				'fields' => [
 					[
+						'type' => 'textarea',
+						'key'  => 'plain',
+					],
+					[
 						'type'              => 'textarea',
-						'key'               => 'template',
-						'label'             => 'Template',
-						'sanitize_callback' => [ __CLASS__, 'sanitize_marking_the_value' ],
+						'key'               => 'declared',
+						'sanitize_callback' => $callback,
 					],
 				],
 			]
 		);
-
-		Experimental_Tools::save_tool_fields( $slug, [ 'template' => 'Use %CACHE_KEY% here' ] );
-
-		$settings = Experimental_Tools::get_tool_settings( $slug );
-
-		$this->assertEquals( 'Use %CACHE_KEY% here|marked', $settings['fields']['template'] );
 	}
 
 	/**
-	 * The case the per-field callback exists for: the default sanitizer reads a
-	 * percent sign followed by two hex digits as a URL-encoded octet and deletes
-	 * it, so %CACHE_KEY% is stored as CHE_KEY%.
+	 * A field's own sanitizer replaces the default, and only for that field.
+	 *
+	 * The default reads a percent sign followed by two hex digits as a URL-encoded
+	 * octet and deletes it, so %CACHE_KEY% is stored as CHE_KEY%. That is what a
+	 * tool storing placeholders needs to escape, and what every other field keeps.
 	 */
-	public function test_default_sanitizer_destroys_hex_leading_placeholders() {
-		$slug = $this->register_test_tool();
+	public function test_a_declared_callback_replaces_the_default_for_that_field_only() {
+		$slug = $this->register_tool_with_callback( 'wp_kses_post' );
 
-		Experimental_Tools::save_tool_fields( $slug, [ 'api_key' => 'Use %CACHE_KEY% here' ] );
-
-		$settings = Experimental_Tools::get_tool_settings( $slug );
-
-		$this->assertStringNotContainsString( '%CACHE_KEY%', $settings['fields']['api_key'] );
-		$this->assertStringContainsString( 'CHE_KEY%', $settings['fields']['api_key'] );
-	}
-
-	/**
-	 * A declared callback that cannot be called falls back to the default rather
-	 * than fataling or storing the value unsanitized.
-	 */
-	public function test_uncallable_sanitize_callback_falls_back_to_the_default() {
-		// The fallback is safe, but silent would hide a registration typo behind
-		// the exact sanitizer the callback was declared to escape.
-		$this->setExpectedIncorrectUsage( 'Newspack\Experimental_Tools::sanitize_field_value' );
-
-		$slug = $this->register_test_tool(
+		Experimental_Tools::save_tool_fields(
+			$slug,
 			[
-				'fields' => [
-					[
-						'type'              => 'textarea',
-						'key'               => 'template',
-						'label'             => 'Template',
-						'sanitize_callback' => 'newspack_no_such_sanitizer',
-					],
-				],
+				'plain'    => 'Use %CACHE_KEY% here',
+				'declared' => 'Use %CACHE_KEY% here',
 			]
 		);
 
-		Experimental_Tools::save_tool_fields( $slug, [ 'template' => "hi %CACHE_KEY% <script>alert('x')</script>" ] );
+		$fields = Experimental_Tools::get_tool_settings( $slug )['fields'];
 
-		$settings = Experimental_Tools::get_tool_settings( $slug );
+		$this->assertSame( 'Use CHE_KEY% here', $fields['plain'], 'An undeclared field keeps the default.' );
+		$this->assertSame( 'Use %CACHE_KEY% here', $fields['declared'], "The field's own sanitizer runs instead." );
+	}
 
-		$this->assertStringNotContainsString( '<script>', $settings['fields']['template'] );
-		$this->assertStringContainsString(
-			'CHE_KEY%',
-			$settings['fields']['template'],
+	/**
+	 * A callback that cannot be called falls back to the default rather than
+	 * fataling or storing raw input. Silent would hide a registration typo behind
+	 * the very sanitizer the callback was declared to escape.
+	 */
+	public function test_an_uncallable_callback_falls_back_to_the_default() {
+		$this->setExpectedIncorrectUsage( 'Newspack\\Experimental_Tools::sanitize_field_value' );
+
+		$slug = $this->register_tool_with_callback( 'newspack_no_such_sanitizer' );
+
+		Experimental_Tools::save_tool_fields( $slug, [ 'declared' => 'Use %CACHE_KEY% here' ] );
+
+		$this->assertSame(
+			'Use CHE_KEY% here',
+			Experimental_Tools::get_tool_settings( $slug )['fields']['declared'],
 			"The default sanitizer's fingerprint proves which one ran."
 		);
 	}
 
 	/**
 	 * A non-scalar value is not storable, and a malformed request must not wipe
-	 * what the publisher saved. The route validates that `fields` is an object
-	 * but nothing about the values inside it, so this is reachable.
+	 * what was saved. The route validates that `fields` is an object but nothing
+	 * about the values inside it, so this is reachable. The typed callback also
+	 * pins that it is never handed one.
 	 */
 	public function test_a_non_scalar_value_leaves_the_stored_value_alone() {
-		$called = false;
-		$slug   = $this->register_test_tool(
-			[
-				'fields' => [
-					[
-						'type'              => 'textarea',
-						'key'               => 'template',
-						'label'             => 'Template',
-						'sanitize_callback' => function ( string $value ) use ( &$called ) {
-							$called = true;
-							return $value;
-						},
-					],
-				],
-			]
+		$slug = $this->register_tool_with_callback(
+			function ( string $value ) {
+				return $value;
+			}
 		);
 
-		Experimental_Tools::save_tool_fields( $slug, [ 'template' => 'the publisher wrote this' ] );
-		Experimental_Tools::save_tool_fields( $slug, [ 'template' => [ 'an', 'array' ] ] );
+		Experimental_Tools::save_tool_fields( $slug, [ 'declared' => 'what was written' ] );
+		Experimental_Tools::save_tool_fields( $slug, [ 'declared' => [ 'an', 'array' ] ] );
 
 		$this->assertSame(
-			'the publisher wrote this',
-			Experimental_Tools::get_tool_settings( $slug )['fields']['template'],
-			'A malformed value must not overwrite a saved one.'
+			'what was written',
+			Experimental_Tools::get_tool_settings( $slug )['fields']['declared'],
+			'A malformed request must not overwrite a saved value.'
 		);
-		$this->assertTrue( $called, 'The scalar save did reach the callback.' );
 	}
 
 	/**
-	 * The saved-fields action carries what was stored, so a listener never has to
-	 * re-sanitize or reconstruct the value.
+	 * A non-scalar return cannot reach the option either: the stored value is
+	 * merged back into the field definition and sent over REST.
 	 */
-	public function test_fields_saved_action_receives_the_sanitized_value() {
-		$slug = $this->register_test_tool(
-			[
-				'fields' => [
-					[
-						'type'              => 'textarea',
-						'key'               => 'template',
-						'label'             => 'Template',
-						'sanitize_callback' => [ __CLASS__, 'sanitize_marking_the_value' ],
-					],
-				],
-			]
+	public function test_a_non_scalar_return_is_stored_as_an_empty_string() {
+		$slug = $this->register_tool_with_callback(
+			function () {
+				return [ 'not', 'a', 'scalar' ];
+			}
 		);
 
-		$captured = null;
-		add_action(
-			'newspack_experimental_tool_fields_saved',
-			function ( $action_slug, $fields ) use ( &$captured ) {
-				$captured = $fields;
-			},
-			10,
-			2
-		);
+		Experimental_Tools::save_tool_fields( $slug, [ 'declared' => 'anything' ] );
 
-		Experimental_Tools::save_tool_fields( $slug, [ 'template' => 'Use %CACHE_KEY% here' ] );
-
-		$this->assertEquals( 'Use %CACHE_KEY% here|marked', $captured['template'] );
+		$this->assertSame( '', Experimental_Tools::get_tool_settings( $slug )['fields']['declared'] );
 	}
 
 	/**
-	 * The callback is server-side only and never reaches a client. A callable
-	 * serializes into the REST response as an object's public properties, or as
-	 * an opaque object for a closure, and the UI has no use for either.
+	 * The callback is server-side only. A callable would serialize into the REST
+	 * response as an object's public properties, or as an opaque object for a
+	 * closure, and the UI has no use for either.
 	 */
-	public function test_sanitize_callback_is_not_exposed_in_the_rest_payload() {
-		$this->register_test_tool(
-			[
-				'fields' => [
-					[
-						'type'              => 'textarea',
-						'key'               => 'template',
-						'label'             => 'Template',
-						'sanitize_callback' => [ __CLASS__, 'sanitize_marking_the_value' ],
-					],
-				],
-			]
-		);
+	public function test_the_callback_is_not_exposed_in_the_rest_payload() {
+		$this->register_tool_with_callback( 'wp_kses_post' );
 
-		$tools = Experimental_Tools::get_tools();
+		$fields = Experimental_Tools::get_tools()[0]['fields'];
 
-		$this->assertArrayNotHasKey( 'sanitize_callback', $tools[0]['fields'][0] );
-		$this->assertEquals( 'template', $tools[0]['fields'][0]['key'], 'The rest of the field definition still travels.' );
+		$this->assertArrayNotHasKey( 'sanitize_callback', $fields[1] );
+		$this->assertSame( 'declared', $fields[1]['key'], 'The rest of the definition still travels.' );
 	}
 
-	/**
-	 * A callback returning something other than a scalar cannot reach the option:
-	 * the stored value is merged back into the field definition and rendered by a
-	 * text input. The default sanitizer returns an empty string for a non-scalar,
-	 * so the custom path matches it.
-	 */
-	public function test_non_scalar_return_is_stored_as_an_empty_string() {
-		$slug = $this->register_test_tool(
-			[
-				'fields' => [
-					[
-						'type'              => 'textarea',
-						'key'               => 'template',
-						'label'             => 'Template',
-						'sanitize_callback' => function () {
-							return [ 'not', 'a', 'scalar' ];
-						},
-					],
-				],
-			]
-		);
-
-		Experimental_Tools::save_tool_fields( $slug, [ 'template' => 'anything' ] );
-
-		$settings = Experimental_Tools::get_tool_settings( $slug );
-
-		$this->assertSame( '', $settings['fields']['template'] );
-	}
-
-	/**
-	 * Stand-in for a tool-owned sanitizer, marking the value so the test can tell
-	 * which sanitizer ran.
-	 *
-	 * @param string $value The submitted value.
-	 * @return string
-	 */
-	public static function sanitize_marking_the_value( $value ) {
-		return $value . '|marked';
-	}
 
 	/**
 	 * Saved field values are merged into the tool's fields in get_tools().

--- a/plugins/newspack-plugin/tests/unit-tests/experimental-tools.php
+++ b/plugins/newspack-plugin/tests/unit-tests/experimental-tools.php
@@ -197,6 +197,10 @@ class Newspack_Test_Experimental_Tools extends WP_UnitTestCase {
 	 * than fataling or storing the value unsanitized.
 	 */
 	public function test_uncallable_sanitize_callback_falls_back_to_the_default() {
+		// The fallback is safe, but silent would hide a registration typo behind
+		// the exact sanitizer the callback was declared to escape.
+		$this->setExpectedIncorrectUsage( 'Newspack\Experimental_Tools::sanitize_field_value' );
+
 		$slug = $this->register_test_tool(
 			[
 				'fields' => [
@@ -210,11 +214,50 @@ class Newspack_Test_Experimental_Tools extends WP_UnitTestCase {
 			]
 		);
 
-		Experimental_Tools::save_tool_fields( $slug, [ 'template' => "hi <script>alert('x')</script>" ] );
+		Experimental_Tools::save_tool_fields( $slug, [ 'template' => "hi %CATEGORIES% <script>alert('x')</script>" ] );
 
 		$settings = Experimental_Tools::get_tool_settings( $slug );
 
 		$this->assertStringNotContainsString( '<script>', $settings['fields']['template'] );
+		$this->assertStringContainsString(
+			'TEGORIES%',
+			$settings['fields']['template'],
+			"The default sanitizer's fingerprint proves which one ran."
+		);
+	}
+
+	/**
+	 * A non-scalar value is not storable, and a malformed request must not wipe
+	 * what the publisher saved. The route validates that `fields` is an object
+	 * but nothing about the values inside it, so this is reachable.
+	 */
+	public function test_a_non_scalar_value_leaves_the_stored_value_alone() {
+		$called = false;
+		$slug   = $this->register_test_tool(
+			[
+				'fields' => [
+					[
+						'type'              => 'textarea',
+						'key'               => 'template',
+						'label'             => 'Template',
+						'sanitize_callback' => function ( string $value ) use ( &$called ) {
+							$called = true;
+							return $value;
+						},
+					],
+				],
+			]
+		);
+
+		Experimental_Tools::save_tool_fields( $slug, [ 'template' => 'the publisher wrote this' ] );
+		Experimental_Tools::save_tool_fields( $slug, [ 'template' => [ 'an', 'array' ] ] );
+
+		$this->assertSame(
+			'the publisher wrote this',
+			Experimental_Tools::get_tool_settings( $slug )['fields']['template'],
+			'A malformed value must not overwrite a saved one.'
+		);
+		$this->assertTrue( $called, 'The scalar save did reach the callback.' );
 	}
 
 	/**
@@ -248,6 +291,60 @@ class Newspack_Test_Experimental_Tools extends WP_UnitTestCase {
 		Experimental_Tools::save_tool_fields( $slug, [ 'template' => 'Use %CATEGORIES% here' ] );
 
 		$this->assertEquals( 'Use %CATEGORIES% here|marked', $captured['template'] );
+	}
+
+	/**
+	 * The callback is server-side only and never reaches a client. A callable
+	 * serializes into the REST response as an object's public properties, or as
+	 * an opaque object for a closure, and the UI has no use for either.
+	 */
+	public function test_sanitize_callback_is_not_exposed_in_the_rest_payload() {
+		$this->register_test_tool(
+			[
+				'fields' => [
+					[
+						'type'              => 'textarea',
+						'key'               => 'template',
+						'label'             => 'Template',
+						'sanitize_callback' => [ __CLASS__, 'sanitize_marking_the_value' ],
+					],
+				],
+			]
+		);
+
+		$tools = Experimental_Tools::get_tools();
+
+		$this->assertArrayNotHasKey( 'sanitize_callback', $tools[0]['fields'][0] );
+		$this->assertEquals( 'template', $tools[0]['fields'][0]['key'], 'The rest of the field definition still travels.' );
+	}
+
+	/**
+	 * A callback returning something other than a scalar cannot reach the option:
+	 * the stored value is merged back into the field definition and rendered by a
+	 * text input. The default sanitizer returns an empty string for a non-scalar,
+	 * so the custom path matches it.
+	 */
+	public function test_non_scalar_return_is_stored_as_an_empty_string() {
+		$slug = $this->register_test_tool(
+			[
+				'fields' => [
+					[
+						'type'              => 'textarea',
+						'key'               => 'template',
+						'label'             => 'Template',
+						'sanitize_callback' => function () {
+							return [ 'not', 'a', 'scalar' ];
+						},
+					],
+				],
+			]
+		);
+
+		Experimental_Tools::save_tool_fields( $slug, [ 'template' => 'anything' ] );
+
+		$settings = Experimental_Tools::get_tool_settings( $slug );
+
+		$this->assertSame( '', $settings['fields']['template'] );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/experimental-tools.php
+++ b/plugins/newspack-plugin/tests/unit-tests/experimental-tools.php
@@ -152,7 +152,7 @@ class Newspack_Test_Experimental_Tools extends WP_UnitTestCase {
 
 	/**
 	 * A field can declare its own sanitizer. Some tools store values with syntax
-	 * of their own — a prompt template carrying %PLACEHOLDER% tokens, say — that
+	 * of their own — a template carrying %PLACEHOLDER% tokens, say — that
 	 * the default sanitizer destroys, and only the owning tool knows the rules.
 	 */
 	public function test_field_sanitize_callback_is_used_when_declared() {
@@ -169,27 +169,27 @@ class Newspack_Test_Experimental_Tools extends WP_UnitTestCase {
 			]
 		);
 
-		Experimental_Tools::save_tool_fields( $slug, [ 'template' => 'Use %CATEGORIES% here' ] );
+		Experimental_Tools::save_tool_fields( $slug, [ 'template' => 'Use %CACHE_KEY% here' ] );
 
 		$settings = Experimental_Tools::get_tool_settings( $slug );
 
-		$this->assertEquals( 'Use %CATEGORIES% here|marked', $settings['fields']['template'] );
+		$this->assertEquals( 'Use %CACHE_KEY% here|marked', $settings['fields']['template'] );
 	}
 
 	/**
 	 * The case the per-field callback exists for: the default sanitizer reads a
 	 * percent sign followed by two hex digits as a URL-encoded octet and deletes
-	 * it, so %CATEGORIES% is stored as TEGORIES%.
+	 * it, so %CACHE_KEY% is stored as CHE_KEY%.
 	 */
 	public function test_default_sanitizer_destroys_hex_leading_placeholders() {
 		$slug = $this->register_test_tool();
 
-		Experimental_Tools::save_tool_fields( $slug, [ 'api_key' => 'Use %CATEGORIES% here' ] );
+		Experimental_Tools::save_tool_fields( $slug, [ 'api_key' => 'Use %CACHE_KEY% here' ] );
 
 		$settings = Experimental_Tools::get_tool_settings( $slug );
 
-		$this->assertStringNotContainsString( '%CATEGORIES%', $settings['fields']['api_key'] );
-		$this->assertStringContainsString( 'TEGORIES%', $settings['fields']['api_key'] );
+		$this->assertStringNotContainsString( '%CACHE_KEY%', $settings['fields']['api_key'] );
+		$this->assertStringContainsString( 'CHE_KEY%', $settings['fields']['api_key'] );
 	}
 
 	/**
@@ -214,13 +214,13 @@ class Newspack_Test_Experimental_Tools extends WP_UnitTestCase {
 			]
 		);
 
-		Experimental_Tools::save_tool_fields( $slug, [ 'template' => "hi %CATEGORIES% <script>alert('x')</script>" ] );
+		Experimental_Tools::save_tool_fields( $slug, [ 'template' => "hi %CACHE_KEY% <script>alert('x')</script>" ] );
 
 		$settings = Experimental_Tools::get_tool_settings( $slug );
 
 		$this->assertStringNotContainsString( '<script>', $settings['fields']['template'] );
 		$this->assertStringContainsString(
-			'TEGORIES%',
+			'CHE_KEY%',
 			$settings['fields']['template'],
 			"The default sanitizer's fingerprint proves which one ran."
 		);
@@ -288,9 +288,9 @@ class Newspack_Test_Experimental_Tools extends WP_UnitTestCase {
 			2
 		);
 
-		Experimental_Tools::save_tool_fields( $slug, [ 'template' => 'Use %CATEGORIES% here' ] );
+		Experimental_Tools::save_tool_fields( $slug, [ 'template' => 'Use %CACHE_KEY% here' ] );
 
-		$this->assertEquals( 'Use %CATEGORIES% here|marked', $captured['template'] );
+		$this->assertEquals( 'Use %CACHE_KEY% here|marked', $captured['template'] );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/experimental-tools.php
+++ b/plugins/newspack-plugin/tests/unit-tests/experimental-tools.php
@@ -137,6 +137,131 @@ class Newspack_Test_Experimental_Tools extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Field values are sanitized on the way in.
+	 */
+	public function test_save_fields_sanitizes_by_default() {
+		$slug = $this->register_test_tool();
+
+		Experimental_Tools::save_tool_fields( $slug, [ 'api_key' => "key <script>alert('x')</script>" ] );
+
+		$settings = Experimental_Tools::get_tool_settings( $slug );
+
+		$this->assertStringNotContainsString( '<script>', $settings['fields']['api_key'] );
+		$this->assertStringContainsString( 'key', $settings['fields']['api_key'] );
+	}
+
+	/**
+	 * A field can declare its own sanitizer. Some tools store values with syntax
+	 * of their own — a prompt template carrying %PLACEHOLDER% tokens, say — that
+	 * the default sanitizer destroys, and only the owning tool knows the rules.
+	 */
+	public function test_field_sanitize_callback_is_used_when_declared() {
+		$slug = $this->register_test_tool(
+			[
+				'fields' => [
+					[
+						'type'              => 'textarea',
+						'key'               => 'template',
+						'label'             => 'Template',
+						'sanitize_callback' => [ __CLASS__, 'sanitize_marking_the_value' ],
+					],
+				],
+			]
+		);
+
+		Experimental_Tools::save_tool_fields( $slug, [ 'template' => 'Use %CATEGORIES% here' ] );
+
+		$settings = Experimental_Tools::get_tool_settings( $slug );
+
+		$this->assertEquals( 'Use %CATEGORIES% here|marked', $settings['fields']['template'] );
+	}
+
+	/**
+	 * The case the per-field callback exists for: the default sanitizer reads a
+	 * percent sign followed by two hex digits as a URL-encoded octet and deletes
+	 * it, so %CATEGORIES% is stored as TEGORIES%.
+	 */
+	public function test_default_sanitizer_destroys_hex_leading_placeholders() {
+		$slug = $this->register_test_tool();
+
+		Experimental_Tools::save_tool_fields( $slug, [ 'api_key' => 'Use %CATEGORIES% here' ] );
+
+		$settings = Experimental_Tools::get_tool_settings( $slug );
+
+		$this->assertStringNotContainsString( '%CATEGORIES%', $settings['fields']['api_key'] );
+		$this->assertStringContainsString( 'TEGORIES%', $settings['fields']['api_key'] );
+	}
+
+	/**
+	 * A declared callback that cannot be called falls back to the default rather
+	 * than fataling or storing the value unsanitized.
+	 */
+	public function test_uncallable_sanitize_callback_falls_back_to_the_default() {
+		$slug = $this->register_test_tool(
+			[
+				'fields' => [
+					[
+						'type'              => 'textarea',
+						'key'               => 'template',
+						'label'             => 'Template',
+						'sanitize_callback' => 'newspack_no_such_sanitizer',
+					],
+				],
+			]
+		);
+
+		Experimental_Tools::save_tool_fields( $slug, [ 'template' => "hi <script>alert('x')</script>" ] );
+
+		$settings = Experimental_Tools::get_tool_settings( $slug );
+
+		$this->assertStringNotContainsString( '<script>', $settings['fields']['template'] );
+	}
+
+	/**
+	 * The saved-fields action carries what was stored, so a listener never has to
+	 * re-sanitize or reconstruct the value.
+	 */
+	public function test_fields_saved_action_receives_the_sanitized_value() {
+		$slug = $this->register_test_tool(
+			[
+				'fields' => [
+					[
+						'type'              => 'textarea',
+						'key'               => 'template',
+						'label'             => 'Template',
+						'sanitize_callback' => [ __CLASS__, 'sanitize_marking_the_value' ],
+					],
+				],
+			]
+		);
+
+		$captured = null;
+		add_action(
+			'newspack_experimental_tool_fields_saved',
+			function ( $action_slug, $fields ) use ( &$captured ) {
+				$captured = $fields;
+			},
+			10,
+			2
+		);
+
+		Experimental_Tools::save_tool_fields( $slug, [ 'template' => 'Use %CATEGORIES% here' ] );
+
+		$this->assertEquals( 'Use %CATEGORIES% here|marked', $captured['template'] );
+	}
+
+	/**
+	 * Stand-in for a tool-owned sanitizer, marking the value so the test can tell
+	 * which sanitizer ran.
+	 *
+	 * @param string $value The submitted value.
+	 * @return string
+	 */
+	public static function sanitize_marking_the_value( $value ) {
+		return $value . '|marked';
+	}
+
+	/**
 	 * Saved field values are merged into the tool's fields in get_tools().
 	 */
 	public function test_saved_values_appear_in_get_tools() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Experimental-tool field values are sanitized with `sanitize_textarea_field()`, which deletes a percent sign followed by two hex digits as a URL-encoded octet. A field holding a template therefore loses any placeholder whose name opens with two hex characters: `%CACHE_KEY%` is stored as `CHE_KEY%`. The owning tool cannot repair it either, because the saved-fields action carries the already-sanitized value.

Placeholders are now held out of the sanitizer and restored afterwards, for every field. Everything else is sanitized exactly as before, and a bare `%CA` stays an octet rather than becoming a placeholder.

`wp_kses_post` would be the obvious alternative, but it entity-encodes plain `<` and `>` and still eats angle-bracket type markers such as `<integer>`, so it trades one corruption for another while widening every field to post HTML.

**Rollout note.** Values already corrupted are not migrated; they have to be re-saved.

### How to test the changes in this Pull Request:

1. Register a tool with a `textarea` field through the `newspack_experimental_tools` filter.
2. Save the value `Use %CACHE_KEY% here` into that field.
3. Read the stored value. Before this change it is `Use CHE_KEY% here`; after it, unchanged.
4. Save `a <script>alert(1)</script> %CA b` into the same field.
5. Read it. The markup and the bare `%CA` octet are both gone.
6. Run `n test-php --filter Newspack_Test_Experimental_Tools`. Thirteen tests pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
