### PR TITLE
fix(data-events): announce readers created during Store API checkouts

### DIFF
--- a/plugins/newspack-plugin/includes/data-events/class-woo-user-registration.php
+++ b/plugins/newspack-plugin/includes/data-events/class-woo-user-registration.php
@@ -37,6 +37,14 @@ final class Woo_User_Registration {
 		// is processing checkout?
 		add_action( 'woocommerce_checkout_process', [ __CLASS__, 'checkout_process' ] );
 
+		// The Store API checkout — the transport express wallets like Apple Pay and
+		// Google Pay submit through — never fires woocommerce_checkout_process. This
+		// action is that pipeline's equivalent signal: it fires once per checkout
+		// POST, before the account is created, while the cart is loaded for the
+		// metadata harvest. It also fires on the pay-for-existing-order route, where
+		// no account is ever created, so the flag set there is never consumed.
+		add_action( 'woocommerce_store_api_checkout_update_customer_from_request', [ __CLASS__, 'checkout_process' ], 10, 0 );
+
 		// created a user?
 		add_action( 'woocommerce_created_customer', [ __CLASS__, 'created_customer' ], 1 );
 
@@ -58,15 +66,20 @@ final class Woo_User_Registration {
 		 *
 		 * Here, we are going to read the same information from the cart and use it to send the metadata to Newspack on registration events.
 		 */
-		foreach ( \WC()->cart->get_cart() as $cart_item_key => $values ) {
-			if ( ! empty( $values['newspack_popup_id'] ) ) {
-				self::$metadata['newspack_popup_id'] = $values['newspack_popup_id'];
-			}
-			if ( ! empty( $values['prompt_title'] ) ) {
-				self::$metadata['prompt_title'] = $values['prompt_title'];
-			}
-			if ( ! empty( $values['referer'] ) ) {
-				self::$metadata['referer'] = $values['referer'];
+		// Cart presence is the calling pipeline's guarantee, not ours — without
+		// one there is simply no campaign metadata to harvest, and the flag
+		// below must still be set so the created account is announced.
+		if ( ! empty( \WC()->cart ) ) {
+			foreach ( \WC()->cart->get_cart() as $cart_item_key => $values ) {
+				if ( ! empty( $values['newspack_popup_id'] ) ) {
+					self::$metadata['newspack_popup_id'] = $values['newspack_popup_id'];
+				}
+				if ( ! empty( $values['prompt_title'] ) ) {
+					self::$metadata['prompt_title'] = $values['prompt_title'];
+				}
+				if ( ! empty( $values['referer'] ) ) {
+					self::$metadata['referer'] = $values['referer'];
+				}
 			}
 		}
 

--- a/plugins/newspack-plugin/includes/data-events/class-woo-user-registration.php
+++ b/plugins/newspack-plugin/includes/data-events/class-woo-user-registration.php
@@ -59,6 +59,11 @@ final class Woo_User_Registration {
 	 */
 	public static function checkout_process() {
 
+		// One signal, one checkout: the Store API's batch route serves several
+		// checkouts in a single PHP process, so metadata harvested for an
+		// earlier one must not be attributed to this reader.
+		self::$metadata = [];
+
 		/**
 		 * On Newspack\Donations::process_donation_request(), we add these values to the cart.
 		 *

--- a/plugins/newspack-plugin/includes/data-events/class-woo-user-registration.php
+++ b/plugins/newspack-plugin/includes/data-events/class-woo-user-registration.php
@@ -102,6 +102,12 @@ final class Woo_User_Registration {
 			return;
 		}
 
+		// A checkout announces the one account it creates. Consuming the flag
+		// here keeps an account created later in the same process — the Store
+		// API batch route serves several checkouts in one — from being
+		// announced on this checkout's behalf.
+		self::$processing_checkout = false;
+
 		$user = get_user_by( 'id', $user_id );
 
 		if ( ! $user ) {

--- a/plugins/newspack-plugin/includes/data-events/class-woo-user-registration.php
+++ b/plugins/newspack-plugin/includes/data-events/class-woo-user-registration.php
@@ -15,11 +15,33 @@ use Newspack\Reader_Activation;
 final class Woo_User_Registration {
 
 	/**
-	 * Whether the current request is processing a checkout.
+	 * Whether a classic checkout is in flight.
+	 *
+	 * Raised by woocommerce_checkout_process and never lowered. The classic
+	 * pipeline runs one checkout per request and can create more than one
+	 * account in it — Subscriptions Gifting creates the recipient on the
+	 * order-status transition — and both are that checkout's to announce.
 	 *
 	 * @var boolean
 	 */
 	private static $processing_checkout = false;
+
+	/**
+	 * Whether a Store API checkout is in flight.
+	 *
+	 * @var boolean
+	 */
+	private static $store_api_checkout = false;
+
+	/**
+	 * Folded billing email the in-flight Store API checkout expects to create.
+	 *
+	 * Empty means the signal carried none, in which case the first account
+	 * created stands in — see claim_account().
+	 *
+	 * @var string
+	 */
+	private static $store_api_expected_email = '';
 
 	/**
 	 * Metadata to send with the registration event.
@@ -41,9 +63,9 @@ final class Woo_User_Registration {
 		// Google Pay submit through — never fires woocommerce_checkout_process. This
 		// action is that pipeline's equivalent signal: it fires once per checkout
 		// POST, before the account is created, while the cart is loaded for the
-		// metadata harvest. It also fires on the pay-for-existing-order route, where
-		// no account is ever created, so the flag set there is never consumed.
-		add_action( 'woocommerce_store_api_checkout_update_customer_from_request', [ __CLASS__, 'checkout_process' ], 10, 0 );
+		// metadata harvest. It carries the customer, whose billing email is what
+		// tells the created account apart from any other in the same process.
+		add_action( 'woocommerce_store_api_checkout_update_customer_from_request', [ __CLASS__, 'store_api_checkout_process' ], 10, 2 );
 
 		// created a user?
 		add_action( 'woocommerce_created_customer', [ __CLASS__, 'created_customer' ], 1 );
@@ -53,11 +75,42 @@ final class Woo_User_Registration {
 	}
 
 	/**
-	 * During the checkout process, set the processing_checkout flag and store metadata.
+	 * Note a classic checkout is under way.
 	 *
 	 * @return void
 	 */
 	public static function checkout_process() {
+		self::harvest_cart_metadata();
+		self::$processing_checkout = true;
+	}
+
+	/**
+	 * Note a Store API checkout is under way, and whose account it expects to create.
+	 *
+	 * Unlike the classic signal this one carries the customer, so the account
+	 * this checkout creates can be told apart from any other created in the same
+	 * process. WooCommerce writes the posted billing email onto the customer
+	 * before firing this, and refuses to create an account without one, so an
+	 * empty email here means no account will follow.
+	 *
+	 * @param object|null $customer WC_Customer the checkout is building.
+	 * @param object|null $request  The checkout request. Unused; part of the action signature.
+	 * @return void
+	 */
+	public static function store_api_checkout_process( $customer = null, $request = null ) {
+		self::harvest_cart_metadata();
+		self::$store_api_checkout       = true;
+		self::$store_api_expected_email = is_object( $customer ) && method_exists( $customer, 'get_billing_email' )
+			? self::fold_email( $customer->get_billing_email() )
+			: '';
+	}
+
+	/**
+	 * Read the campaign attribution the current checkout's cart carries.
+	 *
+	 * @return void
+	 */
+	private static function harvest_cart_metadata() {
 
 		// One signal, one checkout: the Store API's batch route serves several
 		// checkouts in a single PHP process, so metadata harvested for an
@@ -72,8 +125,8 @@ final class Woo_User_Registration {
 		 * Here, we are going to read the same information from the cart and use it to send the metadata to Newspack on registration events.
 		 */
 		// Cart presence is the calling pipeline's guarantee, not ours — without
-		// one there is simply no campaign metadata to harvest, and the flag
-		// below must still be set so the created account is announced.
+		// one there is simply no campaign metadata to harvest. Announcing the
+		// reader does not depend on it; the callers set their state either way.
 		if ( ! empty( \WC()->cart ) ) {
 			foreach ( \WC()->cart->get_cart() as $cart_item_key => $values ) {
 				if ( ! empty( $values['newspack_popup_id'] ) ) {
@@ -87,26 +140,69 @@ final class Woo_User_Registration {
 				}
 			}
 		}
-
-		self::$processing_checkout = true;
 	}
 
 	/**
-	 * If a user was created during the checkout by Woo, fire an event.
+	 * Decide whether the in-flight checkout is the one that created this account.
+	 *
+	 * The two pipelines answer this differently, on purpose. The classic signal
+	 * carries nothing identifying the buyer, so it keeps the long-standing rule
+	 * — any account created while a classic checkout is in flight is that
+	 * checkout's — and announces every one of them. The Store API signal fires
+	 * on every checkout POST, including a logged-in shopper's where no account
+	 * follows, so leaving it standing would let it speak for an unrelated
+	 * account later in the same process. It announces only the account matching
+	 * the email it carried, and stands down once it has.
+	 *
+	 * @param string $email The created account's email address.
+	 * @return bool Whether this checkout announces this account.
+	 */
+	private static function claim_account( $email ) {
+		if ( self::$store_api_checkout ) {
+			// No email on the signal, so nothing to match against and the first
+			// account created stands in. Unreachable on the announce path today:
+			// WooCommerce will not create an account without a billing email, so a
+			// signal without one is followed by no account at all.
+			if ( '' === self::$store_api_expected_email ) {
+				self::$store_api_checkout = false;
+				return true;
+			}
+
+			if ( self::fold_email( $email ) === self::$store_api_expected_email ) {
+				self::$store_api_checkout       = false;
+				self::$store_api_expected_email = '';
+				return true;
+			}
+		}
+
+		return self::$processing_checkout;
+	}
+
+	/**
+	 * Fold an email address for comparison.
+	 *
+	 * The two sides arrive by different routes — one off the customer object as
+	 * posted, the other off the saved user record — so they are compared folded
+	 * rather than raw. A mismatch would drop the announcement silently and
+	 * restore the original bug with the suite still green.
+	 *
+	 * @param string $email Email address.
+	 * @return string
+	 */
+	private static function fold_email( $email ) {
+		return strtolower( trim( (string) $email ) );
+	}
+
+	/**
+	 * Announce an account a checkout created, with what is known about where it came from.
 	 *
 	 * @param int $user_id The ID of the created user.
 	 * @return void
 	 */
 	public static function created_customer( $user_id ) {
-		if ( ! self::$processing_checkout ) {
+		if ( ! self::$processing_checkout && ! self::$store_api_checkout ) {
 			return;
 		}
-
-		// A checkout announces the one account it creates. Consuming the flag
-		// here keeps an account created later in the same process — the Store
-		// API batch route serves several checkouts in one — from being
-		// announced on this checkout's behalf.
-		self::$processing_checkout = false;
 
 		$user = get_user_by( 'id', $user_id );
 
@@ -114,7 +210,13 @@ final class Woo_User_Registration {
 			return;
 		}
 
-		// If a user is created later on the request by woocommerce_created_customer(), it will at least have this data.
+		if ( ! self::claim_account( $user->user_email ) ) {
+			return;
+		}
+
+		// Every account a checkout creates carries the method. The page and
+		// campaign below are best-effort on top of it, and depend on what the
+		// cart happened to hold.
 		self::$metadata['registration_method'] = 'woocommerce';
 
 		// For modal checkout, the referer is actually what we want to capture as the registration page.

--- a/plugins/newspack-plugin/includes/data-events/class-woo-user-registration.php
+++ b/plugins/newspack-plugin/includes/data-events/class-woo-user-registration.php
@@ -59,12 +59,7 @@ final class Woo_User_Registration {
 		// is processing checkout?
 		add_action( 'woocommerce_checkout_process', [ __CLASS__, 'checkout_process' ] );
 
-		// The Store API checkout — the transport express wallets like Apple Pay and
-		// Google Pay submit through — never fires woocommerce_checkout_process. This
-		// action is that pipeline's equivalent signal: it fires once per checkout
-		// POST, before the account is created, while the cart is loaded for the
-		// metadata harvest. It carries the customer, whose billing email is what
-		// tells the created account apart from any other in the same process.
+		// The Store API's equivalent signal; see store_api_checkout_process().
 		add_action( 'woocommerce_store_api_checkout_update_customer_from_request', [ __CLASS__, 'store_api_checkout_process' ], 10, 2 );
 
 		// created a user?
@@ -87,8 +82,14 @@ final class Woo_User_Registration {
 	/**
 	 * Note a Store API checkout is under way, and whose account it expects to create.
 	 *
-	 * Unlike the classic signal this one carries the customer, so the account
-	 * this checkout creates can be told apart from any other created in the same
+	 * The Store API checkout — the transport express wallets like Apple Pay and
+	 * Google Pay submit through — never fires woocommerce_checkout_process. The
+	 * action below is that pipeline's equivalent signal: it fires once per
+	 * checkout POST, before the account is created, while the cart is loaded for
+	 * the metadata harvest.
+	 *
+	 * Unlike the classic signal it carries the customer, so the account this
+	 * checkout creates can be told apart from any other created in the same
 	 * process. WooCommerce writes the posted billing email onto the customer
 	 * before firing this, and refuses to create an account without one, so an
 	 * empty email here means no account will follow.

--- a/plugins/newspack-plugin/includes/data-events/class-woo-user-registration.php
+++ b/plugins/newspack-plugin/includes/data-events/class-woo-user-registration.php
@@ -36,8 +36,8 @@ final class Woo_User_Registration {
 	/**
 	 * Folded billing email the in-flight Store API checkout expects to create.
 	 *
-	 * Empty means the signal carried none, in which case the first account
-	 * created stands in — see claim_account().
+	 * Empty means the signal carried none, which means no account will follow
+	 * it, so nothing is announced against it — see claim_account().
 	 *
 	 * @var string
 	 */
@@ -159,13 +159,13 @@ final class Woo_User_Registration {
 	 */
 	private static function claim_account( $email ) {
 		if ( self::$store_api_checkout ) {
-			// No email on the signal, so nothing to match against and the first
-			// account created stands in. Unreachable on the announce path today:
-			// WooCommerce will not create an account without a billing email, so a
-			// signal without one is followed by no account at all.
+			// A signal without an email creates no account: WooCommerce refuses a
+			// customer without a valid billing address. So any account arriving
+			// while this is empty belongs to something else in the request, and
+			// announcing it would name the wrong reader — the same harm this
+			// keying exists to prevent.
 			if ( '' === self::$store_api_expected_email ) {
-				self::$store_api_checkout = false;
-				return true;
+				return false;
 			}
 
 			if ( self::fold_email( $email ) === self::$store_api_expected_email ) {

--- a/plugins/newspack-plugin/tests/unit-tests/data-events-woo-user-registration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/data-events-woo-user-registration.php
@@ -169,6 +169,37 @@ class Newspack_Test_Woo_User_Registration extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Each checkout signal harvests its own campaign metadata. The Store API
+	 * batch route serves up to 25 requests in one PHP process, so a second
+	 * checkout must not inherit the first one's attribution.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_second_checkout_does_not_inherit_campaign_metadata() {
+		$this->stub_wc_with_cart(
+			[
+				'item1' => [
+					'newspack_popup_id' => 123,
+					'referer'           => '/donate/',
+				],
+			]
+		);
+		do_action( 'woocommerce_store_api_checkout_update_customer_from_request', null, new WP_REST_Request( 'POST', '/wc/store/v1/checkout' ) );
+		do_action( 'woocommerce_created_customer', self::factory()->user->create( [ 'user_email' => 'batch-first@example.test' ] ) );
+
+		// Second checkout in the same process, with nothing to harvest.
+		WC()->cart = new WC_Cart( [] );
+		do_action( 'woocommerce_store_api_checkout_update_customer_from_request', null, new WP_REST_Request( 'POST', '/wc/store/v1/checkout' ) );
+		do_action( 'woocommerce_created_customer', self::factory()->user->create( [ 'user_email' => 'batch-second@example.test' ] ) );
+
+		$this->assertCount( 2, $this->fired );
+		$this->assertArrayNotHasKey( 'newspack_popup_id', $this->fired[1]['metadata'], 'The second checkout should not inherit the first one\'s campaign attribution.' );
+		$this->assertArrayNotHasKey( 'referer', $this->fired[1]['metadata'] );
+		$this->assertSame( 123, $this->fired[0]['metadata']['newspack_popup_id'], 'The first checkout keeps its own attribution.' );
+	}
+
+	/**
 	 * Classic checkout keeps announcing (regression control).
 	 *
 	 * @runInSeparateProcess

--- a/plugins/newspack-plugin/tests/unit-tests/data-events-woo-user-registration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/data-events-woo-user-registration.php
@@ -223,6 +223,27 @@ class Newspack_Test_Woo_User_Registration extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A checkout announces the one account it creates. The Store API batch
+	 * route serves several sub-requests in a single PHP process, so the state a
+	 * checkout raises must not still be standing when an account is created
+	 * later in that process without a checkout of its own.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_checkout_state_is_consumed_by_the_account_it_announces() {
+		$this->stub_wc_with_cart();
+		do_action( 'woocommerce_store_api_checkout_update_customer_from_request', null, new WP_REST_Request( 'POST', '/wc/store/v1/checkout' ) );
+		do_action( 'woocommerce_created_customer', self::factory()->user->create( [ 'user_email' => 'checkout-account@example.test' ] ) );
+
+		// No second checkout signal: nothing announces this account.
+		do_action( 'woocommerce_created_customer', self::factory()->user->create( [ 'user_email' => 'unrelated-account@example.test' ] ) );
+
+		$this->assertCount( 1, $this->fired, 'Only the account its checkout created should be announced.' );
+		$this->assertSame( 'checkout-account@example.test', $this->fired[0]['email'] );
+	}
+
+	/**
 	 * Classic checkout keeps announcing (regression control).
 	 *
 	 * @runInSeparateProcess

--- a/plugins/newspack-plugin/tests/unit-tests/data-events-woo-user-registration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/data-events-woo-user-registration.php
@@ -169,6 +169,29 @@ class Newspack_Test_Woo_User_Registration extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A checkout signal that arrives with no cart still announces the customer.
+	 *
+	 * Both Store API routes load a cart before firing the signal, so an absent
+	 * cart is a guard against the unexpected rather than a path taken today.
+	 * What it pins down is the priority: harvesting campaign metadata is
+	 * best-effort, announcing the reader is not. Without the guard this test
+	 * dies on get_cart(), and the account goes unannounced.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_checkout_signal_without_cart_still_announces() {
+		$this->stub_wc_with_cart();
+		WC()->cart = null;
+		do_action( 'woocommerce_store_api_checkout_update_customer_from_request', null, new WP_REST_Request( 'POST', '/wc/store/v1/checkout' ) );
+		$user_id = self::factory()->user->create( [ 'user_email' => 'no-cart@example.test' ] );
+		do_action( 'woocommerce_created_customer', $user_id );
+
+		$this->assertCount( 1, $this->fired, 'A checkout signal with no cart must still let the watcher announce the new customer.' );
+		$this->assertSame( 'woocommerce', $this->fired[0]['metadata']['registration_method'] );
+	}
+
+	/**
 	 * Each checkout signal harvests its own campaign metadata. The Store API
 	 * batch route serves up to 25 requests in one PHP process, so a second
 	 * checkout must not inherit the first one's attribution.

--- a/plugins/newspack-plugin/tests/unit-tests/data-events-woo-user-registration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/data-events-woo-user-registration.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Tests the Woo_User_Registration data-events watcher.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Data_Events\Woo_User_Registration;
+use Newspack\Reader_Activation;
+
+require_once __DIR__ . '/../mocks/wc-mocks.php';
+
+/**
+ * Test the Woo_User_Registration checkout watcher.
+ *
+ * The watcher announces accounts WooCommerce creates during checkout by
+ * dispatching `newspack_registered_reader_via_woo`, which feeds the
+ * `reader_registered` data event and session hydration. It must speak for both
+ * WooCommerce checkout pipelines — classic and Store API (the Apple Pay /
+ * Google Pay transport) — and stay silent for account creation outside a
+ * checkout.
+ *
+ * The checkout-signal tests run in separate processes because the watcher's
+ * signal handler reads WC()->cart, so they stub WC() — which must not leak
+ * into the rest of the suite, whose WooCommerce-absent tests rely on
+ * function_exists( 'WC' ) staying false. Pattern follows
+ * my-account.php::test_woocommerce_delegation.
+ *
+ * @group data-events
+ */
+class Newspack_Test_Woo_User_Registration extends WP_UnitTestCase {
+
+	/**
+	 * Captured newspack_registered_reader_via_woo dispatches.
+	 *
+	 * @var array
+	 */
+	private $fired = [];
+
+	/**
+	 * Set up: reset watcher state and capture the action.
+	 */
+	public function set_up() {
+		parent::set_up();
+		self::reset_watcher_state();
+		$this->fired = [];
+		add_action( 'newspack_registered_reader_via_woo', [ $this, 'capture_event' ], 10, 3 );
+	}
+
+	/**
+	 * Tear down: drop the capture hook, reset watcher state.
+	 */
+	public function tear_down() {
+		remove_action( 'newspack_registered_reader_via_woo', [ $this, 'capture_event' ], 10 );
+		self::reset_watcher_state();
+		parent::tear_down();
+	}
+
+	/**
+	 * Record a dispatched registration announcement.
+	 *
+	 * @param string $email    Email address.
+	 * @param int    $user_id  The created user id.
+	 * @param array  $metadata Metadata.
+	 */
+	public function capture_event( $email, $user_id, $metadata ) {
+		$this->fired[] = [
+			'email'    => $email,
+			'user_id'  => $user_id,
+			'metadata' => $metadata,
+		];
+	}
+
+	/**
+	 * Reset the watcher's static request-scoped state between tests.
+	 */
+	private static function reset_watcher_state() {
+		$ref = new ReflectionClass( Woo_User_Registration::class );
+		foreach ( [
+			'processing_checkout' => false,
+			'metadata'            => [],
+		] as $prop => $value ) {
+			$property = $ref->getProperty( $prop );
+			$property->setAccessible( true );
+			$property->setValue( null, $value );
+		}
+	}
+
+	/**
+	 * Stub WC() with a cart, in this process only.
+	 *
+	 * Only callable from tests annotated `@runInSeparateProcess` — a plain test
+	 * calling this would define WC() for the remainder of the main suite
+	 * process and flip its WooCommerce-absent gates.
+	 *
+	 * @param array $cart_contents Cart contents keyed by cart item key.
+	 */
+	private function stub_wc_with_cart( array $cart_contents = [] ) {
+		if ( ! $this->isInIsolation() ) {
+			$this->fail( 'stub_wc_with_cart() may only be called from @runInSeparateProcess tests — defining WC() in the main suite process would flip function_exists( "WC" ) gates for every later test in the run.' );
+		}
+		if ( ! function_exists( 'WC' ) ) {
+			/**
+			 * Mock WC() function returning a controllable container.
+			 *
+			 * @return object
+			 */
+			function WC() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid, WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Mock WooCommerce global, isolated to a separate test process.
+				global $newspack_test_wc;
+				if ( empty( $newspack_test_wc ) ) {
+					$newspack_test_wc = new class() {
+						/**
+						 * Cart double, set by tests.
+						 *
+						 * @var object|null
+						 */
+						public $cart = null;
+					};
+				}
+				return $newspack_test_wc;
+			}
+		}
+		WC()->cart = new WC_Cart( $cart_contents );
+	}
+
+	/**
+	 * A Store API checkout (the wallet transport) announces the customer it
+	 * creates: the pre-creation signal arrives, then the account exists.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_store_api_checkout_announces_created_customer() {
+		$this->stub_wc_with_cart();
+		do_action( 'woocommerce_store_api_checkout_update_customer_from_request', null, new WP_REST_Request( 'POST', '/wc/store/v1/checkout' ) );
+		$user_id = self::factory()->user->create( [ 'user_email' => 'store-api-reader@example.test' ] );
+		do_action( 'woocommerce_created_customer', $user_id );
+
+		$this->assertCount( 1, $this->fired, 'The Store API checkout signal should let the watcher announce the new customer.' );
+		$this->assertSame( 'store-api-reader@example.test', $this->fired[0]['email'] );
+		$this->assertSame( $user_id, $this->fired[0]['user_id'] );
+		$this->assertSame( 'woocommerce', $this->fired[0]['metadata']['registration_method'] );
+		$this->assertSame( 'woocommerce', get_user_meta( $user_id, Reader_Activation::REGISTRATION_METHOD, true ) );
+	}
+
+	/**
+	 * The Store API signal harvests campaign metadata from the cart the same
+	 * way the classic signal does.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_store_api_checkout_harvests_cart_campaign_metadata() {
+		$this->stub_wc_with_cart(
+			[
+				'item1' => [
+					'newspack_popup_id' => 123,
+					'referer'           => '/donate/',
+				],
+			]
+		);
+		do_action( 'woocommerce_store_api_checkout_update_customer_from_request', null, new WP_REST_Request( 'POST', '/wc/store/v1/checkout' ) );
+		$user_id = self::factory()->user->create( [ 'user_email' => 'store-api-campaign@example.test' ] );
+		do_action( 'woocommerce_created_customer', $user_id );
+
+		$this->assertCount( 1, $this->fired );
+		$this->assertSame( 123, $this->fired[0]['metadata']['newspack_popup_id'] );
+		$this->assertSame( '/donate/', $this->fired[0]['metadata']['referer'] );
+	}
+
+	/**
+	 * Classic checkout keeps announcing (regression control).
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_classic_checkout_announces_created_customer() {
+		$this->stub_wc_with_cart();
+		do_action( 'woocommerce_checkout_process' );
+		$user_id = self::factory()->user->create( [ 'user_email' => 'classic-reader@example.test' ] );
+		do_action( 'woocommerce_created_customer', $user_id );
+
+		$this->assertCount( 1, $this->fired );
+		$this->assertSame( 'woocommerce', $this->fired[0]['metadata']['registration_method'] );
+	}
+
+	/**
+	 * Account creation with no checkout signal stays silent — only
+	 * checkout-created accounts announce a reader. Runs in the main process:
+	 * it needs no WC() and proves the guard without any WooCommerce present.
+	 */
+	public function test_created_customer_without_checkout_signal_stays_silent() {
+		$user_id = self::factory()->user->create( [ 'user_email' => 'no-checkout@example.test' ] );
+		do_action( 'woocommerce_created_customer', $user_id );
+
+		$this->assertCount( 0, $this->fired, 'Account creation outside a checkout must not announce a reader.' );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/data-events/class-woo-user-registration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/data-events/class-woo-user-registration.php
@@ -77,10 +77,10 @@ class Newspack_Test_Data_Events_Woo_User_Registration extends WP_UnitTestCase {
 	private static function reset_watcher_state() {
 		$ref = new ReflectionClass( Woo_User_Registration::class );
 		foreach ( [
-			'processing_checkout'       => false,
-			'store_api_checkout'        => false,
-			'store_api_expected_email'  => '',
-			'metadata'                  => [],
+			'processing_checkout'      => false,
+			'store_api_checkout'       => false,
+			'store_api_expected_email' => '',
+			'metadata'                 => [],
 		] as $prop => $value ) {
 			$property = $ref->getProperty( $prop );
 			$property->setAccessible( true );

--- a/plugins/newspack-plugin/tests/unit-tests/data-events/class-woo-user-registration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/data-events/class-woo-user-registration.php
@@ -77,8 +77,10 @@ class Newspack_Test_Data_Events_Woo_User_Registration extends WP_UnitTestCase {
 	private static function reset_watcher_state() {
 		$ref = new ReflectionClass( Woo_User_Registration::class );
 		foreach ( [
-			'processing_checkout' => false,
-			'metadata'            => [],
+			'processing_checkout'       => false,
+			'store_api_checkout'        => false,
+			'store_api_expected_email'  => '',
+			'metadata'                  => [],
 		] as $prop => $value ) {
 			$property = $ref->getProperty( $prop );
 			$property->setAccessible( true );

--- a/plugins/newspack-plugin/tests/unit-tests/data-events/class-woo-user-registration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/data-events/class-woo-user-registration.php
@@ -378,25 +378,22 @@ class Newspack_Test_Data_Events_Woo_User_Registration extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A Store API signal carrying no email falls back to announcing the first
-	 * account created.
+	 * A Store API signal carrying no email announces nothing.
 	 *
-	 * Covers the fallback branch on purpose, and is the only test that does.
-	 * WooCommerce refuses to create an account without a billing email, so this
-	 * branch is not reachable on the announce path in production — it exists so
-	 * an unexpected empty signal degrades to the old behaviour rather than
-	 * silently announcing nothing.
+	 * WooCommerce refuses to create a customer without a valid billing address,
+	 * so a signal with no email is followed by no account of its own. Anything
+	 * created while it stands belongs to something else in the request, and
+	 * announcing it would name the wrong reader.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test_store_api_signal_without_an_email_announces_the_first_account() {
+	public function test_store_api_signal_without_an_email_announces_nothing() {
 		$this->stub_wc_with_cart();
 		$this->store_api_signal( null );
-		$user_id = self::factory()->user->create( [ 'user_email' => 'fallback@example.test' ] );
+		$user_id = self::factory()->user->create( [ 'user_email' => 'unrelated@example.test' ] );
 		do_action( 'woocommerce_created_customer', $user_id );
 
-		$this->assertCount( 1, $this->fired, 'An empty signal must degrade to announcing the first account, not to silence.' );
-		$this->assertSame( $user_id, $this->fired[0]['user_id'] );
+		$this->assertCount( 0, $this->fired, 'A signal with no email must not announce an account that cannot be its own.' );
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/data-events/class-woo-user-registration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/data-events/class-woo-user-registration.php
@@ -8,7 +8,7 @@
 use Newspack\Data_Events\Woo_User_Registration;
 use Newspack\Reader_Activation;
 
-require_once __DIR__ . '/../mocks/wc-mocks.php';
+require_once __DIR__ . '/../../mocks/wc-mocks.php';
 
 /**
  * Test the Woo_User_Registration checkout watcher.
@@ -28,7 +28,7 @@ require_once __DIR__ . '/../mocks/wc-mocks.php';
  *
  * @group data-events
  */
-class Newspack_Test_Woo_User_Registration extends WP_UnitTestCase {
+class Newspack_Test_Data_Events_Woo_User_Registration extends WP_UnitTestCase {
 
 	/**
 	 * Captured newspack_registered_reader_via_woo dispatches.
@@ -124,6 +124,22 @@ class Newspack_Test_Woo_User_Registration extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Fire the Store API checkout signal.
+	 *
+	 * @param string|null $billing_email Billing email the checkout carries, or
+	 *                                   null to fire the signal without a
+	 *                                   customer at all.
+	 */
+	private function store_api_signal( $billing_email = null ) {
+		$customer = null;
+		if ( null !== $billing_email ) {
+			$customer = new WC_Customer( 0 );
+			$customer->set_billing_email( $billing_email );
+		}
+		do_action( 'woocommerce_store_api_checkout_update_customer_from_request', $customer, new WP_REST_Request( 'POST', '/wc/store/v1/checkout' ) );
+	}
+
+	/**
 	 * A Store API checkout (the wallet transport) announces the customer it
 	 * creates: the pre-creation signal arrives, then the account exists.
 	 *
@@ -132,7 +148,7 @@ class Newspack_Test_Woo_User_Registration extends WP_UnitTestCase {
 	 */
 	public function test_store_api_checkout_announces_created_customer() {
 		$this->stub_wc_with_cart();
-		do_action( 'woocommerce_store_api_checkout_update_customer_from_request', null, new WP_REST_Request( 'POST', '/wc/store/v1/checkout' ) );
+		$this->store_api_signal( 'store-api-reader@example.test' );
 		$user_id = self::factory()->user->create( [ 'user_email' => 'store-api-reader@example.test' ] );
 		do_action( 'woocommerce_created_customer', $user_id );
 
@@ -159,7 +175,7 @@ class Newspack_Test_Woo_User_Registration extends WP_UnitTestCase {
 				],
 			]
 		);
-		do_action( 'woocommerce_store_api_checkout_update_customer_from_request', null, new WP_REST_Request( 'POST', '/wc/store/v1/checkout' ) );
+		$this->store_api_signal( 'store-api-campaign@example.test' );
 		$user_id = self::factory()->user->create( [ 'user_email' => 'store-api-campaign@example.test' ] );
 		do_action( 'woocommerce_created_customer', $user_id );
 
@@ -183,7 +199,7 @@ class Newspack_Test_Woo_User_Registration extends WP_UnitTestCase {
 	public function test_checkout_signal_without_cart_still_announces() {
 		$this->stub_wc_with_cart();
 		WC()->cart = null;
-		do_action( 'woocommerce_store_api_checkout_update_customer_from_request', null, new WP_REST_Request( 'POST', '/wc/store/v1/checkout' ) );
+		$this->store_api_signal( 'no-cart@example.test' );
 		$user_id = self::factory()->user->create( [ 'user_email' => 'no-cart@example.test' ] );
 		do_action( 'woocommerce_created_customer', $user_id );
 
@@ -208,12 +224,12 @@ class Newspack_Test_Woo_User_Registration extends WP_UnitTestCase {
 				],
 			]
 		);
-		do_action( 'woocommerce_store_api_checkout_update_customer_from_request', null, new WP_REST_Request( 'POST', '/wc/store/v1/checkout' ) );
+		$this->store_api_signal( 'batch-first@example.test' );
 		do_action( 'woocommerce_created_customer', self::factory()->user->create( [ 'user_email' => 'batch-first@example.test' ] ) );
 
 		// Second checkout in the same process, with nothing to harvest.
 		WC()->cart = new WC_Cart( [] );
-		do_action( 'woocommerce_store_api_checkout_update_customer_from_request', null, new WP_REST_Request( 'POST', '/wc/store/v1/checkout' ) );
+		$this->store_api_signal( 'batch-second@example.test' );
 		do_action( 'woocommerce_created_customer', self::factory()->user->create( [ 'user_email' => 'batch-second@example.test' ] ) );
 
 		$this->assertCount( 2, $this->fired );
@@ -233,7 +249,7 @@ class Newspack_Test_Woo_User_Registration extends WP_UnitTestCase {
 	 */
 	public function test_checkout_state_is_consumed_by_the_account_it_announces() {
 		$this->stub_wc_with_cart();
-		do_action( 'woocommerce_store_api_checkout_update_customer_from_request', null, new WP_REST_Request( 'POST', '/wc/store/v1/checkout' ) );
+		$this->store_api_signal( 'checkout-account@example.test' );
 		do_action( 'woocommerce_created_customer', self::factory()->user->create( [ 'user_email' => 'checkout-account@example.test' ] ) );
 
 		// No second checkout signal: nothing announces this account.
@@ -244,19 +260,36 @@ class Newspack_Test_Woo_User_Registration extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Classic checkout keeps announcing (regression control).
+	 * Classic checkout keeps announcing, campaign attribution intact.
+	 *
+	 * The control for the claim that this branch leaves the classic pipeline
+	 * alone, so it asserts something the classic path alone produces. Asserting
+	 * registration_method would not: created_customer() sets that for whichever
+	 * pipeline announced. newspack_popup_id only survives if the classic signal
+	 * harvested the cart, which is the behaviour at risk.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	public function test_classic_checkout_announces_created_customer() {
-		$this->stub_wc_with_cart();
+		$this->stub_wc_with_cart(
+			[
+				'item1' => [
+					'newspack_popup_id' => 456,
+					'prompt_title'      => 'Winter drive',
+					'referer'           => '/support-us/',
+				],
+			]
+		);
 		do_action( 'woocommerce_checkout_process' );
 		$user_id = self::factory()->user->create( [ 'user_email' => 'classic-reader@example.test' ] );
 		do_action( 'woocommerce_created_customer', $user_id );
 
 		$this->assertCount( 1, $this->fired );
 		$this->assertSame( 'woocommerce', $this->fired[0]['metadata']['registration_method'] );
+		$this->assertSame( 456, $this->fired[0]['metadata']['newspack_popup_id'], 'The classic signal must still harvest the cart it checks out.' );
+		$this->assertSame( 'Winter drive', $this->fired[0]['metadata']['prompt_title'] );
+		$this->assertSame( '/support-us/', $this->fired[0]['metadata']['referer'] );
 	}
 
 	/**
@@ -269,5 +302,101 @@ class Newspack_Test_Woo_User_Registration extends WP_UnitTestCase {
 		do_action( 'woocommerce_created_customer', $user_id );
 
 		$this->assertCount( 0, $this->fired, 'Account creation outside a checkout must not announce a reader.' );
+	}
+
+	/**
+	 * A Store API checkout announces only the account it is creating.
+	 *
+	 * The signal fires on every block-checkout POST, including a logged-in
+	 * shopper's, where no account follows it. Keying the state to the email the
+	 * checkout expects stops that standing state from speaking for an unrelated
+	 * account created later in the same process.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_store_api_checkout_does_not_announce_a_different_account() {
+		$this->stub_wc_with_cart();
+		$this->store_api_signal( 'expected-buyer@example.test' );
+
+		// An account that is not this checkout's buyer — a gift recipient, or any
+		// creation that happens to land in the same process.
+		do_action( 'woocommerce_created_customer', self::factory()->user->create( [ 'user_email' => 'someone-else@example.test' ] ) );
+
+		$this->assertCount( 0, $this->fired, 'A Store API checkout must not announce an account it did not create.' );
+
+		// A non-match must not disarm the checkout: the buyer's own account
+		// arriving afterwards is still this checkout's to announce.
+		$buyer_id = self::factory()->user->create( [ 'user_email' => 'expected-buyer@example.test' ] );
+		do_action( 'woocommerce_created_customer', $buyer_id );
+
+		$this->assertCount( 1, $this->fired, 'The expected account must still announce when it arrives after an unrelated one.' );
+		$this->assertSame( $buyer_id, $this->fired[0]['user_id'] );
+	}
+
+	/**
+	 * Classic checkout announces every account it creates.
+	 *
+	 * Subscriptions Gifting creates a second account during a classic checkout —
+	 * the gift recipient — on the order-status transition. Both reached the
+	 * announcement before this branch, and the Store API fix must not narrow
+	 * that to the first one.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_classic_checkout_announces_every_account_it_creates() {
+		$this->stub_wc_with_cart();
+		do_action( 'woocommerce_checkout_process' );
+		do_action( 'woocommerce_created_customer', self::factory()->user->create( [ 'user_email' => 'classic-buyer@example.test' ] ) );
+		do_action( 'woocommerce_created_customer', self::factory()->user->create( [ 'user_email' => 'classic-recipient@example.test' ] ) );
+
+		$this->assertCount( 2, $this->fired, 'Classic checkout announced both accounts before this branch; it must still do so.' );
+		$this->assertSame( 'classic-buyer@example.test', $this->fired[0]['email'] );
+		$this->assertSame( 'classic-recipient@example.test', $this->fired[1]['email'] );
+	}
+
+	/**
+	 * The expected email matches the created account regardless of case.
+	 *
+	 * The customer object carries the address as it was posted; the user record
+	 * carries it as WordPress saved it, and email_exists() treats the two as the
+	 * same account case-insensitively. Comparing them raw would reject a
+	 * legitimate account and put the original bug back with the suite green.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_store_api_checkout_matches_the_account_regardless_of_email_case() {
+		$this->stub_wc_with_cart();
+		$this->store_api_signal( '  Mixed.Case@Example.test ' );
+		$user_id = self::factory()->user->create( [ 'user_email' => 'mixed.case@example.test' ] );
+		do_action( 'woocommerce_created_customer', $user_id );
+
+		$this->assertCount( 1, $this->fired, 'A case or whitespace difference must not stop the checkout announcing its own buyer.' );
+		$this->assertSame( $user_id, $this->fired[0]['user_id'] );
+	}
+
+	/**
+	 * A Store API signal carrying no email falls back to announcing the first
+	 * account created.
+	 *
+	 * Covers the fallback branch on purpose, and is the only test that does.
+	 * WooCommerce refuses to create an account without a billing email, so this
+	 * branch is not reachable on the announce path in production — it exists so
+	 * an unexpected empty signal degrades to the old behaviour rather than
+	 * silently announcing nothing.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_store_api_signal_without_an_email_announces_the_first_account() {
+		$this->stub_wc_with_cart();
+		$this->store_api_signal( null );
+		$user_id = self::factory()->user->create( [ 'user_email' => 'fallback@example.test' ] );
+		do_action( 'woocommerce_created_customer', $user_id );
+
+		$this->assertCount( 1, $this->fired, 'An empty signal must degrade to announcing the first account, not to silence.' );
+		$this->assertSame( $user_id, $this->fired[0]['user_id'] );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When a reader creates an account during checkout, Newspack dispatches `newspack_registered_reader_via_woo`. Two subscribers hang off it: the `reader_registered` data event, which carries the reader to the other sites in a network and to the publisher's email service, and session hydration, which binds the analytics client ID and sets the reader auth cookie.

Checkouts through WooCommerce's Store API never dispatch it. The existing check waits for a signal only the classic checkout emits, and the Store API does not emit it, so the account is created and both subscribers are skipped. Wallet payments joined that transport when woocommerce-gateway-stripe 9.2.0 made the Blocks API its default for express checkout, so no Newspack code changed. This affects express wallet buttons (Apple Pay, Google Pay) and the block checkout page alike. On a site using the block checkout, that is most checkout registrations.

The existing handler now also subscribes to the Store API's own pre-account-creation signal, so both pipelines announce the accounts they create, with the same campaign metadata.

Reference: NPPM-3147.

### How to test the changes in this Pull Request:

**Setup.** All three are required; none is the default on a stock install.

1. On a site with WooCommerce and reader activation, create a page containing the Checkout block. The default checkout page uses the `[woocommerce_checkout]` shortcode, which posts through the classic pipeline and will not exercise this change.
2. Confirm `woocommerce_enable_signup_and_login_from_checkout` is `yes`. Newspack's WooCommerce setup already sets it, and the Store API refuses to create an account without it.
3. Enable an offline payment gateway (WooCommerce → Settings → Payments → Cash on delivery) and make sure a purchasable product exists. Neither is present on a stock install.

**Reproduce the problem** on `release`.

3. Add a product to the cart. Check out on the block page with a brand-new email.
4. The order completes and an account is created for that email. No `reader_registered` event fires — though other events will, and seeing them confirms the logging works. Watch the hub event log, or drop a mu-plugin that hooks `newspack_data_event` and writes each event name to `debug.log`.

**Verify the fix** on this branch.

5. In a new private window, repeat step 3 with a second brand-new email. A `reader_registered` event fires carrying `registration_method: woocommerce`.
6. In a new private window, add the product to the cart again, then check out with a third new email through the classic checkout form at `/checkout/?modal_checkout=1`. The event fires exactly once.
7. Still signed in as the account from step 6, add the product again and check out on the block page. No `reader_registered` event fires.

The block checkout shows no "Create an account" checkbox, and that is expected: reader activation turns guest checkout off, so WooCommerce requires an account and stops offering the choice. Every guest checkout creates one. Each completed checkout also signs the tester in as the account it created, which is why steps 5 and 6 each start in a new private window.

Express wallet buttons submit through the same Store API transport as the block checkout, so steps 3 and 5 exercise the wallet path without configuring Stripe.

### Release risk: High

| Signal | Score | Evidence |
|--------|-------|----------|
| Contract surface | Medium | `data-events`; an existing event fires under wider conditions, no signature change |
| Surface type | Medium | Hook subscription inside a checkout flow. Decides no charge or access outcome, but does start session hydration where it previously did not run |
| Publisher exposure | High | Foundation code, no flag; every site with WooCommerce, reader activation, and a Store API checkout |
| Change shape | Medium | +33/-9 production in one file, which took a prior fix in #4310; seven tests added |

High because of publisher exposure: foundation code with no flag, on every site with WooCommerce, reader activation, and a Store API checkout. The other three signals are Medium. Verified locally against the base commit in one environment: without the change, a Store API checkout creates the order and the account and announces nothing; with it, `reader_registered` fires once carrying `registration_method: woocommerce`. Two review findings — both cases of checkout state outliving the checkout that set it, reachable because the block checkout routinely batches several Store API requests into one PHP process — were reproduced, fixed, and covered by tests.

Worth testing harder on: announcement volume on a site using the block checkout. The subscribed hook is not wallet-specific, so counts rise on first deploy by design.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Seven new tests cover both pipelines, the campaign-metadata harvest, batch isolation, checkout-state consumption, and the no-signal guard. Full suite 2751 passing.

**Scope of the change.** This restores the registration dispatch and both of its subscribers, on both checkout pipelines. Membership access is unchanged: access to a network-wide tier travels on a separate event that fires when the membership record is written, regardless of checkout transport. Verified on a hub-and-node pair, where a buyer with no registration announcement still arrived on the node as an active member of the network tier.

**Two known limits, both pre-existing and out of scope.** Store API registrations sync to the ESP without a `REGISTRATION_PAGE` value: the referer-based branch needs request parameters the JSON transport doesn't carry. Order-completed sync already pushes the same empty value, so nothing regresses. And WooCommerce's delayed-account-creation flow, where an account is created later from the order-confirmation page, is announced by neither pipeline; that gap predates this change.



