### PR TITLE
fix(colors): correct the Tertiary 200 hex value

### DIFF
--- a/packages/colors/colors.module.scss
+++ b/packages/colors/colors.module.scss
@@ -7,12 +7,18 @@
 @use "sass:math";
 
 @function to-rgb($color) {
-	@return color.channel($color, "red", $space: rgb) + ", " + color.channel($color, "green", $space: rgb) + ", " + color.channel($color, "blue", $space: rgb);
+	@return color.channel($color, "red", $space: rgb) + ", " + color.channel($color, "green", $space: rgb) + ", " +
+		color.channel($color, "blue", $space: rgb);
 }
 
 @function to-rgba($color) {
 	$alpha: math.div(math.round(color.channel($color, "alpha") * 100), 100);
-	@return rgba(color.channel($color, "red", $space: rgb), color.channel($color, "green", $space: rgb), color.channel($color, "blue", $space: rgb), $alpha);
+	@return rgba(
+		color.channel($color, "red", $space: rgb),
+		color.channel($color, "green", $space: rgb),
+		color.channel($color, "blue", $space: rgb),
+		$alpha
+	);
 }
 
 // Primary: Hex

--- a/packages/colors/colors.module.scss
+++ b/packages/colors/colors.module.scss
@@ -75,7 +75,7 @@ $secondary-1000--rgb: to-rgb($secondary-1000);
 $tertiary-000: #fff4f6;
 $tertiary-050: #fee8ed;
 $tertiary-100: #fedbe3;
-$tertiary-200: #fcded8;
+$tertiary-200: #fdced8;
 $tertiary-300: #fdbfcd;
 $tertiary-400: #fcaec0;
 $tertiary-500: #fc9bb3;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`$tertiary-200` is `#fcded8` in this package, but the value in our published brand palette is `#fdced8`. The middle two digits are swapped.

The published value is the correct one, because the wrong one puts the step out of order in a scale that otherwise descends evenly from white to Morganite:

| step | hex | R | G | B |
|---|---|---|---|---|
| Tertiary 100 | `#fedbe3` | 254 | 219 | 227 |
| **Tertiary 200 (current)** | `#fcded8` | **252** | **222** | 216 |
| **Tertiary 200 (fixed)** | `#fdced8` | **253** | **206** | 216 |
| Tertiary 300 | `#fdbfcd` | 253 | 191 | 205 |

Two channels break with the current value: green 222 is *lighter* than Tertiary 100's 219, and red 252 is *darker* than Tertiary 300's 253. With `#fdced8` both stay monotonic, and the green channel runs evenly down the ramp: 244, 232, 219, 206, 191, 174, 155. The published CMYK build for the step, 0/23/7/0, also sits evenly between Tertiary 100's 0/16/7/0 and Tertiary 300's 0/31/8/0.

Only the hex variable changes. `$tertiary-200--rgb` and the `:export` map derive from it, so no token is added, renamed or removed and every consumer picks up the corrected tint on its next build. Nothing else in the repo hardcodes the old value: the other matches are all untracked `dist/` output.

The second commit is unrelated to the value and can be dropped if you would rather keep this PR to one line. Prettier flags this file every time it is touched, because the `@return` lines in `to-rgb` and `to-rgba` run past the shared printWidth of 150. Wrapping them is the only change there.

No linked issue, spotted while collecting the CMYK builds for a print PDF.

### How to test the changes in this Pull Request:

1. Compare `$tertiary-200` against the Tertiary 200 swatch in our brand guidelines.
2. Compile the package and confirm the exported token and its RGB variant follow: `tertiary-200: #fdced8` and `253, 206, 216`.
3. Build a consumer that uses the tertiary ramp and confirm the 200 step now sits between 100 and 300 instead of reading lighter than 100.
4. Run Prettier over `packages/colors/colors.module.scss` and confirm it reports no issues.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? The package has no test suite. The value is verified against the published palette, and I compiled the package to confirm the hex, the derived RGB and the export map.
* [x] Have you successfully run tests with your changes locally? Compiled with Sass before and after the formatting commit: the output is byte-for-byte identical apart from the corrected hex.
