### PR TITLE
fix(wizard): refetch data after the installer adds required plugins

### DIFF
--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -150,6 +150,10 @@ const Wizard = (
 	// wizard a second request on every load.
 	const requirementsWereUnmet = useRef( false );
 	const onPluginStatus = ( { complete } ) => {
+		// Leave the installer first: whatever happens to the refetch, the user
+		// should not be stranded on a required-plugins screen for a plugin they
+		// just installed.
+		setPluginRequirementsSatisfied( complete );
 		if ( ! complete ) {
 			requirementsWereUnmet.current = true;
 		} else if ( requirementsWereUnmet.current ) {
@@ -158,7 +162,6 @@ const Wizard = (
 				invalidateResolution( 'getWizardAPIData', [ apiSlug ] );
 			}
 		}
-		setPluginRequirementsSatisfied( complete );
 	};
 
 	if ( ! pluginRequirementsSatisfied ) {

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -126,6 +126,7 @@ const Wizard = (
 	const isQuietLoading = useSelect( select => select( WIZARD_STORE_NAMESPACE ).isQuietLoading() );
 	const headerData = useSelect( select => select( WIZARD_STORE_NAMESPACE ).getHeaderData() );
 	const notices = useSelect( select => select( WIZARD_STORE_NAMESPACE ).getNotices() );
+	const { invalidateResolution } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const { actions, backNav, badges, sectionDescription, sectionMenu, sectionName, sectionTitle, sectionPrimaryAction, sectionSecondaryAction } =
 		headerData;
 
@@ -138,17 +139,15 @@ const Wizard = (
 
 	let displayedSections = sections.filter( section => ! section.isHidden );
 
-	const { invalidateResolution } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ pluginRequirementsSatisfied, setPluginRequirementsSatisfied ] = useState( requiredPlugins.length === 0 );
 
-	// The wizard fetches its data once, on mount. When a required plugin is
-	// missing that fetch runs against an endpoint that cannot answer yet — some
-	// return an error outright — so the response it caches describes a site
-	// without the plugin. Remember that we saw the requirements unmet, so the
-	// data can be refetched once the installer satisfies them. Without the
-	// refetch the section mounts against that stale response and renders empty
-	// until the user saves. Requirements already met on mount need nothing: the
-	// one fetch saw the real site.
+	// The data fetch above runs once per mount, while the required plugins are
+	// still missing — endpoints that need them answer empty or error outright,
+	// and either way the resolver records that as the answer. So the installer
+	// has to trigger a refetch, or the section mounts against it and renders
+	// nothing until the user saves. Requirements already met on mount are left
+	// alone: that fetch saw the real site, and refetching would cost every such
+	// wizard a second request on every load.
 	const requirementsWereUnmet = useRef( false );
 	const onPluginStatus = ( { complete } ) => {
 		if ( ! complete ) {

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { cloneElement, isValidElement, useEffect, useState, forwardRef } from '@wordpress/element';
+import { cloneElement, isValidElement, useEffect, useRef, useState, forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { category, chevronLeft, moreVertical } from '@wordpress/icons';
 
@@ -138,15 +138,36 @@ const Wizard = (
 
 	let displayedSections = sections.filter( section => ! section.isHidden );
 
+	const { invalidateResolution } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ pluginRequirementsSatisfied, setPluginRequirementsSatisfied ] = useState( requiredPlugins.length === 0 );
+
+	// The wizard fetches its data once, on mount. When a required plugin is
+	// missing that fetch runs against an endpoint that cannot answer yet — some
+	// return an error outright — so the response it caches describes a site
+	// without the plugin. Remember that we saw the requirements unmet, so the
+	// data can be refetched once the installer satisfies them. Without the
+	// refetch the section mounts against that stale response and renders empty
+	// until the user saves. Requirements already met on mount need nothing: the
+	// one fetch saw the real site.
+	const requirementsWereUnmet = useRef( false );
+	const onPluginStatus = ( { complete } ) => {
+		if ( ! complete ) {
+			requirementsWereUnmet.current = true;
+		} else if ( requirementsWereUnmet.current ) {
+			requirementsWereUnmet.current = false;
+			if ( apiSlug && isInitialFetchTriggered ) {
+				invalidateResolution( 'getWizardAPIData', [ apiSlug ] );
+			}
+		}
+		setPluginRequirementsSatisfied( complete );
+	};
+
 	if ( ! pluginRequirementsSatisfied ) {
 		headerText = requiredPlugins.length > 1 ? __( 'Required plugins', 'newspack-plugin' ) : __( 'Required plugin', 'newspack-plugin' );
 		displayedSections = [
 			{
 				path: '/',
-				render: () => (
-					<PluginInstaller plugins={ requiredPlugins } onStatus={ ( { complete } ) => setPluginRequirementsSatisfied( complete ) } />
-				),
+				render: () => <PluginInstaller plugins={ requiredPlugins } onStatus={ onPluginStatus } />,
 			},
 		];
 	}

--- a/packages/components/src/wizard/index.test.js
+++ b/packages/components/src/wizard/index.test.js
@@ -1,0 +1,132 @@
+/**
+ * External dependencies.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+/**
+ * WordPress dependencies.
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies.
+ */
+import Wizard from './';
+import { useWizardData } from './store/utils';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+global.newspack_aux_data = { is_debug_mode: false };
+// The wizard footer links out to the docs; both globals are localized onto every
+// real wizard screen, and the footer's ExternalLink needs a string href.
+window.newspack_urls = { support: 'https://help.newspack.com/' };
+
+const SETTINGS = { minimumDonation: '5' };
+
+/**
+ * Stands in for a wizard section that can only render once its API data has
+ * arrived — the shape every Newspack wizard section has.
+ *
+ * @param {Object} props      Component props.
+ * @param {string} props.slug Wizard API slug.
+ * @return {JSX.Element} Section content.
+ */
+const Section = ( { slug } ) => {
+	const wizardData = useWizardData( slug );
+	return <div>{ wizardData.settings ? 'Settings form' : null }</div>;
+};
+
+/**
+ * Mocks the endpoints a wizard hits, gated on whether the required plugin is
+ * active: the wizard's own endpoint 400s while the plugin is missing, exactly
+ * as Audience_Donations::api_get_donation_settings() does without WooCommerce.
+ *
+ * @param {string} slug Wizard API slug.
+ * @return {Object} Call counters.
+ */
+const mockEndpoints = slug => {
+	const counts = { wizard: 0 };
+	let pluginStatus = 'inactive';
+	apiFetch.mockImplementation( ( { path, method } ) => {
+		if ( path === `/newspack/v1/wizard/${ slug }` && 'POST' !== method ) {
+			counts.wizard++;
+			return 'active' === pluginStatus
+				? Promise.resolve( { settings: SETTINGS } )
+				: Promise.reject( {
+						code: 'newspack_missing_required_plugin',
+						message: 'The WooCommerce plugin is not installed and activated.',
+				  } );
+		}
+		if ( path === '/newspack/v1/plugins/' ) {
+			return Promise.resolve( {
+				woocommerce: { Name: 'WooCommerce', Description: 'Store', Status: pluginStatus, Download: 'wporg' },
+			} );
+		}
+		if ( path === '/newspack/v1/plugins/woocommerce/configure/' ) {
+			pluginStatus = 'active';
+			return Promise.resolve( { Name: 'WooCommerce', Description: 'Store', Status: 'active', Download: 'wporg' } );
+		}
+		return Promise.resolve( {} );
+	} );
+	return counts;
+};
+
+const renderWizard = slug =>
+	render(
+		<Wizard
+			headerText="Test wizard"
+			apiSlug={ slug }
+			requiredPlugins={ [ 'woocommerce' ] }
+			sections={ [ { label: 'Configuration', path: '/configuration', render: () => <Section slug={ slug } /> } ] }
+		/>
+	);
+
+describe( 'Wizard', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+	} );
+
+	it( 'refetches its API data after the installer satisfies the plugin requirements', async () => {
+		// A distinct slug per test: the store's resolver cache is process-wide.
+		const slug = 'test-wizard-refetch';
+		const counts = mockEndpoints( slug );
+
+		renderWizard( slug );
+
+		// The first fetch runs before the plugin exists, so it fails.
+		await waitFor( () => expect( counts.wizard ).toBe( 1 ) );
+		expect( screen.queryByText( 'Settings form' ) ).not.toBeInTheDocument();
+
+		// Two buttons read "Activate": the plugin's own row and the footer's
+		// activate-all. The row button comes first in the DOM.
+		const [ activate ] = await screen.findAllByRole( 'button', { name: 'Activate' } );
+		fireEvent.click( activate );
+
+		// Activation makes the endpoint answerable, so the section must render
+		// against fresh data rather than the empty pre-activation response.
+		expect( await screen.findByText( 'Settings form' ) ).toBeInTheDocument();
+		expect( counts.wizard ).toBe( 2 );
+	} );
+
+	it( 'does not refetch when the required plugins were already active', async () => {
+		const slug = 'test-wizard-no-refetch';
+		const counts = mockEndpoints( slug );
+		apiFetch.mockImplementation( ( { path } ) => {
+			if ( path === `/newspack/v1/wizard/${ slug }` ) {
+				counts.wizard++;
+				return Promise.resolve( { settings: SETTINGS } );
+			}
+			if ( path === '/newspack/v1/plugins/' ) {
+				return Promise.resolve( {
+					woocommerce: { Name: 'WooCommerce', Description: 'Store', Status: 'active', Download: 'wporg' },
+				} );
+			}
+			return Promise.resolve( {} );
+		} );
+
+		renderWizard( slug );
+
+		expect( await screen.findByText( 'Settings form' ) ).toBeInTheDocument();
+		await waitFor( () => expect( counts.wizard ).toBe( 1 ) );
+	} );
+} );

--- a/packages/components/src/wizard/index.test.js
+++ b/packages/components/src/wizard/index.test.js
@@ -16,30 +16,35 @@ import { useWizardData } from './store/utils';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
-global.newspack_aux_data = { is_debug_mode: false };
-// The wizard footer links out to the docs; both globals are localized onto every
-// real wizard screen, and the footer's ExternalLink needs a string href.
+// Both globals are localized onto every real wizard screen. The footer's
+// ExternalLink needs a string href, and the debug Notice reads aux data.
+window.newspack_aux_data = { is_debug_mode: false };
 window.newspack_urls = { support: 'https://help.newspack.com/' };
 
 const SETTINGS = { minimumDonation: '5' };
 
 // Stands in for a wizard section that can only render once its API data has
-// arrived — the shape every Newspack wizard section has.
+// arrived — the shape a wizard section has when the wizard owns an apiSlug.
 const Section = ( { slug } ) => {
 	const wizardData = useWizardData( slug );
 	return <div>{ wizardData.settings ? 'Settings form' : null }</div>;
 };
 
+// The other shape: a section on a wizard with no apiSlug, which reads page-load
+// globals rather than wizard API data and so never touches the store.
+const StaticSection = () => <div>Static section</div>;
+
 // Mocks the endpoints a wizard hits, gated on whether the required plugin is
 // active: the wizard's own endpoint 400s while the plugin is missing, exactly as
 // Audience_Donations::api_get_donation_settings() does without WooCommerce.
-// Returns a counter so a test can assert how many times the wizard refetched.
+// Counts every wizard-endpoint GET, whatever the slug, so a test can assert that
+// a wizard given no apiSlug fetches nothing at all.
 const mockEndpoints = ( slug, initialStatus = 'inactive' ) => {
 	const counts = { wizard: 0 };
 	let pluginStatus = initialStatus;
 	const plugin = () => ( { Name: 'WooCommerce', Description: 'Store', Status: pluginStatus, Download: 'wporg' } );
 	apiFetch.mockImplementation( ( { path, method } ) => {
-		if ( path === `/newspack/v1/wizard/${ slug }` && 'POST' !== method ) {
+		if ( path.startsWith( '/newspack/v1/wizard/' ) && 'POST' !== method ) {
 			counts.wizard++;
 			return 'active' === pluginStatus
 				? Promise.resolve( { settings: SETTINGS } )
@@ -60,15 +65,28 @@ const mockEndpoints = ( slug, initialStatus = 'inactive' ) => {
 	return counts;
 };
 
-const renderWizard = slug =>
+const renderWizard = ( slug, { withApiSlug = true } = {} ) =>
 	render(
 		<Wizard
 			headerText="Test wizard"
-			apiSlug={ slug }
+			apiSlug={ withApiSlug ? slug : undefined }
 			requiredPlugins={ [ 'woocommerce' ] }
-			sections={ [ { label: 'Configuration', path: '/configuration', render: () => <Section slug={ slug } /> } ] }
+			sections={ [
+				{
+					label: 'Configuration',
+					path: '/configuration',
+					render: () => ( withApiSlug ? <Section slug={ slug } /> : <StaticSection /> ),
+				},
+			] }
 		/>
 	);
+
+// The plugin's own row button, not the footer's activate-all — both read
+// "Activate", and the row button comes first in the DOM.
+const clickActivate = async () => {
+	const [ activate ] = await screen.findAllByRole( 'button', { name: 'Activate' } );
+	fireEvent.click( activate );
+};
 
 // Lets every already-queued promise settle, so an assertion that something did
 // NOT happen has actually given it the chance to.
@@ -80,24 +98,29 @@ describe( 'Wizard', () => {
 	} );
 
 	it( 'refetches its API data after the installer satisfies the plugin requirements', async () => {
-		// A distinct slug per test: the store's resolver cache is process-wide.
+		// A distinct slug per test: the store's resolution cache lives in the
+		// module registry, so it is shared by every test in this file.
 		const slug = 'test-wizard-refetch';
 		const counts = mockEndpoints( slug );
 
 		renderWizard( slug );
 
-		// The first fetch runs before the plugin exists, so it fails.
+		// The first fetch runs before the plugin exists, so it fails. Until the
+		// installer is satisfied it owns the whole route, so the installer screen
+		// showing is what proves we are in the pre-activation state.
 		await waitFor( () => expect( counts.wizard ).toBe( 1 ) );
-		expect( screen.queryByText( 'Settings form' ) ).not.toBeInTheDocument();
+		expect( await screen.findByText( 'WooCommerce' ) ).toBeInTheDocument();
 
-		// Two buttons read "Activate": the plugin's own row and the footer's
-		// activate-all. The row button comes first in the DOM.
-		const [ activate ] = await screen.findAllByRole( 'button', { name: 'Activate' } );
-		fireEvent.click( activate );
+		await clickActivate();
 
 		// Activation makes the endpoint answerable, so the section must render
 		// against fresh data rather than the empty pre-activation response.
 		expect( await screen.findByText( 'Settings form' ) ).toBeInTheDocument();
+
+		// Exactly one refetch. The installer re-reports its status on every
+		// re-render while it is mounted, so this is the assertion that would
+		// catch a latch that re-fired.
+		await flushPending();
 		expect( counts.wizard ).toBe( 2 );
 	} );
 
@@ -110,5 +133,24 @@ describe( 'Wizard', () => {
 		expect( await screen.findByText( 'Settings form' ) ).toBeInTheDocument();
 		await flushPending();
 		expect( counts.wizard ).toBe( 1 );
+	} );
+
+	it( 'fetches nothing for a wizard that has required plugins but no API slug', async () => {
+		// The shape of every other Newspack wizard that gates on plugins: it
+		// reads page-load globals rather than wizard API data. This change has to
+		// stay inert for them. Note this pins the inertness, not the `apiSlug`
+		// guard itself — the resolver already no-ops on an undefined slug, so
+		// that guard is a second line of defence rather than the load-bearing one.
+		const slug = 'test-wizard-no-api-slug';
+		const counts = mockEndpoints( slug );
+
+		renderWizard( slug, { withApiSlug: false } );
+
+		await clickActivate();
+
+		// The installer still completes and hands the route back to the section.
+		expect( await screen.findByText( 'Static section' ) ).toBeInTheDocument();
+		await flushPending();
+		expect( counts.wizard ).toBe( 0 );
 	} );
 } );

--- a/packages/components/src/wizard/index.test.js
+++ b/packages/components/src/wizard/index.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 /**
  * WordPress dependencies.
@@ -23,30 +23,21 @@ window.newspack_urls = { support: 'https://help.newspack.com/' };
 
 const SETTINGS = { minimumDonation: '5' };
 
-/**
- * Stands in for a wizard section that can only render once its API data has
- * arrived — the shape every Newspack wizard section has.
- *
- * @param {Object} props      Component props.
- * @param {string} props.slug Wizard API slug.
- * @return {JSX.Element} Section content.
- */
+// Stands in for a wizard section that can only render once its API data has
+// arrived — the shape every Newspack wizard section has.
 const Section = ( { slug } ) => {
 	const wizardData = useWizardData( slug );
 	return <div>{ wizardData.settings ? 'Settings form' : null }</div>;
 };
 
-/**
- * Mocks the endpoints a wizard hits, gated on whether the required plugin is
- * active: the wizard's own endpoint 400s while the plugin is missing, exactly
- * as Audience_Donations::api_get_donation_settings() does without WooCommerce.
- *
- * @param {string} slug Wizard API slug.
- * @return {Object} Call counters.
- */
-const mockEndpoints = slug => {
+// Mocks the endpoints a wizard hits, gated on whether the required plugin is
+// active: the wizard's own endpoint 400s while the plugin is missing, exactly as
+// Audience_Donations::api_get_donation_settings() does without WooCommerce.
+// Returns a counter so a test can assert how many times the wizard refetched.
+const mockEndpoints = ( slug, initialStatus = 'inactive' ) => {
 	const counts = { wizard: 0 };
-	let pluginStatus = 'inactive';
+	let pluginStatus = initialStatus;
+	const plugin = () => ( { Name: 'WooCommerce', Description: 'Store', Status: pluginStatus, Download: 'wporg' } );
 	apiFetch.mockImplementation( ( { path, method } ) => {
 		if ( path === `/newspack/v1/wizard/${ slug }` && 'POST' !== method ) {
 			counts.wizard++;
@@ -58,13 +49,11 @@ const mockEndpoints = slug => {
 				  } );
 		}
 		if ( path === '/newspack/v1/plugins/' ) {
-			return Promise.resolve( {
-				woocommerce: { Name: 'WooCommerce', Description: 'Store', Status: pluginStatus, Download: 'wporg' },
-			} );
+			return Promise.resolve( { woocommerce: plugin() } );
 		}
 		if ( path === '/newspack/v1/plugins/woocommerce/configure/' ) {
 			pluginStatus = 'active';
-			return Promise.resolve( { Name: 'WooCommerce', Description: 'Store', Status: 'active', Download: 'wporg' } );
+			return Promise.resolve( plugin() );
 		}
 		return Promise.resolve( {} );
 	} );
@@ -80,6 +69,10 @@ const renderWizard = slug =>
 			sections={ [ { label: 'Configuration', path: '/configuration', render: () => <Section slug={ slug } /> } ] }
 		/>
 	);
+
+// Lets every already-queued promise settle, so an assertion that something did
+// NOT happen has actually given it the chance to.
+const flushPending = () => act( () => new Promise( resolve => setTimeout( resolve, 0 ) ) );
 
 describe( 'Wizard', () => {
 	beforeEach( () => {
@@ -110,23 +103,12 @@ describe( 'Wizard', () => {
 
 	it( 'does not refetch when the required plugins were already active', async () => {
 		const slug = 'test-wizard-no-refetch';
-		const counts = mockEndpoints( slug );
-		apiFetch.mockImplementation( ( { path } ) => {
-			if ( path === `/newspack/v1/wizard/${ slug }` ) {
-				counts.wizard++;
-				return Promise.resolve( { settings: SETTINGS } );
-			}
-			if ( path === '/newspack/v1/plugins/' ) {
-				return Promise.resolve( {
-					woocommerce: { Name: 'WooCommerce', Description: 'Store', Status: 'active', Download: 'wporg' },
-				} );
-			}
-			return Promise.resolve( {} );
-		} );
+		const counts = mockEndpoints( slug, 'active' );
 
 		renderWizard( slug );
 
 		expect( await screen.findByText( 'Settings form' ) ).toBeInTheDocument();
-		await waitFor( () => expect( counts.wizard ).toBe( 1 ) );
+		await flushPending();
+		expect( counts.wizard ).toBe( 1 );
 	} );
 } );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Setting up Donations on a fresh site left publishers looking at an empty Configuration screen the moment they activated WooCommerce and WooCommerce Subscriptions from the wizard. Every option appeared once they clicked Save, with nothing on screen to suggest that was the way out.

A wizard fetches its data once, when it mounts. With `requiredPlugins` set, that fetch runs while the plugins are still missing, and endpoints that depend on them answer empty or fail outright. The plugin installer then reported success by flipping React state alone, so nothing re-asked the server and the section rendered against the plugin-less response.

The shared `Wizard` now records that the installer reported the requirements unmet, and invalidates its `getWizardAPIData` resolution once they are satisfied. Wizards whose plugins were already active when the page loaded are left alone: that fetch saw the real site, and refetching would cost them a second request on every load.

Of the four `requiredPlugins` call sites across the monorepo and the standalone repos, Donations is the only one that passes an `apiSlug`, so it is the only screen whose behavior changes.

Closes NPPM-3123.

### How to test the changes in this Pull Request:

1. Start from a site with WooCommerce and WooCommerce Subscriptions inactive, and the reader revenue platform left at its default. Audience Management does not need to be set up.
2. Go to **Audience > Donations**. The wizard shows the required-plugins screen.
3. Activate WooCommerce, then WooCommerce Subscriptions, from that screen.
4. The Configuration form appears on its own. Suggested donation amounts and the minimum donation field are populated, and no save was needed. Before this change the screen was empty.
5. Reload the page. The form matches what step 4 showed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

**Verified in a local environment**, as an A/B where the only variable was the compiled bundle. Same site state both rounds: WooCommerce and WooCommerce Subscriptions present but inactive, no Audience Management setup, no donation products, and the wizard endpoint returning `400 newspack_missing_required_plugin` on both runs.

* **Before:** activating both plugins left the Configuration tab showing its heading and nothing else. Clicking Save filled the form in, matching the report.
* **After:** the form rendered populated the moment activation finished, with no Save. The network trace is the mechanism exactly — `GET /newspack/v1/wizard/newspack-audience-donations` returns 400 on page load, then 200 after activation, and no POST is involved.
* Reloading afterward produced an identical form, no console errors, and no new entries in `debug.log`.

**Known limitation, checked.** Data localized into the page at render time is not reconciled here, because `wp_localize_script` output cannot be invalidated. On this screen that is `can_use_name_your_price`, which gates the Donation Type selector. Name Your Price is not one of the wizard's required plugins, so this flow never activates it. The post-activation form and a freshly reloaded one matched field for field in testing, so this does not bite on a fresh install. A site carrying Name Your Price while WooCommerce was inactive would still need a reload before the selector appears.

**Scope.** The Subscriptions and Newsletters wizards use the same install-and-continue flow but pass no `apiSlug`, so they are unchanged. Subscriptions reads its state from a page-load global rather than the wizard store, so a store refetch would not repair it there.

**Follow-ups, filed separately rather than carried by a hotfix:**

* The wizard store records a failed fetch as a successful resolution. `FETCH_FROM_API` catches the rejection into `setError` and resolves `undefined`, so the resolver still marks the slug resolved. Any failed wizard fetch pins that screen to empty until a page reload. The plugin-install flow is one door into this; this change closes that one.
* `Audience_Donations::api_get_donation_settings()` returns a bare 400 when WooCommerce is inactive, while the same class of failure with Subscriptions inactive returns 200 with a `donation_data.errors` payload both clients already degrade on.
* `WizardError` only mounts inside `TabbedNavigation`, which needs more than one visible section, so a single-section wizard shows nothing when its fetch fails. Mounting it unconditionally would be worse: the donations error carries `level: fatal`, which renders as a blocking modal, so it would land over the required-plugins screen. The fix has to suppress or downgrade errors while requirements are unmet.

<details>
<summary>Implementation notes</summary>

**Mechanism, at `origin/release`:**

1. `Audience_Donations::api_get_donation_settings()` returns a `WP_Error` (`newspack_missing_required_plugin`, 400) when the reader revenue platform is `wc`, which is the default from `Donations::get_platform_slug()`, and WooCommerce is inactive.
2. `Wizard` triggers its only fetch on mount through the `getWizardAPIData` resolver. Resolution is cached per slug, so it runs exactly once.
3. The store's `FETCH_FROM_API` control swallows the rejection into `setError` and resolves `undefined`, so `apiData[ slug ]` ends up empty and the resolution is recorded as finished.
4. `PluginInstaller` completion only called `setPluginRequirementsSatisfied`.
5. `DonationAmounts` early-returns `null` on `! wizardData.donation_data`, and `wizardData.donation_page` is undefined, so the section rendered its title and nothing else.

Saving repaired it because `saveWizardSettings` writes the POST response into the store.

**Why a ref rather than comparing state:** `pluginRequirementsSatisfied` starts `false` for any non-empty `requiredPlugins`, so a state comparison cannot tell "the installer just activated something" from "the plugins were already active." `PluginInstaller` reports `complete: true` on its very first callback in the already-active case, which is what the ref distinguishes.

`setPluginRequirementsSatisfied` runs before the invalidation so that a failure in the dispatch could not strand someone on a required-plugins screen for a plugin they had just installed. Ordering is not load-bearing for correctness: both are synchronous, and the re-render re-runs the `useSelect` either way.

**Verification:** the new test reproduces the mechanism (the section renders nothing after activation) and passes with the change. Mutation testing confirms both tests discriminate: reverting the component fails only the refetch test, and defeating the ref guard so it always invalidates fails only the already-active control. `packages/components` 14/14 suites and 97 tests; `newspack-plugin` 60/60 suites and 567 tests.

**Known edge, not guarded:** `PluginInstaller.retrievePluginInfo` keeps only slugs the plugins endpoint returns, and `Object.values( … ).every( … )` is vacuously true for an empty object. A slug the plugin manager does not know reports `complete: true` on the first callback, so the latch never sets and no refetch happens. Pre-existing, and the first thing to check if this is ever reported for one specific slug.

</details>
