### PR TITLE
fix(newsletters): persist list appearance and cut load time (NPPM-3140)

### DIFF
--- a/plugins/newspack-newsletters/includes/admin/class-admin-shell-assets.php
+++ b/plugins/newspack-newsletters/includes/admin/class-admin-shell-assets.php
@@ -51,6 +51,16 @@ class Admin_Shell_Assets {
 
 		$current_page->enqueue_extras( self::SCRIPT_HANDLE );
 
+		// `wp_localize_script` interpolates `wp_json_encode()`'s return without
+		// checking it, so one unencodable value would print the global as a
+		// syntax error and stop the app booting, on every screen, with no way
+		// back through the UI. Preferences come from user meta, which anything
+		// can write.
+		$view_prefs = Admin_Shell_Preferences::get_preferences();
+		if ( false === wp_json_encode( $view_prefs ) ) {
+			$view_prefs = [];
+		}
+
 		wp_localize_script(
 			self::SCRIPT_HANDLE,
 			'newspackNewslettersAdmin',
@@ -66,7 +76,7 @@ class Admin_Shell_Assets {
 				'cptSlug'         => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 				'serviceProvider' => Newspack_Newsletters::service_provider(),
 				// Object-shaped even when empty so the JS side always sees a map.
-				'viewPrefs'       => (object) Admin_Shell_Preferences::get_preferences(),
+				'viewPrefs'       => (object) $view_prefs,
 			]
 		);
 	}

--- a/plugins/newspack-newsletters/includes/admin/class-admin-shell-collection-params.php
+++ b/plugins/newspack-newsletters/includes/admin/class-admin-shell-collection-params.php
@@ -10,6 +10,7 @@ namespace Newspack\Newsletters\Admin;
 use Newspack_Newsletters;
 use Newspack_Newsletters\Ads;
 use Newspack_Newsletters_Layouts;
+use WP_Error;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -24,9 +25,20 @@ defined( 'ABSPATH' ) || exit;
  * count, not the query, is what a publisher waits on. Raising the
  * ceiling lets the client walk the same collection in far fewer trips.
  *
+ * The cost this trades against is memory: `WP_Query` selects whole rows,
+ * so a page holds that many `WP_Post` objects, `post_content` included,
+ * whatever `_fields` the client asks for. Measured at roughly 3.3KB per
+ * row before content, so the ceiling itself is a few megabytes and the
+ * rest scales with how long a site's newsletters are.
+ *
  * The walk still chunks rather than asking for everything at once, so a
  * site with thousands of newsletters can't turn one request into a
  * multi-megabyte response.
+ *
+ * The raise is gated on the capability the list screens already require:
+ * the newsletters CPT is public, so without a gate any anonymous caller
+ * could ask one request to render ten times as many rows through the
+ * full `the_content` chain as core's ceiling allows.
  *
  * This is not the per-page value the controls offer — that stays at 100
  * (`Admin_Shell_Preferences::PER_PAGE_MAX`).
@@ -38,6 +50,11 @@ class Admin_Shell_Collection_Params {
 	 * together.
 	 */
 	const MAX_PER_PAGE = 1000;
+
+	/**
+	 * Core's own ceiling, and the most an unprivileged caller may ask for.
+	 */
+	const CORE_MAX_PER_PAGE = 100;
 
 	/**
 	 * Boot hooks.
@@ -80,8 +97,44 @@ class Admin_Shell_Collection_Params {
 	 */
 	public static function raise_per_page_cap( $params ) {
 		if ( isset( $params['per_page'] ) && is_array( $params['per_page'] ) ) {
-			$params['per_page']['maximum'] = self::MAX_PER_PAGE;
+			$params['per_page']['maximum']           = self::MAX_PER_PAGE;
+			$params['per_page']['validate_callback'] = [ __CLASS__, 'validate_per_page' ];
 		}
 		return $params;
+	}
+
+	/**
+	 * Hold unprivileged callers to core's ceiling.
+	 *
+	 * The capability check can't live in `raise_per_page_cap()`: collection
+	 * params are filtered on `rest_api_init`, and resolving the current
+	 * user that early pre-empts `rest_authentication_errors`, which breaks
+	 * application-password auth. A validate callback runs at dispatch,
+	 * after authentication has settled.
+	 *
+	 * @param mixed            $value   Submitted value.
+	 * @param \WP_REST_Request $request Incoming request.
+	 * @param string           $param   Parameter name.
+	 * @return true|WP_Error
+	 */
+	public static function validate_per_page( $value, $request, $param ) {
+		$valid = rest_validate_request_arg( $value, $request, $param );
+		if ( is_wp_error( $valid ) ) {
+			return $valid;
+		}
+
+		if ( (int) $value > self::CORE_MAX_PER_PAGE && ! current_user_can( 'edit_posts' ) ) {
+			return new WP_Error(
+				'rest_invalid_param',
+				sprintf(
+					/* translators: %d: the highest per_page value available to this user. */
+					__( 'per_page must be %d or fewer.', 'newspack-newsletters' ),
+					self::CORE_MAX_PER_PAGE
+				),
+				[ 'status' => 400 ]
+			);
+		}
+
+		return true;
 	}
 }

--- a/plugins/newspack-newsletters/includes/admin/class-admin-shell-collection-params.php
+++ b/plugins/newspack-newsletters/includes/admin/class-admin-shell-collection-params.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Admin shell — REST collection parameters.
+ *
+ * @package Newspack_Newsletters
+ */
+
+namespace Newspack\Newsletters\Admin;
+
+use Newspack_Newsletters;
+use Newspack_Newsletters\Ads;
+use Newspack_Newsletters_Layouts;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Raises the `per_page` ceiling on the collections the admin-shell list
+ * screens read.
+ *
+ * Core caps `per_page` at 100, which is what makes the "All" option fan
+ * out into one request per 100 rows. At that size the response itself is
+ * cheap (roughly 0.13s of server time per 100 newsletters) while each
+ * extra round trip costs the full WordPress bootstrap, so the request
+ * count, not the query, is what a publisher waits on. Raising the
+ * ceiling lets the client walk the same collection in far fewer trips.
+ *
+ * The walk still chunks rather than asking for everything at once, so a
+ * site with thousands of newsletters can't turn one request into a
+ * multi-megabyte response.
+ *
+ * This is not the per-page value the controls offer — that stays at 100
+ * (`Admin_Shell_Preferences::PER_PAGE_MAX`).
+ */
+class Admin_Shell_Collection_Params {
+	/**
+	 * The `per_page` ceiling these collections accept. Mirrored client
+	 * side by `FETCH_ALL_CHUNK_SIZE` in `utils/per-page.js`; change both
+	 * together.
+	 */
+	const MAX_PER_PAGE = 1000;
+
+	/**
+	 * Boot hooks.
+	 *
+	 * Registered on `rest_api_init` rather than at load time because the
+	 * CPTs and taxonomies these filters name are registered on `init`.
+	 */
+	public static function init(): void {
+		add_action( 'rest_api_init', [ __CLASS__, 'register_filters' ] );
+	}
+
+	/**
+	 * Hook the cap onto every collection the list screens read.
+	 */
+	public static function register_filters(): void {
+		foreach ( self::get_collections() as $rest_base ) {
+			add_filter( 'rest_' . $rest_base . '_collection_params', [ __CLASS__, 'raise_per_page_cap' ] );
+		}
+	}
+
+	/**
+	 * The post types and taxonomies whose collections back a list screen.
+	 *
+	 * @return array<string>
+	 */
+	public static function get_collections(): array {
+		return [
+			Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+			Ads::CPT,
+			Ads::ADVERTISER_TAX,
+			Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT,
+		];
+	}
+
+	/**
+	 * Raise the collection's `per_page` maximum.
+	 *
+	 * @param array $params Collection parameters.
+	 * @return array
+	 */
+	public static function raise_per_page_cap( $params ) {
+		if ( isset( $params['per_page'] ) && is_array( $params['per_page'] ) ) {
+			$params['per_page']['maximum'] = self::MAX_PER_PAGE;
+		}
+		return $params;
+	}
+}

--- a/plugins/newspack-newsletters/includes/admin/class-admin-shell-collection-params.php
+++ b/plugins/newspack-newsletters/includes/admin/class-admin-shell-collection-params.php
@@ -70,8 +70,8 @@ class Admin_Shell_Collection_Params {
 	 * Hook the cap onto every collection the list screens read.
 	 */
 	public static function register_filters(): void {
-		foreach ( self::get_collections() as $rest_base ) {
-			add_filter( 'rest_' . $rest_base . '_collection_params', [ __CLASS__, 'raise_per_page_cap' ] );
+		foreach ( self::get_collections() as $collection ) {
+			add_filter( 'rest_' . $collection . '_collection_params', [ __CLASS__, 'raise_per_page_cap' ] );
 		}
 	}
 

--- a/plugins/newspack-newsletters/includes/admin/class-admin-shell-preferences.php
+++ b/plugins/newspack-newsletters/includes/admin/class-admin-shell-preferences.php
@@ -119,17 +119,18 @@ class Admin_Shell_Preferences {
 	 * @return array
 	 */
 	private static function get_prefs_schema(): array {
+		// Sanitised rather than rejected: DataViews owns this shape, and
+		// schema validation fails the whole request on the first unknown
+		// key, so one added property would silently stop every appearance
+		// setting persisting. `sanitize_column_style()` allowlists the same
+		// four keys on write and on read.
 		$column_style = [
-			'type'                 => 'object',
-			'additionalProperties' => false,
-			'properties'           => [
+			'type'       => 'object',
+			'properties' => [
 				'width'    => [ 'type' => [ 'string', 'integer' ] ],
 				'minWidth' => [ 'type' => [ 'string', 'integer' ] ],
 				'maxWidth' => [ 'type' => [ 'string', 'integer' ] ],
-				'align'    => [
-					'type' => 'string',
-					'enum' => self::ALIGNMENTS,
-				],
+				'align'    => [ 'type' => 'string' ],
 			],
 		];
 
@@ -423,7 +424,15 @@ class Admin_Shell_Preferences {
 	 * @return string
 	 */
 	public static function get_user_meta_key( string $screen_key ): string {
-		return self::USER_META_KEY_PREFIX . $screen_key;
+		global $wpdb;
+
+		// `usermeta` is network-global, so on multisite a bare key would
+		// share one list configuration across every site in the network.
+		// Single-site installs keep the unprefixed key so preferences saved
+		// before this survive.
+		$prefix = is_multisite() ? $wpdb->get_blog_prefix() : '';
+
+		return $prefix . self::USER_META_KEY_PREFIX . $screen_key;
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/admin/class-admin-shell-preferences.php
+++ b/plugins/newspack-newsletters/includes/admin/class-admin-shell-preferences.php
@@ -22,9 +22,9 @@ defined( 'ABSPATH' ) || exit;
  * each other via a shared read-modify-write.
  *
  * The stored shape is the presentation half of the DataViews `view`:
- * layout type, sort, visible fields (in their display order), and the
- * per-layout settings (density, column widths, grid preview size), plus
- * items per page. Query state — page, search and filters — is
+ * layout type, sort, visible fields (in their display order and with
+ * their toggles), and the per-layout settings (density, column widths,
+ * grid preview size), plus items per page. Query state — page, search and filters — is
  * deliberately not stored, matching classic Screen Options: a saved
  * list configuration, not a saved query.
  *
@@ -126,17 +126,15 @@ class Admin_Shell_Preferences {
 	 * @return array
 	 */
 	private static function get_prefs_schema(): array {
-		// Sanitised rather than rejected: DataViews owns this shape, and
-		// schema validation fails the whole request on the first unknown
-		// key, so one added property would silently stop every appearance
-		// setting persisting. `sanitize_column_style()` allowlists the same
-		// four keys on write and on read.
+		// Sanitised rather than rejected: schema validation fails the whole
+		// request on the first unknown key, so one property added upstream
+		// would silently stop every appearance setting persisting.
 		$column_style = [
 			'type'       => 'object',
 			'properties' => [
-				'width'    => [ 'type' => [ 'string', 'integer' ] ],
-				'minWidth' => [ 'type' => [ 'string', 'integer' ] ],
-				'maxWidth' => [ 'type' => [ 'string', 'integer' ] ],
+				'width'    => [ 'type' => [ 'string', 'number' ] ],
+				'minWidth' => [ 'type' => [ 'string', 'number' ] ],
+				'maxWidth' => [ 'type' => [ 'string', 'number' ] ],
 				'align'    => [ 'type' => 'string' ],
 			],
 		];
@@ -445,10 +443,9 @@ class Admin_Shell_Preferences {
 	public static function get_user_meta_key( string $screen_key ): string {
 		global $wpdb;
 
-		// `usermeta` is network-global, so on multisite a bare key would
-		// share one list configuration across every site in the network.
-		// Single-site installs keep the unprefixed key so preferences saved
-		// before this survive.
+		// `usermeta` is network-global, so a bare key would share one list
+		// configuration across a whole network. Single-site installs keep the
+		// unprefixed key so preferences saved before this survive.
 		$prefix = is_multisite() ? $wpdb->get_blog_prefix() : '';
 
 		return $prefix . self::USER_META_KEY_PREFIX . $screen_key;

--- a/plugins/newspack-newsletters/includes/admin/class-admin-shell-preferences.php
+++ b/plugins/newspack-newsletters/includes/admin/class-admin-shell-preferences.php
@@ -51,6 +51,13 @@ class Admin_Shell_Preferences {
 	const PER_PAGE_ALL = -1;
 	const PER_PAGE_MAX = 100;
 
+	/**
+	 * DataViews renders these alongside the field checkboxes in View
+	 * options, so they persist with them. Mirrored client side by
+	 * `VISIBILITY_FLAGS` in `use-persisted-view.js`.
+	 */
+	const VISIBILITY_FLAGS = [ 'showTitle', 'showMedia', 'showDescription' ];
+
 	const LAYOUT_TYPES = [ 'table', 'grid', 'list' ];
 	const DENSITIES    = [ 'compact', 'balanced', 'comfortable' ];
 	const ALIGNMENTS   = [ 'start', 'center', 'end' ];
@@ -134,7 +141,7 @@ class Admin_Shell_Preferences {
 			],
 		];
 
-		return [
+		$schema = [
 			'perPage'    => [ 'type' => 'integer' ],
 			'type'       => [
 				'type' => 'string',
@@ -177,6 +184,12 @@ class Admin_Shell_Preferences {
 				],
 			],
 		];
+
+		foreach ( self::VISIBILITY_FLAGS as $flag ) {
+			$schema[ $flag ] = [ 'type' => 'boolean' ];
+		}
+
+		return $schema;
 	}
 
 	/**
@@ -292,6 +305,12 @@ class Admin_Shell_Preferences {
 			}
 			// An empty array is meaningful — every column hidden.
 			$clean['fields'] = $fields;
+		}
+
+		foreach ( self::VISIBILITY_FLAGS as $flag ) {
+			if ( isset( $prefs[ $flag ] ) && is_bool( $prefs[ $flag ] ) ) {
+				$clean[ $flag ] = $prefs[ $flag ];
+			}
 		}
 
 		$sort = isset( $prefs['sort'] ) && is_array( $prefs['sort'] ) ? self::sanitize_sort( $prefs['sort'] ) : null;

--- a/plugins/newspack-newsletters/includes/admin/class-admin-shell-preferences.php
+++ b/plugins/newspack-newsletters/includes/admin/class-admin-shell-preferences.php
@@ -13,13 +13,26 @@ use WP_REST_Server;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Per-user view preferences for the admin-shell list screens (items per
- * page), stored in user meta so they follow the user across browsers.
- * Values are bootstrapped into the localized `newspackNewslettersAdmin`
- * global (see `Admin_Shell_Assets`), so the REST route is write-only in
- * practice. Each screen gets its own user-meta key so a save only ever
- * touches that screen's value — two tabs saving different screens can't
- * clobber each other via a shared read-modify-write.
+ * Per-user view preferences for the admin-shell list screens, stored in
+ * user meta so they follow the user across browsers. Values are
+ * bootstrapped into the localized `newspackNewslettersAdmin` global (see
+ * `Admin_Shell_Assets`), so the REST route is write-only in practice.
+ * Each screen gets its own user-meta key so a save only ever touches
+ * that screen's value — two tabs saving different screens can't clobber
+ * each other via a shared read-modify-write.
+ *
+ * The stored shape is the presentation half of the DataViews `view`:
+ * layout type, sort, visible fields (in their display order), and the
+ * per-layout settings (density, column widths, grid preview size), plus
+ * items per page. Query state — page, search and filters — is
+ * deliberately not stored, matching classic Screen Options: a saved
+ * list configuration, not a saved query.
+ *
+ * A save replaces a screen's stored value outright; the client always
+ * sends its complete presentation state. Field IDs are validated for
+ * shape and size here, not against a per-screen allowlist — the screen
+ * that reads them back drops the ones it no longer offers, which keeps
+ * this class from having to track every screen's field set.
  */
 class Admin_Shell_Preferences {
 	const API_NAMESPACE = 'newspack-newsletters/v1';
@@ -34,6 +47,27 @@ class Admin_Shell_Preferences {
 	 */
 	const PER_PAGE_ALL = -1;
 	const PER_PAGE_MAX = 100;
+
+	const LAYOUT_TYPES = [ 'table', 'grid', 'list' ];
+	const DENSITIES    = [ 'compact', 'balanced', 'comfortable' ];
+	const ALIGNMENTS   = [ 'start', 'center', 'end' ];
+
+	/**
+	 * Caps on the free-form halves of the payload — field IDs and the
+	 * per-column style map are keyed by whatever the screen defines, so
+	 * bound them rather than trusting the client not to bloat user meta.
+	 */
+	const MAX_FIELDS         = 50;
+	const MAX_STYLED_COLUMNS = 50;
+	const MAX_ID_LENGTH      = 64;
+	const MAX_WIDTH_LENGTH   = 16;
+
+	/**
+	 * Upper bound for the grid layout's preview-size control, which
+	 * stores a pixel width (the slider positions map onto it). DataViews
+	 * publishes no range, so this is a sanity check rather than a mirror.
+	 */
+	const MAX_PREVIEW_SIZE = 4000;
 
 	/**
 	 * Boot hooks.
@@ -64,17 +98,81 @@ class Admin_Shell_Preferences {
 							'type'                 => 'object',
 							'required'             => true,
 							'additionalProperties' => false,
-							'properties'           => [
-								'perPage' => [
-									'type'     => 'integer',
-									'required' => true,
-								],
-							],
+							'properties'           => self::get_prefs_schema(),
 						],
 					],
 				],
 			]
 		);
+	}
+
+	/**
+	 * Schema for the storable half of a DataViews view.
+	 *
+	 * `perPage` carries no range here — the "All" sentinel sits outside
+	 * any single min/max pair, so the range check lives in
+	 * `is_valid_per_page`.
+	 *
+	 * @return array
+	 */
+	private static function get_prefs_schema(): array {
+		$column_style = [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => [
+				'width'    => [ 'type' => [ 'string', 'integer' ] ],
+				'minWidth' => [ 'type' => [ 'string', 'integer' ] ],
+				'maxWidth' => [ 'type' => [ 'string', 'integer' ] ],
+				'align'    => [
+					'type' => 'string',
+					'enum' => self::ALIGNMENTS,
+				],
+			],
+		];
+
+		return [
+			'perPage'    => [ 'type' => 'integer' ],
+			'type'       => [
+				'type' => 'string',
+				'enum' => self::LAYOUT_TYPES,
+			],
+			'titleField' => [ 'type' => 'string' ],
+			'fields'     => [
+				'type'     => 'array',
+				'items'    => [ 'type' => 'string' ],
+				'maxItems' => self::MAX_FIELDS,
+			],
+			'sort'       => [
+				'type'                 => 'object',
+				'additionalProperties' => false,
+				'properties'           => [
+					'field'     => [ 'type' => 'string' ],
+					'direction' => [
+						'type' => 'string',
+						'enum' => [ 'asc', 'desc' ],
+					],
+				],
+			],
+			'layout'     => [
+				'type'                 => 'object',
+				'additionalProperties' => false,
+				'properties'           => [
+					'density'     => [
+						'type' => 'string',
+						'enum' => self::DENSITIES,
+					],
+					'previewSize' => [
+						'type'    => 'integer',
+						'minimum' => 0,
+						'maximum' => self::MAX_PREVIEW_SIZE,
+					],
+					'styles'      => [
+						'type'                 => 'object',
+						'additionalProperties' => $column_style,
+					],
+				],
+			],
+		];
 	}
 
 	/**
@@ -96,20 +194,39 @@ class Admin_Shell_Preferences {
 	 * @return \WP_REST_Response|WP_Error
 	 */
 	public static function update_preferences( $request ) {
-		$prefs    = $request->get_param( 'prefs' );
-		$per_page = is_array( $prefs ) && isset( $prefs['perPage'] ) && is_numeric( $prefs['perPage'] ) ? (int) $prefs['perPage'] : null;
-		if ( null === $per_page || ! self::is_valid_per_page( $per_page ) ) {
-			return new WP_Error(
-				'newspack_newsletters_invalid_preference',
-				__( 'Invalid preference value.', 'newspack-newsletters' ),
-				[ 'status' => 400 ]
-			);
+		$prefs = $request->get_param( 'prefs' );
+		if ( ! is_array( $prefs ) ) {
+			return self::invalid_preference_error();
+		}
+
+		// An explicit per-page outside the storable range is a client
+		// bug, not a stale key — reject rather than silently dropping it.
+		if ( isset( $prefs['perPage'] ) && ! self::is_valid_per_page( (int) $prefs['perPage'] ) ) {
+			return self::invalid_preference_error();
+		}
+
+		$sanitized = self::sanitize_prefs( $prefs );
+		if ( empty( $sanitized ) ) {
+			return self::invalid_preference_error();
 		}
 
 		$screen_key = $request->get_param( 'screen' );
-		update_user_meta( get_current_user_id(), self::get_user_meta_key( $screen_key ), [ 'perPage' => $per_page ] );
+		update_user_meta( get_current_user_id(), self::get_user_meta_key( $screen_key ), $sanitized );
 
 		return rest_ensure_response( self::get_preferences() );
+	}
+
+	/**
+	 * The 400 returned for a payload with nothing storable in it.
+	 *
+	 * @return WP_Error
+	 */
+	private static function invalid_preference_error(): WP_Error {
+		return new WP_Error(
+			'newspack_newsletters_invalid_preference',
+			__( 'Invalid preference value.', 'newspack-newsletters' ),
+			[ 'status' => 400 ]
+		);
 	}
 
 	/**
@@ -121,15 +238,179 @@ class Admin_Shell_Preferences {
 		$prefs = [];
 		foreach ( self::SCREEN_KEYS as $screen_key ) {
 			$raw = get_user_meta( get_current_user_id(), self::get_user_meta_key( $screen_key ), true );
-			if ( ! is_array( $raw ) || ! isset( $raw['perPage'] ) || ! is_numeric( $raw['perPage'] ) ) {
+			if ( ! is_array( $raw ) ) {
 				continue;
 			}
-			$per_page = (int) $raw['perPage'];
-			if ( self::is_valid_per_page( $per_page ) ) {
-				$prefs[ $screen_key ] = [ 'perPage' => $per_page ];
+			$sanitized = self::sanitize_prefs( $raw );
+			if ( ! empty( $sanitized ) ) {
+				$prefs[ $screen_key ] = $sanitized;
 			}
 		}
 		return $prefs;
+	}
+
+	/**
+	 * Normalize a preferences payload, dropping anything unstorable.
+	 *
+	 * Runs on write and again on read, so meta stored by an older
+	 * plugin version — or hand-edited — can't reach the client
+	 * malformed.
+	 *
+	 * @param array $prefs Raw preferences.
+	 * @return array Sanitized preferences.
+	 */
+	public static function sanitize_prefs( array $prefs ): array {
+		$clean = [];
+
+		if ( isset( $prefs['perPage'] ) && is_numeric( $prefs['perPage'] ) && self::is_valid_per_page( (int) $prefs['perPage'] ) ) {
+			$clean['perPage'] = (int) $prefs['perPage'];
+		}
+
+		if ( isset( $prefs['type'] ) && in_array( $prefs['type'], self::LAYOUT_TYPES, true ) ) {
+			$clean['type'] = (string) $prefs['type'];
+		}
+
+		$title_field = isset( $prefs['titleField'] ) ? self::sanitize_field_id( $prefs['titleField'] ) : null;
+		if ( null !== $title_field ) {
+			$clean['titleField'] = $title_field;
+		}
+
+		if ( isset( $prefs['fields'] ) && is_array( $prefs['fields'] ) ) {
+			$fields = [];
+			foreach ( $prefs['fields'] as $field ) {
+				$id = self::sanitize_field_id( $field );
+				if ( null !== $id && ! in_array( $id, $fields, true ) ) {
+					$fields[] = $id;
+				}
+				if ( count( $fields ) >= self::MAX_FIELDS ) {
+					break;
+				}
+			}
+			// An empty array is meaningful — every column hidden.
+			$clean['fields'] = $fields;
+		}
+
+		$sort = isset( $prefs['sort'] ) && is_array( $prefs['sort'] ) ? self::sanitize_sort( $prefs['sort'] ) : null;
+		if ( null !== $sort ) {
+			$clean['sort'] = $sort;
+		}
+
+		$layout = isset( $prefs['layout'] ) && is_array( $prefs['layout'] ) ? self::sanitize_layout( $prefs['layout'] ) : null;
+		if ( null !== $layout ) {
+			$clean['layout'] = $layout;
+		}
+
+		return $clean;
+	}
+
+	/**
+	 * A field ID reduced to a storable string, or null when unusable.
+	 *
+	 * @param mixed $value Candidate ID.
+	 * @return string|null
+	 */
+	private static function sanitize_field_id( $value ): ?string {
+		if ( ! is_string( $value ) ) {
+			return null;
+		}
+		$id = trim( $value );
+		if ( '' === $id || strlen( $id ) > self::MAX_ID_LENGTH ) {
+			return null;
+		}
+		return $id;
+	}
+
+	/**
+	 * Sort clause, or null when neither half survives.
+	 *
+	 * @param array $sort Raw sort clause.
+	 * @return array|null
+	 */
+	private static function sanitize_sort( array $sort ): ?array {
+		$clean = [];
+
+		$field = isset( $sort['field'] ) ? self::sanitize_field_id( $sort['field'] ) : null;
+		if ( null !== $field ) {
+			$clean['field'] = $field;
+		}
+
+		if ( isset( $sort['direction'] ) && in_array( $sort['direction'], [ 'asc', 'desc' ], true ) ) {
+			$clean['direction'] = (string) $sort['direction'];
+		}
+
+		return empty( $clean ) ? null : $clean;
+	}
+
+	/**
+	 * Layout settings for whichever layout the screen is in, or null
+	 * when nothing storable remains.
+	 *
+	 * @param array $layout Raw layout settings.
+	 * @return array|null
+	 */
+	private static function sanitize_layout( array $layout ): ?array {
+		$clean = [];
+
+		if ( isset( $layout['density'] ) && in_array( $layout['density'], self::DENSITIES, true ) ) {
+			$clean['density'] = (string) $layout['density'];
+		}
+
+		if ( isset( $layout['previewSize'] ) && is_numeric( $layout['previewSize'] ) ) {
+			$preview_size = (int) $layout['previewSize'];
+			if ( $preview_size >= 0 && $preview_size <= self::MAX_PREVIEW_SIZE ) {
+				$clean['previewSize'] = $preview_size;
+			}
+		}
+
+		if ( isset( $layout['styles'] ) && is_array( $layout['styles'] ) ) {
+			$styles = [];
+			foreach ( $layout['styles'] as $field => $style ) {
+				$id = self::sanitize_field_id( $field );
+				if ( null === $id || ! is_array( $style ) ) {
+					continue;
+				}
+				$column = self::sanitize_column_style( $style );
+				if ( null !== $column ) {
+					$styles[ $id ] = $column;
+				}
+				if ( count( $styles ) >= self::MAX_STYLED_COLUMNS ) {
+					break;
+				}
+			}
+			if ( ! empty( $styles ) ) {
+				$clean['styles'] = $styles;
+			}
+		}
+
+		return empty( $clean ) ? null : $clean;
+	}
+
+	/**
+	 * One column's style entry, or null when nothing storable remains.
+	 *
+	 * @param array $style Raw column style.
+	 * @return array|null
+	 */
+	private static function sanitize_column_style( array $style ): ?array {
+		$clean = [];
+
+		foreach ( [ 'width', 'minWidth', 'maxWidth' ] as $key ) {
+			if ( ! isset( $style[ $key ] ) ) {
+				continue;
+			}
+			$value = $style[ $key ];
+			if ( is_int( $value ) || is_float( $value ) ) {
+				$clean[ $key ] = (int) $value;
+			} elseif ( is_string( $value ) && '' !== trim( $value ) && strlen( $value ) <= self::MAX_WIDTH_LENGTH ) {
+				$clean[ $key ] = trim( $value );
+			}
+		}
+
+		if ( isset( $style['align'] ) && in_array( $style['align'], self::ALIGNMENTS, true ) ) {
+			$clean['align'] = (string) $style['align'];
+		}
+
+		return empty( $clean ) ? null : $clean;
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/admin/class-admin-shell-preferences.php
+++ b/plugins/newspack-newsletters/includes/admin/class-admin-shell-preferences.php
@@ -42,8 +42,11 @@ class Admin_Shell_Preferences {
 	const SCREEN_KEYS = [ 'newsletters-list', 'ads-list', 'advertisers-list', 'layouts-list' ];
 
 	/**
-	 * Client-side sentinel for "All" — the REST API caps `per_page` at
-	 * 100, so the client fetches in chunks and concatenates.
+	 * `PER_PAGE_ALL` is the client-side sentinel for "All", which fetches
+	 * the collection in chunks and concatenates. `PER_PAGE_MAX` is the
+	 * largest value the items-per-page controls offer, and so the largest
+	 * a stored preference may hold. It is deliberately not the ceiling
+	 * those collections accept — see `Admin_Shell_Collection_Params`.
 	 */
 	const PER_PAGE_ALL = -1;
 	const PER_PAGE_MAX = 100;

--- a/plugins/newspack-newsletters/includes/admin/class-admin-shell-preferences.php
+++ b/plugins/newspack-newsletters/includes/admin/class-admin-shell-preferences.php
@@ -105,10 +105,9 @@ class Admin_Shell_Preferences {
 							'required' => true,
 						],
 						'prefs'  => [
-							'type'                 => 'object',
-							'required'             => true,
-							'additionalProperties' => false,
-							'properties'           => self::get_prefs_schema(),
+							'type'       => 'object',
+							'required'   => true,
+							'properties' => self::get_prefs_schema(),
 						],
 					],
 				],
@@ -119,6 +118,13 @@ class Admin_Shell_Preferences {
 	/**
 	 * Schema for the storable half of a DataViews view.
 	 *
+	 * Nothing here declares `additionalProperties => false`: validation
+	 * fails the whole request on the first unknown key, so one property
+	 * added upstream would silently stop every appearance setting
+	 * persisting. `sanitize_prefs()` whitelists key by key instead, which
+	 * drops an unrecognised key rather than rejecting the payload it
+	 * arrived in.
+	 *
 	 * `perPage` carries no range here — the "All" sentinel sits outside
 	 * any single min/max pair, so the range check lives in
 	 * `is_valid_per_page`.
@@ -126,9 +132,6 @@ class Admin_Shell_Preferences {
 	 * @return array
 	 */
 	private static function get_prefs_schema(): array {
-		// Sanitised rather than rejected: schema validation fails the whole
-		// request on the first unknown key, so one property added upstream
-		// would silently stop every appearance setting persisting.
 		$column_style = [
 			'type'       => 'object',
 			'properties' => [
@@ -152,9 +155,8 @@ class Admin_Shell_Preferences {
 				'maxItems' => self::MAX_FIELDS,
 			],
 			'sort'       => [
-				'type'                 => 'object',
-				'additionalProperties' => false,
-				'properties'           => [
+				'type'       => 'object',
+				'properties' => [
 					'field'     => [ 'type' => 'string' ],
 					'direction' => [
 						'type' => 'string',
@@ -163,9 +165,8 @@ class Admin_Shell_Preferences {
 				],
 			],
 			'layout'     => [
-				'type'                 => 'object',
-				'additionalProperties' => false,
-				'properties'           => [
+				'type'       => 'object',
+				'properties' => [
 					'density'     => [
 						'type' => 'string',
 						'enum' => self::DENSITIES,
@@ -421,7 +422,7 @@ class Admin_Shell_Preferences {
 			}
 			$value = $style[ $key ];
 			if ( is_int( $value ) || is_float( $value ) ) {
-				$clean[ $key ] = (int) $value;
+				$clean[ $key ] = $value;
 			} elseif ( is_string( $value ) && '' !== trim( $value ) && strlen( $value ) <= self::MAX_WIDTH_LENGTH ) {
 				$clean[ $key ] = trim( $value );
 			}
@@ -444,8 +445,8 @@ class Admin_Shell_Preferences {
 		global $wpdb;
 
 		// `usermeta` is network-global, so a bare key would share one list
-		// configuration across a whole network. Single-site installs keep the
-		// unprefixed key so preferences saved before this survive.
+		// configuration across a whole network. Single-site keys stay
+		// unprefixed to remain compatible with values already stored.
 		$prefix = is_multisite() ? $wpdb->get_blog_prefix() : '';
 
 		return $prefix . self::USER_META_KEY_PREFIX . $screen_key;

--- a/plugins/newspack-newsletters/includes/admin/class-admin-shell-preferences.php
+++ b/plugins/newspack-newsletters/includes/admin/class-admin-shell-preferences.php
@@ -71,6 +71,7 @@ class Admin_Shell_Preferences {
 	const MAX_STYLED_COLUMNS = 50;
 	const MAX_ID_LENGTH      = 64;
 	const MAX_WIDTH_LENGTH   = 16;
+	const MAX_PREF_KEYS      = 64;
 
 	/**
 	 * Upper bound for the grid layout's preview-size control, which
@@ -105,9 +106,13 @@ class Admin_Shell_Preferences {
 							'required' => true,
 						],
 						'prefs'  => [
-							'type'       => 'object',
-							'required'   => true,
-							'properties' => self::get_prefs_schema(),
+							'type'          => 'object',
+							'required'      => true,
+							// Generously above the whitelist so a key added
+							// upstream can never hit it; it exists only to bound
+							// the work an oversized payload can ask for.
+							'maxProperties' => self::MAX_PREF_KEYS,
+							'properties'    => self::get_prefs_schema(),
 						],
 					],
 				],
@@ -421,7 +426,11 @@ class Admin_Shell_Preferences {
 				continue;
 			}
 			$value = $style[ $key ];
-			if ( is_int( $value ) || is_float( $value ) ) {
+			// `INF`/`NAN` survive `is_numeric()` but can't be JSON-encoded, and
+			// these values are bootstrapped into the page through
+			// `wp_localize_script` — one of them stored would print the admin
+			// global as a syntax error and stop the app booting.
+			if ( is_int( $value ) || ( is_float( $value ) && is_finite( $value ) ) ) {
 				$clean[ $key ] = $value;
 			} elseif ( is_string( $value ) && '' !== trim( $value ) && strlen( $value ) <= self::MAX_WIDTH_LENGTH ) {
 				$clean[ $key ] = trim( $value );

--- a/plugins/newspack-newsletters/includes/admin/class-ads-list-rest.php
+++ b/plugins/newspack-newsletters/includes/admin/class-ads-list-rest.php
@@ -22,9 +22,18 @@ use WP_REST_Request;
  */
 class Ads_List_REST {
 	use Rest_Status_Field;
+	use Rest_Terms_Field;
 	use Status_Filter_Builder;
 
 	const STATUS_QUERY_PARAM = 'newspack_newsletters_ad_status';
+
+	/**
+	 * Taxonomies behind the Advertiser, Ad placement and Categories
+	 * columns. Quick Edit seeds all three from the same payload and
+	 * sends them back on every save, so the list asks for this field
+	 * whether or not those columns are visible.
+	 */
+	const LIST_TAXONOMIES = [ 'newspack_nl_advertiser', 'newspack_nl_ad_placement', 'category' ];
 
 	/**
 	 * Boot hooks.
@@ -335,6 +344,12 @@ class Ads_List_REST {
 					'type' => [ 'integer', 'null' ],
 				],
 			]
+		);
+
+		self::register_terms_field(
+			Ads::CPT,
+			'newspack_newsletters_terms',
+			self::LIST_TAXONOMIES
 		);
 	}
 

--- a/plugins/newspack-newsletters/includes/admin/class-ads-list-rest.php
+++ b/plugins/newspack-newsletters/includes/admin/class-ads-list-rest.php
@@ -29,9 +29,9 @@ class Ads_List_REST {
 
 	/**
 	 * Taxonomies behind the Advertiser, Ad placement and Categories
-	 * columns. Quick Edit seeds all three from the same payload and
-	 * sends them back on every save, so the list asks for this field
-	 * whether or not those columns are visible.
+	 * columns. Quick Edit has no other source for the names, so the list
+	 * asks for this field whether or not those columns are visible —
+	 * otherwise a hidden column would leave its picker empty.
 	 */
 	const LIST_TAXONOMIES = [ 'newspack_nl_advertiser', 'newspack_nl_ad_placement', 'category' ];
 

--- a/plugins/newspack-newsletters/includes/admin/class-layouts-list-rest.php
+++ b/plugins/newspack-newsletters/includes/admin/class-layouts-list-rest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * REST surface for the Layouts list DataView.
+ *
+ * @package Newspack_Newsletters
+ */
+
+namespace Newspack\Newsletters\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+use Newspack_Newsletters_Layouts;
+
+/**
+ * Adds the read-only author field the Layouts list renders, so the list
+ * never has to ask for `_embed=author` (see `Rest_Author_Field`).
+ */
+class Layouts_List_REST {
+	use Rest_Author_Field;
+
+	/**
+	 * Boot hooks.
+	 */
+	public static function init(): void {
+		add_action( 'rest_api_init', [ __CLASS__, 'register_rest_fields' ] );
+	}
+
+	/**
+	 * Register REST fields on the layouts CPT.
+	 */
+	public static function register_rest_fields(): void {
+		self::register_author_field(
+			Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT,
+			'newspack_newsletters_author'
+		);
+	}
+}

--- a/plugins/newspack-newsletters/includes/admin/class-newsletters-list-rest.php
+++ b/plugins/newspack-newsletters/includes/admin/class-newsletters-list-rest.php
@@ -19,8 +19,15 @@ use WP_Post;
  * needs.
  */
 class Newsletters_List_REST {
+	use Rest_Author_Field;
 	use Rest_Status_Field;
+	use Rest_Terms_Field;
 	use Status_Filter_Builder;
+
+	/**
+	 * Taxonomies behind the Categories and Tags columns.
+	 */
+	const LIST_TAXONOMIES = [ 'category', 'post_tag' ];
 
 	const IS_PUBLIC_QUERY_PARAM = 'newspack_newsletters_is_public';
 	const SEND_LIST_QUERY_PARAM = 'newspack_newsletters_send_list_id';
@@ -427,6 +434,17 @@ class Newsletters_List_REST {
 					'type' => [ 'integer', 'null' ],
 				],
 			]
+		);
+
+		self::register_author_field(
+			Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+			'newspack_newsletters_author'
+		);
+
+		self::register_terms_field(
+			Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+			'newspack_newsletters_terms',
+			self::LIST_TAXONOMIES
 		);
 	}
 

--- a/plugins/newspack-newsletters/includes/admin/trait-rest-author-field.php
+++ b/plugins/newspack-newsletters/includes/admin/trait-rest-author-field.php
@@ -35,9 +35,9 @@ trait Rest_Author_Field {
 			[
 				'get_callback' => [ static::class, 'rest_get_author' ],
 				'schema'       => [
-					// Only the list screens read this, and they all ask for
-					// `edit`. Keeping `view` would ship it to anonymous reads
-					// of the public newsletters collection.
+					// Only the list screens read this, and they ask for `edit`.
+					// `view` would ship it to anonymous reads of the public
+					// newsletters collection.
 					'context'    => [ 'edit' ],
 					'type'       => [ 'object', 'null' ],
 					'readonly'   => true,

--- a/plugins/newspack-newsletters/includes/admin/trait-rest-author-field.php
+++ b/plugins/newspack-newsletters/includes/admin/trait-rest-author-field.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * REST author field trait.
+ *
+ * @package Newspack_Newsletters
+ */
+
+namespace Newspack\Newsletters\Admin;
+
+use WP_Post;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Shared `register_rest_field` scaffolding for the list pages' Author
+ * column.
+ *
+ * It exists so a list never has to ask for `_embed=author`. Embedding
+ * forces `_links` into the response, and core answers that by building
+ * every row's link set and computing target hints for its `self` link,
+ * which re-resolves the whole REST route map per row. Reading the two
+ * values the column renders costs a primed cache lookup instead.
+ */
+trait Rest_Author_Field {
+	/**
+	 * Register an author field on the given CPT.
+	 *
+	 * @param string $cpt        CPT slug.
+	 * @param string $field_name REST field name.
+	 */
+	protected static function register_author_field( string $cpt, string $field_name ): void {
+		register_rest_field(
+			$cpt,
+			$field_name,
+			[
+				'get_callback' => static function ( $post_array ) {
+					return self::get_author_payload( isset( $post_array['id'] ) ? (int) $post_array['id'] : 0 );
+				},
+				'schema'       => [
+					'context'    => [ 'view', 'edit' ],
+					'type'       => [ 'object', 'null' ],
+					'readonly'   => true,
+					'properties' => [
+						'id'     => [ 'type' => 'integer' ],
+						'name'   => [ 'type' => 'string' ],
+						'avatar' => [ 'type' => 'string' ],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * A post author reduced to what the Author column renders.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return array|null { id, name, avatar }, or null when the author is gone.
+	 */
+	public static function get_author_payload( int $post_id ): ?array {
+		$post = $post_id ? get_post( $post_id ) : null;
+		if ( ! $post instanceof WP_Post ) {
+			return null;
+		}
+
+		$user = get_userdata( (int) $post->post_author );
+		if ( ! $user ) {
+			return null;
+		}
+
+		// The 48px source keeps the 16px display crisp on hi-DPI screens.
+		$avatar = get_avatar_url( $user->ID, [ 'size' => 48 ] );
+
+		return [
+			'id'     => (int) $user->ID,
+			'name'   => (string) $user->display_name,
+			'avatar' => is_string( $avatar ) ? $avatar : '',
+		];
+	}
+}

--- a/plugins/newspack-newsletters/includes/admin/trait-rest-author-field.php
+++ b/plugins/newspack-newsletters/includes/admin/trait-rest-author-field.php
@@ -33,11 +33,12 @@ trait Rest_Author_Field {
 			$cpt,
 			$field_name,
 			[
-				'get_callback' => static function ( $post_array ) {
-					return self::get_author_payload( isset( $post_array['id'] ) ? (int) $post_array['id'] : 0 );
-				},
+				'get_callback' => [ static::class, 'rest_get_author' ],
 				'schema'       => [
-					'context'    => [ 'view', 'edit' ],
+					// Only the list screens read this, and they all ask for
+					// `edit`. Keeping `view` would ship it to anonymous reads
+					// of the public newsletters collection.
+					'context'    => [ 'edit' ],
 					'type'       => [ 'object', 'null' ],
 					'readonly'   => true,
 					'properties' => [
@@ -48,6 +49,16 @@ trait Rest_Author_Field {
 				],
 			]
 		);
+	}
+
+	/**
+	 * `get_callback` adapter, matching `Rest_Status_Field`.
+	 *
+	 * @param array $post_array Prepared post, as passed by the controller.
+	 * @return array|null
+	 */
+	public static function rest_get_author( $post_array ): ?array {
+		return self::get_author_payload( isset( $post_array['id'] ) ? (int) $post_array['id'] : 0 );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/admin/trait-rest-terms-field.php
+++ b/plugins/newspack-newsletters/includes/admin/trait-rest-terms-field.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * REST terms field trait.
+ *
+ * @package Newspack_Newsletters
+ */
+
+namespace Newspack\Newsletters\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Shared `register_rest_field` scaffolding for the list pages' taxonomy
+ * columns.
+ *
+ * The counterpart to `Rest_Author_Field`, and there for the same reason:
+ * `_embed=wp:term` dispatches an internal REST request per term group
+ * per row, and asking for it drags `_links` (and core's per-row target
+ * hints) in with it.
+ *
+ * Terms ship as `{ id, name }` rather than names alone so Quick Edit can
+ * seed its taxonomy pickers from the same payload the column renders.
+ */
+trait Rest_Terms_Field {
+	/**
+	 * Register a terms field on the given CPT.
+	 *
+	 * @param string        $cpt        CPT slug.
+	 * @param string        $field_name REST field name.
+	 * @param array<string> $taxonomies Taxonomies to expose, keyed into the payload by slug.
+	 */
+	protected static function register_terms_field( string $cpt, string $field_name, array $taxonomies ): void {
+		$properties = [];
+		foreach ( $taxonomies as $taxonomy ) {
+			$properties[ $taxonomy ] = [
+				'type'  => 'array',
+				'items' => [
+					'type'       => 'object',
+					'properties' => [
+						'id'   => [ 'type' => 'integer' ],
+						'name' => [ 'type' => 'string' ],
+					],
+				],
+			];
+		}
+
+		register_rest_field(
+			$cpt,
+			$field_name,
+			[
+				'get_callback' => static function ( $post_array ) use ( $taxonomies ) {
+					return self::get_terms_payload( isset( $post_array['id'] ) ? (int) $post_array['id'] : 0, $taxonomies );
+				},
+				'schema'       => [
+					'context'    => [ 'view', 'edit' ],
+					'type'       => 'object',
+					'readonly'   => true,
+					'properties' => $properties,
+				],
+			]
+		);
+	}
+
+	/**
+	 * A post's terms in the given taxonomies.
+	 *
+	 * Every requested taxonomy is present in the result, so a renderer
+	 * never has to tell "no terms" apart from "taxonomy missing".
+	 *
+	 * @param int           $post_id    Post ID.
+	 * @param array<string> $taxonomies Taxonomies to read.
+	 * @return array<string, array<array{id: int, name: string}>>
+	 */
+	public static function get_terms_payload( int $post_id, array $taxonomies ): array {
+		$payload = array_fill_keys( $taxonomies, [] );
+		if ( ! $post_id ) {
+			return $payload;
+		}
+
+		foreach ( $taxonomies as $taxonomy ) {
+			$terms = get_the_terms( $post_id, $taxonomy );
+			if ( ! is_array( $terms ) ) {
+				continue;
+			}
+			$payload[ $taxonomy ] = array_values(
+				array_map(
+					static function ( $term ) {
+						return [
+							'id'   => (int) $term->term_id,
+							'name' => (string) $term->name,
+						];
+					},
+					$terms
+				)
+			);
+		}
+
+		return $payload;
+	}
+}

--- a/plugins/newspack-newsletters/includes/admin/trait-rest-terms-field.php
+++ b/plugins/newspack-newsletters/includes/admin/trait-rest-terms-field.php
@@ -28,7 +28,7 @@ trait Rest_Terms_Field {
 	 *
 	 * @var array<string, array<string>>
 	 */
-	private static $terms_field_taxonomies = [];
+	private static array $terms_field_taxonomies = [];
 
 	/**
 	 * Register a terms field on the given CPT.

--- a/plugins/newspack-newsletters/includes/admin/trait-rest-terms-field.php
+++ b/plugins/newspack-newsletters/includes/admin/trait-rest-terms-field.php
@@ -61,8 +61,8 @@ trait Rest_Terms_Field {
 				'get_callback' => [ static::class, 'rest_get_terms' ],
 				'schema'       => [
 					// Only the list screens and Quick Edit read this, and they
-					// all ask for `edit`. Keeping `view` would put every ad's
-					// targeting into anonymous responses.
+					// ask for `edit`. `view` would put every ad's targeting into
+					// anonymous responses.
 					'context'    => [ 'edit' ],
 					'type'       => 'object',
 					'readonly'   => true,

--- a/plugins/newspack-newsletters/includes/admin/trait-rest-terms-field.php
+++ b/plugins/newspack-newsletters/includes/admin/trait-rest-terms-field.php
@@ -23,7 +23,8 @@ defined( 'ABSPATH' ) || exit;
  */
 trait Rest_Terms_Field {
 	/**
-	 * Taxonomies behind each registered field, keyed by field name.
+	 * Taxonomies behind each registered field, keyed by object type and
+	 * field name so the same field name can back two object types.
 	 *
 	 * @var array<string, array<string>>
 	 */
@@ -51,7 +52,7 @@ trait Rest_Terms_Field {
 			];
 		}
 
-		self::$terms_field_taxonomies[ $field_name ] = $taxonomies;
+		self::$terms_field_taxonomies[ $cpt . ':' . $field_name ] = $taxonomies;
 
 		register_rest_field(
 			$cpt,
@@ -74,14 +75,16 @@ trait Rest_Terms_Field {
 	/**
 	 * `get_callback` adapter, matching `Rest_Status_Field`.
 	 *
-	 * @param array  $post_array Prepared post, as passed by the controller.
-	 * @param string $field_name Registered field name.
+	 * @param array            $post_array  Prepared post, as passed by the controller.
+	 * @param string           $field_name  Registered field name.
+	 * @param \WP_REST_Request $request     Incoming request.
+	 * @param string           $object_type Object type the field is registered on.
 	 * @return array<string, array<array{id: int, name: string}>>
 	 */
-	public static function rest_get_terms( $post_array, $field_name ): array {
+	public static function rest_get_terms( $post_array, $field_name = '', $request = null, $object_type = '' ): array {
 		return self::get_terms_payload(
 			isset( $post_array['id'] ) ? (int) $post_array['id'] : 0,
-			self::$terms_field_taxonomies[ $field_name ] ?? []
+			self::$terms_field_taxonomies[ $object_type . ':' . $field_name ] ?? []
 		);
 	}
 

--- a/plugins/newspack-newsletters/includes/admin/trait-rest-terms-field.php
+++ b/plugins/newspack-newsletters/includes/admin/trait-rest-terms-field.php
@@ -23,6 +23,13 @@ defined( 'ABSPATH' ) || exit;
  */
 trait Rest_Terms_Field {
 	/**
+	 * Taxonomies behind each registered field, keyed by field name.
+	 *
+	 * @var array<string, array<string>>
+	 */
+	private static $terms_field_taxonomies = [];
+
+	/**
 	 * Register a terms field on the given CPT.
 	 *
 	 * @param string        $cpt        CPT slug.
@@ -44,20 +51,37 @@ trait Rest_Terms_Field {
 			];
 		}
 
+		self::$terms_field_taxonomies[ $field_name ] = $taxonomies;
+
 		register_rest_field(
 			$cpt,
 			$field_name,
 			[
-				'get_callback' => static function ( $post_array ) use ( $taxonomies ) {
-					return self::get_terms_payload( isset( $post_array['id'] ) ? (int) $post_array['id'] : 0, $taxonomies );
-				},
+				'get_callback' => [ static::class, 'rest_get_terms' ],
 				'schema'       => [
-					'context'    => [ 'view', 'edit' ],
+					// Only the list screens and Quick Edit read this, and they
+					// all ask for `edit`. Keeping `view` would put every ad's
+					// targeting into anonymous responses.
+					'context'    => [ 'edit' ],
 					'type'       => 'object',
 					'readonly'   => true,
 					'properties' => $properties,
 				],
 			]
+		);
+	}
+
+	/**
+	 * `get_callback` adapter, matching `Rest_Status_Field`.
+	 *
+	 * @param array  $post_array Prepared post, as passed by the controller.
+	 * @param string $field_name Registered field name.
+	 * @return array<string, array<array{id: int, name: string}>>
+	 */
+	public static function rest_get_terms( $post_array, $field_name ): array {
+		return self::get_terms_payload(
+			isset( $post_array['id'] ) ? (int) $post_array['id'] : 0,
+			self::$terms_field_taxonomies[ $field_name ] ?? []
 		);
 	}
 

--- a/plugins/newspack-newsletters/includes/admin/trait-rest-terms-field.php
+++ b/plugins/newspack-newsletters/includes/admin/trait-rest-terms-field.php
@@ -53,7 +53,7 @@ trait Rest_Terms_Field {
 				// different taxonomies, and a lookup that missed would blank
 				// the columns instead of raising.
 				'get_callback' => static function ( $post_array ) use ( $taxonomies ) {
-					return self::get_terms_payload( isset( $post_array['id'] ) ? (int) $post_array['id'] : 0, $taxonomies );
+					return static::get_terms_payload( isset( $post_array['id'] ) ? (int) $post_array['id'] : 0, $taxonomies );
 				},
 				'schema'       => [
 					// Only the list screens and Quick Edit read this, and they

--- a/plugins/newspack-newsletters/includes/admin/trait-rest-terms-field.php
+++ b/plugins/newspack-newsletters/includes/admin/trait-rest-terms-field.php
@@ -23,14 +23,6 @@ defined( 'ABSPATH' ) || exit;
  */
 trait Rest_Terms_Field {
 	/**
-	 * Taxonomies behind each registered field, keyed by object type and
-	 * field name so the same field name can back two object types.
-	 *
-	 * @var array<string, array<string>>
-	 */
-	private static array $terms_field_taxonomies = [];
-
-	/**
 	 * Register a terms field on the given CPT.
 	 *
 	 * @param string        $cpt        CPT slug.
@@ -52,13 +44,17 @@ trait Rest_Terms_Field {
 			];
 		}
 
-		self::$terms_field_taxonomies[ $cpt . ':' . $field_name ] = $taxonomies;
-
 		register_rest_field(
 			$cpt,
 			$field_name,
 			[
-				'get_callback' => [ static::class, 'rest_get_terms' ],
+				// Bound here rather than looked up in a shared registry: the
+				// newsletters and ads CPTs register the same field name over
+				// different taxonomies, and a lookup that missed would blank
+				// the columns instead of raising.
+				'get_callback' => static function ( $post_array ) use ( $taxonomies ) {
+					return self::get_terms_payload( isset( $post_array['id'] ) ? (int) $post_array['id'] : 0, $taxonomies );
+				},
 				'schema'       => [
 					// Only the list screens and Quick Edit read this, and they
 					// ask for `edit`. `view` would put every ad's targeting into
@@ -69,22 +65,6 @@ trait Rest_Terms_Field {
 					'properties' => $properties,
 				],
 			]
-		);
-	}
-
-	/**
-	 * `get_callback` adapter, matching `Rest_Status_Field`.
-	 *
-	 * @param array            $post_array  Prepared post, as passed by the controller.
-	 * @param string           $field_name  Registered field name.
-	 * @param \WP_REST_Request $request     Incoming request.
-	 * @param string           $object_type Object type the field is registered on.
-	 * @return array<string, array<array{id: int, name: string}>>
-	 */
-	public static function rest_get_terms( $post_array, $field_name = '', $request = null, $object_type = '' ): array {
-		return self::get_terms_payload(
-			isset( $post_array['id'] ) ? (int) $post_array['id'] : 0,
-			self::$terms_field_taxonomies[ $object_type . ':' . $field_name ] ?? []
 		);
 	}
 

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-layouts.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-layouts.php
@@ -77,7 +77,8 @@ final class Newspack_Newsletters_Layouts {
 			'show_ui'      => true,
 			'show_in_menu' => false,
 			'show_in_rest' => true,
-			// `author` so `_embed` populates `_embedded.author[0]` for the list.
+			// `author` so the layout keeps a `post_author`, which both the
+			// list's author field and `get_layouts()` read.
 			'supports'     => [ 'editor', 'title', 'custom-fields', 'author' ],
 			'taxonomies'   => [],
 		];

--- a/plugins/newspack-newsletters/newspack-newsletters.php
+++ b/plugins/newspack-newsletters/newspack-newsletters.php
@@ -109,12 +109,16 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/pages/class-ads
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/pages/class-advertisers-list-page.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/pages/class-layouts-list-page.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/pages/class-settings-page.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/trait-rest-author-field.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/trait-rest-status-field.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/trait-rest-terms-field.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/trait-status-filter-builder.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-newsletters-list-rest.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-ads-list-rest.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-advertisers-list-rest.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-layouts-list-rest.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-settings-rest.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-admin-shell-collection-params.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-admin-shell-preferences.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-asset-loader.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-admin-shell-menu.php';
@@ -148,5 +152,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-wizard-bridge.p
 \Newspack\Newsletters\Admin\Newsletters_List_REST::init();
 \Newspack\Newsletters\Admin\Ads_List_REST::init();
 \Newspack\Newsletters\Admin\Advertisers_List_REST::init();
+\Newspack\Newsletters\Admin\Layouts_List_REST::init();
 \Newspack\Newsletters\Admin\Settings_REST::init();
+\Newspack\Newsletters\Admin\Admin_Shell_Collection_Params::init();
 \Newspack\Newsletters\Admin\Admin_Shell_Preferences::init();

--- a/plugins/newspack-newsletters/src/admin-shell/components/items-per-page/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/items-per-page/index.js
@@ -8,22 +8,19 @@
  * sentinel would render as "-1". DataViews offers no slot inside the
  * popover, so this component portals a look-alike ToggleGroupControl
  * into the popover when it opens (anchored on the same class names the
- * package styles against). This component itself is mounted in the
- * DataViews `header` slot; while a fetch-all walk runs it overlays a
- * centered spinner + progress message on the list (the popover is
- * closed during a walk, and the header offers no room for it).
+ * package styles against). It is mounted in the DataViews `header` slot.
+ *
+ * Loading is left entirely to DataViews, which pulses the list and sets
+ * `aria-busy` while a fetch is in flight. A second, custom indicator on
+ * top of that read as two competing animations.
  */
 
-import { speak } from '@wordpress/a11y';
 import {
-	Spinner,
-	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
-import { createPortal, useEffect, useRef, useState } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { createPortal, useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 import { DEFAULT_PER_PAGE_OPTIONS, PER_PAGE_ALL } from '../../utils/per-page';
 
@@ -75,58 +72,15 @@ function usePopoverSlot() {
 
 /**
  * @param {Object}        props
- * @param {number}        props.value      Current `view.perPage`.
- * @param {Function}      props.onChange   Receives the new perPage value.
- * @param {Array<number>} [props.options]  Selectable values; `PER_PAGE_ALL` renders as "All".
- * @param {Object|null}   [props.progress] Fetch-all progress (`{ loaded, total }`) or null.
+ * @param {number}        props.value     Current `view.perPage`.
+ * @param {Function}      props.onChange  Receives the new perPage value.
+ * @param {Array<number>} [props.options] Selectable values; `PER_PAGE_ALL` renders as "All".
  */
-export default function ItemsPerPage( { value, onChange, options = DEFAULT_PER_PAGE_OPTIONS, progress = null } ) {
+export default function ItemsPerPage( { value, onChange, options = DEFAULT_PER_PAGE_OPTIONS } ) {
 	const slot = usePopoverSlot();
-	const isLoadingAll = !! progress;
-
-	// The visible message updates once per batch — up to ~100 times on a
-	// full walk — so it is not a live region. Announce the two moments
-	// that matter instead.
-	const wasLoadingAllRef = useRef( false );
-	useEffect( () => {
-		if ( isLoadingAll === wasLoadingAllRef.current ) {
-			return;
-		}
-		wasLoadingAllRef.current = isLoadingAll;
-		speak(
-			isLoadingAll
-				? __( 'Loading all items. This may take a moment.', 'newspack-newsletters' )
-				: __( 'Finished loading items.', 'newspack-newsletters' ),
-			'polite'
-		);
-	}, [ isLoadingAll ] );
-
-	// Center on the admin content area, not the viewport — otherwise the
-	// admin menu skews the overlay off-center.
-	const wpbodyRect = progress ? document.getElementById( 'wpbody' )?.getBoundingClientRect() : null;
 
 	return (
 		<>
-			{ progress &&
-				createPortal(
-					<VStack
-						className="newspack-newsletters-fetch-all-progress"
-						spacing={ 3 }
-						alignment="center"
-						style={ wpbodyRect ? { left: wpbodyRect.left + wpbodyRect.width / 2 } : undefined }
-					>
-						<Spinner />
-						<Text weight={ 600 }>
-							{ sprintf(
-								/* translators: 1: number of items loaded so far, 2: total number of items. */
-								__( 'Loading %1$s of %2$s…', 'newspack-newsletters' ),
-								progress.loaded.toLocaleString(),
-								progress.total.toLocaleString()
-							) }
-						</Text>
-					</VStack>,
-					document.body
-				) }
 			{ slot &&
 				createPortal(
 					<ToggleGroupControl

--- a/plugins/newspack-newsletters/src/admin-shell/components/items-per-page/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/items-per-page/index.js
@@ -11,8 +11,7 @@
  * package styles against). It is mounted in the DataViews `header` slot.
  *
  * Loading is left entirely to DataViews, which pulses the list and sets
- * `aria-busy` while a fetch is in flight. A second, custom indicator on
- * top of that read as two competing animations.
+ * `aria-busy` while a fetch is in flight.
  */
 
 import {

--- a/plugins/newspack-newsletters/src/admin-shell/components/items-per-page/index.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/items-per-page/index.test.js
@@ -6,12 +6,9 @@
  */
 
 import { act, render, screen, waitFor } from '@testing-library/react';
-import { speak } from '@wordpress/a11y';
 
 import ItemsPerPage from './index';
 import { PER_PAGE_ALL } from '../../utils/per-page';
-
-jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
 
 const openPopover = () => {
 	const popover = document.createElement( 'div' );
@@ -23,7 +20,6 @@ const openPopover = () => {
 
 describe( 'ItemsPerPage', () => {
 	beforeEach( () => {
-		speak.mockClear();
 		document.body.innerHTML = '';
 	} );
 
@@ -51,15 +47,9 @@ describe( 'ItemsPerPage', () => {
 		[ '10', '20', '50', '100' ].forEach( label => expect( screen.getByRole( 'radio', { name: label } ) ).toBeInTheDocument() );
 	} );
 
-	it( 'announces the start and end of a fetch-all walk, not each batch', () => {
-		const { rerender } = render( <ItemsPerPage value={ PER_PAGE_ALL } onChange={ jest.fn() } progress={ { loaded: 100, total: 1200 } } /> );
-		expect( speak ).toHaveBeenCalledTimes( 1 );
-
-		rerender( <ItemsPerPage value={ PER_PAGE_ALL } onChange={ jest.fn() } progress={ { loaded: 200, total: 1200 } } /> );
-		expect( speak ).toHaveBeenCalledTimes( 1 );
-		expect( screen.getByText( 'Loading 200 of 1,200…' ) ).toBeInTheDocument();
-
-		rerender( <ItemsPerPage value={ PER_PAGE_ALL } onChange={ jest.fn() } progress={ null } /> );
-		expect( speak ).toHaveBeenCalledTimes( 2 );
+	it( 'renders no loading indicator of its own', () => {
+		const { container } = render( <ItemsPerPage value={ PER_PAGE_ALL } onChange={ jest.fn() } /> );
+		expect( container ).toBeEmptyDOMElement();
+		expect( document.querySelector( '.newspack-newsletters-fetch-all-progress' ) ).toBeNull();
 	} );
 } );

--- a/plugins/newspack-newsletters/src/admin-shell/components/items-per-page/index.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/items-per-page/index.test.js
@@ -47,8 +47,11 @@ describe( 'ItemsPerPage', () => {
 		[ '10', '20', '50', '100' ].forEach( label => expect( screen.getByRole( 'radio', { name: label } ) ).toBeInTheDocument() );
 	} );
 
+	// `progress` is deliberately passed to a component that no longer
+	// declares it: the removed overlay rendered from exactly that prop, so
+	// without it this assertion would also hold against the old version.
 	it( 'renders no loading indicator of its own', () => {
-		const { container } = render( <ItemsPerPage value={ PER_PAGE_ALL } onChange={ jest.fn() } /> );
+		const { container } = render( <ItemsPerPage value={ PER_PAGE_ALL } onChange={ jest.fn() } progress={ { loaded: 100, total: 1200 } } /> );
 		expect( container ).toBeEmptyDOMElement();
 		expect( document.querySelector( '.newspack-newsletters-fetch-all-progress' ) ).toBeNull();
 	} );

--- a/plugins/newspack-newsletters/src/admin-shell/components/loading-state/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/loading-state/index.js
@@ -6,7 +6,9 @@
  * has rendered, DataViews' own loading treatment takes over.
  */
 
+import { speak } from '@wordpress/a11y';
 import { Spinner, __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { useEffect } from '@wordpress/element';
 
 /**
  * @param {Object} props
@@ -14,6 +16,12 @@ import { Spinner, __experimentalText as Text, __experimentalVStack as VStack } f
  * @return {JSX.Element} The rendered loading state.
  */
 export default function LoadingState( { label } ) {
+	// A live region that mounts with its text already in place isn't
+	// reliably announced, so say it directly.
+	useEffect( () => {
+		speak( label, 'polite' );
+	}, [ label ] );
+
 	return (
 		<VStack className="newspack-newsletters-admin__loading" alignment="center" spacing={ 3 } role="status">
 			<Spinner />

--- a/plugins/newspack-newsletters/src/admin-shell/components/loading-state/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/loading-state/index.js
@@ -16,14 +16,16 @@ import { useEffect } from '@wordpress/element';
  * @return {JSX.Element} The rendered loading state.
  */
 export default function LoadingState( { label } ) {
-	// A live region that mounts with its text already in place isn't
-	// reliably announced, so say it directly.
+	// `speak()` owns the announcement rather than a `role="status"` here:
+	// a live region that mounts with its text already in place isn't
+	// announced at all by some screen readers and is announced twice by
+	// others once both are present.
 	useEffect( () => {
 		speak( label, 'polite' );
 	}, [ label ] );
 
 	return (
-		<VStack className="newspack-newsletters-admin__loading" alignment="center" spacing={ 3 } role="status">
+		<VStack className="newspack-newsletters-admin__loading" alignment="center" spacing={ 3 }>
 			<Spinner />
 			<Text as="p">{ label }</Text>
 		</VStack>

--- a/plugins/newspack-newsletters/src/admin-shell/components/loading-state/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/loading-state/index.js
@@ -16,10 +16,9 @@ import { useEffect } from '@wordpress/element';
  * @return {JSX.Element} The rendered loading state.
  */
 export default function LoadingState( { label } ) {
-	// `speak()` owns the announcement rather than a `role="status"` here:
-	// a live region that mounts with its text already in place isn't
-	// announced at all by some screen readers and is announced twice by
-	// others once both are present.
+	// `speak()` owns this rather than a `role="status"`: a live region that
+	// mounts with its text already in place is unreliable, and carrying
+	// both makes some screen readers say it twice.
 	useEffect( () => {
 		speak( label, 'polite' );
 	}, [ label ] );

--- a/plugins/newspack-newsletters/src/admin-shell/components/loading-state/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/loading-state/index.js
@@ -1,0 +1,23 @@
+/**
+ * Reusable loading state for admin-shell screens.
+ *
+ * For the first paint only, where there is no list behind it and so no
+ * `aria-busy` either — hence the label and the live region. Once a list
+ * has rendered, DataViews' own loading treatment takes over.
+ */
+
+import { Spinner, __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+
+/**
+ * @param {Object} props
+ * @param {string} props.label What is being fetched, e.g. "Fetching newsletters…".
+ * @return {JSX.Element} The rendered loading state.
+ */
+export default function LoadingState( { label } ) {
+	return (
+		<VStack className="newspack-newsletters-admin__loading" alignment="center" spacing={ 3 } role="status">
+			<Spinner />
+			<Text as="p">{ label }</Text>
+		</VStack>
+	);
+}

--- a/plugins/newspack-newsletters/src/admin-shell/components/loading-state/index.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/loading-state/index.test.js
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+
+import LoadingState from './index';
+
+describe( 'LoadingState', () => {
+	it( 'labels the spinner so the first paint says what it is fetching', () => {
+		const { container } = render( <LoadingState label="Fetching newsletters…" /> );
+
+		expect( screen.getByText( 'Fetching newsletters…' ) ).toBeInTheDocument();
+		expect( container.querySelector( '.components-spinner' ) ).toBeInTheDocument();
+	} );
+
+	it( 'announces itself politely', () => {
+		render( <LoadingState label="Fetching layouts…" /> );
+
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Fetching layouts…' );
+	} );
+} );

--- a/plugins/newspack-newsletters/src/admin-shell/components/loading-state/index.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/loading-state/index.test.js
@@ -23,8 +23,6 @@ describe( 'LoadingState', () => {
 		expect( speak ).toHaveBeenCalledWith( 'Fetching layouts…', 'polite' );
 	} );
 
-	// Two live regions carrying the same text means some screen readers
-	// say it twice, so `speak()` is the only announcement.
 	it( 'leaves the announcement to speak rather than a second live region', () => {
 		const { container } = render( <LoadingState label="Fetching ads…" /> );
 

--- a/plugins/newspack-newsletters/src/admin-shell/components/loading-state/index.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/loading-state/index.test.js
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react';
+import { render, within } from '@testing-library/react';
 import { speak } from '@wordpress/a11y';
 
 import LoadingState from './index';
@@ -20,14 +20,15 @@ describe( 'LoadingState', () => {
 	it( 'announces itself politely', () => {
 		render( <LoadingState label="Fetching layouts…" /> );
 
-		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Fetching layouts…' );
+		expect( speak ).toHaveBeenCalledWith( 'Fetching layouts…', 'polite' );
 	} );
 
-	// The region mounts with its text already in place, which screen
-	// readers don't reliably announce, so the label is spoken directly.
-	it( 'speaks the label rather than relying on the live region alone', () => {
-		render( <LoadingState label="Fetching ads…" /> );
+	// Two live regions carrying the same text means some screen readers
+	// say it twice, so `speak()` is the only announcement.
+	it( 'leaves the announcement to speak rather than a second live region', () => {
+		const { container } = render( <LoadingState label="Fetching ads…" /> );
 
-		expect( speak ).toHaveBeenCalledWith( 'Fetching ads…', 'polite' );
+		expect( within( container ).queryByRole( 'status' ) ).toBeNull();
+		expect( speak ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/plugins/newspack-newsletters/src/admin-shell/components/loading-state/index.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/loading-state/index.test.js
@@ -1,12 +1,19 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import { speak } from '@wordpress/a11y';
 
 import LoadingState from './index';
 
+jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
+
 describe( 'LoadingState', () => {
+	beforeEach( () => {
+		speak.mockClear();
+	} );
+
 	it( 'labels the spinner so the first paint says what it is fetching', () => {
 		const { container } = render( <LoadingState label="Fetching newsletters…" /> );
 
-		expect( screen.getByText( 'Fetching newsletters…' ) ).toBeInTheDocument();
+		expect( within( container ).getByText( 'Fetching newsletters…' ) ).toBeInTheDocument();
 		expect( container.querySelector( '.components-spinner' ) ).toBeInTheDocument();
 	} );
 
@@ -14,5 +21,13 @@ describe( 'LoadingState', () => {
 		render( <LoadingState label="Fetching layouts…" /> );
 
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Fetching layouts…' );
+	} );
+
+	// The region mounts with its text already in place, which screen
+	// readers don't reliably announce, so the label is spoken directly.
+	it( 'speaks the label rather than relying on the live region alone', () => {
+		render( <LoadingState label="Fetching ads…" /> );
+
+		expect( speak ).toHaveBeenCalledWith( 'Fetching ads…', 'polite' );
 	} );
 } );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
@@ -38,7 +38,8 @@ function isOutOfRangePageError( error ) {
  * trash sub-fetch — `hasResolved` flips solely on the main resolution.
  *
  * When `fetchAll` is set, the first response's `X-WP-TotalPages` drives
- * a walk over the remaining pages (the REST API caps `per_page` at 100).
+ * a walk over the remaining pages (these four collections cap `per_page`
+ * at `FETCH_ALL_CHUNK_SIZE`).
  * `data` commits once the walk finishes (or aborts), and `totalPages` is
  * clamped to 1 so the footer doesn't offer pagination. DataViews shows
  * the walk via its own loading state; there is no separate indicator.
@@ -169,7 +170,12 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 				}
 
 				setData( all );
-				speak( __( 'Finished loading items.', 'newspack-newsletters' ), 'polite' );
+				speak(
+					endedEarly
+						? __( 'Stopped loading items before the end of the list.', 'newspack-newsletters' )
+						: __( 'Finished loading items.', 'newspack-newsletters' ),
+					'polite'
+				);
 
 				if ( endedEarly ) {
 					setPaginationInfo( { totalItems: all.length, totalPages: 1 } );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
@@ -1,3 +1,4 @@
+import { speak } from '@wordpress/a11y';
 import apiFetch from '@wordpress/api-fetch';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -99,6 +100,11 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 					return;
 				}
 
+				// DataViews' loading treatment is visual only, so a walk over
+				// several pages is silent to a screen reader. Announce both
+				// ends of it.
+				speak( __( 'Loading all items. This may take a moment.', 'newspack-newsletters' ), 'polite' );
+
 				const maxPage = Math.min( pagination.totalPages, Math.ceil( FETCH_ALL_MAX_ITEMS / FETCH_ALL_CHUNK_SIZE ) );
 
 				let endedEarly = false;
@@ -163,6 +169,7 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 				}
 
 				setData( all );
+				speak( __( 'Finished loading items.', 'newspack-newsletters' ), 'polite' );
 
 				if ( endedEarly ) {
 					setPaginationInfo( { totalItems: all.length, totalPages: 1 } );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
@@ -38,9 +38,9 @@ function isOutOfRangePageError( error ) {
  *
  * When `fetchAll` is set, the first response's `X-WP-TotalPages` drives
  * a walk over the remaining pages (the REST API caps `per_page` at 100).
- * `data` commits once the walk finishes (or aborts); `progress` reports
- * the walk meanwhile (`{ loaded, total }`, `null` outside a walk) and
- * `totalPages` is clamped to 1 so the footer doesn't offer pagination.
+ * `data` commits once the walk finishes (or aborts), and `totalPages` is
+ * clamped to 1 so the footer doesn't offer pagination. DataViews shows
+ * the walk via its own loading state; there is no separate indicator.
  *
  * @param {Object}  options
  * @param {string}  options.path             Pre-computed REST path. Falsy ⇒ defer.
@@ -49,7 +49,7 @@ function isOutOfRangePageError( error ) {
  * @param {string}  [options.errorMessage]   notifyError message on fetch failure.
  * @param {string}  [options.errorNoticeId]  notifyError dedupe id.
  * @param {boolean} [options.fetchAll]       Walk every page of the collection.
- * @return {{ data: Array, paginationInfo: Object, isLoading: boolean, hasResolved: boolean, hasLoadedOnce: boolean, trashCount: number|null, progress: Object|null, refresh: () => void }} Hook state.
+ * @return {{ data: Array, paginationInfo: Object, isLoading: boolean, hasResolved: boolean, hasLoadedOnce: boolean, trashCount: number|null, refresh: () => void }} Hook state.
  */
 export default function useCollectionData( { path, trashCountPath = null, mutationKey = 0, errorMessage, errorNoticeId, fetchAll = false } ) {
 	const [ data, setData ] = useState( [] );
@@ -61,7 +61,6 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 	const [ hasLoadedOnce, setHasLoadedOnce ] = useState( false );
 	// `null` ⇒ unknown; failed trash fetch stays `null` so `=== 0` stays false and the banner stays hidden.
 	const [ trashCount, setTrashCount ] = useState( null );
-	const [ progress, setProgress ] = useState( null );
 
 	const refresh = useCallback( () => setRefreshKey( key => key + 1 ), [] );
 
@@ -74,7 +73,6 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 		}
 		let cancelled = false;
 		setIsLoading( true );
-		setProgress( null );
 
 		apiFetch( { path, parse: false } )
 			.then( async response => {
@@ -103,7 +101,6 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 
 				const maxPage = Math.min( pagination.totalPages, Math.ceil( FETCH_ALL_MAX_ITEMS / FETCH_ALL_CHUNK_SIZE ) );
 
-				setProgress( { loaded: all.length, total: pagination.totalItems } );
 				let endedEarly = false;
 				let cappedByMax = false;
 				// Settled, so one bad page doesn't discard its siblings.
@@ -150,7 +147,6 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 						}
 					}
 
-					setProgress( { loaded: all.length, total: pagination.totalItems } );
 					if ( failedAt !== -1 ) {
 						endedEarly = true;
 						break;
@@ -193,7 +189,6 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 				if ( ! cancelled ) {
 					setIsLoading( false );
 					setMainResolved( true );
-					setProgress( null );
 				}
 			} );
 
@@ -228,5 +223,5 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 
 	const hasResolved = mainResolved && trashResolved;
 
-	return { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce, trashCount, progress, refresh };
+	return { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce, trashCount, refresh };
 }

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
@@ -101,9 +101,8 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 					return;
 				}
 
-				// DataViews' loading treatment is visual only, so a walk over
-				// several pages is silent to a screen reader. Announce both
-				// ends of it.
+				// DataViews' loading treatment is visual only, so a multi-page
+				// walk is otherwise silent to a screen reader.
 				speak( __( 'Loading all items. This may take a moment.', 'newspack-newsletters' ), 'polite' );
 
 				const maxPage = Math.min( pagination.totalPages, Math.ceil( FETCH_ALL_MAX_ITEMS / FETCH_ALL_CHUNK_SIZE ) );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
@@ -38,22 +38,32 @@ function isOutOfRangePageError( error ) {
  * trash sub-fetch — `hasResolved` flips solely on the main resolution.
  *
  * When `fetchAll` is set, the first response's `X-WP-TotalPages` drives
- * a walk over the remaining pages (these four collections cap `per_page`
- * at `FETCH_ALL_CHUNK_SIZE`).
+ * a walk over the remaining pages. `fetchAllChunkSize` must match the
+ * `per_page` the caller built its path with, since it is what turns
+ * `FETCH_ALL_MAX_ITEMS` into a page ceiling.
  * `data` commits once the walk finishes (or aborts), and `totalPages` is
  * clamped to 1 so the footer doesn't offer pagination. DataViews shows
  * the walk via its own loading state; there is no separate indicator.
  *
  * @param {Object}  options
- * @param {string}  options.path             Pre-computed REST path. Falsy ⇒ defer.
- * @param {string}  [options.trashCountPath] When set, sub-fetch for the trash banner.
- * @param {number}  [options.mutationKey]    Bump externally to refetch (alongside internal refresh).
- * @param {string}  [options.errorMessage]   notifyError message on fetch failure.
- * @param {string}  [options.errorNoticeId]  notifyError dedupe id.
- * @param {boolean} [options.fetchAll]       Walk every page of the collection.
+ * @param {string}  options.path                Pre-computed REST path. Falsy ⇒ defer.
+ * @param {string}  [options.trashCountPath]    When set, sub-fetch for the trash banner.
+ * @param {number}  [options.mutationKey]       Bump externally to refetch (alongside internal refresh).
+ * @param {string}  [options.errorMessage]      notifyError message on fetch failure.
+ * @param {string}  [options.errorNoticeId]     notifyError dedupe id.
+ * @param {boolean} [options.fetchAll]          Walk every page of the collection.
+ * @param {number}  [options.fetchAllChunkSize] Rows per request of that walk.
  * @return {{ data: Array, paginationInfo: Object, isLoading: boolean, hasResolved: boolean, hasLoadedOnce: boolean, trashCount: number|null, refresh: () => void }} Hook state.
  */
-export default function useCollectionData( { path, trashCountPath = null, mutationKey = 0, errorMessage, errorNoticeId, fetchAll = false } ) {
+export default function useCollectionData( {
+	path,
+	trashCountPath = null,
+	mutationKey = 0,
+	errorMessage,
+	errorNoticeId,
+	fetchAll = false,
+	fetchAllChunkSize = FETCH_ALL_CHUNK_SIZE,
+} ) {
 	const [ data, setData ] = useState( [] );
 	const [ paginationInfo, setPaginationInfo ] = useState( { totalItems: 0, totalPages: 0 } );
 	const [ isLoading, setIsLoading ] = useState( true );
@@ -105,7 +115,7 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 				// walk is otherwise silent to a screen reader.
 				speak( __( 'Loading all items. This may take a moment.', 'newspack-newsletters' ), 'polite' );
 
-				const maxPage = Math.min( pagination.totalPages, Math.ceil( FETCH_ALL_MAX_ITEMS / FETCH_ALL_CHUNK_SIZE ) );
+				const maxPage = Math.min( pagination.totalPages, Math.ceil( FETCH_ALL_MAX_ITEMS / fetchAllChunkSize ) );
 
 				let endedEarly = false;
 				let cappedByMax = false;
@@ -207,7 +217,7 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 		return () => {
 			cancelled = true;
 		};
-	}, [ path, mutationKey, refreshKey, errorMessage, errorNoticeId, fetchAll ] );
+	}, [ path, mutationKey, refreshKey, errorMessage, errorNoticeId, fetchAll, fetchAllChunkSize ] );
 
 	useEffect( () => {
 		if ( ! trashCountPath ) {

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
@@ -23,6 +23,15 @@ function readPaginationInfo( response ) {
 	};
 }
 
+// Read back off the path rather than taken as a second argument: the page
+// ceiling has to agree with the `per_page` the caller actually asked for, and
+// two independent sources could drift apart silently.
+function chunkSizeFromPath( path ) {
+	const query = path.split( '?' )[ 1 ];
+	const perPage = query ? parseInt( new URLSearchParams( query ).get( 'per_page' ), 10 ) : NaN;
+	return Number.isInteger( perPage ) && perPage > 0 ? perPage : FETCH_ALL_CHUNK_SIZE;
+}
+
 // The collection got shorter mid-walk — retrying won't help.
 const OUT_OF_RANGE_PAGE_CODES = [ 'rest_post_invalid_page_number', 'rest_term_invalid_page_number' ];
 
@@ -38,32 +47,22 @@ function isOutOfRangePageError( error ) {
  * trash sub-fetch — `hasResolved` flips solely on the main resolution.
  *
  * When `fetchAll` is set, the first response's `X-WP-TotalPages` drives
- * a walk over the remaining pages. `fetchAllChunkSize` must match the
- * `per_page` the caller built its path with, since it is what turns
- * `FETCH_ALL_MAX_ITEMS` into a page ceiling.
+ * a walk over the remaining pages, capped at `FETCH_ALL_MAX_ITEMS` rows
+ * using the `per_page` read off `path`.
  * `data` commits once the walk finishes (or aborts), and `totalPages` is
  * clamped to 1 so the footer doesn't offer pagination. DataViews shows
  * the walk via its own loading state; there is no separate indicator.
  *
  * @param {Object}  options
- * @param {string}  options.path                Pre-computed REST path. Falsy ⇒ defer.
- * @param {string}  [options.trashCountPath]    When set, sub-fetch for the trash banner.
- * @param {number}  [options.mutationKey]       Bump externally to refetch (alongside internal refresh).
- * @param {string}  [options.errorMessage]      notifyError message on fetch failure.
- * @param {string}  [options.errorNoticeId]     notifyError dedupe id.
- * @param {boolean} [options.fetchAll]          Walk every page of the collection.
- * @param {number}  [options.fetchAllChunkSize] Rows per request of that walk.
+ * @param {string}  options.path             Pre-computed REST path. Falsy ⇒ defer.
+ * @param {string}  [options.trashCountPath] When set, sub-fetch for the trash banner.
+ * @param {number}  [options.mutationKey]    Bump externally to refetch (alongside internal refresh).
+ * @param {string}  [options.errorMessage]   notifyError message on fetch failure.
+ * @param {string}  [options.errorNoticeId]  notifyError dedupe id.
+ * @param {boolean} [options.fetchAll]       Walk every page of the collection.
  * @return {{ data: Array, paginationInfo: Object, isLoading: boolean, hasResolved: boolean, hasLoadedOnce: boolean, trashCount: number|null, refresh: () => void }} Hook state.
  */
-export default function useCollectionData( {
-	path,
-	trashCountPath = null,
-	mutationKey = 0,
-	errorMessage,
-	errorNoticeId,
-	fetchAll = false,
-	fetchAllChunkSize = FETCH_ALL_CHUNK_SIZE,
-} ) {
+export default function useCollectionData( { path, trashCountPath = null, mutationKey = 0, errorMessage, errorNoticeId, fetchAll = false } ) {
 	const [ data, setData ] = useState( [] );
 	const [ paginationInfo, setPaginationInfo ] = useState( { totalItems: 0, totalPages: 0 } );
 	const [ isLoading, setIsLoading ] = useState( true );
@@ -115,7 +114,7 @@ export default function useCollectionData( {
 				// walk is otherwise silent to a screen reader.
 				speak( __( 'Loading all items. This may take a moment.', 'newspack-newsletters' ), 'polite' );
 
-				const maxPage = Math.min( pagination.totalPages, Math.ceil( FETCH_ALL_MAX_ITEMS / fetchAllChunkSize ) );
+				const maxPage = Math.min( pagination.totalPages, Math.ceil( FETCH_ALL_MAX_ITEMS / chunkSizeFromPath( path ) ) );
 
 				let endedEarly = false;
 				let cappedByMax = false;
@@ -217,7 +216,7 @@ export default function useCollectionData( {
 		return () => {
 			cancelled = true;
 		};
-	}, [ path, mutationKey, refreshKey, errorMessage, errorNoticeId, fetchAll, fetchAllChunkSize ] );
+	}, [ path, mutationKey, refreshKey, errorMessage, errorNoticeId, fetchAll ] );
 
 	useEffect( () => {
 		if ( ! trashCountPath ) {

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.test.js
@@ -3,7 +3,7 @@ import apiFetch from '@wordpress/api-fetch';
 
 import useCollectionData from './use-collection-data';
 import { notifyError, notifyInfo } from '../notices';
-import { FETCH_ALL_MAX_ITEMS } from '../utils/per-page';
+import { FETCH_ALL_CHUNK_SIZE, FETCH_ALL_MAX_ITEMS } from '../utils/per-page';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 jest.mock( '../notices', () => ( { notifyError: jest.fn(), notifyInfo: jest.fn() } ) );
@@ -30,7 +30,6 @@ describe( 'useCollectionData', () => {
 		await waitFor( () => expect( result.current.hasResolved ).toBe( true ) );
 		expect( result.current.data ).toHaveLength( 2 );
 		expect( result.current.paginationInfo ).toEqual( { totalItems: 60, totalPages: 3 } );
-		expect( result.current.progress ).toBeNull();
 		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
 	} );
 
@@ -51,8 +50,6 @@ describe( 'useCollectionData', () => {
 			await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
 			expect( result.current.data.map( item => item.id ) ).toEqual( [ 1, 2, 3, 4, 5 ] );
 			expect( result.current.paginationInfo ).toEqual( { totalItems: 5, totalPages: 1 } );
-			// Walk finished — progress resets so the control label recovers.
-			expect( result.current.progress ).toBeNull();
 			expect( apiFetch ).toHaveBeenCalledTimes( 3 );
 		} );
 
@@ -93,15 +90,15 @@ describe( 'useCollectionData', () => {
 		it( 'stops at the fetch-all cap and notifies the list was truncated', async () => {
 			apiFetch.mockImplementation( ( { path, parse } ) => {
 				const page = Number( ( path.match( /[?&]page=(\d+)/ ) || [] )[ 1 ] || 1 );
-				const items = Array.from( { length: 100 }, ( unused, i ) => ( { id: page * 100 + i } ) );
+				const items = Array.from( { length: FETCH_ALL_CHUNK_SIZE }, ( unused, i ) => ( { id: page * FETCH_ALL_CHUNK_SIZE + i } ) );
 				return Promise.resolve( parse === false ? makeResponse( items, { total: 50000, totalPages: 500 } ) : items );
 			} );
 
-			const { result } = renderHook( () => useCollectionData( { path: '/wp/v2/test?per_page=100&page=1', fetchAll: true } ) );
+			const { result } = renderHook( () => useCollectionData( { path: '/wp/v2/test?page=1', fetchAll: true } ) );
 
 			await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
 			expect( result.current.data ).toHaveLength( FETCH_ALL_MAX_ITEMS );
-			expect( apiFetch ).toHaveBeenCalledTimes( FETCH_ALL_MAX_ITEMS / 100 );
+			expect( apiFetch ).toHaveBeenCalledTimes( FETCH_ALL_MAX_ITEMS / FETCH_ALL_CHUNK_SIZE );
 			expect( notifyInfo ).toHaveBeenCalledWith(
 				`Showing the first ${ FETCH_ALL_MAX_ITEMS.toLocaleString() } items. Use search or filters to narrow the list.`
 			);

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.test.js
@@ -105,6 +105,21 @@ describe( 'useCollectionData', () => {
 			expect( result.current.paginationInfo ).toEqual( { totalItems: result.current.data.length, totalPages: 1 } );
 		} );
 
+		it( 'derives the fetch-all page ceiling from the path per_page', async () => {
+			const chunk = 200;
+			apiFetch.mockImplementation( ( { path, parse } ) => {
+				const page = Number( ( path.match( /[?&]page=(\d+)/ ) || [] )[ 1 ] || 1 );
+				const items = Array.from( { length: chunk }, ( unused, i ) => ( { id: page * chunk + i } ) );
+				return Promise.resolve( parse === false ? makeResponse( items, { total: 50000, totalPages: 500 } ) : items );
+			} );
+
+			const { result } = renderHook( () => useCollectionData( { path: `/wp/v2/test?per_page=${ chunk }&page=1`, fetchAll: true } ) );
+
+			await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+			expect( apiFetch ).toHaveBeenCalledTimes( FETCH_ALL_MAX_ITEMS / chunk );
+			expect( result.current.data ).toHaveLength( FETCH_ALL_MAX_ITEMS );
+		} );
+
 		it( 'stops quietly on a deterministic out-of-range page — no retry, no error notice', async () => {
 			let page2Attempts = 0;
 			apiFetch.mockImplementation( ( { path } ) => {

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
@@ -1,77 +1,271 @@
 /**
  * `useState` for a DataViews `view`, seeded from and persisted to the
  * current user's saved preferences (user meta via
- * `Admin_Shell_Preferences`). Only `perPage` is persisted for now —
- * the saved value follows the user across browsers, matching classic
- * Screen Options behaviour.
+ * `Admin_Shell_Preferences`), so a configured list survives a reload and
+ * follows the user across browsers, matching classic Screen Options.
  *
- * The save is not debounced: `perPage` is a discrete control, so a change
- * costs at most one request per click, and firing immediately means a
- * navigation right after the click can't drop the preference.
+ * Persisted: the presentation half of the view — layout type, sort,
+ * visible fields (in their display order), density, column widths and
+ * items per page. Not persisted: page, search and filters, which are a
+ * query rather than a configuration.
+ *
+ * Saves are debounced because column resizing streams changes, and
+ * flushed on `pagehide` so navigating away right after a click can't
+ * drop the preference.
  */
 
 import apiFetch from '@wordpress/api-fetch';
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 
 import { getViewPrefs } from '../admin-globals';
 import { DEFAULT_PER_PAGE_OPTIONS, isValidPerPage } from '../utils/per-page';
 
 const PREFERENCES_PATH = '/newspack-newsletters/v1/admin-shell/preferences';
 
+const SAVE_DEBOUNCE_MS = 500;
+
+// Mirrors `Admin_Shell_Preferences::DENSITIES`.
+const DENSITIES = [ 'compact', 'balanced', 'comfortable' ];
+
+const SORT_DIRECTIONS = [ 'asc', 'desc' ];
+
+// Mirrors `Admin_Shell_Preferences::MAX_PREVIEW_SIZE`. The grid stores a
+// pixel width here, not the slider position.
+const MAX_PREVIEW_SIZE = 4000;
+
+const isPreviewSize = value => Number.isInteger( value ) && value >= 0 && value <= MAX_PREVIEW_SIZE;
+
+const isNonEmptyString = value => typeof value === 'string' && value.length > 0;
+
+// The server rejects a payload with nothing storable in it, so don't send one.
+const isSavable = payload => payload !== '{}';
+
+// DataViews rebuilds `layout.styles` as columns are resized, and key
+// order follows insertion — sort so an unchanged view can't serialise
+// differently and trigger a save on its own.
+function stableStringify( value ) {
+	if ( Array.isArray( value ) ) {
+		return `[${ value.map( stableStringify ).join( ',' ) }]`;
+	}
+	if ( value && typeof value === 'object' ) {
+		const entries = Object.keys( value )
+			.sort()
+			.map( key => `${ JSON.stringify( key ) }:${ stableStringify( value[ key ] ) }` );
+		return `{${ entries.join( ',' ) }}`;
+	}
+	return JSON.stringify( value ) ?? 'null';
+}
+
 /**
- * @param {string}        screenKey        Screen identifier (allowlisted server-side).
- * @param {Object}        defaultView      Default view state.
- * @param {Array<number>} [perPageOptions] Values this screen's control offers.
+ * Extract the storable slice of a view.
+ *
+ * @param {Object} view DataViews view state.
+ * @return {Object} Preferences payload.
+ */
+function toPrefs( view = {} ) {
+	const prefs = {};
+
+	if ( isValidPerPage( view.perPage ) ) {
+		prefs.perPage = view.perPage;
+	}
+	if ( isNonEmptyString( view.type ) ) {
+		prefs.type = view.type;
+	}
+	if ( isNonEmptyString( view.titleField ) ) {
+		prefs.titleField = view.titleField;
+	}
+	if ( Array.isArray( view.fields ) ) {
+		prefs.fields = view.fields.filter( isNonEmptyString );
+	}
+	if ( isNonEmptyString( view.sort?.field ) ) {
+		prefs.sort = {
+			field: view.sort.field,
+			direction: SORT_DIRECTIONS.includes( view.sort.direction ) ? view.sort.direction : 'desc',
+		};
+	}
+
+	const layout = {};
+	if ( DENSITIES.includes( view.layout?.density ) ) {
+		layout.density = view.layout.density;
+	}
+	if ( isPreviewSize( view.layout?.previewSize ) ) {
+		layout.previewSize = view.layout.previewSize;
+	}
+	const styles = view.layout?.styles;
+	if ( styles && typeof styles === 'object' && Object.keys( styles ).length > 0 ) {
+		layout.styles = styles;
+	}
+	if ( Object.keys( layout ).length > 0 ) {
+		prefs.layout = layout;
+	}
+
+	return prefs;
+}
+
+/**
+ * Turn stored preferences into a view patch, dropping anything this
+ * screen no longer offers.
+ *
+ * The server validates shape and size, not a per-screen field
+ * allowlist — a value saved before a column was renamed or removed is
+ * dropped here rather than left to render an empty column.
+ *
+ * @param {Object}        prefs                  Stored preferences.
+ * @param {Object}        options                Screen bindings.
+ * @param {Array<number>} options.perPageOptions Values this screen's control offers.
+ * @param {Array<string>} [options.fieldIds]     Field IDs this screen defines.
+ * @param {Array<string>} [options.layoutTypes]  Layout types this screen offers.
+ * @return {Object} View patch.
+ */
+function toViewPatch( prefs, { perPageOptions, fieldIds, layoutTypes } ) {
+	const patch = {};
+	if ( ! prefs || typeof prefs !== 'object' ) {
+		return patch;
+	}
+
+	const isKnownField = id => ! fieldIds || fieldIds.includes( id );
+
+	// The server validates a range, not a per-screen set — a stored
+	// value this screen doesn't offer (a legacy value, or one saved on a
+	// screen with different steps) would leave the control with nothing
+	// highlighted, so fall back to the default.
+	if ( isValidPerPage( prefs.perPage ) && perPageOptions.includes( prefs.perPage ) ) {
+		patch.perPage = prefs.perPage;
+	}
+
+	if ( isNonEmptyString( prefs.type ) && ( ! layoutTypes || layoutTypes.includes( prefs.type ) ) ) {
+		patch.type = prefs.type;
+	}
+
+	if ( isNonEmptyString( prefs.titleField ) && isKnownField( prefs.titleField ) ) {
+		patch.titleField = prefs.titleField;
+	}
+
+	if ( Array.isArray( prefs.fields ) ) {
+		patch.fields = prefs.fields.filter( id => isNonEmptyString( id ) && isKnownField( id ) );
+	}
+
+	if ( isNonEmptyString( prefs.sort?.field ) && isKnownField( prefs.sort.field ) ) {
+		patch.sort = {
+			field: prefs.sort.field,
+			direction: SORT_DIRECTIONS.includes( prefs.sort.direction ) ? prefs.sort.direction : 'desc',
+		};
+	}
+
+	const layout = {};
+	if ( DENSITIES.includes( prefs.layout?.density ) ) {
+		layout.density = prefs.layout.density;
+	}
+	if ( isPreviewSize( prefs.layout?.previewSize ) ) {
+		layout.previewSize = prefs.layout.previewSize;
+	}
+	if ( prefs.layout?.styles && typeof prefs.layout.styles === 'object' ) {
+		const styles = {};
+		for ( const [ id, style ] of Object.entries( prefs.layout.styles ) ) {
+			if ( isKnownField( id ) && style && typeof style === 'object' ) {
+				styles[ id ] = style;
+			}
+		}
+		if ( Object.keys( styles ).length > 0 ) {
+			layout.styles = styles;
+		}
+	}
+	if ( Object.keys( layout ).length > 0 ) {
+		patch.layout = layout;
+	}
+
+	return patch;
+}
+
+/**
+ * @param {string}        screenKey                Screen identifier (allowlisted server-side).
+ * @param {Object}        defaultView              Default view state.
+ * @param {Object}        [options]                Screen bindings.
+ * @param {Array<number>} [options.perPageOptions] Values this screen's control offers.
+ * @param {Array<string>} [options.fieldIds]       Field IDs this screen defines.
+ * @param {Array<string>} [options.layoutTypes]    Layout types this screen offers.
+ * @param {Object}        [options.urlPatch]       View patch seeded from the URL. Applied last, so a
+ *                                                 forwarded legacy link still wins over saved preferences.
  * @return {[Object, Function]} `[ view, setView ]` pair.
  */
-export default function usePersistedView( screenKey, defaultView, perPageOptions = DEFAULT_PER_PAGE_OPTIONS ) {
-	const [ view, setView ] = useState( () => {
-		const perPage = getViewPrefs()[ screenKey ]?.perPage;
-		// The server validates a range, not a per-screen set — a stored
-		// value this screen doesn't offer (a legacy value, or one saved
-		// on a screen with different steps) would leave the control with
-		// nothing highlighted, so fall back to the default.
-		return isValidPerPage( perPage ) && perPageOptions.includes( perPage ) ? { ...defaultView, perPage } : defaultView;
-	} );
+export default function usePersistedView(
+	screenKey,
+	defaultView,
+	{ perPageOptions = DEFAULT_PER_PAGE_OPTIONS, fieldIds = null, layoutTypes = null, urlPatch = null } = {}
+) {
+	const [ view, setView ] = useState( () => ( {
+		...defaultView,
+		...toViewPatch( getViewPrefs()[ screenKey ], { perPageOptions, fieldIds, layoutTypes } ),
+		...( urlPatch || {} ),
+	} ) );
 
-	const lastSavedRef = useRef( view.perPage );
-	const desiredRef = useRef( view.perPage );
+	const serialized = useMemo( () => stableStringify( toPrefs( view ) ), [ view ] );
+
+	// The mounted view is the baseline, so nothing is written until the
+	// user changes something and a one-off legacy deep link can't rewrite
+	// a saved configuration.
+	const lastSavedRef = useRef( serialized );
+	const desiredRef = useRef( serialized );
 	const inFlightRef = useRef( false );
+	const flushRef = useRef( () => {} );
 
 	useEffect( () => {
-		desiredRef.current = view.perPage;
-		if ( view.perPage === lastSavedRef.current || ! isValidPerPage( view.perPage ) || inFlightRef.current ) {
-			return;
-		}
 		// One at a time — concurrent writes could land out of order.
-		const save = ( perPage, attempt = 0 ) => {
+		const save = ( payload, { attempt = 0, keepalive = false } = {} ) => {
 			inFlightRef.current = true;
 			let failed = false;
 			apiFetch( {
 				path: PREFERENCES_PATH,
 				method: 'POST',
-				data: { screen: screenKey, prefs: { perPage } },
+				data: { screen: screenKey, prefs: JSON.parse( payload ) },
+				...( keepalive ? { keepalive: true } : {} ),
 			} )
 				.then( () => {
-					lastSavedRef.current = perPage;
+					lastSavedRef.current = payload;
 				} )
 				.catch( () => {
 					failed = true;
 				} )
 				.finally( () => {
 					inFlightRef.current = false;
-					if ( desiredRef.current !== perPage && isValidPerPage( desiredRef.current ) ) {
+					if ( desiredRef.current !== payload && isSavable( desiredRef.current ) ) {
 						save( desiredRef.current );
 						return;
 					}
 					// Nothing else will retrigger the effect, so retry once.
 					if ( failed && attempt < 1 ) {
-						save( perPage, attempt + 1 );
+						save( payload, { attempt: attempt + 1 } );
 					}
 				} );
 		};
-		save( view.perPage );
-	}, [ view.perPage, screenKey ] );
+
+		flushRef.current = ( { keepalive = false } = {} ) => {
+			const payload = desiredRef.current;
+			if ( payload === lastSavedRef.current || inFlightRef.current || ! isSavable( payload ) ) {
+				return;
+			}
+			save( payload, { keepalive } );
+		};
+	}, [ screenKey ] );
+
+	useEffect( () => {
+		desiredRef.current = serialized;
+		if ( serialized === lastSavedRef.current ) {
+			return undefined;
+		}
+		const timer = setTimeout( () => flushRef.current(), SAVE_DEBOUNCE_MS );
+		return () => clearTimeout( timer );
+	}, [ serialized ] );
+
+	useEffect( () => {
+		const flushNow = () => flushRef.current( { keepalive: true } );
+		window.addEventListener( 'pagehide', flushNow );
+		return () => {
+			window.removeEventListener( 'pagehide', flushNow );
+			// Navigating between screens unmounts before a debounced save fires.
+			flushRef.current();
+		};
+	}, [] );
 
 	return [ view, setView ];
 }

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
@@ -57,7 +57,10 @@ function toColumnStyles( styles ) {
 		}
 		const picked = {};
 		for ( const key of [ 'width', 'minWidth', 'maxWidth' ] ) {
-			if ( typeof style[ key ] === 'number' || isNonEmptyString( style[ key ] ) ) {
+			// `Number.isFinite`, not `typeof`: NaN and Infinity serialise to
+			// `null`, which the schema rejects, and a rejected payload is
+			// re-sent on every later change.
+			if ( Number.isFinite( style[ key ] ) || isNonEmptyString( style[ key ] ) ) {
 				picked[ key ] = style[ key ];
 			}
 		}
@@ -268,19 +271,19 @@ export default function usePersistedView(
 	// anything else, since the payload is the whole presentation state.
 	const lastSavedRef = useRef( serialized );
 	const desiredRef = useRef( serialized );
-	// The payload currently being written, or null.
+	// The write currently in flight, or null. Identity matters: each save
+	// clears it only if it is still the one in flight.
 	const inFlightRef = useRef( null );
-	const abortRef = useRef( null );
 	const unloadingRef = useRef( false );
 	const flushRef = useRef( () => {} );
 
 	useEffect( () => {
 		// One at a time — concurrent writes could land out of order.
 		const save = ( payload, { attempt = 0, keepalive = false } = {} ) => {
-			inFlightRef.current = payload;
 			let failed = false;
 			const controller = 'undefined' === typeof AbortController ? null : new AbortController();
-			abortRef.current = controller;
+			const inFlight = { controller };
+			inFlightRef.current = inFlight;
 			apiFetch( {
 				path: PREFERENCES_PATH,
 				method: 'POST',
@@ -295,7 +298,11 @@ export default function usePersistedView(
 					failed = true;
 				} )
 				.finally( () => {
-					inFlightRef.current = null;
+					// Only if this is still the write in flight: an aborted
+					// request settles after its replacement has started.
+					if ( inFlightRef.current === inFlight ) {
+						inFlightRef.current = null;
+					}
 					// The page is going: a chained save would be cancelled
 					// with it, and a retry would re-send what we just
 					// superseded.
@@ -323,14 +330,16 @@ export default function usePersistedView(
 			// out that chain can't be relied on: the request in flight was
 			// started without `keepalive`, so it goes with the page.
 			if ( inFlightRef.current ) {
-				if ( ! keepalive || inFlightRef.current === payload ) {
+				if ( ! keepalive ) {
 					return;
 				}
-				// Cancel the older write first. Left running, it could reach
-				// the server after this one and put back the values this
-				// payload replaces.
+				// Replace the write in flight rather than waiting on it. It
+				// was started without `keepalive`, so navigation is free to
+				// tear it down mid-request, and if it did survive it could
+				// land after this one and put back what this payload
+				// replaces. Re-sending the same payload is harmless.
 				unloadingRef.current = true;
-				abortRef.current?.abort();
+				inFlightRef.current.controller?.abort();
 			}
 			save( payload, { keepalive } );
 		};
@@ -347,9 +356,11 @@ export default function usePersistedView(
 
 	useEffect( () => {
 		const flushNow = () => flushRef.current( { keepalive: true } );
-		// A page restored from the back/forward cache goes on saving.
+		// A page restored from the back/forward cache goes on saving, and
+		// re-sends anything the freeze dropped.
 		const resume = () => {
 			unloadingRef.current = false;
+			flushRef.current();
 		};
 		window.addEventListener( 'pagehide', flushNow );
 		window.addEventListener( 'pageshow', resume );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
@@ -37,6 +37,35 @@ const isPreviewSize = value => Number.isInteger( value ) && value >= 0 && value 
 
 const isNonEmptyString = value => typeof value === 'string' && value.length > 0;
 
+// Mirrors `Admin_Shell_Preferences::ALIGNMENTS`.
+const ALIGNMENTS = [ 'start', 'center', 'end' ];
+
+// DataViews owns the shape of a column style, so pick the keys the server
+// stores rather than forwarding it whole: an unknown key or an unknown
+// alignment would fail schema validation, and a rejected save takes every
+// other appearance setting down with it.
+function toColumnStyles( styles ) {
+	const clean = {};
+	for ( const [ id, style ] of Object.entries( styles ) ) {
+		if ( ! style || typeof style !== 'object' ) {
+			continue;
+		}
+		const picked = {};
+		for ( const key of [ 'width', 'minWidth', 'maxWidth' ] ) {
+			if ( typeof style[ key ] === 'number' || isNonEmptyString( style[ key ] ) ) {
+				picked[ key ] = style[ key ];
+			}
+		}
+		if ( ALIGNMENTS.includes( style.align ) ) {
+			picked.align = style.align;
+		}
+		if ( Object.keys( picked ).length > 0 ) {
+			clean[ id ] = picked;
+		}
+	}
+	return clean;
+}
+
 // The server rejects a payload with nothing storable in it, so don't send one.
 const isSavable = payload => payload !== '{}';
 
@@ -92,8 +121,11 @@ function toPrefs( view = {} ) {
 		layout.previewSize = view.layout.previewSize;
 	}
 	const styles = view.layout?.styles;
-	if ( styles && typeof styles === 'object' && Object.keys( styles ).length > 0 ) {
-		layout.styles = styles;
+	if ( styles && typeof styles === 'object' ) {
+		const picked = toColumnStyles( styles );
+		if ( Object.keys( picked ).length > 0 ) {
+			layout.styles = picked;
+		}
 	}
 	if ( Object.keys( layout ).length > 0 ) {
 		prefs.layout = layout;
@@ -142,7 +174,14 @@ function toViewPatch( prefs, { perPageOptions, fieldIds, layoutTypes } ) {
 	}
 
 	if ( Array.isArray( prefs.fields ) ) {
-		patch.fields = prefs.fields.filter( id => isNonEmptyString( id ) && isKnownField( id ) );
+		const fields = prefs.fields.filter( id => isNonEmptyString( id ) && isKnownField( id ) );
+		// An empty stored array means "hide every column" and is honoured.
+		// An array the filter emptied means every stored column has since
+		// been renamed or removed, so fall back to the screen's default
+		// rather than restoring a title-only list nobody asked for.
+		if ( fields.length > 0 || prefs.fields.length === 0 ) {
+			patch.fields = fields;
+		}
 	}
 
 	if ( isNonEmptyString( prefs.sort?.field ) && isKnownField( prefs.sort.field ) ) {
@@ -186,18 +225,24 @@ function toViewPatch( prefs, { perPageOptions, fieldIds, layoutTypes } ) {
  * @param {Array<string>} [options.layoutTypes]    Layout types this screen offers.
  * @param {Object}        [options.urlPatch]       View patch seeded from the URL. Applied last, so a
  *                                                 forwarded legacy link still wins over saved preferences.
+ * @param {Function}      [options.normalize]      Reconciles the restored view with the screen's own rules. Runs on
+ *                                                 the merged view, so settings a stored layout type implies are
+ *                                                 applied at mount rather than only on the next change.
  * @return {[Object, Function]} `[ view, setView ]` pair.
  */
 export default function usePersistedView(
 	screenKey,
 	defaultView,
-	{ perPageOptions = DEFAULT_PER_PAGE_OPTIONS, fieldIds = null, layoutTypes = null, urlPatch = null } = {}
+	{ perPageOptions = DEFAULT_PER_PAGE_OPTIONS, fieldIds = null, layoutTypes = null, urlPatch = null, normalize = null } = {}
 ) {
-	const [ view, setView ] = useState( () => ( {
-		...defaultView,
-		...toViewPatch( getViewPrefs()[ screenKey ], { perPageOptions, fieldIds, layoutTypes } ),
-		...( urlPatch || {} ),
-	} ) );
+	const [ view, setView ] = useState( () => {
+		const merged = {
+			...defaultView,
+			...toViewPatch( getViewPrefs()[ screenKey ], { perPageOptions, fieldIds, layoutTypes } ),
+			...( urlPatch || {} ),
+		};
+		return normalize ? normalize( merged ) : merged;
+	} );
 
 	const serialized = useMemo( () => stableStringify( toPrefs( view ) ), [ view ] );
 
@@ -241,7 +286,14 @@ export default function usePersistedView(
 
 		flushRef.current = ( { keepalive = false } = {} ) => {
 			const payload = desiredRef.current;
-			if ( payload === lastSavedRef.current || inFlightRef.current || ! isSavable( payload ) ) {
+			if ( payload === lastSavedRef.current || ! isSavable( payload ) ) {
+				return;
+			}
+			// The in-flight guard keeps debounced saves in order. On the way
+			// out ordering no longer matters, and the request in flight was
+			// started without `keepalive`, so the browser is about to cancel
+			// it and the chained save can't be relied on.
+			if ( inFlightRef.current && ! keepalive ) {
 				return;
 			}
 			save( payload, { keepalive } );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
@@ -5,9 +5,9 @@
  * follows the user across browsers, matching classic Screen Options.
  *
  * Persisted: the presentation half of the view — layout type, sort,
- * visible fields (in their display order), density, column widths and
- * items per page. Not persisted: page, search and filters, which are a
- * query rather than a configuration.
+ * visible fields (in their display order and with their toggles),
+ * density, column widths and items per page. Not persisted: page,
+ * search and filters, which are a query rather than a configuration.
  *
  * Saves are debounced because column resizing streams changes, and
  * flushed on `pagehide` so navigating away right after a click can't
@@ -29,9 +29,8 @@ const DENSITIES = [ 'compact', 'balanced', 'comfortable' ];
 
 const SORT_DIRECTIONS = [ 'asc', 'desc' ];
 
-// DataViews renders these alongside the field checkboxes in View options,
-// so they have to persist with them. Mirrors
-// `Admin_Shell_Preferences::VISIBILITY_FLAGS`.
+// DataViews renders these in View options alongside the field
+// checkboxes. Mirrors `Admin_Shell_Preferences::VISIBILITY_FLAGS`.
 const VISIBILITY_FLAGS = [ 'showTitle', 'showMedia', 'showDescription' ];
 
 // Mirrors `Admin_Shell_Preferences::MAX_PREVIEW_SIZE`. The grid stores a
@@ -45,10 +44,8 @@ const isNonEmptyString = value => typeof value === 'string' && value.length > 0;
 // Mirrors `Admin_Shell_Preferences::ALIGNMENTS`.
 const ALIGNMENTS = [ 'start', 'center', 'end' ];
 
-// DataViews owns the shape of a column style, so pick the keys the server
-// stores rather than forwarding it whole: an unknown key or an unknown
-// alignment would fail schema validation, and a rejected save takes every
-// other appearance setting down with it.
+// Picked key by key rather than forwarded whole: DataViews owns this
+// shape, and one unknown key would fail validation for the whole payload.
 function toColumnStyles( styles ) {
 	const clean = {};
 	for ( const [ id, style ] of Object.entries( styles ) ) {
@@ -57,9 +54,7 @@ function toColumnStyles( styles ) {
 		}
 		const picked = {};
 		for ( const key of [ 'width', 'minWidth', 'maxWidth' ] ) {
-			// `Number.isFinite`, not `typeof`: NaN and Infinity serialise to
-			// `null`, which the schema rejects, and a rejected payload is
-			// re-sent on every later change.
+			// NaN and Infinity serialise to `null`, which the schema rejects.
 			if ( Number.isFinite( style[ key ] ) || isNonEmptyString( style[ key ] ) ) {
 				picked[ key ] = style[ key ];
 			}
@@ -77,9 +72,8 @@ function toColumnStyles( styles ) {
 // The server rejects a payload with nothing storable in it, so don't send one.
 const isSavable = payload => payload !== '{}';
 
-// DataViews rebuilds `layout.styles` as columns are resized, and key
-// order follows insertion — sort so an unchanged view can't serialise
-// differently and trigger a save on its own.
+// Key order follows insertion, so sort: an unchanged view must not
+// serialise differently and trigger a save on its own.
 function stableStringify( value ) {
 	if ( Array.isArray( value ) ) {
 		return `[${ value.map( stableStringify ).join( ',' ) }]`;
@@ -170,10 +164,8 @@ function toViewPatch( prefs, { perPageOptions, fieldIds, layoutTypes } ) {
 
 	const isKnownField = id => ! fieldIds || fieldIds.includes( id );
 
-	// The server validates a range, not a per-screen set — a stored
-	// value this screen doesn't offer (a legacy value, or one saved on a
-	// screen with different steps) would leave the control with nothing
-	// highlighted, so fall back to the default.
+	// A stored value this screen doesn't offer would leave the control
+	// with nothing highlighted, so fall back to the default.
 	if ( isValidPerPage( prefs.perPage ) && perPageOptions.includes( prefs.perPage ) ) {
 		patch.perPage = prefs.perPage;
 	}
@@ -188,10 +180,8 @@ function toViewPatch( prefs, { perPageOptions, fieldIds, layoutTypes } ) {
 
 	if ( Array.isArray( prefs.fields ) ) {
 		const fields = prefs.fields.filter( id => isNonEmptyString( id ) && isKnownField( id ) );
-		// An empty stored array means "hide every column" and is honoured.
-		// An array the filter emptied means every stored column has since
-		// been renamed or removed, so fall back to the screen's default
-		// rather than restoring a title-only list nobody asked for.
+		// An empty stored array means "hide every column". An array the
+		// filter emptied means those columns are gone, so use the default.
 		if ( fields.length > 0 || prefs.fields.length === 0 ) {
 			patch.fields = fields;
 		}
@@ -265,14 +255,10 @@ export default function usePersistedView(
 
 	const serialized = useMemo( () => stableStringify( toPrefs( view ) ), [ view ] );
 
-	// The mounted view is the baseline, so nothing is written until the
-	// user changes something. A legacy deep link therefore doesn't write
-	// on arrival, though its sort does ride along once the user changes
-	// anything else, since the payload is the whole presentation state.
+	// The mounted view is the baseline, so nothing is written on arrival.
+	// A legacy deep link's sort rides along on the first save after that.
 	const lastSavedRef = useRef( serialized );
 	const desiredRef = useRef( serialized );
-	// The write currently in flight, or null. Identity matters: each save
-	// clears it only if it is still the one in flight.
 	const inFlightRef = useRef( null );
 	const unloadingRef = useRef( false );
 	const flushRef = useRef( () => {} );
@@ -303,9 +289,7 @@ export default function usePersistedView(
 					if ( inFlightRef.current === inFlight ) {
 						inFlightRef.current = null;
 					}
-					// The page is going: a chained save would be cancelled
-					// with it, and a retry would re-send what we just
-					// superseded.
+					// The page is going: a chained save or retry goes with it.
 					if ( unloadingRef.current ) {
 						return;
 					}
@@ -325,19 +309,13 @@ export default function usePersistedView(
 			if ( payload === lastSavedRef.current || ! isSavable( payload ) ) {
 				return;
 			}
-			// The in-flight guard keeps debounced saves in order, and the
-			// chained save in `finally` picks up anything newer. On the way
-			// out that chain can't be relied on: the request in flight was
-			// started without `keepalive`, so it goes with the page.
 			if ( inFlightRef.current ) {
 				if ( ! keepalive ) {
 					return;
 				}
-				// Replace the write in flight rather than waiting on it. It
-				// was started without `keepalive`, so navigation is free to
-				// tear it down mid-request, and if it did survive it could
-				// land after this one and put back what this payload
-				// replaces. Re-sending the same payload is harmless.
+				// Replace the write in flight: it was started without
+				// `keepalive`, so navigation can tear it down, and if it did
+				// survive it could land after this one.
 				unloadingRef.current = true;
 				inFlightRef.current.controller?.abort();
 			}
@@ -356,8 +334,8 @@ export default function usePersistedView(
 
 	useEffect( () => {
 		const flushNow = () => flushRef.current( { keepalive: true } );
-		// A page restored from the back/forward cache goes on saving, and
-		// re-sends anything the freeze dropped.
+		// Restored from the back/forward cache: resume, and re-send
+		// anything the freeze dropped.
 		const resume = () => {
 			unloadingRef.current = false;
 			flushRef.current();

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
@@ -29,6 +29,11 @@ const DENSITIES = [ 'compact', 'balanced', 'comfortable' ];
 
 const SORT_DIRECTIONS = [ 'asc', 'desc' ];
 
+// DataViews renders these alongside the field checkboxes in View options,
+// so they have to persist with them. Mirrors
+// `Admin_Shell_Preferences::VISIBILITY_FLAGS`.
+const VISIBILITY_FLAGS = [ 'showTitle', 'showMedia', 'showDescription' ];
+
 // Mirrors `Admin_Shell_Preferences::MAX_PREVIEW_SIZE`. The grid stores a
 // pixel width here, not the slider position.
 const MAX_PREVIEW_SIZE = 4000;
@@ -112,6 +117,11 @@ function toPrefs( view = {} ) {
 			direction: SORT_DIRECTIONS.includes( view.sort.direction ) ? view.sort.direction : 'desc',
 		};
 	}
+	for ( const flag of VISIBILITY_FLAGS ) {
+		if ( typeof view[ flag ] === 'boolean' ) {
+			prefs[ flag ] = view[ flag ];
+		}
+	}
 
 	const layout = {};
 	if ( DENSITIES.includes( view.layout?.density ) ) {
@@ -191,6 +201,12 @@ function toViewPatch( prefs, { perPageOptions, fieldIds, layoutTypes } ) {
 		};
 	}
 
+	for ( const flag of VISIBILITY_FLAGS ) {
+		if ( typeof prefs[ flag ] === 'boolean' ) {
+			patch[ flag ] = prefs[ flag ];
+		}
+	}
+
 	const layout = {};
 	if ( DENSITIES.includes( prefs.layout?.density ) ) {
 		layout.density = prefs.layout.density;
@@ -247,23 +263,30 @@ export default function usePersistedView(
 	const serialized = useMemo( () => stableStringify( toPrefs( view ) ), [ view ] );
 
 	// The mounted view is the baseline, so nothing is written until the
-	// user changes something and a one-off legacy deep link can't rewrite
-	// a saved configuration.
+	// user changes something. A legacy deep link therefore doesn't write
+	// on arrival, though its sort does ride along once the user changes
+	// anything else, since the payload is the whole presentation state.
 	const lastSavedRef = useRef( serialized );
 	const desiredRef = useRef( serialized );
-	const inFlightRef = useRef( false );
+	// The payload currently being written, or null.
+	const inFlightRef = useRef( null );
+	const abortRef = useRef( null );
+	const unloadingRef = useRef( false );
 	const flushRef = useRef( () => {} );
 
 	useEffect( () => {
 		// One at a time — concurrent writes could land out of order.
 		const save = ( payload, { attempt = 0, keepalive = false } = {} ) => {
-			inFlightRef.current = true;
+			inFlightRef.current = payload;
 			let failed = false;
+			const controller = 'undefined' === typeof AbortController ? null : new AbortController();
+			abortRef.current = controller;
 			apiFetch( {
 				path: PREFERENCES_PATH,
 				method: 'POST',
 				data: { screen: screenKey, prefs: JSON.parse( payload ) },
 				...( keepalive ? { keepalive: true } : {} ),
+				...( controller ? { signal: controller.signal } : {} ),
 			} )
 				.then( () => {
 					lastSavedRef.current = payload;
@@ -272,7 +295,13 @@ export default function usePersistedView(
 					failed = true;
 				} )
 				.finally( () => {
-					inFlightRef.current = false;
+					inFlightRef.current = null;
+					// The page is going: a chained save would be cancelled
+					// with it, and a retry would re-send what we just
+					// superseded.
+					if ( unloadingRef.current ) {
+						return;
+					}
 					if ( desiredRef.current !== payload && isSavable( desiredRef.current ) ) {
 						save( desiredRef.current );
 						return;
@@ -289,12 +318,19 @@ export default function usePersistedView(
 			if ( payload === lastSavedRef.current || ! isSavable( payload ) ) {
 				return;
 			}
-			// The in-flight guard keeps debounced saves in order. On the way
-			// out ordering no longer matters, and the request in flight was
-			// started without `keepalive`, so the browser is about to cancel
-			// it and the chained save can't be relied on.
-			if ( inFlightRef.current && ! keepalive ) {
-				return;
+			// The in-flight guard keeps debounced saves in order, and the
+			// chained save in `finally` picks up anything newer. On the way
+			// out that chain can't be relied on: the request in flight was
+			// started without `keepalive`, so it goes with the page.
+			if ( inFlightRef.current ) {
+				if ( ! keepalive || inFlightRef.current === payload ) {
+					return;
+				}
+				// Cancel the older write first. Left running, it could reach
+				// the server after this one and put back the values this
+				// payload replaces.
+				unloadingRef.current = true;
+				abortRef.current?.abort();
 			}
 			save( payload, { keepalive } );
 		};
@@ -311,9 +347,15 @@ export default function usePersistedView(
 
 	useEffect( () => {
 		const flushNow = () => flushRef.current( { keepalive: true } );
+		// A page restored from the back/forward cache goes on saving.
+		const resume = () => {
+			unloadingRef.current = false;
+		};
 		window.addEventListener( 'pagehide', flushNow );
+		window.addEventListener( 'pageshow', resume );
 		return () => {
 			window.removeEventListener( 'pagehide', flushNow );
+			window.removeEventListener( 'pageshow', resume );
 			// Navigating between screens unmounts before a debounced save fires.
 			flushRef.current();
 		};

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
@@ -36,6 +36,11 @@ const SAVE_ERROR_NOTICE_ID = 'newspack-newsletters-view-prefs-save-error';
 // list outright rather than truncating it.
 const MAX_FIELDS = 50;
 
+// Mirrors `Admin_Shell_Preferences::LAYOUT_TYPES`. A screen's own
+// `layoutTypes` is narrower than this today, but it is the screen's list, so
+// it can't stand in for the server enum.
+const LAYOUT_TYPES = [ 'table', 'grid', 'list' ];
+
 // Mirrors `Admin_Shell_Preferences::DENSITIES`.
 const DENSITIES = [ 'compact', 'balanced', 'comfortable' ];
 
@@ -117,7 +122,7 @@ function toPrefs( view = {}, { layoutTypes = null } = {} ) {
 	if ( isValidPerPage( view.perPage ) ) {
 		prefs.perPage = view.perPage;
 	}
-	if ( isNonEmptyString( view.type ) && ( ! layoutTypes || layoutTypes.includes( view.type ) ) ) {
+	if ( LAYOUT_TYPES.includes( view.type ) && ( ! layoutTypes || layoutTypes.includes( view.type ) ) ) {
 		prefs.type = view.type;
 	}
 	if ( isNonEmptyString( view.titleField ) ) {
@@ -283,6 +288,13 @@ export default function usePersistedView(
 	const flushRef = useRef( () => {} );
 
 	useEffect( () => {
+		// A rejected payload fails identically on a retry; only a transport
+		// blip or a server fault is worth sending twice.
+		const isRetryable = reason => {
+			const status = reason?.data?.status;
+			return ! status || status >= 500;
+		};
+
 		// A drifted schema fails every save, so report the first one and stay
 		// quiet after that rather than raising a snackbar per density toggle.
 		const reportFailure = reason => {
@@ -312,6 +324,9 @@ export default function usePersistedView(
 			} )
 				.then( () => {
 					lastSavedRef.current = payload;
+					// A blip that recovers shouldn't leave the latch spent, or
+					// a genuine failure later in the session goes unreported.
+					saveFailureReportedRef.current = false;
 				} )
 				.catch( error => {
 					failed = true;
@@ -336,7 +351,7 @@ export default function usePersistedView(
 					}
 					// Nothing else will retrigger the effect, so retry once —
 					// still keepalive if the page is on its way out.
-					if ( attempt < 1 ) {
+					if ( attempt < 1 && isRetryable( failureReason ) ) {
 						save( payload, { attempt: attempt + 1, keepalive } );
 						return;
 					}

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
@@ -6,23 +6,35 @@
  *
  * Persisted: the presentation half of the view — layout type, sort,
  * visible fields (in their display order and with their toggles),
- * density, column widths and items per page. Not persisted: page,
+ * density, grid preview size and items per page. Not persisted: page,
  * search and filters, which are a query rather than a configuration.
  *
- * Saves are debounced because column resizing streams changes, and
- * flushed on `pagehide` so navigating away right after a click can't
- * drop the preference.
+ * Column widths (`view.layout.styles`) round-trip too, but nothing writes
+ * them yet: DataViews 16 reads the map to size cells and ships no resize
+ * handle. The plumbing is here so widths persist the day one appears.
+ *
+ * Saves are debounced because the grid's preview-size slider streams
+ * changes, and flushed on `pagehide` so navigating away right after a
+ * click can't drop the preference.
  */
 
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 import { getViewPrefs } from '../admin-globals';
+import { notifyError } from '../notices';
 import { DEFAULT_PER_PAGE_OPTIONS, isValidPerPage } from '../utils/per-page';
 
 const PREFERENCES_PATH = '/newspack-newsletters/v1/admin-shell/preferences';
 
 const SAVE_DEBOUNCE_MS = 500;
+
+const SAVE_ERROR_NOTICE_ID = 'newspack-newsletters-view-prefs-save-error';
+
+// Mirrors `Admin_Shell_Preferences::MAX_FIELDS`, which rejects a longer
+// list outright rather than truncating it.
+const MAX_FIELDS = 50;
 
 // Mirrors `Admin_Shell_Preferences::DENSITIES`.
 const DENSITIES = [ 'compact', 'balanced', 'comfortable' ];
@@ -90,23 +102,29 @@ function stableStringify( value ) {
 /**
  * Extract the storable slice of a view.
  *
- * @param {Object} view DataViews view state.
+ * Every value is held to the same bounds the route enforces: the schema
+ * fails the whole request on the first value it rejects, so one key out
+ * of range would stop every appearance setting persisting.
+ *
+ * @param {Object}        view                  DataViews view state.
+ * @param {Object}        [options]             Screen bindings.
+ * @param {Array<string>} [options.layoutTypes] Layout types this screen offers.
  * @return {Object} Preferences payload.
  */
-function toPrefs( view = {} ) {
+function toPrefs( view = {}, { layoutTypes = null } = {} ) {
 	const prefs = {};
 
 	if ( isValidPerPage( view.perPage ) ) {
 		prefs.perPage = view.perPage;
 	}
-	if ( isNonEmptyString( view.type ) ) {
+	if ( isNonEmptyString( view.type ) && ( ! layoutTypes || layoutTypes.includes( view.type ) ) ) {
 		prefs.type = view.type;
 	}
 	if ( isNonEmptyString( view.titleField ) ) {
 		prefs.titleField = view.titleField;
 	}
 	if ( Array.isArray( view.fields ) ) {
-		prefs.fields = view.fields.filter( isNonEmptyString );
+		prefs.fields = view.fields.filter( isNonEmptyString ).slice( 0, MAX_FIELDS );
 	}
 	if ( isNonEmptyString( view.sort?.field ) ) {
 		prefs.sort = {
@@ -253,7 +271,7 @@ export default function usePersistedView(
 		return normalize ? normalize( merged ) : merged;
 	} );
 
-	const serialized = useMemo( () => stableStringify( toPrefs( view ) ), [ view ] );
+	const serialized = useMemo( () => stableStringify( toPrefs( view, { layoutTypes } ) ), [ view, layoutTypes ] );
 
 	// The mounted view is the baseline, so nothing is written on arrival.
 	// A legacy deep link's sort rides along on the first save after that.
@@ -261,12 +279,27 @@ export default function usePersistedView(
 	const desiredRef = useRef( serialized );
 	const inFlightRef = useRef( null );
 	const unloadingRef = useRef( false );
+	const saveFailureReportedRef = useRef( false );
 	const flushRef = useRef( () => {} );
 
 	useEffect( () => {
+		// A drifted schema fails every save, so report the first one and stay
+		// quiet after that rather than raising a snackbar per density toggle.
+		const reportFailure = reason => {
+			if ( saveFailureReportedRef.current ) {
+				return;
+			}
+			saveFailureReportedRef.current = true;
+			console.warn( '[newspack-newsletters] Saving view preferences failed.', reason?.code ?? reason ); // eslint-disable-line no-console
+			notifyError( __( 'Your view settings could not be saved, so they will not be restored next time.', 'newspack-newsletters' ), {
+				id: SAVE_ERROR_NOTICE_ID,
+			} );
+		};
+
 		// One at a time — concurrent writes could land out of order.
 		const save = ( payload, { attempt = 0, keepalive = false } = {} ) => {
 			let failed = false;
+			let failureReason = null;
 			const controller = 'undefined' === typeof AbortController ? null : new AbortController();
 			const inFlight = { controller };
 			inFlightRef.current = inFlight;
@@ -280,8 +313,9 @@ export default function usePersistedView(
 				.then( () => {
 					lastSavedRef.current = payload;
 				} )
-				.catch( () => {
+				.catch( error => {
 					failed = true;
+					failureReason = error;
 				} )
 				.finally( () => {
 					// Only if this is still the write in flight: an aborted
@@ -297,9 +331,19 @@ export default function usePersistedView(
 						save( desiredRef.current );
 						return;
 					}
-					// Nothing else will retrigger the effect, so retry once.
-					if ( failed && attempt < 1 ) {
-						save( payload, { attempt: attempt + 1 } );
+					if ( ! failed ) {
+						return;
+					}
+					// Nothing else will retrigger the effect, so retry once —
+					// still keepalive if the page is on its way out.
+					if ( attempt < 1 ) {
+						save( payload, { attempt: attempt + 1, keepalive } );
+						return;
+					}
+					// A keepalive write is the unload flush, and there is no
+					// page left to show a notice on.
+					if ( ! keepalive ) {
+						reportFailure( failureReason );
 					}
 				} );
 		};

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
@@ -21,8 +21,7 @@ const saved = ( prefs, screen = 'newsletters-list' ) => ( {
 	path: PATH,
 	method: 'POST',
 	data: { screen, prefs },
-	// Every save carries one so a `pagehide` flush can cancel the write it
-	// supersedes.
+	// Carried so a `pagehide` flush can cancel the write it supersedes.
 	signal: expect.any( AbortSignal ),
 } );
 
@@ -274,8 +273,6 @@ describe( 'usePersistedView', () => {
 			expect( apiFetch ).toHaveBeenLastCalledWith( saved( { perPage: 20, type: 'table' } ) );
 		} );
 
-		// The request in flight was started without `keepalive`, so the
-		// browser cancels it on the way out and the chained save can't run.
 		it( 'flushes the newest value on pagehide even while a save is in flight', async () => {
 			const deferred = {};
 			apiFetch.mockImplementationOnce( () => new Promise( resolve => ( deferred.resolve = resolve ) ) );
@@ -299,9 +296,6 @@ describe( 'usePersistedView', () => {
 			expect( apiFetch ).toHaveBeenLastCalledWith( { ...saved( { perPage: 20, type: 'table' } ), keepalive: true } );
 		} );
 
-		// The request in flight was started without `keepalive`, so leaving
-		// it to finish is exactly the nondeterminism the flush exists to
-		// remove, even when it carries the value we want.
 		it( 'reissues an in-flight save with keepalive when the page goes away', async () => {
 			apiFetch.mockImplementationOnce( () => new Promise( () => {} ) );
 
@@ -335,8 +329,6 @@ describe( 'usePersistedView', () => {
 			expect( apiFetch ).toHaveBeenCalledWith( saved( { perPage: 25, type: 'table', layout: { styles: { status: { minWidth: 40 } } } } ) );
 		} );
 
-		// The server rejects the whole payload on an unknown key, which
-		// would take every other appearance setting down with it.
 		it( 'sends only the column-style keys the server stores', async () => {
 			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
 

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
@@ -21,6 +21,9 @@ const saved = ( prefs, screen = 'newsletters-list' ) => ( {
 	path: PATH,
 	method: 'POST',
 	data: { screen, prefs },
+	// Every save carries one so a `pagehide` flush can cancel the write it
+	// supersedes.
+	signal: expect.any( AbortSignal ),
 } );
 
 describe( 'usePersistedView', () => {
@@ -296,6 +299,24 @@ describe( 'usePersistedView', () => {
 			expect( apiFetch ).toHaveBeenLastCalledWith( { ...saved( { perPage: 20, type: 'table' } ), keepalive: true } );
 		} );
 
+		it( 'does not repeat a save that is already in flight with the same value', async () => {
+			apiFetch.mockImplementationOnce( () => new Promise( () => {} ) );
+
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
+			} );
+			await settle();
+			expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+
+			act( () => {
+				window.dispatchEvent( new window.Event( 'pagehide' ) );
+			} );
+
+			expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		} );
+
 		// The server rejects the whole payload on an unknown key, which
 		// would take every other appearance setting down with it.
 		it( 'sends only the column-style keys the server stores', async () => {
@@ -312,6 +333,29 @@ describe( 'usePersistedView', () => {
 			expect( apiFetch ).toHaveBeenCalledWith(
 				saved( { perPage: 25, type: 'table', layout: { styles: { status: { width: '120px', minWidth: 40, align: 'center' } } } } )
 			);
+		} );
+	} );
+
+	describe( 'property visibility toggles', () => {
+		it( 'persists them alongside the field checkboxes', async () => {
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, showMedia: false } ) );
+			} );
+			await settle();
+
+			expect( apiFetch ).toHaveBeenCalledWith( saved( { perPage: 25, type: 'table', showMedia: false } ) );
+		} );
+
+		it( 'seeds them from the stored preferences', () => {
+			window.newspackNewslettersAdmin = {
+				viewPrefs: { 'newsletters-list': { showMedia: false, showTitle: true } },
+			};
+
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+			expect( result.current[ 0 ] ).toMatchObject( { showMedia: false, showTitle: true } );
 		} );
 	} );
 

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
@@ -270,5 +270,82 @@ describe( 'usePersistedView', () => {
 
 			expect( apiFetch ).toHaveBeenLastCalledWith( saved( { perPage: 20, type: 'table' } ) );
 		} );
+
+		// The request in flight was started without `keepalive`, so the
+		// browser cancels it on the way out and the chained save can't run.
+		it( 'flushes the newest value on pagehide even while a save is in flight', async () => {
+			const deferred = {};
+			apiFetch.mockImplementationOnce( () => new Promise( resolve => ( deferred.resolve = resolve ) ) );
+			apiFetch.mockResolvedValue( {} );
+
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
+			} );
+			await settle();
+			expect( apiFetch ).toHaveBeenLastCalledWith( saved( { perPage: 50, type: 'table' } ) );
+
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, perPage: 20 } ) );
+			} );
+			act( () => {
+				window.dispatchEvent( new window.Event( 'pagehide' ) );
+			} );
+
+			expect( apiFetch ).toHaveBeenLastCalledWith( { ...saved( { perPage: 20, type: 'table' } ), keepalive: true } );
+		} );
+
+		// The server rejects the whole payload on an unknown key, which
+		// would take every other appearance setting down with it.
+		it( 'sends only the column-style keys the server stores', async () => {
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+			act( () => {
+				result.current[ 1 ]( current => ( {
+					...current,
+					layout: { styles: { status: { width: '120px', minWidth: 40, align: 'center', resizable: true }, date: { align: 'diagonal' } } },
+				} ) );
+			} );
+			await settle();
+
+			expect( apiFetch ).toHaveBeenCalledWith(
+				saved( { perPage: 25, type: 'table', layout: { styles: { status: { width: '120px', minWidth: 40, align: 'center' } } } } )
+			);
+		} );
+	} );
+
+	describe( 'reconciling a restored view', () => {
+		it( 'applies the screen normalize to the restored view', () => {
+			window.newspackNewslettersAdmin = { viewPrefs: { 'layouts-list': { type: 'table' } } };
+			const normalize = view => ( 'table' === view.type ? { ...view, mediaField: undefined } : view );
+
+			const { result } = renderHook( () =>
+				usePersistedView(
+					'layouts-list',
+					{ type: 'grid', perPage: 24, mediaField: 'preview' },
+					{ perPageOptions: [ 24 ], layoutTypes: [ 'grid', 'table' ], normalize }
+				)
+			);
+
+			expect( result.current[ 0 ].type ).toBe( 'table' );
+			expect( result.current[ 0 ].mediaField ).toBeUndefined();
+		} );
+
+		it( 'falls back to the screen default when every stored column has been renamed', () => {
+			window.newspackNewslettersAdmin = { viewPrefs: { 'newsletters-list': { fields: [ 'legacy_one', 'legacy_two' ] } } };
+
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', { ...DEFAULT_VIEW, fields: FIELDS }, { fieldIds: FIELDS } ) );
+
+			expect( result.current[ 0 ].fields ).toEqual( FIELDS );
+		} );
+
+		it( 'still honours a stored empty field list', () => {
+			window.newspackNewslettersAdmin = { viewPrefs: { 'newsletters-list': { fields: [] } } };
+
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', { ...DEFAULT_VIEW, fields: FIELDS }, { fieldIds: FIELDS } ) );
+
+			expect( result.current[ 0 ].fields ).toEqual( [] );
+		} );
 	} );
 } );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
@@ -299,7 +299,10 @@ describe( 'usePersistedView', () => {
 			expect( apiFetch ).toHaveBeenLastCalledWith( { ...saved( { perPage: 20, type: 'table' } ), keepalive: true } );
 		} );
 
-		it( 'does not repeat a save that is already in flight with the same value', async () => {
+		// The request in flight was started without `keepalive`, so leaving
+		// it to finish is exactly the nondeterminism the flush exists to
+		// remove, even when it carries the value we want.
+		it( 'reissues an in-flight save with keepalive when the page goes away', async () => {
 			apiFetch.mockImplementationOnce( () => new Promise( () => {} ) );
 
 			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
@@ -314,7 +317,22 @@ describe( 'usePersistedView', () => {
 				window.dispatchEvent( new window.Event( 'pagehide' ) );
 			} );
 
-			expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+			expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+			expect( apiFetch ).toHaveBeenLastCalledWith( { ...saved( { perPage: 50, type: 'table' } ), keepalive: true } );
+		} );
+
+		it( 'drops a non-finite column width rather than poisoning the payload', async () => {
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+			act( () => {
+				result.current[ 1 ]( current => ( {
+					...current,
+					layout: { styles: { status: { width: NaN, minWidth: 40 } } },
+				} ) );
+			} );
+			await settle();
+
+			expect( apiFetch ).toHaveBeenCalledWith( saved( { perPage: 25, type: 'table', layout: { styles: { status: { minWidth: 40 } } } } ) );
 		} );
 
 		// The server rejects the whole payload on an unknown key, which

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
@@ -6,131 +6,269 @@ import { PER_PAGE_ALL } from '../utils/per-page';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
+const PATH = '/newspack-newsletters/v1/admin-shell/preferences';
 const DEFAULT_VIEW = { type: 'table', page: 1, perPage: 25 };
+const FIELDS = [ 'status', 'date', 'author' ];
+
+// Longer than the hook's debounce.
+const settle = async () => {
+	await act( async () => {
+		jest.advanceTimersByTime( 1000 );
+	} );
+};
+
+const saved = ( prefs, screen = 'newsletters-list' ) => ( {
+	path: PATH,
+	method: 'POST',
+	data: { screen, prefs },
+} );
 
 describe( 'usePersistedView', () => {
 	beforeEach( () => {
+		jest.useFakeTimers();
 		apiFetch.mockReset();
 		apiFetch.mockResolvedValue( {} );
 		delete window.newspackNewslettersAdmin;
 	} );
 
-	it( 'seeds perPage from the bootstrapped preferences', () => {
-		window.newspackNewslettersAdmin = { viewPrefs: { 'newsletters-list': { perPage: 100 } } };
-		const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
-		expect( result.current[ 0 ].perPage ).toBe( 100 );
+	afterEach( () => {
+		jest.useRealTimers();
 	} );
 
-	it( 'ignores invalid stored values and other screens', () => {
-		window.newspackNewslettersAdmin = { viewPrefs: { 'newsletters-list': { perPage: 9999 }, 'ads-list': { perPage: 50 } } };
-		const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
-		expect( result.current[ 0 ].perPage ).toBe( 25 );
+	describe( 'seeding', () => {
+		it( 'seeds perPage from the bootstrapped preferences', () => {
+			window.newspackNewslettersAdmin = { viewPrefs: { 'newsletters-list': { perPage: 100 } } };
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+			expect( result.current[ 0 ].perPage ).toBe( 100 );
+		} );
+
+		it( 'ignores invalid stored values and other screens', () => {
+			window.newspackNewslettersAdmin = { viewPrefs: { 'newsletters-list': { perPage: 9999 }, 'ads-list': { perPage: 50 } } };
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+			expect( result.current[ 0 ].perPage ).toBe( 25 );
+		} );
+
+		it( 'seeds density, column widths, field order and sort', () => {
+			window.newspackNewslettersAdmin = {
+				viewPrefs: {
+					'newsletters-list': {
+						fields: [ 'author', 'status' ],
+						sort: { field: 'author', direction: 'asc' },
+						layout: { density: 'compact', styles: { status: { width: '120px' } } },
+					},
+				},
+			};
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW, { fieldIds: FIELDS } ) );
+
+			expect( result.current[ 0 ] ).toMatchObject( {
+				fields: [ 'author', 'status' ],
+				sort: { field: 'author', direction: 'asc' },
+				layout: { density: 'compact', styles: { status: { width: '120px' } } },
+			} );
+		} );
+
+		it( 'drops stored values for columns the screen no longer defines', () => {
+			window.newspackNewslettersAdmin = {
+				viewPrefs: {
+					'newsletters-list': {
+						fields: [ 'author', 'retired_column' ],
+						sort: { field: 'retired_column', direction: 'asc' },
+						layout: { styles: { retired_column: { width: '120px' } } },
+					},
+				},
+			};
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW, { fieldIds: FIELDS } ) );
+
+			expect( result.current[ 0 ].fields ).toEqual( [ 'author' ] );
+			expect( result.current[ 0 ].sort ).toBeUndefined();
+			expect( result.current[ 0 ].layout ).toBeUndefined();
+		} );
+
+		it( 'keeps a stored layout type only while the screen still offers it', () => {
+			window.newspackNewslettersAdmin = { viewPrefs: { 'layouts-list': { type: 'grid' } } };
+
+			const offered = renderHook( () => usePersistedView( 'layouts-list', DEFAULT_VIEW, { layoutTypes: [ 'table', 'grid' ] } ) );
+			expect( offered.result.current[ 0 ].type ).toBe( 'grid' );
+
+			const notOffered = renderHook( () => usePersistedView( 'layouts-list', DEFAULT_VIEW, { layoutTypes: [ 'table' ] } ) );
+			expect( notOffered.result.current[ 0 ].type ).toBe( 'table' );
+		} );
+
+		it( 'lets a forwarded legacy link override the saved view', () => {
+			window.newspackNewslettersAdmin = { viewPrefs: { 'newsletters-list': { sort: { field: 'author', direction: 'asc' } } } };
+			const { result } = renderHook( () =>
+				usePersistedView( 'newsletters-list', DEFAULT_VIEW, {
+					fieldIds: FIELDS,
+					urlPatch: { sort: { field: 'date', direction: 'desc' } },
+				} )
+			);
+			expect( result.current[ 0 ].sort ).toEqual( { field: 'date', direction: 'desc' } );
+		} );
+
+		it( 'writes nothing on mount', async () => {
+			window.newspackNewslettersAdmin = { viewPrefs: { 'newsletters-list': { perPage: 100 } } };
+			renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW, { urlPatch: { sort: { field: 'date', direction: 'desc' } } } ) );
+			await settle();
+			expect( apiFetch ).not.toHaveBeenCalled();
+		} );
 	} );
 
-	it( 'persists a perPage change, including the All sentinel', () => {
-		const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+	describe( 'persisting', () => {
+		it( 'persists a perPage change, including the All sentinel', async () => {
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
 
-		act( () => {
-			result.current[ 1 ]( current => ( { ...current, perPage: PER_PAGE_ALL, page: 1 } ) );
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, perPage: PER_PAGE_ALL, page: 1 } ) );
+			} );
+			await settle();
+
+			expect( apiFetch ).toHaveBeenCalledWith( saved( { perPage: PER_PAGE_ALL, type: 'table' } ) );
 		} );
 
-		expect( apiFetch ).toHaveBeenCalledWith( {
-			path: '/newspack-newsletters/v1/admin-shell/preferences',
-			method: 'POST',
-			data: { screen: 'newsletters-list', prefs: { perPage: PER_PAGE_ALL } },
-		} );
-	} );
+		it( 'persists density, field order and column widths', async () => {
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW, { fieldIds: FIELDS } ) );
 
-	it( 'does not persist non-perPage view changes', () => {
-		const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+			act( () => {
+				result.current[ 1 ]( current => ( {
+					...current,
+					fields: [ 'author', 'status' ],
+					layout: { density: 'compact', styles: { status: { width: '120px' } } },
+				} ) );
+			} );
+			await settle();
 
-		act( () => {
-			result.current[ 1 ]( current => ( { ...current, page: 3, search: 'digest' } ) );
-		} );
-
-		expect( apiFetch ).not.toHaveBeenCalled();
-	} );
-
-	it( 'retries once when a save fails and nothing else would retrigger it', async () => {
-		apiFetch.mockRejectedValueOnce( new Error( 'save failed' ) );
-
-		const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
-
-		await act( async () => {
-			result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
-			await Promise.resolve();
-			await Promise.resolve();
+			expect( apiFetch ).toHaveBeenCalledWith(
+				saved( {
+					perPage: 25,
+					type: 'table',
+					fields: [ 'author', 'status' ],
+					layout: { density: 'compact', styles: { status: { width: '120px' } } },
+				} )
+			);
 		} );
 
-		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
-		expect( apiFetch ).toHaveBeenLastCalledWith( {
-			path: '/newspack-newsletters/v1/admin-shell/preferences',
-			method: 'POST',
-			data: { screen: 'newsletters-list', prefs: { perPage: 50 } },
-		} );
-	} );
+		it( 'does not persist page, search or filters', async () => {
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
 
-	it( 'never has two saves in flight, so writes cannot reach the server out of order', async () => {
-		const deferred = {};
-		apiFetch.mockImplementationOnce( () => new Promise( resolve => ( deferred.resolve = resolve ) ) );
-		apiFetch.mockResolvedValue( {} );
+			act( () => {
+				result.current[ 1 ]( current => ( {
+					...current,
+					page: 3,
+					search: 'digest',
+					filters: [ { field: 'status', operator: 'isAny', value: [ 'draft' ] } ],
+				} ) );
+			} );
+			await settle();
 
-		const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
-
-		act( () => {
-			result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
-		} );
-		act( () => {
-			result.current[ 1 ]( current => ( { ...current, perPage: 100 } ) );
-		} );
-		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
-
-		await act( async () => {
-			deferred.resolve( {} );
-			await Promise.resolve();
-			await Promise.resolve();
+			expect( apiFetch ).not.toHaveBeenCalled();
 		} );
 
-		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
-		expect( apiFetch ).toHaveBeenLastCalledWith( {
-			path: '/newspack-newsletters/v1/admin-shell/preferences',
-			method: 'POST',
-			data: { screen: 'newsletters-list', prefs: { perPage: 100 } },
-		} );
-	} );
+		it( 'collapses a burst of changes into one save', async () => {
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW, { fieldIds: FIELDS } ) );
 
-	it( 'converges on the last chosen value when reverted while a save is in flight', async () => {
-		const DEFAULT_20 = { type: 'table', page: 1, perPage: 20 };
-		const deferred = {};
-		apiFetch.mockImplementationOnce( () => new Promise( resolve => ( deferred.resolve = resolve ) ) );
-		apiFetch.mockResolvedValue( {} );
+			for ( const width of [ '100px', '110px', '120px' ] ) {
+				act( () => {
+					result.current[ 1 ]( current => ( { ...current, layout: { styles: { status: { width } } } } ) );
+				} );
+			}
+			await settle();
 
-		const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_20 ) );
-
-		act( () => {
-			result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
-		} );
-		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
-		expect( apiFetch ).toHaveBeenLastCalledWith( {
-			path: '/newspack-newsletters/v1/admin-shell/preferences',
-			method: 'POST',
-			data: { screen: 'newsletters-list', prefs: { perPage: 50 } },
+			expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+			expect( apiFetch ).toHaveBeenCalledWith( saved( { perPage: 25, type: 'table', layout: { styles: { status: { width: '120px' } } } } ) );
 		} );
 
-		act( () => {
-			result.current[ 1 ]( current => ( { ...current, perPage: 20 } ) );
+		it( 'flushes a pending save when the page goes away', async () => {
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
+			} );
+			expect( apiFetch ).not.toHaveBeenCalled();
+
+			act( () => {
+				window.dispatchEvent( new window.Event( 'pagehide' ) );
+			} );
+
+			expect( apiFetch ).toHaveBeenCalledWith( { ...saved( { perPage: 50, type: 'table' } ), keepalive: true } );
 		} );
 
-		await act( async () => {
-			deferred.resolve( {} );
-			await Promise.resolve();
-			await Promise.resolve();
+		it( 'flushes a pending save when the screen unmounts', () => {
+			const { result, unmount } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
+			} );
+			expect( apiFetch ).not.toHaveBeenCalled();
+
+			unmount();
+
+			expect( apiFetch ).toHaveBeenCalledWith( saved( { perPage: 50, type: 'table' } ) );
 		} );
 
-		expect( apiFetch ).toHaveBeenLastCalledWith( {
-			path: '/newspack-newsletters/v1/admin-shell/preferences',
-			method: 'POST',
-			data: { screen: 'newsletters-list', prefs: { perPage: 20 } },
+		it( 'retries once when a save fails and nothing else would retrigger it', async () => {
+			apiFetch.mockRejectedValueOnce( new Error( 'save failed' ) );
+
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
+			} );
+			await settle();
+
+			expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+			expect( apiFetch ).toHaveBeenLastCalledWith( saved( { perPage: 50, type: 'table' } ) );
+		} );
+
+		it( 'never has two saves in flight, so writes cannot reach the server out of order', async () => {
+			const deferred = {};
+			apiFetch.mockImplementationOnce( () => new Promise( resolve => ( deferred.resolve = resolve ) ) );
+			apiFetch.mockResolvedValue( {} );
+
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
+			} );
+			await settle();
+			expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, perPage: 100 } ) );
+			} );
+			await settle();
+			expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+
+			await act( async () => {
+				deferred.resolve( {} );
+			} );
+
+			expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+			expect( apiFetch ).toHaveBeenLastCalledWith( saved( { perPage: 100, type: 'table' } ) );
+		} );
+
+		it( 'converges on the last chosen value when reverted while a save is in flight', async () => {
+			const deferred = {};
+			apiFetch.mockImplementationOnce( () => new Promise( resolve => ( deferred.resolve = resolve ) ) );
+			apiFetch.mockResolvedValue( {} );
+
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
+			} );
+			await settle();
+			expect( apiFetch ).toHaveBeenLastCalledWith( saved( { perPage: 50, type: 'table' } ) );
+
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, perPage: 20 } ) );
+			} );
+			await settle();
+
+			await act( async () => {
+				deferred.resolve( {} );
+			} );
+
+			expect( apiFetch ).toHaveBeenLastCalledWith( saved( { perPage: 20, type: 'table' } ) );
 		} );
 	} );
 } );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
@@ -279,6 +279,57 @@ describe( 'usePersistedView', () => {
 			expect( apiFetch ).toHaveBeenCalledWith( saved( { perPage: 25, fields: fields.slice( 0, 50 ) } ) );
 		} );
 
+		it( 'does not retry a payload the server rejected', async () => {
+			apiFetch.mockRejectedValue( Object.assign( new Error( 'bad request' ), { data: { status: 400 } } ) );
+
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
+			} );
+			await settle();
+
+			expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+			expect( notifyError ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'reports a later failure after an earlier one recovered', async () => {
+			apiFetch.mockRejectedValueOnce( new Error( 'blip' ) ).mockRejectedValueOnce( new Error( 'blip' ) );
+
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
+			} );
+			await settle();
+			expect( notifyError ).toHaveBeenCalledTimes( 1 );
+
+			// Recovers on the next change, which must clear the latch.
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, perPage: 20 } ) );
+			} );
+			await settle();
+
+			apiFetch.mockRejectedValue( new Error( 'blip' ) );
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, perPage: 10 } ) );
+			} );
+			await settle();
+
+			expect( notifyError ).toHaveBeenCalledTimes( 2 );
+		} );
+
+		it( 'never sends a layout type the server enum lacks', async () => {
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, type: 'carousel', perPage: 50 } ) );
+			} );
+			await settle();
+
+			expect( apiFetch ).toHaveBeenCalledWith( saved( { perPage: 50 } ) );
+		} );
+
 		it( 'never has two saves in flight, so writes cannot reach the server out of order', async () => {
 			const deferred = {};
 			apiFetch.mockImplementationOnce( () => new Promise( resolve => ( deferred.resolve = resolve ) ) );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
@@ -2,9 +2,11 @@ import { act, renderHook } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 
 import usePersistedView from './use-persisted-view';
+import { notifyError } from '../notices';
 import { PER_PAGE_ALL } from '../utils/per-page';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+jest.mock( '../notices', () => ( { notifyError: jest.fn() } ) );
 
 const PATH = '/newspack-newsletters/v1/admin-shell/preferences';
 const DEFAULT_VIEW = { type: 'table', page: 1, perPage: 25 };
@@ -26,15 +28,21 @@ const saved = ( prefs, screen = 'newsletters-list' ) => ( {
 } );
 
 describe( 'usePersistedView', () => {
+	// The hook logs the rejected save's code alongside the notice.
+	let warnSpy;
+
 	beforeEach( () => {
 		jest.useFakeTimers();
 		apiFetch.mockReset();
 		apiFetch.mockResolvedValue( {} );
+		notifyError.mockReset();
+		warnSpy = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
 		delete window.newspackNewslettersAdmin;
 	} );
 
 	afterEach( () => {
 		jest.useRealTimers();
+		warnSpy.mockRestore();
 	} );
 
 	describe( 'seeding', () => {
@@ -219,6 +227,56 @@ describe( 'usePersistedView', () => {
 
 			expect( apiFetch ).toHaveBeenCalledTimes( 2 );
 			expect( apiFetch ).toHaveBeenLastCalledWith( saved( { perPage: 50, type: 'table' } ) );
+		} );
+
+		it( 'tells the user once when the retry is exhausted', async () => {
+			apiFetch.mockRejectedValue( new Error( 'save failed' ) );
+
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
+			} );
+			await settle();
+
+			expect( notifyError ).toHaveBeenCalledTimes( 1 );
+
+			// A drifted schema fails every save, so the notice must not repeat.
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, perPage: 10 } ) );
+			} );
+			await settle();
+
+			expect( notifyError ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'stays quiet when a save fails on the way out', async () => {
+			apiFetch.mockRejectedValue( new Error( 'save failed' ) );
+
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
+			} );
+			act( () => {
+				window.dispatchEvent( new Event( 'pagehide' ) );
+			} );
+			await settle();
+
+			expect( notifyError ).not.toHaveBeenCalled();
+		} );
+
+		it( 'holds the payload to the bounds the route enforces', async () => {
+			const fields = Array.from( { length: 60 }, ( unused, i ) => `field-${ i }` );
+
+			const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW, { layoutTypes: [ 'table' ] } ) );
+
+			act( () => {
+				result.current[ 1 ]( current => ( { ...current, type: 'grid', fields } ) );
+			} );
+			await settle();
+
+			expect( apiFetch ).toHaveBeenCalledWith( saved( { perPage: 25, fields: fields.slice( 0, 50 ) } ) );
 		} );
 
 		it( 'never has two saves in flight, so writes cannot reach the server out of order', async () => {

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/build-query.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/build-query.js
@@ -51,9 +51,9 @@ export function buildQueryParams( view = {} ) {
 		// No `_links` — see the newsletters-list note for what it costs.
 		//
 		// The terms field is unconditional, unlike the newsletters list:
-		// Quick Edit hydrates advertiser and placement from it and sends
-		// both back on every save, so dropping it when those columns are
-		// hidden would clear them.
+		// Quick Edit hydrates advertiser, placement and category from it,
+		// and has no other source for the names, so the pickers would open
+		// empty whenever those columns are hidden.
 		extraParams: {
 			_fields: 'id,status,title,date,meta,newspack_newsletters_ad_status,newspack_newsletters_terms',
 		},

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/build-query.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/build-query.js
@@ -48,17 +48,14 @@ export function buildQueryParams( view = {} ) {
 		// Active kind filter → custom REST param; no filter → wide post_status default.
 		statusFilterParam: 'newspack_newsletters_ad_status',
 		defaultStatusParam: 'status',
-		// `_fields` short-circuits `content.rendered` / `excerpt.rendered`
-		// and the unused editor REST fields (see newsletters-list note).
-		// `_links` stays in the list — `_embed` only expands links that
-		// survive the `_fields` filter.
+		// No `_links` — see the newsletters-list note for what it costs.
+		//
+		// The terms field is unconditional, unlike the newsletters list:
+		// Quick Edit hydrates advertiser and placement from it and sends
+		// both back on every save, so dropping it when those columns are
+		// hidden would clear them.
 		extraParams: {
-			// Unconditional, unlike the newsletters list: Quick Edit here
-			// hydrates advertiser and placement from the embedded terms
-			// alone and sends both taxonomies on every save, so dropping
-			// the embed when those columns are hidden would clear them.
-			_embed: 'wp:term',
-			_fields: 'id,status,title,date,meta,newspack_newsletters_ad_status,_links',
+			_fields: 'id,status,title,date,meta,newspack_newsletters_ad_status,newspack_newsletters_terms',
 		},
 	} );
 }

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/build-query.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/build-query.js
@@ -49,11 +49,9 @@ export function buildQueryParams( view = {} ) {
 		statusFilterParam: 'newspack_newsletters_ad_status',
 		defaultStatusParam: 'status',
 		// No `_links` — see the newsletters-list note for what it costs.
-		//
-		// The terms field is unconditional, unlike the newsletters list:
-		// Quick Edit hydrates advertiser, placement and category from it,
-		// and has no other source for the names, so the pickers would open
-		// empty whenever those columns are hidden.
+		// The terms field is unconditional here because Quick Edit has no
+		// other source for the names, so hiding those columns would leave
+		// its pickers empty.
 		extraParams: {
 			_fields: 'id,status,title,date,meta,newspack_newsletters_ad_status,newspack_newsletters_terms',
 		},

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/build-query.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/build-query.test.js
@@ -1,5 +1,5 @@
 import { buildQueryParams, toQueryString } from './build-query';
-import { PER_PAGE_ALL } from '../../utils/per-page';
+import { FETCH_ALL_CHUNK_SIZE, PER_PAGE_ALL } from '../../utils/per-page';
 
 describe( 'ads buildQueryParams', () => {
 	it( 'sets page and per_page from the view, defaulting to 1 and 20', () => {
@@ -11,7 +11,7 @@ describe( 'ads buildQueryParams', () => {
 	} );
 
 	it( 'maps the All sentinel to max-size chunks starting at page 1', () => {
-		expect( buildQueryParams( { perPage: PER_PAGE_ALL, page: 4 } ) ).toMatchObject( { page: 1, per_page: 100 } );
+		expect( buildQueryParams( { perPage: PER_PAGE_ALL, page: 4 } ) ).toMatchObject( { page: 1, per_page: FETCH_ALL_CHUNK_SIZE } );
 	} );
 
 	it( 'restricts fields so content/excerpt are never rendered server-side', () => {
@@ -19,16 +19,22 @@ describe( 'ads buildQueryParams', () => {
 		expect( _fields ).not.toContain( 'content' );
 		expect( _fields ).not.toContain( 'excerpt' );
 		expect( _fields.split( ',' ) ).toEqual( expect.arrayContaining( [ 'id', 'meta', 'newspack_newsletters_ad_status' ] ) );
-		// Without `_links`, `_embed` expands nothing and the terms columns go blank.
-		expect( _fields.split( ',' ) ).toContain( '_links' );
 	} );
 
 	it( 'requests context=edit so meta and private fields are returned', () => {
 		expect( buildQueryParams( {} ).context ).toBe( 'edit' );
 	} );
 
-	it( 'embeds wp:term so the advertiser and placement columns can read terms', () => {
-		expect( buildQueryParams( {} )._embed ).toBe( 'wp:term' );
+	it( 'never asks for _links or embeds', () => {
+		const params = buildQueryParams( {} );
+		expect( params ).not.toHaveProperty( '_embed' );
+		expect( params._fields.split( ',' ) ).not.toContain( '_links' );
+	} );
+
+	it( 'always requests term names, whatever the visible columns', () => {
+		for ( const view of [ {}, { fields: [ 'status' ] }, { fields: [ 'advertiser' ] } ] ) {
+			expect( buildQueryParams( view )._fields.split( ',' ) ).toContain( 'newspack_newsletters_terms' );
+		}
 	} );
 
 	it( 'defaults to writable statuses (no trash) when no kind filter is set', () => {

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.js
@@ -269,3 +269,5 @@ export function getFields( { advertisers = [], placements = [] } = {} ) {
 		},
 	];
 }
+
+export const FIELD_IDS = getFields().map( field => field.id );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/index.js
@@ -2,7 +2,6 @@
  * Ads list screen — React DataView replacing the classic ads CPT list.
  */
 
-import { __experimentalHStack as HStack, Spinner } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { DataViews } from '@wordpress/dataviews/wp';
 import { useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -10,6 +9,7 @@ import { emailAd } from 'newspack-icons';
 
 import { getAdminUrl } from '../../admin-globals';
 import EmptyState from '../../components/empty-state';
+import LoadingState from '../../components/loading-state';
 import HeaderCount from '../../components/header-count';
 import ItemsPerPage from '../../components/items-per-page';
 import { useHeaderActions } from '../../header-actions-context';
@@ -76,7 +76,7 @@ function useFilterTerms() {
 export default function AdsListScreen() {
 	const [ view, setView ] = usePersistedView( 'ads-list', DEFAULT_VIEW, PERSIST_OPTIONS );
 	const [ quickEditItem, setQuickEditItem ] = useState( null );
-	const { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce, trashCount, progress, refresh } = useAdsData( view );
+	const { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce, trashCount, refresh } = useAdsData( view );
 	const filterTerms = useFilterTerms();
 
 	const addNewHref = `${ getAdminUrl() }post-new.php?post_type=${ ADS_CPT }`;
@@ -109,11 +109,7 @@ export default function AdsListScreen() {
 	);
 
 	if ( ! hasResolved ) {
-		return (
-			<HStack className="newspack-newsletters-admin__loading" justify="center">
-				<Spinner />
-			</HStack>
-		);
+		return <LoadingState label={ __( 'Fetching ads…', 'newspack-newsletters' ) } />;
 	}
 
 	if ( isStrictEmpty ) {
@@ -147,13 +143,7 @@ export default function AdsListScreen() {
 				getItemId={ item => String( item.id ) }
 				search
 				config={ DATAVIEWS_CONFIG }
-				header={
-					<ItemsPerPage
-						value={ view.perPage }
-						progress={ progress }
-						onChange={ perPage => setView( current => ( { ...current, perPage, page: 1 } ) ) }
-					/>
-				}
+				header={ <ItemsPerPage value={ view.perPage } onChange={ perPage => setView( current => ( { ...current, perPage, page: 1 } ) ) } /> }
 			/>
 			{ quickEditItem && (
 				<AdsQuickEditPanel

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/index.js
@@ -16,7 +16,7 @@ import { useHeaderActions } from '../../header-actions-context';
 import usePersistedView from '../../hooks/use-persisted-view';
 import { fetchAllTerms } from '../../utils/terms';
 import useAdsData from './use-ads-data';
-import { getFields } from './fields';
+import { FIELD_IDS, getFields } from './fields';
 import { getActions } from './actions';
 import { getInitialView } from './initial-filters';
 import AdsQuickEditPanel from './quick-edit-panel';
@@ -30,10 +30,15 @@ const DEFAULT_VIEW = {
 	filters: [],
 	titleField: 'title',
 	fields: [ 'advertiser', 'ad_placement', 'status', 'start_date', 'expiry_date', 'impressions', 'clicks', 'price' ],
-	...getInitialView(),
 };
 
 const DEFAULT_LAYOUTS = { table: {} };
+
+const PERSIST_OPTIONS = {
+	fieldIds: FIELD_IDS,
+	layoutTypes: Object.keys( DEFAULT_LAYOUTS ),
+	urlPatch: getInitialView(),
+};
 
 // Suppress the built-in ViewConfig per-page control — the custom
 // `ItemsPerPage` renders in its place inside the View options popover.
@@ -69,7 +74,7 @@ function useFilterTerms() {
 }
 
 export default function AdsListScreen() {
-	const [ view, setView ] = usePersistedView( 'ads-list', DEFAULT_VIEW );
+	const [ view, setView ] = usePersistedView( 'ads-list', DEFAULT_VIEW, PERSIST_OPTIONS );
 	const [ quickEditItem, setQuickEditItem ] = useState( null );
 	const { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce, trashCount, progress, refresh } = useAdsData( view );
 	const filterTerms = useFilterTerms();

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/quick-edit-panel.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/quick-edit-panel.js
@@ -60,14 +60,18 @@ export default function AdsQuickEditPanel( { item, advertisers, placements, onCl
 	const [ price, setPrice ] = useState( initialPrice );
 	const [ isBusy, setIsBusy ] = useState( false );
 
+	const advertisersDirty = ! sortedIdsEqual( advertiserSelections, initialAdvertiserSelections );
+	const placementsDirty = ! sortedIdsEqual( placementSelections, initialPlacementSelections );
+	const categoriesDirty = ! sortedIdsEqual( categorySelections, initialCategorySelections );
+
 	const isDirty =
 		status !== initialStatus ||
 		startDate !== initialStartDate ||
 		expiryDate !== initialExpiryDate ||
 		price !== initialPrice ||
-		! sortedIdsEqual( advertiserSelections, initialAdvertiserSelections ) ||
-		! sortedIdsEqual( placementSelections, initialPlacementSelections ) ||
-		! sortedIdsEqual( categorySelections, initialCategorySelections );
+		advertisersDirty ||
+		placementsDirty ||
+		categoriesDirty;
 
 	const advertiserSuggestions = useMemo( () => advertisers.map( t => String( t.name ) ), [ advertisers ] );
 	const placementSuggestions = useMemo( () => placements.map( t => String( t.name ) ), [ placements ] );
@@ -96,12 +100,20 @@ export default function AdsQuickEditPanel( { item, advertisers, placements, onCl
 			expiry_date: expiryDate,
 			price: price === '' ? 0 : Number( price ),
 		};
-		const data = {
-			newspack_nl_advertiser: advertiserSelections.map( s => s.id ),
-			ad_placement: placementSelections.map( s => s.id ),
-			categories: categorySelections.map( s => s.id ),
-			meta,
-		};
+		// Only send a taxonomy the user actually touched. Sending all three
+		// unconditionally would clear them whenever the seed came back
+		// empty, and an ad with no categories runs in every newsletter
+		// rather than none.
+		const data = { meta };
+		if ( advertisersDirty ) {
+			data.newspack_nl_advertiser = advertiserSelections.map( s => s.id );
+		}
+		if ( placementsDirty ) {
+			data.ad_placement = placementSelections.map( s => s.id );
+		}
+		if ( categoriesDirty ) {
+			data.categories = categorySelections.map( s => s.id );
+		}
 		if ( status !== initialStatus ) {
 			data.status = status === 'active' ? 'publish' : 'draft';
 		}

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/quick-edit-panel.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/quick-edit-panel.js
@@ -100,10 +100,9 @@ export default function AdsQuickEditPanel( { item, advertisers, placements, onCl
 			expiry_date: expiryDate,
 			price: price === '' ? 0 : Number( price ),
 		};
-		// Only send a taxonomy the user actually touched. Sending all three
-		// unconditionally would clear them whenever the seed came back
-		// empty, and an ad with no categories runs in every newsletter
-		// rather than none.
+		// Only what the user touched: sending all three would clear them
+		// whenever a seed came back empty, and an ad with no categories runs
+		// in every newsletter rather than none.
 		const data = { meta };
 		if ( advertisersDirty ) {
 			data.newspack_nl_advertiser = advertiserSelections.map( s => s.id );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/quick-edit-panel.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/quick-edit-panel.test.js
@@ -161,9 +161,11 @@ describe( 'AdsQuickEditPanel taxonomy seeding', () => {
 		expect( screen.getByTestId( 'panel-dirty' ) ).toHaveTextContent( 'false' );
 	} );
 
-	// Every save sends all three taxonomies, so a picker that seeded empty
-	// would silently clear the ad's terms.
-	it( 'sends the existing term IDs back on a status-only save', async () => {
+	// A save only carries the taxonomies the user touched. Sending all
+	// three every time would clear them whenever a seed came back empty,
+	// and an ad with no categories runs in every newsletter rather than
+	// none.
+	it( 'leaves the taxonomies out of a status-only save', async () => {
 		renderPanel( itemWithTerms() );
 		await screen.findByRole( 'radio', { name: 'Active' } );
 
@@ -171,10 +173,38 @@ describe( 'AdsQuickEditPanel taxonomy seeding', () => {
 		fireEvent.click( screen.getByTestId( 'panel-save' ) );
 
 		await waitFor( () => expect( postCall() ).toBeDefined() );
-		expect( postCall().data ).toMatchObject( {
-			newspack_nl_advertiser: [ 10 ],
-			ad_placement: [ 20 ],
-			categories: [],
-		} );
+		expect( postCall().data ).not.toHaveProperty( 'newspack_nl_advertiser' );
+		expect( postCall().data ).not.toHaveProperty( 'ad_placement' );
+		expect( postCall().data ).not.toHaveProperty( 'categories' );
+		expect( postCall().data ).toMatchObject( { status: 'draft' } );
+	} );
+
+	it( 'omits the taxonomies when the item arrives without the terms field', async () => {
+		const item = itemWithTerms();
+		delete item.newspack_newsletters_terms;
+		renderPanel( item );
+		await screen.findByRole( 'radio', { name: 'Active' } );
+
+		fireEvent.click( screen.getByRole( 'radio', { name: 'Inactive' } ) );
+		fireEvent.click( screen.getByTestId( 'panel-save' ) );
+
+		await waitFor( () => expect( postCall() ).toBeDefined() );
+		expect( postCall().data ).not.toHaveProperty( 'newspack_nl_advertiser' );
+		expect( postCall().data ).not.toHaveProperty( 'ad_placement' );
+		expect( postCall().data ).not.toHaveProperty( 'categories' );
+	} );
+
+	it( 'sends a taxonomy the user actually edited', async () => {
+		const { container } = renderPanel( itemWithTerms() );
+		await screen.findByRole( 'radio', { name: 'Active' } );
+
+		const removeAcme = [ ...container.querySelectorAll( '.components-form-token-field__remove-token' ) ][ 0 ];
+		fireEvent.click( removeAcme );
+		fireEvent.click( screen.getByTestId( 'panel-save' ) );
+
+		await waitFor( () => expect( postCall() ).toBeDefined() );
+		expect( postCall().data ).toMatchObject( { newspack_nl_advertiser: [] } );
+		expect( postCall().data ).not.toHaveProperty( 'ad_placement' );
+		expect( postCall().data ).not.toHaveProperty( 'categories' );
 	} );
 } );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/quick-edit-panel.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/quick-edit-panel.test.js
@@ -161,10 +161,6 @@ describe( 'AdsQuickEditPanel taxonomy seeding', () => {
 		expect( screen.getByTestId( 'panel-dirty' ) ).toHaveTextContent( 'false' );
 	} );
 
-	// A save only carries the taxonomies the user touched. Sending all
-	// three every time would clear them whenever a seed came back empty,
-	// and an ad with no categories runs in every newsletter rather than
-	// none.
 	it( 'leaves the taxonomies out of a status-only save', async () => {
 		renderPanel( itemWithTerms() );
 		await screen.findByRole( 'radio', { name: 'Active' } );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/quick-edit-panel.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/quick-edit-panel.test.js
@@ -132,3 +132,49 @@ describe( 'AdsQuickEditPanel status control', () => {
 		expect( screen.getByTestId( 'panel-dirty' ) ).toHaveTextContent( 'true' );
 	} );
 } );
+
+describe( 'AdsQuickEditPanel taxonomy seeding', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+		apiFetch.mockResolvedValue( {} );
+	} );
+
+	const itemWithTerms = () => ( {
+		id: 42,
+		status: 'publish',
+		title: { raw: 'Summer sale' },
+		meta: {},
+		newspack_newsletters_terms: {
+			newspack_nl_advertiser: [ { id: 10, name: 'Acme' } ],
+			newspack_nl_ad_placement: [ { id: 20, name: 'Header' } ],
+			category: [],
+		},
+	} );
+
+	it( 'seeds the advertiser and placement pickers from the terms field', async () => {
+		const { container } = renderPanel( itemWithTerms() );
+		await screen.findByRole( 'radio', { name: 'Active' } );
+
+		const tokens = [ ...container.querySelectorAll( '.components-form-token-field__token-text' ) ].map( el => el.textContent );
+		expect( tokens.some( text => text.includes( 'Acme' ) ) ).toBe( true );
+		expect( tokens.some( text => text.includes( 'Header' ) ) ).toBe( true );
+		expect( screen.getByTestId( 'panel-dirty' ) ).toHaveTextContent( 'false' );
+	} );
+
+	// Every save sends all three taxonomies, so a picker that seeded empty
+	// would silently clear the ad's terms.
+	it( 'sends the existing term IDs back on a status-only save', async () => {
+		renderPanel( itemWithTerms() );
+		await screen.findByRole( 'radio', { name: 'Active' } );
+
+		fireEvent.click( screen.getByRole( 'radio', { name: 'Inactive' } ) );
+		fireEvent.click( screen.getByTestId( 'panel-save' ) );
+
+		await waitFor( () => expect( postCall() ).toBeDefined() );
+		expect( postCall().data ).toMatchObject( {
+			newspack_nl_advertiser: [ 10 ],
+			ad_placement: [ 20 ],
+			categories: [],
+		} );
+	} );
+} );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/advertisers-list/fields.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/advertisers-list/fields.js
@@ -70,3 +70,5 @@ export function getFields( { onEdit } = {} ) {
 		},
 	];
 }
+
+export const FIELD_IDS = getFields().map( field => field.id );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/advertisers-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/advertisers-list/index.js
@@ -7,13 +7,13 @@
  * `useAllAdvertisers`).
  */
 
-import { __experimentalHStack as HStack, Spinner } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { DataViews } from '@wordpress/dataviews/wp';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store } from '@wordpress/icons';
 
 import EmptyState from '../../components/empty-state';
+import LoadingState from '../../components/loading-state';
 import HeaderCount from '../../components/header-count';
 import ItemsPerPage from '../../components/items-per-page';
 import { useHeaderActions } from '../../header-actions-context';
@@ -59,7 +59,7 @@ export default function AdvertisersListScreen() {
 	// created one appears immediately on the next modal open.
 	const [ mutationKey, setMutationKey ] = useState( 0 );
 
-	const { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce, progress } = useAdvertisersData( view, mutationKey );
+	const { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce } = useAdvertisersData( view, mutationKey );
 	const allAdvertisers = useAllAdvertisers( mutationKey );
 
 	// `setModalState` (a `useState` setter) is itself stable, but wrapping
@@ -95,11 +95,7 @@ export default function AdvertisersListScreen() {
 	);
 
 	if ( ! hasResolved ) {
-		return (
-			<HStack className="newspack-newsletters-admin__loading" justify="center">
-				<Spinner />
-			</HStack>
-		);
+		return <LoadingState label={ __( 'Fetching advertisers…', 'newspack-newsletters' ) } />;
 	}
 
 	return (
@@ -131,11 +127,7 @@ export default function AdvertisersListScreen() {
 					search
 					config={ DATAVIEWS_CONFIG }
 					header={
-						<ItemsPerPage
-							value={ view.perPage }
-							progress={ progress }
-							onChange={ perPage => setView( current => ( { ...current, perPage, page: 1 } ) ) }
-						/>
+						<ItemsPerPage value={ view.perPage } onChange={ perPage => setView( current => ( { ...current, perPage, page: 1 } ) ) } />
 					}
 				/>
 			) }

--- a/plugins/newspack-newsletters/src/admin-shell/screens/advertisers-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/advertisers-list/index.js
@@ -22,7 +22,7 @@ import AdvertiserModal from './modal';
 import useAdvertisersData from './use-advertisers-data';
 import useAllAdvertisers from './use-all-advertisers';
 import { getInitialView } from './initial-filters';
-import { getFields } from './fields';
+import { FIELD_IDS, getFields } from './fields';
 import { getActions } from './actions';
 
 const DEFAULT_VIEW = {
@@ -34,17 +34,22 @@ const DEFAULT_VIEW = {
 	filters: [],
 	titleField: 'name',
 	fields: [ 'description', 'slug', 'count' ],
-	...getInitialView(),
 };
 
 const DEFAULT_LAYOUTS = { table: {} };
+
+const PERSIST_OPTIONS = {
+	fieldIds: FIELD_IDS,
+	layoutTypes: Object.keys( DEFAULT_LAYOUTS ),
+	urlPatch: getInitialView(),
+};
 
 // Suppress the built-in ViewConfig per-page control — the custom
 // `ItemsPerPage` renders in its place inside the View options popover.
 const DATAVIEWS_CONFIG = { perPageSizes: [] };
 
 export default function AdvertisersListScreen() {
-	const [ view, setView ] = usePersistedView( 'advertisers-list', DEFAULT_VIEW );
+	const [ view, setView ] = usePersistedView( 'advertisers-list', DEFAULT_VIEW, PERSIST_OPTIONS );
 	const [ modalState, setModalState ] = useState( null ); // null | { mode: 'add' | 'edit', advertiser?: Object }
 	// Single mutation trigger shared by every write path (Modal save,
 	// per-row Delete, bulk Delete). Bumping it refetches both the

--- a/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/fields.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/fields.js
@@ -245,3 +245,7 @@ function PreviewCard( { item } ) {
 		</LazyPreview>
 	);
 }
+
+// The IDs this screen defines, for validating a stored view against the
+// columns that still exist.
+export const FIELD_IDS = getFields().map( field => field.id );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/fields.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/fields.js
@@ -131,13 +131,12 @@ export function getFields( { renamingId = null, onRenameCommit, onRenameCancel, 
 	};
 
 	const renderAuthor = ( { item } ) => {
-		const author = item?._embedded?.author?.[ 0 ];
+		const author = item?.newspack_newsletters_author;
 		if ( ! author ) {
 			return null;
 		}
 		const isPrebuilt = !! item?.is_prebuilt;
-		// Prefer the 48px source so the 16px display stays crisp on hi-DPI screens.
-		const avatarUrl = ! isPrebuilt && ( author.avatar_urls?.[ 48 ] || author.avatar_urls?.[ 24 ] );
+		const avatarUrl = ! isPrebuilt && author.avatar;
 		return (
 			<span className="newspack-newsletters-list__author">
 				{ avatarUrl ? (
@@ -156,7 +155,8 @@ export function getFields( { renamingId = null, onRenameCommit, onRenameCancel, 
 		id: 'author',
 		label: __( 'Author', 'newspack-newsletters' ),
 		enableSorting: false,
-		getValue: ( { item } ) => ( item?.is_prebuilt ? PREBUILT_AUTHOR_VALUE : String( item?._embedded?.author?.[ 0 ]?.id ?? item?.author ?? '' ) ),
+		getValue: ( { item } ) =>
+			item?.is_prebuilt ? PREBUILT_AUTHOR_VALUE : String( item?.newspack_newsletters_author?.id ?? item?.author ?? '' ),
 		render: renderAuthor,
 	};
 
@@ -246,6 +246,4 @@ function PreviewCard( { item } ) {
 	);
 }
 
-// The IDs this screen defines, for validating a stored view against the
-// columns that still exist.
 export const FIELD_IDS = getFields().map( field => field.id );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/index.js
@@ -73,11 +73,26 @@ const DEFAULT_LAYOUTS = {
 const DATAVIEWS_CONFIG = { perPageSizes: [] };
 const PER_PAGE_OPTIONS = [ 12, 24, 48, 96, PER_PAGE_ALL ];
 
+// `mediaField` is grid-only: the table renders it in the primary column,
+// so leaving it set mounts a BlockPreview iframe in every row. Applied
+// to the restored view as well as to changes, since a stored `table`
+// arrives merged over a default that carries the grid's `preview`.
+const withLayoutMedia = view => {
+	if ( 'table' === view.type && view.mediaField ) {
+		return { ...view, mediaField: undefined };
+	}
+	if ( 'grid' === view.type && ! view.mediaField ) {
+		return { ...view, mediaField: 'preview' };
+	}
+	return view;
+};
+
 const PERSIST_OPTIONS = {
 	perPageOptions: PER_PAGE_OPTIONS,
 	fieldIds: FIELD_IDS,
 	layoutTypes: Object.keys( DEFAULT_LAYOUTS ),
 	urlPatch: getInitialView(),
+	normalize: withLayoutMedia,
 };
 
 export default function LayoutsListScreen() {
@@ -211,17 +226,7 @@ export default function LayoutsListScreen() {
 		};
 	}, [ savedPagination, prebuiltCount, showSaved, authorShowPrebuilts, ridingAlong, firstPageSavedSlots, view.perPage, view.search, fetchingAll ] );
 
-	// `mediaField` is grid-only — in table mode the per-row iframe blows
-	// out row heights, so strip it on layout switches.
-	const onChangeView = useCallback( next => {
-		if ( next.type === 'table' ) {
-			setView( { ...next, mediaField: undefined } );
-		} else if ( next.type === 'grid' && ! next.mediaField ) {
-			setView( { ...next, mediaField: 'preview' } );
-		} else {
-			setView( next );
-		}
-	}, [] );
+	const onChangeView = useCallback( next => setView( withLayoutMedia( next ) ), [] );
 
 	const onMutated = useCallback( () => setMutationKey( key => key + 1 ), [] );
 

--- a/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/index.js
@@ -6,13 +6,13 @@
 
 import { getBlockType, registerBlockType } from '@wordpress/blocks';
 import { registerCoreBlocks } from '@wordpress/block-library';
-import { Spinner } from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews/wp';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 import { getAdminUrl } from '../../admin-globals';
 import HeaderCount from '../../components/header-count';
+import LoadingState from '../../components/loading-state';
 import ItemsPerPage from '../../components/items-per-page';
 import { useHeaderActions } from '../../header-actions-context';
 import usePersistedView from '../../hooks/use-persisted-view';
@@ -279,11 +279,7 @@ export default function LayoutsListScreen() {
 	}, [ hasResolvedOnce, isPrebuiltLoading, showSaved, savedHasResolved ] );
 
 	if ( ! hasResolvedOnce ) {
-		return (
-			<div className="newspack-newsletters-admin__loading">
-				<Spinner />
-			</div>
-		);
+		return <LoadingState label={ __( 'Fetching layouts…', 'newspack-newsletters' ) } />;
 	}
 
 	return (

--- a/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/index.js
@@ -21,7 +21,7 @@ import { isFetchAllPerPage, PER_PAGE_ALL } from '../../utils/per-page';
 import { LAYOUT_CPT_SLUG } from '../../../utils/consts';
 import useLayoutsData from './use-layouts-data';
 import usePrebuiltLayouts from './use-prebuilt-layouts';
-import { getFields, PREBUILT_AUTHOR_VALUE } from './fields';
+import { FIELD_IDS, getFields, PREBUILT_AUTHOR_VALUE } from './fields';
 import { getActions, renameLayout } from './actions';
 import { getInitialView } from './initial-filters';
 
@@ -59,7 +59,6 @@ const DEFAULT_VIEW = {
 	titleField: 'title',
 	mediaField: 'preview',
 	fields: [ 'author' ],
-	...getInitialView(),
 };
 
 const DEFAULT_LAYOUTS = {
@@ -74,12 +73,19 @@ const DEFAULT_LAYOUTS = {
 const DATAVIEWS_CONFIG = { perPageSizes: [] };
 const PER_PAGE_OPTIONS = [ 12, 24, 48, 96, PER_PAGE_ALL ];
 
+const PERSIST_OPTIONS = {
+	perPageOptions: PER_PAGE_OPTIONS,
+	fieldIds: FIELD_IDS,
+	layoutTypes: Object.keys( DEFAULT_LAYOUTS ),
+	urlPatch: getInitialView(),
+};
+
 export default function LayoutsListScreen() {
 	useEffect( () => {
 		ensureCoreBlocksRegistered();
 	}, [] );
 
-	const [ view, setView ] = usePersistedView( 'layouts-list', DEFAULT_VIEW, PER_PAGE_OPTIONS );
+	const [ view, setView ] = usePersistedView( 'layouts-list', DEFAULT_VIEW, PERSIST_OPTIONS );
 	const [ renamingId, setRenamingId ] = useState( null );
 	// Bumping this forces every write path to refetch the saved data.
 	const [ mutationKey, setMutationKey ] = useState( 0 );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/index.js
@@ -159,13 +159,7 @@ export default function LayoutsListScreen() {
 		return baseView;
 	}, [ view, showSaved, couldRideAlong, isPrebuiltLoading, ridingAlong, firstPageSavedSlots, restrictedAuthorIds ] );
 
-	const {
-		data: savedData,
-		paginationInfo: savedPagination,
-		isLoading,
-		hasResolved: savedHasResolved,
-		progress,
-	} = useLayoutsData( savedView, mutationKey );
+	const { data: savedData, paginationInfo: savedPagination, isLoading, hasResolved: savedHasResolved } = useLayoutsData( savedView, mutationKey );
 
 	const filteredPrebuilts = showPrebuilts ? prebuiltData : [];
 	const filteredSaved = showSaved ? savedData : [];
@@ -178,7 +172,7 @@ export default function LayoutsListScreen() {
 		const elements = [ { value: PREBUILT_AUTHOR_VALUE, label: __( 'Newspack', 'newspack-newsletters' ) } ];
 		const seen = new Set();
 		savedData.forEach( item => {
-			const author = item?._embedded?.author?.[ 0 ];
+			const author = item?.newspack_newsletters_author;
 			const id = author?.id;
 			const name = author?.name;
 			if ( id && name && ! seen.has( id ) ) {
@@ -312,7 +306,6 @@ export default function LayoutsListScreen() {
 					<ItemsPerPage
 						value={ view.perPage }
 						options={ PER_PAGE_OPTIONS }
-						progress={ progress }
 						onChange={ perPage => setView( current => ( { ...current, perPage, page: 1 } ) ) }
 					/>
 				}

--- a/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/index.js
@@ -74,9 +74,8 @@ const DATAVIEWS_CONFIG = { perPageSizes: [] };
 const PER_PAGE_OPTIONS = [ 12, 24, 48, 96, PER_PAGE_ALL ];
 
 // `mediaField` is grid-only: the table renders it in the primary column,
-// so leaving it set mounts a BlockPreview iframe in every row. Applied
-// to the restored view as well as to changes, since a stored `table`
-// arrives merged over a default that carries the grid's `preview`.
+// so leaving it set mounts a BlockPreview iframe per row. Applied to the
+// restored view too, which arrives merged over the grid default.
 const withLayoutMedia = view => {
 	if ( 'table' === view.type && view.mediaField ) {
 		return { ...view, mediaField: undefined };

--- a/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/use-layouts-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/use-layouts-data.js
@@ -19,12 +19,10 @@ function buildPath( view ) {
 		// `offset` overrides `page` so page 1 can reserve slots for prebuilts.
 		supportsOffset: true,
 		// `content.raw` (not `.rendered`) — previews parse blocks client-side,
-		// so skip the whole `the_content` chain. Term embeds aren't consumed.
-		// `_links` stays in the list — `_embed` only expands links that
-		// survive the `_fields` filter.
+		// so skip the whole `the_content` chain. No `_links` either: see
+		// the newsletters-list note for what it costs.
 		extraParams: {
-			_embed: 'author',
-			_fields: 'id,status,title,date,modified,author,content.raw,meta,_links',
+			_fields: 'id,status,title,date,modified,author,content.raw,meta,newspack_newsletters_author',
 		},
 		arrayParams: [ { viewKey: 'author', param: 'author' } ],
 	} );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/use-layouts-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/use-layouts-data.js
@@ -3,7 +3,7 @@ import { __ } from '@wordpress/i18n';
 import { LAYOUT_CPT_SLUG } from '../../../utils/consts';
 import useCollectionData from '../../hooks/use-collection-data';
 import { buildQueryParams, toQueryString } from '../../utils/build-query';
-import { isFetchAllPerPage } from '../../utils/per-page';
+import { isFetchAllPerPage, LAYOUTS_FETCH_ALL_CHUNK_SIZE } from '../../utils/per-page';
 
 const COLLECTION_PATH = `/wp/v2/${ LAYOUT_CPT_SLUG }`;
 // `future` is excluded — layouts don't surface scheduling. `auto-draft` keeps "Add new" + back visible.
@@ -15,6 +15,7 @@ function buildPath( view ) {
 	}
 	const params = buildQueryParams( view, {
 		defaultPerPage: 12,
+		fetchAllChunkSize: LAYOUTS_FETCH_ALL_CHUNK_SIZE,
 		defaultStatuses: DEFAULT_STATUSES,
 		// `offset` overrides `page` so page 1 can reserve slots for prebuilts.
 		supportsOffset: true,
@@ -39,6 +40,7 @@ export default function useLayoutsData( view, mutationKey = 0 ) {
 		path: buildPath( view ),
 		mutationKey,
 		fetchAll: isFetchAllPerPage( view?.perPage ),
+		fetchAllChunkSize: LAYOUTS_FETCH_ALL_CHUNK_SIZE,
 		errorMessage: __( 'Failed to load layouts. Please refresh the page.', 'newspack-newsletters' ),
 		errorNoticeId: 'newspack-newsletters-layouts-list-fetch-error',
 	} );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/use-layouts-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/use-layouts-data.js
@@ -40,7 +40,6 @@ export default function useLayoutsData( view, mutationKey = 0 ) {
 		path: buildPath( view ),
 		mutationKey,
 		fetchAll: isFetchAllPerPage( view?.perPage ),
-		fetchAllChunkSize: LAYOUTS_FETCH_ALL_CHUNK_SIZE,
 		errorMessage: __( 'Failed to load layouts. Please refresh the page.', 'newspack-newsletters' ),
 		errorNoticeId: 'newspack-newsletters-layouts-list-fetch-error',
 	} );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/use-prebuilt-layouts.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/use-prebuilt-layouts.js
@@ -47,7 +47,7 @@ export default function usePrebuiltLayouts() {
 							// id=0 is unreachable for real users — doubles as the
 							// prebuilt sentinel for the author filter.
 							author: 0,
-							_embedded: { author: [ { id: 0, name: __( 'Newspack', 'newspack-newsletters' ) } ] },
+							newspack_newsletters_author: { id: 0, name: __( 'Newspack', 'newspack-newsletters' ), avatar: '' },
 						};
 					} );
 				setLayouts( prebuilts );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.js
@@ -32,26 +32,40 @@ const SORT_FIELD_TO_ORDERBY = {
 	author: 'author',
 };
 
+// `_fields` short-circuits `content.rendered` / `excerpt.rendered`, the
+// full `the_content` chain including synchronous oEmbed fetches.
+//
+// Leaving out `_links` is what keeps the list fast: it is the only way
+// to make `_embed` expand anything, and asking for it makes core build
+// every row's link set and compute target hints for its `self` link,
+// re-resolving the entire REST route map per row. Author and term names
+// come from dedicated fields instead — see `Newsletters_List_REST`.
+//
+// `categories`/`tags` are the raw ID arrays Quick Edit seeds from.
+const BASE_FIELDS = [
+	'id',
+	'status',
+	'title',
+	'date',
+	'link',
+	'meta',
+	'categories',
+	'tags',
+	'newspack_newsletters_status',
+	'newspack_newsletters_author',
+];
+
 export function buildQueryParams( view = {} ) {
-	// Term embeds cost ~2 internal REST dispatches per row and only the
-	// (hidden-by-default) Categories/Tags columns read them.
+	// Only the (hidden-by-default) Categories/Tags columns read term names.
 	const visibleFields = Array.isArray( view.fields ) ? view.fields : null;
 	const needsTerms = ! visibleFields || visibleFields.includes( 'categories' ) || visibleFields.includes( 'tags' );
+	const fields = needsTerms ? [ ...BASE_FIELDS, 'newspack_newsletters_terms' ] : BASE_FIELDS;
 
 	return baseBuildQueryParams( view, {
 		fieldToQueryParam: FIELD_TO_QUERY_PARAM,
 		sortFieldToOrderby: SORT_FIELD_TO_ORDERBY,
 		defaultStatuses: DEFAULT_STATUSES,
-		// `_fields` short-circuits `content.rendered` / `excerpt.rendered`
-		// (the full `the_content` chain, incl. synchronous oEmbed fetches)
-		// and the unused editor REST fields — per-item cost the list never
-		// reads. `_links` must stay in the list: `_embed` only expands
-		// links that survive the `_fields` filter.
-		extraParams: {
-			_embed: needsTerms ? 'author,wp:term' : 'author',
-			// `categories`/`tags`: Quick Edit needs them when the embed is skipped.
-			_fields: 'id,status,title,date,link,meta,categories,tags,newspack_newsletters_status,_links',
-		},
+		extraParams: { _fields: fields.join( ',' ) },
 	} );
 }
 

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.js
@@ -32,16 +32,12 @@ const SORT_FIELD_TO_ORDERBY = {
 	author: 'author',
 };
 
-// `_fields` short-circuits `content.rendered` / `excerpt.rendered`, the
-// full `the_content` chain including synchronous oEmbed fetches.
-//
-// Leaving out `_links` is what keeps the list fast: it is the only way
-// to make `_embed` expand anything, and asking for it makes core build
-// every row's link set and compute target hints for its `self` link,
-// re-resolving the entire REST route map per row. Author and term names
-// come from dedicated fields instead — see `Newsletters_List_REST`.
-//
-// `categories`/`tags` are the raw ID arrays Quick Edit seeds from.
+// `_fields` short-circuits the `the_content` chain, and leaving out
+// `_links` is what keeps the list fast: it is the only way to make
+// `_embed` expand anything, and core answers it by re-resolving the REST
+// route map per row. Author and term names come from dedicated fields
+// instead — see `Newsletters_List_REST`. `categories`/`tags` are the raw
+// ID arrays Quick Edit seeds from.
 const BASE_FIELDS = [
 	'id',
 	'status',

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.test.js
@@ -1,5 +1,5 @@
 import { buildQueryParams, toQueryString } from './build-query';
-import { PER_PAGE_ALL } from '../../utils/per-page';
+import { FETCH_ALL_CHUNK_SIZE, PER_PAGE_ALL } from '../../utils/per-page';
 
 describe( 'buildQueryParams', () => {
 	it( 'sets page and per_page from the view, defaulting to 1 and 20', () => {
@@ -11,7 +11,7 @@ describe( 'buildQueryParams', () => {
 	} );
 
 	it( 'maps the All sentinel to max-size chunks starting at page 1', () => {
-		expect( buildQueryParams( { perPage: PER_PAGE_ALL, page: 7 } ) ).toMatchObject( { page: 1, per_page: 100 } );
+		expect( buildQueryParams( { perPage: PER_PAGE_ALL, page: 7 } ) ).toMatchObject( { page: 1, per_page: FETCH_ALL_CHUNK_SIZE } );
 	} );
 
 	it( 'restricts fields so content/excerpt are never rendered server-side', () => {
@@ -21,8 +21,6 @@ describe( 'buildQueryParams', () => {
 		);
 		expect( _fields ).not.toContain( 'content' );
 		expect( _fields ).not.toContain( 'excerpt' );
-		// Without `_links`, `_embed` expands nothing and the author/terms columns go blank.
-		expect( _fields.split( ',' ) ).toContain( '_links' );
 		expect( _fields.split( ',' ) ).toEqual( expect.arrayContaining( [ 'categories', 'tags' ] ) );
 	} );
 
@@ -30,14 +28,25 @@ describe( 'buildQueryParams', () => {
 		expect( buildQueryParams( {} ).context ).toBe( 'edit' );
 	} );
 
-	it( 'includes author and wp:term embeds when field visibility is unknown', () => {
-		expect( buildQueryParams( {} )._embed ).toBe( 'author,wp:term' );
+	it( 'never asks for _links or embeds', () => {
+		for ( const view of [ {}, { fields: [ 'categories', 'tags' ] }, { fields: [ 'status' ] } ] ) {
+			const params = buildQueryParams( view );
+			expect( params ).not.toHaveProperty( '_embed' );
+			expect( params._fields.split( ',' ) ).not.toContain( '_links' );
+		}
 	} );
 
-	it( 'drops the expensive wp:term embed when the Categories/Tags columns are hidden', () => {
-		expect( buildQueryParams( { fields: [ 'status', 'date', 'author' ] } )._embed ).toBe( 'author' );
-		expect( buildQueryParams( { fields: [ 'status', 'categories' ] } )._embed ).toBe( 'author,wp:term' );
-		expect( buildQueryParams( { fields: [ 'tags' ] } )._embed ).toBe( 'author,wp:term' );
+	it( 'reads author display data from a dedicated field rather than an embed', () => {
+		expect( buildQueryParams( {} )._fields.split( ',' ) ).toContain( 'newspack_newsletters_author' );
+	} );
+
+	it( 'requests term names only while a taxonomy column is visible', () => {
+		const hasTerms = view => buildQueryParams( view )._fields.split( ',' ).includes( 'newspack_newsletters_terms' );
+		// Unknown visibility — assume the columns are on.
+		expect( hasTerms( {} ) ).toBe( true );
+		expect( hasTerms( { fields: [ 'status', 'categories' ] } ) ).toBe( true );
+		expect( hasTerms( { fields: [ 'tags' ] } ) ).toBe( true );
+		expect( hasTerms( { fields: [ 'status', 'date', 'author' ] } ) ).toBe( false );
 	} );
 
 	it( 'defaults status to all common writable statuses (no trash) when no filter is set', () => {

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/fields.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/fields.js
@@ -103,11 +103,11 @@ const renderSendList = ( { item } ) => {
 };
 
 const renderAuthor = ( { item } ) => {
-	const author = item?._embedded?.author?.[ 0 ];
+	const author = item?.newspack_newsletters_author;
 	if ( ! author ) {
 		return '';
 	}
-	const avatarUrl = author.avatar_urls?.[ 48 ] || author.avatar_urls?.[ 24 ];
+	const avatarUrl = author.avatar;
 	return (
 		<span className="newspack-newsletters-list__author">
 			{ avatarUrl ? (
@@ -122,13 +122,15 @@ const renderAuthor = ( { item } ) => {
 	);
 };
 
+const termNames = ( item, taxonomy ) =>
+	termsForTaxonomy( item, taxonomy )
+		.map( term => term?.name )
+		.filter( Boolean );
+
 const renderTerms =
 	taxonomy =>
 	( { item } ) =>
-		termsForTaxonomy( item, taxonomy )
-			.map( term => term?.name )
-			.filter( Boolean )
-			.join( ', ' );
+		termNames( item, taxonomy ).join( ', ' );
 
 const renderPublicPage = ( { item } ) => {
 	const isPublic = !! item?.meta?.is_public;
@@ -207,7 +209,7 @@ export function getFields( { authors = [], categories = [], tags = [], sendLists
 			} ) ),
 			filterBy: { operators: [ 'isAny' ], isPrimary: true },
 			enableSorting: true,
-			getValue: ( { item } ) => String( item?._embedded?.author?.[ 0 ]?.id || '' ),
+			getValue: ( { item } ) => String( item?.newspack_newsletters_author?.id || '' ),
 			render: renderAuthor,
 		},
 		{
@@ -219,11 +221,7 @@ export function getFields( { authors = [], categories = [], tags = [], sendLists
 			} ) ),
 			filterBy: { operators: [ 'isAny' ], isPrimary: true },
 			enableSorting: false,
-			getValue: ( { item } ) =>
-				termsForTaxonomy( item, 'category' )
-					.map( term => term?.name )
-					.filter( Boolean )
-					.join( ', ' ),
+			getValue: ( { item } ) => termNames( item, 'category' ).join( ', ' ),
 			render: renderTerms( 'category' ),
 		},
 		{
@@ -235,11 +233,7 @@ export function getFields( { authors = [], categories = [], tags = [], sendLists
 			} ) ),
 			filterBy: { operators: [ 'isAny' ], isPrimary: true },
 			enableSorting: false,
-			getValue: ( { item } ) =>
-				termsForTaxonomy( item, 'post_tag' )
-					.map( term => term?.name )
-					.filter( Boolean )
-					.join( ', ' ),
+			getValue: ( { item } ) => termNames( item, 'post_tag' ).join( ', ' ),
 			render: renderTerms( 'post_tag' ),
 		},
 		{
@@ -262,3 +256,5 @@ export function getFields( { authors = [], categories = [], tags = [], sendLists
 		},
 	];
 }
+
+export const FIELD_IDS = getFields().map( field => field.id );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/index.js
@@ -2,7 +2,6 @@
  * Newsletters list screen — React DataView replacing the classic CPT list.
  */
 
-import { __experimentalHStack as HStack, Spinner } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { DataViews } from '@wordpress/dataviews/wp';
 import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -10,6 +9,7 @@ import { envelope } from '@wordpress/icons';
 
 import { getAdminUrl, getCptSlug } from '../../admin-globals';
 import EmptyState from '../../components/empty-state';
+import LoadingState from '../../components/loading-state';
 import HeaderCount from '../../components/header-count';
 import ItemsPerPage from '../../components/items-per-page';
 import { useHeaderActions } from '../../header-actions-context';
@@ -34,9 +34,8 @@ const DEFAULT_VIEW = {
 
 const DEFAULT_LAYOUTS = { table: {} };
 
-// `urlPatch` is read once, at module scope: it seeds the view a
-// forwarded legacy link asks for, and must not be re-applied when a
-// later preference save re-renders the screen.
+// `urlPatch` is read at module scope so a forwarded legacy link seeds
+// the view once, rather than being re-applied on every re-render.
 const PERSIST_OPTIONS = {
 	fieldIds: FIELD_IDS,
 	layoutTypes: Object.keys( DEFAULT_LAYOUTS ),
@@ -50,7 +49,7 @@ const DATAVIEWS_CONFIG = { perPageSizes: [] };
 export default function NewslettersListScreen() {
 	const [ view, setView ] = usePersistedView( 'newsletters-list', DEFAULT_VIEW, PERSIST_OPTIONS );
 	const [ quickEditItem, setQuickEditItem ] = useState( null );
-	const { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce, trashCount, progress, refresh } = useNewslettersData( view );
+	const { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce, trashCount, refresh } = useNewslettersData( view );
 	const filterElements = useFilterElements();
 
 	const addNewHref = `${ getAdminUrl() }post-new.php?post_type=${ getCptSlug() }`;
@@ -83,11 +82,7 @@ export default function NewslettersListScreen() {
 	);
 
 	if ( ! hasResolved ) {
-		return (
-			<HStack className="newspack-newsletters-admin__loading" justify="center">
-				<Spinner />
-			</HStack>
-		);
+		return <LoadingState label={ __( 'Fetching newsletters…', 'newspack-newsletters' ) } />;
 	}
 
 	if ( isStrictEmpty ) {
@@ -118,13 +113,7 @@ export default function NewslettersListScreen() {
 				getItemId={ item => String( item.id ) }
 				search
 				config={ DATAVIEWS_CONFIG }
-				header={
-					<ItemsPerPage
-						value={ view.perPage }
-						progress={ progress }
-						onChange={ perPage => setView( current => ( { ...current, perPage, page: 1 } ) ) }
-					/>
-				}
+				header={ <ItemsPerPage value={ view.perPage } onChange={ perPage => setView( current => ( { ...current, perPage, page: 1 } ) ) } /> }
 			/>
 			{ quickEditItem && (
 				<NewslettersQuickEditPanel

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/index.js
@@ -16,12 +16,11 @@ import { useHeaderActions } from '../../header-actions-context';
 import usePersistedView from '../../hooks/use-persisted-view';
 import useNewslettersData from './use-newsletters-data';
 import useFilterElements from './use-filter-elements';
-import { getFields } from './fields';
+import { FIELD_IDS, getFields } from './fields';
 import { getActions } from './actions';
 import { getInitialView } from './initial-filters';
 import NewslettersQuickEditPanel from './quick-edit-panel';
 
-// URL-seeded patch last so forwarded-from-legacy values override defaults.
 const DEFAULT_VIEW = {
 	type: 'table',
 	page: 1,
@@ -31,17 +30,25 @@ const DEFAULT_VIEW = {
 	filters: [],
 	titleField: 'title',
 	fields: [ 'status', 'date', 'send_date', 'send_list', 'author', 'public_page' ],
-	...getInitialView(),
 };
 
 const DEFAULT_LAYOUTS = { table: {} };
+
+// `urlPatch` is read once, at module scope: it seeds the view a
+// forwarded legacy link asks for, and must not be re-applied when a
+// later preference save re-renders the screen.
+const PERSIST_OPTIONS = {
+	fieldIds: FIELD_IDS,
+	layoutTypes: Object.keys( DEFAULT_LAYOUTS ),
+	urlPatch: getInitialView(),
+};
 
 // Suppress the built-in ViewConfig per-page control — the custom
 // `ItemsPerPage` renders in its place inside the View options popover.
 const DATAVIEWS_CONFIG = { perPageSizes: [] };
 
 export default function NewslettersListScreen() {
-	const [ view, setView ] = usePersistedView( 'newsletters-list', DEFAULT_VIEW );
+	const [ view, setView ] = usePersistedView( 'newsletters-list', DEFAULT_VIEW, PERSIST_OPTIONS );
 	const [ quickEditItem, setQuickEditItem ] = useState( null );
 	const { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce, trashCount, progress, refresh } = useNewslettersData( view );
 	const filterElements = useFilterElements();

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/index.js
@@ -34,8 +34,8 @@ const DEFAULT_VIEW = {
 
 const DEFAULT_LAYOUTS = { table: {} };
 
-// `urlPatch` is read at module scope so a forwarded legacy link seeds
-// the view once, rather than being re-applied on every re-render.
+// Built at module scope so a forwarded legacy link is parsed out of
+// `window.location.search` once rather than on every render.
 const PERSIST_OPTIONS = {
 	fieldIds: FIELD_IDS,
 	layoutTypes: Object.keys( DEFAULT_LAYOUTS ),

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/quick-edit-panel.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/quick-edit-panel.js
@@ -15,7 +15,7 @@ import { envelope } from '@wordpress/icons';
 import QuickEditPanel from '../../components/quick-edit-panel';
 import { getNewsletterVisibilityDescriptions } from '../../../utils/service-provider';
 import { notifyError, notifySuccess } from '../../notices';
-import { fetchAllTerms, initialSelectionsForTaxonomy, resolveTokens, selectionsFromIds, sortedIdsEqual, unresolvedIds } from '../../utils/terms';
+import { fetchAllTerms, resolveTokens, selectionsFromIds, sortedIdsEqual, unresolvedIds } from '../../utils/terms';
 
 const POSTS_PATH = '/wp/v2/newspack_nl_cpt';
 
@@ -46,15 +46,10 @@ function useQuickEditOptions() {
 export default function NewslettersQuickEditPanel( { item, onClose, onSaved } ) {
 	const { categories, tags } = useQuickEditOptions();
 
-	// Terms are only embedded when a taxonomy column is visible.
-	const initialCategorySelections = useMemo( () => {
-		const embedded = initialSelectionsForTaxonomy( item, 'category' );
-		return embedded.length ? embedded : selectionsFromIds( item?.categories, categories );
-	}, [ item, categories ] );
-	const initialTagSelections = useMemo( () => {
-		const embedded = initialSelectionsForTaxonomy( item, 'post_tag' );
-		return embedded.length ? embedded : selectionsFromIds( item?.tags, tags );
-	}, [ item, tags ] );
+	// The row carries term IDs; the option lists that resolve them to
+	// names arrive asynchronously.
+	const initialCategorySelections = useMemo( () => selectionsFromIds( item?.categories, categories ), [ item, categories ] );
+	const initialTagSelections = useMemo( () => selectionsFromIds( item?.tags, tags ), [ item, tags ] );
 	// Unresolvable terms can't be shown or removed, so they ride along on save.
 	const unresolvedCategoryIds = useMemo( () => unresolvedIds( item?.categories, initialCategorySelections ), [ item, initialCategorySelections ] );
 	const unresolvedTagIds = useMemo( () => unresolvedIds( item?.tags, initialTagSelections ), [ item, initialTagSelections ] );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/settings/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/settings/index.js
@@ -1,13 +1,12 @@
 import {
 	Notice,
-	Spinner,
-	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 import { notifyError, notifySuccess } from '../../notices';
+import LoadingState from '../../components/loading-state';
 import ListsSection from './lists-section';
 import OptionsSection from './options-section';
 import ProviderSection from './provider-section';
@@ -140,11 +139,7 @@ export default function SettingsScreen() {
 	);
 
 	if ( isLoading && ! data ) {
-		return (
-			<HStack className="newspack-newsletters-admin__loading" justify="center">
-				<Spinner />
-			</HStack>
-		);
+		return <LoadingState label={ __( 'Fetching settings…', 'newspack-newsletters' ) } />;
 	}
 
 	if ( error && ! data ) {

--- a/plugins/newspack-newsletters/src/admin-shell/style.scss
+++ b/plugins/newspack-newsletters/src/admin-shell/style.scss
@@ -196,12 +196,6 @@ body.newspack-newsletters-admin-screen--bundled {
 	}
 }
 
-// Centered over the admin content while an "All" fetch walks the
-// collection (portalled to body — inside the DataViews tree every
-// ancestor stack is a positioning context, which would pin it to the
-// actions row). `left` is set inline from #wpbody's box. The delayed
-// fade keeps fast walks from flashing the overlay in and out.
-
 body.newspack-newsletters-admin-screen .dataviews-view-table a:not(.newspack-newsletters-list__title) {
 	color: var(--wp-admin-theme-color);
 

--- a/plugins/newspack-newsletters/src/admin-shell/style.scss
+++ b/plugins/newspack-newsletters/src/admin-shell/style.scss
@@ -139,6 +139,15 @@ body.newspack-newsletters-admin-screen--bundled {
 		display: flex;
 		justify-content: center;
 		min-height: 200px;
+
+		.components-spinner {
+			margin: 0;
+		}
+
+		p {
+			font-weight: wp-vars.$font-weight-medium;
+			margin: 0;
+		}
 	}
 
 	&__notices {
@@ -192,30 +201,6 @@ body.newspack-newsletters-admin-screen--bundled {
 // ancestor stack is a positioning context, which would pin it to the
 // actions row). `left` is set inline from #wpbody's box. The delayed
 // fade keeps fast walks from flashing the overlay in and out.
-.newspack-newsletters-fetch-all-progress {
-	animation: newspack-newsletters-fetch-all-progress-in 150ms ease-in-out 300ms both;
-	left: 50%;
-	pointer-events: none;
-	position: fixed;
-	top: 50%;
-	transform: translate(-50%, -50%);
-	z-index: 10;
-
-	.components-spinner {
-		margin: 0;
-	}
-}
-
-@keyframes newspack-newsletters-fetch-all-progress-in {
-	from {
-		opacity: 0;
-	}
-
-	to {
-		opacity: 1;
-	}
-}
-
 
 body.newspack-newsletters-admin-screen .dataviews-view-table a:not(.newspack-newsletters-list__title) {
 	color: var(--wp-admin-theme-color);

--- a/plugins/newspack-newsletters/src/admin-shell/utils/build-query.js
+++ b/plugins/newspack-newsletters/src/admin-shell/utils/build-query.js
@@ -21,7 +21,7 @@ function asArray( value ) {
  * @param {string}                                    [options.defaultStatuses]    Comma-joined statuses to use when no status filter is active.
  * @param {string}                                    [options.statusFilterParam]  REST param to receive status-filter values. When omitted, `status` is used.
  * @param {string}                                    [options.defaultStatusParam] REST param to receive `defaultStatuses`. Defaults to `'status'`.
- * @param {Object}                                    [options.extraParams]        Fixed params merged into the result (e.g. `{ _embed: 'author,wp:term' }`).
+ * @param {Object}                                    [options.extraParams]        Fixed params merged into the result (e.g. `{ _fields: 'id,title' }`).
  * @param {boolean}                                   [options.supportsOffset]     When `true`, `view.offset` overrides `page` so callers can address mid-collection windows.
  * @param {Array<{ viewKey: string, param: string }>} [options.arrayParams]        Pass-through bindings for array-valued view fields (e.g. `view.author`).
  * @return {Object} Flat REST query params.

--- a/plugins/newspack-newsletters/src/admin-shell/utils/build-query.js
+++ b/plugins/newspack-newsletters/src/admin-shell/utils/build-query.js
@@ -18,6 +18,7 @@ function asArray( value ) {
  * @param {Object}                                    [options.fieldToQueryParam]  Map of non-status filter fields → REST query params.
  * @param {Object}                                    [options.sortFieldToOrderby] Map of view.sort.field → REST `orderby`. When omitted, sort is pass-through.
  * @param {number}                                    [options.defaultPerPage]     Default `per_page` when `view.perPage` is missing. Defaults to 20.
+ * @param {number}                                    [options.fetchAllChunkSize]  Rows one request of an "All" walk asks for. Defaults to `FETCH_ALL_CHUNK_SIZE`.
  * @param {string}                                    [options.defaultStatuses]    Comma-joined statuses to use when no status filter is active.
  * @param {string}                                    [options.statusFilterParam]  REST param to receive status-filter values. When omitted, `status` is used.
  * @param {string}                                    [options.defaultStatusParam] REST param to receive `defaultStatuses`. Defaults to `'status'`.
@@ -31,6 +32,7 @@ export function buildQueryParams( view = {}, options = {} ) {
 		fieldToQueryParam = {},
 		sortFieldToOrderby = null,
 		defaultPerPage = 20,
+		fetchAllChunkSize = FETCH_ALL_CHUNK_SIZE,
 		defaultStatuses = null,
 		statusFilterParam = null,
 		defaultStatusParam = 'status',
@@ -39,12 +41,12 @@ export function buildQueryParams( view = {}, options = {} ) {
 		arrayParams = [],
 	} = options;
 
-	// "All" walks the collection in max-size chunks starting at page 1;
+	// "All" walks the collection in chunks starting at page 1;
 	// `use-collection-data` follows `X-WP-TotalPages` for the rest.
 	const fetchAll = isFetchAllPerPage( view.perPage );
 
 	const params = {
-		per_page: fetchAll ? FETCH_ALL_CHUNK_SIZE : view.perPage || defaultPerPage,
+		per_page: fetchAll ? fetchAllChunkSize : view.perPage || defaultPerPage,
 		context: 'edit',
 		...extraParams,
 	};

--- a/plugins/newspack-newsletters/src/admin-shell/utils/per-page.js
+++ b/plugins/newspack-newsletters/src/admin-shell/utils/per-page.js
@@ -1,16 +1,26 @@
 /**
  * Items-per-page constants shared by the DataView list screens.
  *
- * `PER_PAGE_ALL` is a client-side sentinel — the REST API caps
- * `per_page` at 100, so "All" fetches `FETCH_ALL_CHUNK_SIZE` at a time
- * and concatenates (see `use-collection-data.js`).
+ * `PER_PAGE_ALL` is a client-side sentinel: "All" fetches
+ * `FETCH_ALL_CHUNK_SIZE` rows at a time and concatenates (see
+ * `use-collection-data.js`).
+ *
+ * The two ceilings below are deliberately different. `MAX_SELECTABLE_PER_PAGE`
+ * bounds what a user can pick and store; `FETCH_ALL_CHUNK_SIZE` bounds
+ * what one request of the "All" walk asks for, and is larger because
+ * each round trip costs a full WordPress bootstrap while the rows
+ * themselves are cheap.
  */
 
 export const PER_PAGE_ALL = -1;
 
-// Mirrors `Admin_Shell_Preferences::PER_PAGE_MAX` (the REST cap the
-// server validates stored preferences against) — change both together.
-export const FETCH_ALL_CHUNK_SIZE = 100;
+// Mirrors `Admin_Shell_Preferences::PER_PAGE_MAX`, which validates
+// stored preferences — change both together.
+export const MAX_SELECTABLE_PER_PAGE = 100;
+
+// Mirrors `Admin_Shell_Collection_Params::MAX_PER_PAGE`, the ceiling
+// those collections accept — change both together.
+export const FETCH_ALL_CHUNK_SIZE = 1000;
 
 // Caps the "All" walk so a very large site can't lock the tab with an
 // unvirtualised table.
@@ -21,4 +31,4 @@ export const DEFAULT_PER_PAGE_OPTIONS = [ 10, 20, 50, 100, PER_PAGE_ALL ];
 
 export const isFetchAllPerPage = value => value === PER_PAGE_ALL;
 
-export const isValidPerPage = value => Number.isInteger( value ) && ( value === PER_PAGE_ALL || ( value >= 1 && value <= FETCH_ALL_CHUNK_SIZE ) );
+export const isValidPerPage = value => Number.isInteger( value ) && ( value === PER_PAGE_ALL || ( value >= 1 && value <= MAX_SELECTABLE_PER_PAGE ) );

--- a/plugins/newspack-newsletters/src/admin-shell/utils/per-page.js
+++ b/plugins/newspack-newsletters/src/admin-shell/utils/per-page.js
@@ -1,15 +1,14 @@
 /**
  * Items-per-page constants shared by the DataView list screens.
  *
- * `PER_PAGE_ALL` is a client-side sentinel: "All" fetches
- * `FETCH_ALL_CHUNK_SIZE` rows at a time and concatenates (see
- * `use-collection-data.js`).
+ * `PER_PAGE_ALL` is a client-side sentinel: "All" fetches a chunk at a
+ * time and concatenates (see `use-collection-data.js`).
  *
  * The two ceilings below are deliberately different. `MAX_SELECTABLE_PER_PAGE`
  * bounds what a user can pick and store; `FETCH_ALL_CHUNK_SIZE` bounds
  * what one request of the "All" walk asks for, and is larger because
  * each round trip costs a full WordPress bootstrap while the rows
- * themselves are cheap.
+ * themselves are cheap. A screen whose rows are not cheap overrides it.
  */
 
 export const PER_PAGE_ALL = -1;
@@ -21,6 +20,13 @@ export const MAX_SELECTABLE_PER_PAGE = 100;
 // Mirrors `Admin_Shell_Collection_Params::MAX_PER_PAGE`, the ceiling
 // those collections accept — change both together.
 export const FETCH_ALL_CHUNK_SIZE = 1000;
+
+// Layouts are the one screen whose `_fields` ships `content.raw`, so a
+// chunk of them is whole block markup rather than the trimmed rows the
+// other three ask for. A smaller chunk bounds the worst single response
+// and its peak memory, and still costs far fewer round trips than core's
+// ceiling of 100.
+export const LAYOUTS_FETCH_ALL_CHUNK_SIZE = 200;
 
 // Caps the "All" walk so a very large site can't lock the tab with an
 // unvirtualised table.

--- a/plugins/newspack-newsletters/src/admin-shell/utils/terms.js
+++ b/plugins/newspack-newsletters/src/admin-shell/utils/terms.js
@@ -1,10 +1,11 @@
 /**
  * Shared term/taxonomy helpers for DataView screens.
  *
- * Reads `_embedded.wp:term`, paginates beyond the 100-item REST cap,
- * and round-trips `FormTokenField` tokens. `resolveTokens` preserves
- * existing selections' IDs across re-renders (see its comment for the
- * residual duplicate-name caveat on hierarchical taxonomies).
+ * Reads the `newspack_newsletters_terms` REST field, paginates beyond
+ * the 100-item REST cap, and round-trips `FormTokenField` tokens.
+ * `resolveTokens` preserves existing selections' IDs across re-renders
+ * (see its comment for the residual duplicate-name caveat on
+ * hierarchical taxonomies).
  */
 
 import apiFetch from '@wordpress/api-fetch';
@@ -40,15 +41,10 @@ export async function fetchAllTerms( basePath, { fields = [ 'id', 'name' ] } = {
 	return all;
 }
 
-// Keyed lookup — group order isn't guaranteed across post types.
+// Keyed by taxonomy slug — see `Rest_Terms_Field` for the payload shape.
 export const termsForTaxonomy = ( item, taxonomy ) => {
-	const groups = item?._embedded?.[ 'wp:term' ] || [];
-	for ( const group of groups ) {
-		if ( Array.isArray( group ) && group.length > 0 && group[ 0 ]?.taxonomy === taxonomy ) {
-			return group;
-		}
-	}
-	return [];
+	const terms = item?.newspack_newsletters_terms?.[ taxonomy ];
+	return Array.isArray( terms ) ? terms : [];
 };
 
 export const initialSelectionsForTaxonomy = ( item, taxonomy ) =>

--- a/plugins/newspack-newsletters/tests/test-admin-shell-collection-params.php
+++ b/plugins/newspack-newsletters/tests/test-admin-shell-collection-params.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Class Test Admin Shell Collection Params
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Admin\Admin_Shell_Collection_Params;
+
+/**
+ * Tests the raised `per_page` ceiling on the list screens' collections.
+ *
+ * Core caps `per_page` at 100, which is what makes "All" fan out into one
+ * request per 100 rows. Each round trip costs a full WordPress bootstrap
+ * while the rows themselves are cheap, so the ceiling is what a
+ * publisher waits on.
+ */
+class Admin_Shell_Collection_Params_Test extends WP_UnitTestCase {
+	/**
+	 * Set up a REST server with the filters registered.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		global $wp_rest_server;
+		$wp_rest_server = new \WP_REST_Server();
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Reset REST server.
+	 */
+	public function tear_down() {
+		global $wp_rest_server;
+		$wp_rest_server = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * Every collection a list screen reads accepts the raised ceiling.
+	 */
+	public function test_every_list_collection_accepts_the_raised_ceiling() {
+		foreach ( Admin_Shell_Collection_Params::get_collections() as $rest_base ) {
+			$params = apply_filters( 'rest_' . $rest_base . '_collection_params', [ 'per_page' => [ 'maximum' => 100 ] ] );
+			$this->assertSame(
+				Admin_Shell_Collection_Params::MAX_PER_PAGE,
+				$params['per_page']['maximum'],
+				'Expected a raised ceiling for: ' . $rest_base
+			);
+		}
+	}
+
+	/**
+	 * The raised ceiling reaches the live route, not just the filter.
+	 */
+	public function test_request_above_the_core_cap_is_accepted() {
+		self::factory()->post->create_many(
+			3,
+			[
+				'post_type'   => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status' => 'draft',
+			]
+		);
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
+		$request->set_param( 'per_page', Admin_Shell_Collection_Params::MAX_PER_PAGE );
+		$request->set_param( 'context', 'edit' );
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * The ceiling is still a ceiling: past it, the request is rejected
+	 * rather than silently clamped.
+	 */
+	public function test_request_above_the_raised_ceiling_is_rejected() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
+		$request->set_param( 'per_page', Admin_Shell_Collection_Params::MAX_PER_PAGE + 1 );
+
+		$this->assertSame( 400, rest_do_request( $request )->get_status() );
+	}
+
+	/**
+	 * Collections outside the list screens keep core's cap — this raises
+	 * the ceiling where the admin shell needs it, not site-wide.
+	 */
+	public function test_unrelated_collections_keep_the_core_cap() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_param( 'per_page', 101 );
+
+		$this->assertSame( 400, rest_do_request( $request )->get_status() );
+	}
+}

--- a/plugins/newspack-newsletters/tests/test-admin-shell-collection-params.php
+++ b/plugins/newspack-newsletters/tests/test-admin-shell-collection-params.php
@@ -157,15 +157,47 @@ class Admin_Shell_Collection_Params_Test extends WP_UnitTestCase {
 	public function test_the_gate_covers_every_raised_collection() {
 		wp_set_current_user( 0 );
 
-		foreach ( Admin_Shell_Collection_Params::get_collections() as $rest_base ) {
+		$checked = 0;
+		foreach ( Admin_Shell_Collection_Params::get_collections() as $name ) {
+			$rest_base = $this->rest_base_for( $name );
+			if ( null === $rest_base ) {
+				continue;
+			}
+
 			$request = new WP_REST_Request( 'GET', '/wp/v2/' . $rest_base );
 			$request->set_param( 'per_page', Admin_Shell_Collection_Params::MAX_PER_PAGE );
 
-			$this->assertContains(
+			$this->assertSame(
+				400,
 				rest_do_request( $request )->get_status(),
-				[ 400, 404 ],
-				'Expected the core cap to hold for a logged-out caller on: ' . $rest_base
+				'Expected the core cap to hold for a logged-out caller on: ' . $name
 			);
+			++$checked;
 		}
+
+		$this->assertGreaterThan( 0, $checked, 'No collection was reachable, so the gate went untested.' );
+	}
+
+	/**
+	 * The REST base a collection is served from, or null when it is not
+	 * exposed to the current caller.
+	 *
+	 * Resolved rather than assumed: `newspack_nl_ad_placement` already
+	 * overrides `rest_base` elsewhere in this plugin, so a name is not
+	 * safe to use as a path.
+	 *
+	 * @param string $name Post type or taxonomy name.
+	 * @return string|null
+	 */
+	private function rest_base_for( $name ) {
+		$object = get_post_type_object( $name );
+		if ( ! $object ) {
+			$object = get_taxonomy( $name );
+		}
+		if ( ! $object || empty( $object->show_in_rest ) ) {
+			return null;
+		}
+
+		return empty( $object->rest_base ) ? $name : $object->rest_base;
 	}
 }

--- a/plugins/newspack-newsletters/tests/test-admin-shell-collection-params.php
+++ b/plugins/newspack-newsletters/tests/test-admin-shell-collection-params.php
@@ -6,6 +6,7 @@
  */
 
 use Newspack\Newsletters\Admin\Admin_Shell_Collection_Params;
+use Newspack_Newsletters\Ads;
 
 /**
  * Tests the raised `per_page` ceiling on the list screens' collections.
@@ -85,6 +86,18 @@ class Admin_Shell_Collection_Params_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The advertisers screen is the one collection served by the terms
+	 * controller, whose filter is keyed on the taxonomy rather than a
+	 * rest_base, so it is worth asserting end to end.
+	 */
+	public function test_the_advertiser_taxonomy_accepts_the_raised_ceiling() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/' . Ads::ADVERTISER_TAX );
+		$request->set_param( 'per_page', Admin_Shell_Collection_Params::MAX_PER_PAGE );
+
+		$this->assertSame( 200, rest_do_request( $request )->get_status() );
+	}
+
+	/**
 	 * Collections outside the list screens keep core's cap — this raises
 	 * the ceiling where the admin shell needs it, not site-wide.
 	 */
@@ -93,5 +106,66 @@ class Admin_Shell_Collection_Params_Test extends WP_UnitTestCase {
 		$request->set_param( 'per_page', 101 );
 
 		$this->assertSame( 400, rest_do_request( $request )->get_status() );
+	}
+
+	/**
+	 * The newsletters CPT is public, so without a capability gate the
+	 * raised ceiling would let any anonymous caller ask one request to
+	 * render ten times as many rows as core allows.
+	 */
+	public function test_a_logged_out_caller_is_held_to_the_core_cap() {
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
+		$request->set_param( 'per_page', Admin_Shell_Collection_Params::CORE_MAX_PER_PAGE + 1 );
+
+		$this->assertSame( 400, rest_do_request( $request )->get_status() );
+	}
+
+	/**
+	 * The gate is on the raise, not on the collection: core's own ceiling
+	 * still works for everyone.
+	 */
+	public function test_a_logged_out_caller_can_still_reach_the_core_cap() {
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
+		$request->set_param( 'per_page', Admin_Shell_Collection_Params::CORE_MAX_PER_PAGE );
+
+		$this->assertSame( 200, rest_do_request( $request )->get_status() );
+	}
+
+	/**
+	 * A subscriber can read the collection but has no business asking for
+	 * a thousand rows of it.
+	 */
+	public function test_a_subscriber_is_held_to_the_core_cap() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
+		$request->set_param( 'per_page', Admin_Shell_Collection_Params::MAX_PER_PAGE );
+
+		$this->assertSame( 400, rest_do_request( $request )->get_status() );
+	}
+
+	/**
+	 * The gate covers every collection the raise touches, not just the
+	 * newsletters CPT. The layouts CPT only registers for a user who can
+	 * edit others' posts, so for a logged-out caller it is not routable at
+	 * all, which is the same guarantee reached earlier.
+	 */
+	public function test_the_gate_covers_every_raised_collection() {
+		wp_set_current_user( 0 );
+
+		foreach ( Admin_Shell_Collection_Params::get_collections() as $rest_base ) {
+			$request = new WP_REST_Request( 'GET', '/wp/v2/' . $rest_base );
+			$request->set_param( 'per_page', Admin_Shell_Collection_Params::MAX_PER_PAGE );
+
+			$this->assertContains(
+				rest_do_request( $request )->get_status(),
+				[ 400, 404 ],
+				'Expected the core cap to hold for a logged-out caller on: ' . $rest_base
+			);
+		}
 	}
 }

--- a/plugins/newspack-newsletters/tests/test-admin-shell-collection-params.php
+++ b/plugins/newspack-newsletters/tests/test-admin-shell-collection-params.php
@@ -122,13 +122,17 @@ class Admin_Shell_Collection_Params_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * An unprivileged caller is held to core's ceiling on every collection
-	 * the raise touches. The newsletters CPT is public, so without the gate
-	 * an anonymous request could ask for ten times as many rows as core
-	 * allows; a subscriber can read the collection but has no business
-	 * asking for a thousand rows of it either. Collections a caller cannot
-	 * reach at all (layouts needs `edit_others_posts`) are skipped, which
-	 * is the same guarantee by a shorter route.
+	 * An unprivileged caller is held to core's ceiling on every collection the
+	 * raise touches. The newsletters CPT is public, so without the gate an
+	 * anonymous request could ask for ten times as many rows as core allows;
+	 * a subscriber can read the collection but has no business asking for a
+	 * thousand rows of it either.
+	 *
+	 * Both `CORE_MAX_PER_PAGE + 1` and the raised ceiling are asked for: the
+	 * first pins where the gate sits, the second that it still holds well
+	 * above it. Collections not exposed to the caller are skipped — the
+	 * layouts CPT is not registered at all in this suite, since it registers
+	 * on `init` behind `edit_others_posts` and the bootstrap runs as user 0.
 	 *
 	 * @dataProvider unprivileged_callers
 	 * @param string $role Role to authenticate as, or '' for a logged-out caller.
@@ -143,14 +147,16 @@ class Admin_Shell_Collection_Params_Test extends WP_UnitTestCase {
 				continue;
 			}
 
-			$request = new WP_REST_Request( 'GET', '/wp/v2/' . $rest_base );
-			$request->set_param( 'per_page', Admin_Shell_Collection_Params::MAX_PER_PAGE );
+			foreach ( [ Admin_Shell_Collection_Params::CORE_MAX_PER_PAGE + 1, Admin_Shell_Collection_Params::MAX_PER_PAGE ] as $per_page ) {
+				$request = new WP_REST_Request( 'GET', '/wp/v2/' . $rest_base );
+				$request->set_param( 'per_page', $per_page );
 
-			$this->assertSame(
-				400,
-				rest_do_request( $request )->get_status(),
-				'Expected the core cap to hold on: ' . $name
-			);
+				$this->assertSame(
+					400,
+					rest_do_request( $request )->get_status(),
+					'Expected the core cap to hold on ' . $name . ' at per_page ' . $per_page
+				);
+			}
 			++$checked;
 		}
 
@@ -175,7 +181,8 @@ class Admin_Shell_Collection_Params_Test extends WP_UnitTestCase {
 	 *
 	 * Resolved rather than assumed: `newspack_nl_ad_placement` already
 	 * overrides `rest_base` elsewhere in this plugin, so a name is not
-	 * safe to use as a path.
+	 * safe to use as a path. Returns null for anything not registered or not
+	 * exposed to REST, which is how unroutable collections are skipped.
 	 *
 	 * @param string $name Post type or taxonomy name.
 	 * @return string|null

--- a/plugins/newspack-newsletters/tests/test-admin-shell-collection-params.php
+++ b/plugins/newspack-newsletters/tests/test-admin-shell-collection-params.php
@@ -43,12 +43,12 @@ class Admin_Shell_Collection_Params_Test extends WP_UnitTestCase {
 	 * Every collection a list screen reads accepts the raised ceiling.
 	 */
 	public function test_every_list_collection_accepts_the_raised_ceiling() {
-		foreach ( Admin_Shell_Collection_Params::get_collections() as $rest_base ) {
-			$params = apply_filters( 'rest_' . $rest_base . '_collection_params', [ 'per_page' => [ 'maximum' => 100 ] ] );
+		foreach ( Admin_Shell_Collection_Params::get_collections() as $collection ) {
+			$params = apply_filters( 'rest_' . $collection . '_collection_params', [ 'per_page' => [ 'maximum' => 100 ] ] );
 			$this->assertSame(
 				Admin_Shell_Collection_Params::MAX_PER_PAGE,
 				$params['per_page']['maximum'],
-				'Expected a raised ceiling for: ' . $rest_base
+				'Expected a raised ceiling for: ' . $collection
 			);
 		}
 	}
@@ -109,20 +109,6 @@ class Admin_Shell_Collection_Params_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The newsletters CPT is public, so without a capability gate the
-	 * raised ceiling would let any anonymous caller ask one request to
-	 * render ten times as many rows as core allows.
-	 */
-	public function test_a_logged_out_caller_is_held_to_the_core_cap() {
-		wp_set_current_user( 0 );
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
-		$request->set_param( 'per_page', Admin_Shell_Collection_Params::CORE_MAX_PER_PAGE + 1 );
-
-		$this->assertSame( 400, rest_do_request( $request )->get_status() );
-	}
-
-	/**
 	 * The gate is on the raise, not on the collection: core's own ceiling
 	 * still works for everyone.
 	 */
@@ -136,26 +122,19 @@ class Admin_Shell_Collection_Params_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A subscriber can read the collection but has no business asking for
-	 * a thousand rows of it.
+	 * An unprivileged caller is held to core's ceiling on every collection
+	 * the raise touches. The newsletters CPT is public, so without the gate
+	 * an anonymous request could ask for ten times as many rows as core
+	 * allows; a subscriber can read the collection but has no business
+	 * asking for a thousand rows of it either. Collections a caller cannot
+	 * reach at all (layouts needs `edit_others_posts`) are skipped, which
+	 * is the same guarantee by a shorter route.
+	 *
+	 * @dataProvider unprivileged_callers
+	 * @param string $role Role to authenticate as, or '' for a logged-out caller.
 	 */
-	public function test_a_subscriber_is_held_to_the_core_cap() {
-		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
-		$request->set_param( 'per_page', Admin_Shell_Collection_Params::MAX_PER_PAGE );
-
-		$this->assertSame( 400, rest_do_request( $request )->get_status() );
-	}
-
-	/**
-	 * The gate covers every collection the raise touches, not just the
-	 * newsletters CPT. The layouts CPT only registers for a user who can
-	 * edit others' posts, so for a logged-out caller it is not routable at
-	 * all, which is the same guarantee reached earlier.
-	 */
-	public function test_the_gate_covers_every_raised_collection() {
-		wp_set_current_user( 0 );
+	public function test_an_unprivileged_caller_is_held_to_the_core_cap( $role ) {
+		wp_set_current_user( '' === $role ? 0 : self::factory()->user->create( [ 'role' => $role ] ) );
 
 		$checked = 0;
 		foreach ( Admin_Shell_Collection_Params::get_collections() as $name ) {
@@ -170,12 +149,24 @@ class Admin_Shell_Collection_Params_Test extends WP_UnitTestCase {
 			$this->assertSame(
 				400,
 				rest_do_request( $request )->get_status(),
-				'Expected the core cap to hold for a logged-out caller on: ' . $name
+				'Expected the core cap to hold on: ' . $name
 			);
 			++$checked;
 		}
 
 		$this->assertGreaterThan( 0, $checked, 'No collection was reachable, so the gate went untested.' );
+	}
+
+	/**
+	 * Callers the raise is not meant for.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function unprivileged_callers() {
+		return [
+			'logged out' => [ '' ],
+			'subscriber' => [ 'subscriber' ],
+		];
 	}
 
 	/**

--- a/plugins/newspack-newsletters/tests/test-admin-shell-preferences.php
+++ b/plugins/newspack-newsletters/tests/test-admin-shell-preferences.php
@@ -373,6 +373,54 @@ class Admin_Shell_Preferences_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * DataViews renders the Title, Media and Description toggles in the
+	 * same View options list as the field checkboxes, so they have to
+	 * survive a reload alongside them.
+	 */
+	public function test_saves_the_property_visibility_toggles() {
+		$response = rest_do_request(
+			$this->make_request(
+				'layouts-list',
+				[
+					'showMedia'       => false,
+					'showTitle'       => true,
+					'showDescription' => false,
+				]
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			[
+				'showTitle'       => true,
+				'showMedia'       => false,
+				'showDescription' => false,
+			],
+			Admin_Shell_Preferences::get_preferences()['layouts-list']
+		);
+	}
+
+	/**
+	 * A non-boolean toggle is dropped rather than coerced, so a stray
+	 * string can't read back as "on".
+	 */
+	public function test_drops_non_boolean_visibility_toggles() {
+		update_user_meta(
+			$this->editor_id,
+			Admin_Shell_Preferences::get_user_meta_key( 'layouts-list' ),
+			[
+				'perPage'   => 24,
+				'showMedia' => 'false',
+			]
+		);
+
+		$this->assertSame(
+			[ 'perPage' => 24 ],
+			Admin_Shell_Preferences::get_preferences()['layouts-list']
+		);
+	}
+
+	/**
 	 * `usermeta` is network-global. Single-site installs keep the
 	 * unprefixed key so preferences saved before this survive.
 	 */

--- a/plugins/newspack-newsletters/tests/test-admin-shell-preferences.php
+++ b/plugins/newspack-newsletters/tests/test-admin-shell-preferences.php
@@ -160,4 +160,180 @@ class Admin_Shell_Preferences_Test extends WP_UnitTestCase {
 		$this->assertSame( 50, $prefs['newsletters-list']['perPage'] );
 		$this->assertSame( 20, $prefs['ads-list']['perPage'] );
 	}
+
+	/**
+	 * The whole presentation half of a view round-trips: layout type,
+	 * sort, visible fields in their display order, density and column
+	 * widths.
+	 */
+	public function test_saves_the_full_appearance_state() {
+		$prefs = [
+			'perPage'    => 50,
+			'type'       => 'table',
+			'titleField' => 'title',
+			'fields'     => [ 'author', 'status', 'date' ],
+			'sort'       => [
+				'field'     => 'author',
+				'direction' => 'asc',
+			],
+			'layout'     => [
+				'density' => 'compact',
+				'styles'  => [ 'status' => [ 'width' => '120px' ] ],
+			],
+		];
+
+		$response = rest_do_request( $this->make_request( 'newsletters-list', $prefs ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $prefs, Admin_Shell_Preferences::get_preferences()['newsletters-list'] );
+	}
+
+	/**
+	 * The grid layout's preview-size slider is an appearance setting too.
+	 */
+	public function test_saves_the_grid_preview_size() {
+		// A pixel width, not a slider position.
+		$response = rest_do_request( $this->make_request( 'layouts-list', [ 'layout' => [ 'previewSize' => 430 ] ] ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 430, Admin_Shell_Preferences::get_preferences()['layouts-list']['layout']['previewSize'] );
+
+		foreach ( [ -1, 99999 ] as $invalid ) {
+			$rejected = rest_do_request( $this->make_request( 'layouts-list', [ 'layout' => [ 'previewSize' => $invalid ] ] ) );
+			$this->assertSame( 400, $rejected->get_status() );
+		}
+	}
+
+	/**
+	 * Column order is the order of the `fields` array, so it has to
+	 * survive the round trip intact.
+	 */
+	public function test_field_order_is_preserved() {
+		rest_do_request( $this->make_request( 'newsletters-list', [ 'fields' => [ 'date', 'status', 'author' ] ] ) );
+
+		$this->assertSame(
+			[ 'date', 'status', 'author' ],
+			Admin_Shell_Preferences::get_preferences()['newsletters-list']['fields']
+		);
+	}
+
+	/**
+	 * Hiding every column is a real choice, not an empty payload.
+	 */
+	public function test_saves_an_empty_field_list() {
+		$response = rest_do_request( $this->make_request( 'newsletters-list', [ 'fields' => [] ] ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( [], Admin_Shell_Preferences::get_preferences()['newsletters-list']['fields'] );
+	}
+
+	/**
+	 * Query state is not a preference — the schema rejects it outright
+	 * rather than storing a stale search or filter set.
+	 */
+	public function test_rejects_query_state() {
+		foreach ( [ [ 'search' => 'digest' ], [ 'page' => 3 ], [ 'filters' => [] ] ] as $prefs ) {
+			$response = rest_do_request( $this->make_request( 'newsletters-list', $prefs ) );
+			$this->assertSame( 400, $response->get_status() );
+		}
+	}
+
+	/**
+	 * Values outside the enums are rejected rather than stored for the
+	 * client to trip over.
+	 */
+	public function test_rejects_out_of_enum_appearance_values() {
+		$invalid = [
+			[ 'type' => 'carousel' ],
+			[ 'layout' => [ 'density' => 'roomy' ] ],
+			[ 'sort' => [ 'direction' => 'sideways' ] ],
+			[ 'layout' => [ 'styles' => [ 'status' => [ 'align' => 'middle' ] ] ] ],
+		];
+		foreach ( $invalid as $prefs ) {
+			$response = rest_do_request( $this->make_request( 'newsletters-list', $prefs ) );
+			$this->assertSame( 400, $response->get_status(), 'Expected rejection for: ' . wp_json_encode( $prefs ) );
+		}
+		$this->assertSame( [], Admin_Shell_Preferences::get_preferences() );
+	}
+
+	/**
+	 * A payload with nothing storable in it is a client bug, not an
+	 * instruction to blank the screen's preferences.
+	 */
+	public function test_rejects_an_empty_payload() {
+		$response = rest_do_request( $this->make_request( 'newsletters-list', [] ) );
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * Field IDs and the column-style map are keyed by whatever the
+	 * screen defines, so they are bounded rather than trusted.
+	 */
+	public function test_caps_the_free_form_halves_of_the_payload() {
+		$long_id = str_repeat( 'a', 200 );
+		$fields  = array_map(
+			static function ( $i ) {
+				return 'field_' . $i;
+			},
+			range( 1, 80 )
+		);
+
+		$sanitized = Admin_Shell_Preferences::sanitize_prefs(
+			[
+				'fields' => array_merge( [ $long_id, '', '  ' ], $fields ),
+				'layout' => [ 'styles' => [ $long_id => [ 'width' => str_repeat( 'x', 100 ) ] ] ],
+			]
+		);
+
+		$this->assertCount( 50, $sanitized['fields'] );
+		$this->assertNotContains( $long_id, $sanitized['fields'] );
+		$this->assertArrayNotHasKey( 'layout', $sanitized );
+	}
+
+	/**
+	 * Duplicate field IDs would render a column twice.
+	 */
+	public function test_deduplicates_field_ids() {
+		$sanitized = Admin_Shell_Preferences::sanitize_prefs( [ 'fields' => [ 'status', 'author', 'status' ] ] );
+
+		$this->assertSame( [ 'status', 'author' ], $sanitized['fields'] );
+	}
+
+	/**
+	 * Preferences written by an older version stay readable: the extra
+	 * keys simply arrive absent.
+	 */
+	public function test_reads_back_a_per_page_only_value_saved_by_an_earlier_version() {
+		update_user_meta( $this->editor_id, Admin_Shell_Preferences::get_user_meta_key( 'newsletters-list' ), [ 'perPage' => 50 ] );
+
+		$this->assertSame(
+			[ 'newsletters-list' => [ 'perPage' => 50 ] ],
+			Admin_Shell_Preferences::get_preferences()
+		);
+	}
+
+	/**
+	 * Hand-edited or half-corrupt meta is filtered key by key rather
+	 * than discarded wholesale.
+	 */
+	public function test_get_preferences_drops_only_the_corrupt_keys() {
+		update_user_meta(
+			$this->editor_id,
+			Admin_Shell_Preferences::get_user_meta_key( 'newsletters-list' ),
+			[
+				'perPage' => 50,
+				'type'    => 'carousel',
+				'fields'  => [ 'status', 42, null ],
+				'layout'  => [ 'density' => 'roomy' ],
+			]
+		);
+
+		$this->assertSame(
+			[
+				'perPage' => 50,
+				'fields'  => [ 'status' ],
+			],
+			Admin_Shell_Preferences::get_preferences()['newsletters-list']
+		);
+	}
 }

--- a/plugins/newspack-newsletters/tests/test-admin-shell-preferences.php
+++ b/plugins/newspack-newsletters/tests/test-admin-shell-preferences.php
@@ -247,7 +247,6 @@ class Admin_Shell_Preferences_Test extends WP_UnitTestCase {
 			[ 'type' => 'carousel' ],
 			[ 'layout' => [ 'density' => 'roomy' ] ],
 			[ 'sort' => [ 'direction' => 'sideways' ] ],
-			[ 'layout' => [ 'styles' => [ 'status' => [ 'align' => 'middle' ] ] ] ],
 		];
 		foreach ( $invalid as $prefs ) {
 			$response = rest_do_request( $this->make_request( 'newsletters-list', $prefs ) );
@@ -335,5 +334,58 @@ class Admin_Shell_Preferences_Test extends WP_UnitTestCase {
 			],
 			Admin_Shell_Preferences::get_preferences()['newsletters-list']
 		);
+	}
+
+	/**
+	 * DataViews owns the shape of a column style, so an unfamiliar key or
+	 * alignment is sanitised away rather than failing the request. Schema
+	 * validation rejects the whole payload on the first unknown key, which
+	 * would take every other appearance setting down with it and leave no
+	 * trace anywhere.
+	 */
+	public function test_an_unfamiliar_column_style_does_not_reject_the_payload() {
+		$response = rest_do_request(
+			$this->make_request(
+				'newsletters-list',
+				[
+					'layout' => [
+						'density' => 'compact',
+						'styles'  => [
+							'status' => [
+								'width'     => '120px',
+								'align'     => 'middle',
+								'resizable' => true,
+							],
+						],
+					],
+				]
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			[
+				'density' => 'compact',
+				'styles'  => [ 'status' => [ 'width' => '120px' ] ],
+			],
+			Admin_Shell_Preferences::get_preferences()['newsletters-list']['layout']
+		);
+	}
+
+	/**
+	 * `usermeta` is network-global. Single-site installs keep the
+	 * unprefixed key so preferences saved before this survive.
+	 */
+	public function test_the_meta_key_is_scoped_per_site_only_on_multisite() {
+		global $wpdb;
+
+		$key = Admin_Shell_Preferences::get_user_meta_key( 'newsletters-list' );
+
+		if ( is_multisite() ) {
+			$this->assertStringStartsWith( $wpdb->get_blog_prefix() . Admin_Shell_Preferences::USER_META_KEY_PREFIX, $key );
+			return;
+		}
+
+		$this->assertSame( Admin_Shell_Preferences::USER_META_KEY_PREFIX . 'newsletters-list', $key );
 	}
 }

--- a/plugins/newspack-newsletters/tests/test-admin-shell-preferences.php
+++ b/plugins/newspack-newsletters/tests/test-admin-shell-preferences.php
@@ -228,8 +228,10 @@ class Admin_Shell_Preferences_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Query state is not a preference — the schema rejects it outright
-	 * rather than storing a stale search or filter set.
+	 * Query state is not a preference. A payload carrying nothing else is
+	 * rejected, rather than stored as a stale search or filter set: the keys
+	 * pass validation as unrecognised properties, `sanitize_prefs()` drops
+	 * them, and an empty result is what `update_preferences()` refuses.
 	 */
 	public function test_rejects_query_state() {
 		foreach ( [ [ 'search' => 'digest' ], [ 'page' => 3 ], [ 'filters' => [] ] ] as $prefs ) {
@@ -408,31 +410,91 @@ class Admin_Shell_Preferences_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * `usermeta` is network-global, so the key carries the blog prefix on a
-	 * network. Off one it stays unprefixed, which is what keeps values
-	 * already in the table readable.
+	 * `usermeta` is network-global, so on a network the key carries the blog
+	 * prefix — without it one site's list configuration would be read by every
+	 * other site. Off a network it stays unprefixed, which is what keeps
+	 * values already in the table readable.
 	 */
-	public function test_the_meta_key_is_unprefixed_off_a_network() {
-		if ( is_multisite() ) {
-			$this->markTestSkipped( 'The unprefixed key is the single-site branch.' );
-		}
+	public function test_the_meta_key_is_scoped_per_site_only_on_a_network() {
+		global $wpdb;
 
-		$this->assertSame(
-			Admin_Shell_Preferences::USER_META_KEY_PREFIX . 'newsletters-list',
-			Admin_Shell_Preferences::get_user_meta_key( 'newsletters-list' )
-		);
+		$expected = ( is_multisite() ? $wpdb->get_blog_prefix() : '' ) . Admin_Shell_Preferences::USER_META_KEY_PREFIX . 'newsletters-list';
+
+		$this->assertSame( $expected, Admin_Shell_Preferences::get_user_meta_key( 'newsletters-list' ) );
 	}
 
 	/**
-	 * The schema accepts a fractional width, so storing one must not
-	 * truncate it — the two halves would otherwise disagree about what a
-	 * fractional width means.
+	 * A key this version doesn't know is dropped, and the rest of the payload
+	 * still lands. Schema validation fails the whole request on the first
+	 * unrecognised property, so a stricter schema here would let one key added
+	 * upstream stop every appearance setting persisting.
 	 */
-	public function test_a_fractional_column_width_survives_sanitization() {
-		$sanitized = Admin_Shell_Preferences::sanitize_prefs(
-			[ 'layout' => [ 'styles' => [ 'status' => [ 'width' => 217.5 ] ] ] ]
+	public function test_an_unknown_key_does_not_reject_the_rest_of_the_payload() {
+		$payloads = [
+			[
+				'perPage'                => 50,
+				'someFutureDataViewsKey' => 'x',
+			],
+			[
+				'perPage' => 50,
+				'sort'    => [
+					'field'         => 'date',
+					'someFutureKey' => 'x',
+				],
+			],
+			[
+				'perPage' => 50,
+				'layout'  => [
+					'density'       => 'compact',
+					'someFutureKey' => 'x',
+				],
+			],
+		];
+
+		foreach ( $payloads as $prefs ) {
+			$response = rest_do_request( $this->make_request( 'newsletters-list', $prefs ) );
+
+			$this->assertSame( 200, $response->get_status(), 'Expected acceptance for: ' . wp_json_encode( $prefs ) );
+			$this->assertSame( 50, Admin_Shell_Preferences::get_preferences()['newsletters-list']['perPage'] );
+			$this->assertArrayNotHasKey( 'someFutureDataViewsKey', Admin_Shell_Preferences::get_preferences()['newsletters-list'] );
+		}
+	}
+
+	/**
+	 * The schema accepts a fractional width, so storing one must not truncate
+	 * it. Routed through the route rather than the sanitiser alone, because
+	 * the `[ 'string', 'number' ]` union is what hands PHP the float.
+	 */
+	public function test_a_fractional_column_width_survives_the_round_trip() {
+		$response = rest_do_request(
+			$this->make_request( 'newsletters-list', [ 'layout' => [ 'styles' => [ 'status' => [ 'width' => 217.5 ] ] ] ] )
 		);
 
-		$this->assertSame( 217.5, $sanitized['layout']['styles']['status']['width'] );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 217.5, Admin_Shell_Preferences::get_preferences()['newsletters-list']['layout']['styles']['status']['width'] );
+	}
+
+	/**
+	 * `INF` and `NAN` pass `is_numeric()` but cannot be JSON-encoded, and
+	 * preferences are bootstrapped into the page through
+	 * `wp_localize_script`. One of them stored would print the admin global as
+	 * a syntax error and stop the app booting, with no way back through the UI.
+	 */
+	public function test_a_non_finite_column_width_is_not_stored() {
+		$response = rest_do_request(
+			$this->make_request(
+				'newsletters-list',
+				[
+					'perPage' => 50,
+					'layout'  => [ 'styles' => [ 'status' => [ 'width' => INF ] ] ],
+				] 
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$prefs = Admin_Shell_Preferences::get_preferences();
+		$this->assertArrayNotHasKey( 'layout', $prefs['newsletters-list'] );
+		$this->assertIsString( wp_json_encode( $prefs ) );
 	}
 }

--- a/plugins/newspack-newsletters/tests/test-admin-shell-preferences.php
+++ b/plugins/newspack-newsletters/tests/test-admin-shell-preferences.php
@@ -299,19 +299,6 @@ class Admin_Shell_Preferences_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Preferences written by an older version stay readable: the extra
-	 * keys simply arrive absent.
-	 */
-	public function test_reads_back_a_per_page_only_value_saved_by_an_earlier_version() {
-		update_user_meta( $this->editor_id, Admin_Shell_Preferences::get_user_meta_key( 'newsletters-list' ), [ 'perPage' => 50 ] );
-
-		$this->assertSame(
-			[ 'newsletters-list' => [ 'perPage' => 50 ] ],
-			Admin_Shell_Preferences::get_preferences()
-		);
-	}
-
-	/**
 	 * Hand-edited or half-corrupt meta is filtered key by key rather
 	 * than discarded wholesale.
 	 */
@@ -421,19 +408,31 @@ class Admin_Shell_Preferences_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * `usermeta` is network-global. Single-site installs keep the
-	 * unprefixed key so preferences saved before this survive.
+	 * `usermeta` is network-global, so the key carries the blog prefix on a
+	 * network. Off one it stays unprefixed, which is what keeps values
+	 * already in the table readable.
 	 */
-	public function test_the_meta_key_is_scoped_per_site_only_on_multisite() {
-		global $wpdb;
-
-		$key = Admin_Shell_Preferences::get_user_meta_key( 'newsletters-list' );
-
+	public function test_the_meta_key_is_unprefixed_off_a_network() {
 		if ( is_multisite() ) {
-			$this->assertStringStartsWith( $wpdb->get_blog_prefix() . Admin_Shell_Preferences::USER_META_KEY_PREFIX, $key );
-			return;
+			$this->markTestSkipped( 'The unprefixed key is the single-site branch.' );
 		}
 
-		$this->assertSame( Admin_Shell_Preferences::USER_META_KEY_PREFIX . 'newsletters-list', $key );
+		$this->assertSame(
+			Admin_Shell_Preferences::USER_META_KEY_PREFIX . 'newsletters-list',
+			Admin_Shell_Preferences::get_user_meta_key( 'newsletters-list' )
+		);
+	}
+
+	/**
+	 * The schema accepts a fractional width, so storing one must not
+	 * truncate it — the two halves would otherwise disagree about what a
+	 * fractional width means.
+	 */
+	public function test_a_fractional_column_width_survives_sanitization() {
+		$sanitized = Admin_Shell_Preferences::sanitize_prefs(
+			[ 'layout' => [ 'styles' => [ 'status' => [ 'width' => 217.5 ] ] ] ]
+		);
+
+		$this->assertSame( 217.5, $sanitized['layout']['styles']['status']['width'] );
 	}
 }

--- a/plugins/newspack-newsletters/tests/test-ads-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-ads-list-rest.php
@@ -1477,4 +1477,59 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 		$this->assertSame( '0', get_post_meta( $post_id, 'tracking_clicks', true ) );
 		$this->assertNotEmpty( get_post_meta( $post_id, 'tracking_impressions', false ) );
 	}
+
+	/**
+	 * Quick Edit seeds the advertiser, placement and category pickers off
+	 * this payload, so it has to survive a real dispatch with every
+	 * requested taxonomy present, and only in the `edit` context the list
+	 * asks for.
+	 */
+	public function test_the_terms_field_reaches_the_response_only_in_edit_context() {
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		do_action( 'rest_api_init' );
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$post_id    = self::factory()->post->create(
+			[
+				'post_type'   => Ads::CPT,
+				'post_status' => 'publish',
+				'post_title'  => 'Terms field ad',
+			]
+		);
+		$advertiser = self::factory()->term->create(
+			[
+				'taxonomy' => Ads::ADVERTISER_TAX,
+				'name'     => 'Acme',
+			]
+		);
+		wp_set_post_terms( $post_id, [ $advertiser ], Ads::ADVERTISER_TAX );
+
+		$route = '/wp/v2/' . Ads::CPT;
+
+		$edit = new WP_REST_Request( 'GET', $route );
+		$edit->set_param( 'context', 'edit' );
+		$terms = rest_do_request( $edit )->get_data()[0]['newspack_newsletters_terms'];
+
+		$this->assertSame(
+			[
+				[
+					'id'   => $advertiser,
+					'name' => 'Acme',
+				],
+			],
+			$terms[ Ads::ADVERTISER_TAX ]
+		);
+		// Every requested taxonomy is present, so Quick Edit never has to
+		// tell "no terms" apart from "taxonomy missing".
+		foreach ( Ads_List_REST::LIST_TAXONOMIES as $taxonomy ) {
+			$this->assertArrayHasKey( $taxonomy, $terms );
+		}
+
+		$view_item = rest_do_request( new WP_REST_Request( 'GET', $route ) )->get_data()[0];
+		$this->assertArrayNotHasKey( 'newspack_newsletters_terms', $view_item );
+
+		$wp_rest_server = null;
+	}
 }

--- a/plugins/newspack-newsletters/tests/test-ads-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-ads-list-rest.php
@@ -382,6 +382,80 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The terms field is registered too. It exists so the list never has
+	 * to ask for `_links`, which is what makes core build a link set and
+	 * compute target hints for every row.
+	 */
+	public function test_terms_field_is_registered_on_ads_cpt() {
+		do_action( 'rest_api_init' );
+
+		global $wp_rest_additional_fields;
+
+		$cpt    = Ads::CPT;
+		$fields = isset( $wp_rest_additional_fields[ $cpt ] ) ? $wp_rest_additional_fields[ $cpt ] : [];
+
+		$this->assertArrayHasKey( 'newspack_newsletters_terms', $fields );
+		$this->assertIsCallable( $fields['newspack_newsletters_terms']['get_callback'] );
+	}
+
+	/**
+	 * Every taxonomy the ads list touches ships as `{ id, name }`: the
+	 * columns render the names, and Quick Edit seeds its pickers from
+	 * the IDs and sends all three back on every save.
+	 */
+	public function test_terms_field_covers_every_quick_edit_taxonomy() {
+		$post_id     = $this->make_ad();
+		$advertiser  = self::factory()->term->create(
+			[
+				'taxonomy' => 'newspack_nl_advertiser',
+				'name'     => 'Acme',
+			]
+		);
+		$placement   = self::factory()->term->create(
+			[
+				'taxonomy' => 'newspack_nl_ad_placement',
+				'name'     => 'Header',
+			]
+		);
+		$category_id = self::factory()->category->create( [ 'name' => 'Promotions' ] );
+
+		wp_set_post_terms( $post_id, [ $advertiser ], 'newspack_nl_advertiser' );
+		wp_set_post_terms( $post_id, [ $placement ], 'newspack_nl_ad_placement' );
+		wp_set_post_terms( $post_id, [ $category_id ], 'category' );
+
+		$terms = Ads_List_REST::get_terms_payload( $post_id, Ads_List_REST::LIST_TAXONOMIES );
+
+		$this->assertSame( [ 'newspack_nl_advertiser', 'newspack_nl_ad_placement', 'category' ], array_keys( $terms ) );
+		$this->assertSame(
+			[
+				[
+					'id'   => $advertiser,
+					'name' => 'Acme',
+				],
+			],
+			$terms['newspack_nl_advertiser'] 
+		);
+		$this->assertSame(
+			[
+				[
+					'id'   => $placement,
+					'name' => 'Header',
+				],
+			],
+			$terms['newspack_nl_ad_placement'] 
+		);
+		$this->assertSame(
+			[
+				[
+					'id'   => $category_id,
+					'name' => 'Promotions',
+				],
+			],
+			$terms['category'] 
+		);
+	}
+
+	/**
 	 * Helper: build a REST request with the given query params.
 	 *
 	 * @param array $params Query params keyed by name.

--- a/plugins/newspack-newsletters/tests/test-ads-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-ads-list-rest.php
@@ -400,8 +400,8 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 
 	/**
 	 * Every taxonomy the ads list touches ships as `{ id, name }`: the
-	 * columns render the names, and Quick Edit seeds its pickers from
-	 * the IDs and sends all three back on every save.
+	 * columns render the names, and Quick Edit seeds its pickers from the
+	 * IDs, having no other source for them.
 	 */
 	public function test_terms_field_covers_every_quick_edit_taxonomy() {
 		$post_id     = $this->make_ad();

--- a/plugins/newspack-newsletters/tests/test-layouts-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-layouts-list-rest.php
@@ -80,4 +80,40 @@ class Layouts_List_REST_Test extends WP_UnitTestCase {
 		$this->assertNull( Layouts_List_REST::get_author_payload( $post_id ) );
 		$this->assertNull( Layouts_List_REST::get_author_payload( 0 ) );
 	}
+
+	/**
+	 * The field has to survive an actual dispatch, and only in the `edit`
+	 * context the list asks for.
+	 */
+	public function test_the_author_field_reaches_the_response_only_in_edit_context() {
+		$user_id = self::factory()->user->create(
+			[
+				'role'         => 'administrator',
+				'display_name' => 'Grace Hopper',
+			]
+		);
+		wp_set_current_user( $user_id );
+
+		// The CPT only registers for a user who can edit others' posts, so
+		// `init` in the bootstrap left it out.
+		Newspack_Newsletters_Layouts::register_layout_cpt();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		do_action( 'rest_api_init' );
+
+		$this->make_layout( [ 'post_author' => $user_id ] );
+
+		$route = '/wp/v2/' . Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT;
+
+		$edit = new WP_REST_Request( 'GET', $route );
+		$edit->set_param( 'context', 'edit' );
+		$edit_item = rest_do_request( $edit )->get_data()[0];
+		$this->assertSame( 'Grace Hopper', $edit_item['newspack_newsletters_author']['name'] );
+
+		$view_item = rest_do_request( new WP_REST_Request( 'GET', $route ) )->get_data()[0];
+		$this->assertArrayNotHasKey( 'newspack_newsletters_author', $view_item );
+
+		$wp_rest_server = null;
+	}
 }

--- a/plugins/newspack-newsletters/tests/test-layouts-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-layouts-list-rest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Class Test Layouts List REST
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Admin\Layouts_List_REST;
+
+/**
+ * Tests the REST surface the Layouts list DataView consumes.
+ *
+ * The author field exists so the list never has to ask for
+ * `_embed=author`: embedding forces `_links` into the response, and core
+ * answers that by computing target hints for every row's `self` link,
+ * re-resolving the whole REST route map per row.
+ */
+class Layouts_List_REST_Test extends WP_UnitTestCase {
+	/**
+	 * Helper: make a layout post.
+	 *
+	 * @param array $args Post args.
+	 * @return int Post ID.
+	 */
+	private function make_layout( $args = [] ) {
+		return self::factory()->post->create(
+			array_merge(
+				[
+					'post_type'   => Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT,
+					'post_status' => 'publish',
+					'post_title'  => 'Test layout',
+				],
+				$args
+			)
+		);
+	}
+
+	/**
+	 * The author field is registered on the layouts CPT.
+	 */
+	public function test_author_field_is_registered_on_layouts_cpt() {
+		do_action( 'rest_api_init' );
+
+		global $wp_rest_additional_fields;
+
+		$cpt    = Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT;
+		$fields = isset( $wp_rest_additional_fields[ $cpt ] ) ? $wp_rest_additional_fields[ $cpt ] : [];
+
+		$this->assertArrayHasKey( 'newspack_newsletters_author', $fields );
+		$this->assertIsCallable( $fields['newspack_newsletters_author']['get_callback'] );
+	}
+
+	/**
+	 * The field carries what the Author column renders: display name and
+	 * an avatar URL.
+	 */
+	public function test_author_field_returns_display_name_and_avatar() {
+		$user_id = self::factory()->user->create(
+			[
+				'role'         => 'editor',
+				'display_name' => 'Grace Hopper',
+			]
+		);
+		$post_id = $this->make_layout( [ 'post_author' => $user_id ] );
+
+		$author = Layouts_List_REST::get_author_payload( $post_id );
+
+		$this->assertSame( $user_id, $author['id'] );
+		$this->assertSame( 'Grace Hopper', $author['name'] );
+		$this->assertNotSame( '', $author['avatar'] );
+	}
+
+	/**
+	 * A layout whose author no longer exists renders a blank cell rather
+	 * than tripping on a missing user.
+	 */
+	public function test_author_field_is_null_when_the_user_is_gone() {
+		$post_id = $this->make_layout( [ 'post_author' => 999999 ] );
+
+		$this->assertNull( Layouts_List_REST::get_author_payload( $post_id ) );
+		$this->assertNull( Layouts_List_REST::get_author_payload( 0 ) );
+	}
+}

--- a/plugins/newspack-newsletters/tests/test-newsletters-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-newsletters-list-rest.php
@@ -1467,4 +1467,156 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 		$this->assertContains( 'mine-list', array_column( $options['send_lists'], 'id' ) );
 		$this->assertContains( 'their-list', array_column( $options['send_lists'], 'id' ) );
 	}
+
+	/**
+	 * Helper: dispatch a collection request through the REST server.
+	 *
+	 * @param array $params Query params keyed by name.
+	 * @return array First item of the response body.
+	 */
+	private function dispatch_collection( $params = [] ) {
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		do_action( 'rest_api_init' );
+
+		$response = rest_do_request( $this->rest_request( $params ) );
+		$this->assertSame( 200, $response->get_status(), 'Collection request failed: ' . wp_json_encode( $response->get_data() ) );
+		$data = $response->get_data();
+
+		return isset( $data[0] ) ? $data[0] : [];
+	}
+
+	/**
+	 * The fields have to survive an actual dispatch, not just be
+	 * registered: the list reads them off the response body.
+	 */
+	public function test_the_new_fields_reach_the_response_body() {
+		$user_id = self::factory()->user->create(
+			[
+				'role'         => 'editor',
+				'display_name' => 'Ada Lovelace',
+			]
+		);
+		wp_set_current_user( $user_id );
+
+		$post_id  = $this->make_newsletter( [ 'post_author' => $user_id ] );
+		$category = self::factory()->category->create( [ 'name' => 'Weekly' ] );
+		wp_set_post_terms( $post_id, [ $category ], 'category' );
+
+		$item = $this->dispatch_collection(
+			[
+				'context' => 'edit',
+				'status'  => 'draft',
+			]
+		);
+
+		$this->assertSame( 'Ada Lovelace', $item['newspack_newsletters_author']['name'] );
+		$this->assertSame(
+			[
+				[
+					'id'   => $category,
+					'name' => 'Weekly',
+				],
+			],
+			$item['newspack_newsletters_terms']['category']
+		);
+		$this->assertSame( [], $item['newspack_newsletters_terms']['post_tag'] );
+	}
+
+	/**
+	 * The newsletters CPT is public, so an anonymous caller can read the
+	 * collection. Only the list screens need these fields, and they all
+	 * ask for `edit`.
+	 */
+	public function test_the_new_fields_are_absent_from_an_anonymous_read() {
+		$this->make_newsletter(
+			[
+				'post_status' => 'publish',
+				'meta_input'  => [ 'is_public' => 1 ],
+			]
+		);
+		wp_set_current_user( 0 );
+
+		$item = $this->dispatch_collection();
+
+		$this->assertNotEmpty( $item );
+		$this->assertArrayNotHasKey( 'newspack_newsletters_author', $item );
+		$this->assertArrayNotHasKey( 'newspack_newsletters_terms', $item );
+	}
+
+	/**
+	 * `_fields` selection has to keep working, since that is what keeps
+	 * `content.rendered` out of the list's responses.
+	 */
+	public function test_the_new_fields_can_be_selected_with_fields() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'editor' ] ) );
+		$this->make_newsletter();
+
+		$item = $this->dispatch_collection(
+			[
+				'context' => 'edit',
+				'status'  => 'draft',
+				'_fields' => 'id,newspack_newsletters_author',
+			]
+		);
+
+		$this->assertArrayHasKey( 'newspack_newsletters_author', $item );
+		$this->assertArrayNotHasKey( 'content', $item );
+		$this->assertArrayNotHasKey( 'newspack_newsletters_terms', $item );
+	}
+
+	/**
+	 * The point of the fields is that they read primed caches. If either
+	 * ever went to the database per row, the query count would climb with
+	 * the number of rows.
+	 */
+	public function test_the_new_fields_do_not_query_per_row() {
+		$user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $user_id );
+
+		$category = self::factory()->category->create( [ 'name' => 'Weekly' ] );
+		for ( $i = 0; $i < 20; $i++ ) {
+			$post_id = $this->make_newsletter( [ 'post_author' => $user_id ] );
+			wp_set_post_terms( $post_id, [ $category ], 'category' );
+			wp_set_post_terms( $post_id, [ 'digest' ], 'post_tag' );
+		}
+
+		$base = 'id,status,title,date';
+
+		$without = $this->count_queries_for_fields( $base );
+		$with    = $this->count_queries_for_fields( $base . ',newspack_newsletters_author,newspack_newsletters_terms' );
+
+		// Both fields read caches `WP_Query` primes for the page, so the
+		// cost is flat. Per-row lookups across 20 rows and two taxonomies
+		// would add dozens, not a handful.
+		$this->assertLessThanOrEqual(
+			$without + 4,
+			$with,
+			"Adding the fields took the query count from {$without} to {$with} over 20 rows."
+		);
+	}
+
+	/**
+	 * Helper: queries run by one collection dispatch for a `_fields` set.
+	 *
+	 * @param string $fields Comma-joined `_fields` value.
+	 * @return int Query count.
+	 */
+	private function count_queries_for_fields( $fields ) {
+		global $wpdb;
+
+		wp_cache_flush();
+		$before = $wpdb->num_queries;
+
+		$this->dispatch_collection(
+			[
+				'context'  => 'edit',
+				'status'   => 'draft',
+				'per_page' => 100,
+				'_fields'  => $fields,
+			]
+		);
+
+		return $wpdb->num_queries - $before;
+	}
 }

--- a/plugins/newspack-newsletters/tests/test-newsletters-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-newsletters-list-rest.php
@@ -314,6 +314,87 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The author and term fields are registered too. They exist so the
+	 * list never has to ask for `_links`, which is what makes core build
+	 * a link set and compute target hints for every row.
+	 */
+	public function test_author_and_term_fields_are_registered_on_newsletters_cpt() {
+		do_action( 'rest_api_init' );
+
+		global $wp_rest_additional_fields;
+
+		$cpt    = Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT;
+		$fields = isset( $wp_rest_additional_fields[ $cpt ] ) ? $wp_rest_additional_fields[ $cpt ] : [];
+
+		foreach ( [ 'newspack_newsletters_author', 'newspack_newsletters_terms' ] as $field ) {
+			$this->assertArrayHasKey( $field, $fields );
+			$this->assertIsCallable( $fields[ $field ]['get_callback'] );
+		}
+	}
+
+	/**
+	 * The author field carries everything the Author column renders —
+	 * the display name and an avatar URL — so the column no longer needs
+	 * `_embed=author`.
+	 */
+	public function test_author_field_returns_display_name_and_avatar() {
+		$user_id = self::factory()->user->create(
+			[
+				'role'         => 'editor',
+				'display_name' => 'Ada Lovelace',
+			]
+		);
+		$post_id = $this->make_newsletter( [ 'post_author' => $user_id ] );
+
+		$author = Newsletters_List_REST::get_author_payload( $post_id );
+
+		$this->assertSame( $user_id, $author['id'] );
+		$this->assertSame( 'Ada Lovelace', $author['name'] );
+		$this->assertNotSame( '', $author['avatar'] );
+	}
+
+	/**
+	 * A post whose author no longer exists renders a blank cell rather
+	 * than tripping on a missing user.
+	 */
+	public function test_author_field_is_null_when_the_user_is_gone() {
+		$post_id = $this->make_newsletter( [ 'post_author' => 999999 ] );
+
+		$this->assertNull( Newsletters_List_REST::get_author_payload( $post_id ) );
+		$this->assertNull( Newsletters_List_REST::get_author_payload( 0 ) );
+	}
+
+	/**
+	 * The terms field returns `{ id, name }` per taxonomy: the columns
+	 * render the names, Quick Edit seeds its pickers from the IDs.
+	 */
+	public function test_terms_field_returns_names_per_taxonomy() {
+		$post_id = $this->make_newsletter();
+		// Hierarchical taxonomies take IDs — passing names casts them to 0.
+		$category_ids = [
+			self::factory()->category->create( [ 'name' => 'Weekly' ] ),
+			self::factory()->category->create( [ 'name' => 'Culture' ] ),
+		];
+		wp_set_post_terms( $post_id, $category_ids, 'category' );
+		wp_set_post_terms( $post_id, [ 'digest' ], 'post_tag' );
+
+		$terms = Newsletters_List_REST::get_terms_payload( $post_id, Newsletters_List_REST::LIST_TAXONOMIES );
+
+		$this->assertEqualSets( [ 'Weekly', 'Culture' ], wp_list_pluck( $terms['category'], 'name' ) );
+		$this->assertEqualSets( $category_ids, wp_list_pluck( $terms['category'], 'id' ) );
+		$this->assertSame( [ 'digest' ], wp_list_pluck( $terms['post_tag'], 'name' ) );
+
+		$empty = Newsletters_List_REST::get_terms_payload( $this->make_newsletter(), Newsletters_List_REST::LIST_TAXONOMIES );
+		$this->assertSame(
+			[
+				'category' => [],
+				'post_tag' => [],
+			],
+			$empty
+		);
+	}
+
+	/**
 	 * Helper: build a REST request with the given query params.
 	 *
 	 * @param array $params Query params keyed by name.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Two problems a publisher reported on the newsletters admin screens.

**Appearance settings did not survive a reload.** Only items per page was stored, so density, visible columns and their Title, Media and Description toggles, column order, widths, sort and layout had to be set again on every visit. All of it now persists per user, on all four list screens. Page, search and filters stay out: that is a query, not a configuration.

**The lists were slow.** They asked for `_links`, the only way to make `_embed` expand anything, and core answers that by computing target hints for every row's `self` link, re-resolving the whole REST route map per row. Author and term names now come from dedicated REST fields, and "All" fetches in far fewer requests. On a local site with 613 newsletters, 8 requests and 3,381 KB become 2 requests and 934 KB, and the table is ready in 3.2s instead of 5.9s.

Loading is left to DataViews. Our overlay sat on top of it, so two indicators animated at once. The first paint, which has no list behind it, gains a label.

![Newsletters list first paint: spinner with a Fetching newsletters label](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/18/d0qvr662-newsletters-loading-state.png)

Part of NPPM-3140.

### How to test the changes in this Pull Request:

1. On Newsletters, set Density to Compact in View options, toggle on Categories, and move a column.
2. Reload. Density, the column and the new order are all still applied.
3. Repeat on Advertising, Advertisers and Layouts. On Layouts, also switch to Table and change Preview size.
4. Watch the network panel on a reload. No request carries `_embed` or `_links`.
5. Set items per page to All. The whole list arrives in one or two requests.
6. Confirm Author still shows a name and avatar, and Categories and Tags still show names.
7. Open Quick Edit on a newsletter with categories or tags. The pickers are pre-filled.
8. Open Quick Edit on an ad with an advertiser, placement and category. Change only the status, save, reload. All three survived.
9. Throttle the network and reload. The first paint shows a spinner labelled "Fetching newsletters…".
10. On Layouts, switch to Table and reload. The table comes back as a table, with no preview thumbnails in the rows.
11. Logged out, request `/wp/v2/newspack_nl_cpt?per_page=1000`. It returns a 400; `per_page=100` still works.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

The `per_page` ceiling is raised to 1000 on the four collections these screens read, and only those; `/wp/v2/posts` still rejects anything above 100. Anything above core's 100 also requires `edit_posts`, since the newsletters CPT is public and an unauthenticated caller could otherwise ask one request to render ten times as many rows as core allows.

Step 8 is the one worth doing. The ads Quick Edit pickers seed entirely from the new terms field, so a field that ever went missing would show three empty pickers; each taxonomy now travels only when it changed, which is what stops a status-only save clearing the rest.

One behaviour change worth flagging for networks: `usermeta` is network-global, so the stored preference key now carries the site prefix and a single list configuration can no longer be shared across every site on a network. Anyone who had already set items per page will have that one value reset once. It was the only thing persisted before this, so that is the whole scope.

Does not close NPPM-3140. The per-status counts and small-screen column widths are still open there.


