### PR TITLE
test(e2e): assert donation amount from the order details table

### DIFF
--- a/e2e/tests/donations.spec.ts
+++ b/e2e/tests/donations.spec.ts
@@ -25,11 +25,15 @@ test("Donations",  {
   await page.goto("/support-our-publication/");
   await page.getByRole("button", { name: "Donate Now" }).click();
   await expect(
-    // Match just the amount and cadence: the summary's label prefix has varied
-    // across Newspack versions (e.g. "Donate:" then "Donate: Monthly:"), but the
-    // "$15.00 / month" part is stable and is the bit worth asserting.
-    getPageInIframe(page).locator('strong:has-text("$15.00 / month")')
-  ).toBeVisible();
+    // The order details table is the checkout's source of truth for what the
+    // reader will be charged. Assert on the cart item row, matching just the
+    // amount and cadence: the product label has varied across Newspack versions
+    // (e.g. "Donate:" then "Donate: Monthly"), but "$15.00 / month" is stable
+    // and is the bit worth asserting.
+    getPageInIframe(page).locator(
+      ".woocommerce-checkout-review-order-table .cart_item"
+    )
+  ).toContainText(/\$15\.00\s*\/\s*month/);
   await getPageInIframe(page).getByLabel("Email address *").fill(emailAddress);
   await getPageInIframe(page).getByLabel("First name *").fill("John");
   await getPageInIframe(page).getByLabel("Last name *").fill("Doe");


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The nightly E2E suite has failed since Aug 5. #886 fixed the first break; with the `@vanilla` chain green again, the `@with-woo` projects ran for the first time since Aug 4 and exposed a second one.

`donations.spec.ts` asserted the donation amount from the price-summary card above the checkout form. #453 removed that card and made the WooCommerce order details table always visible, so the amount and cadence now live in the cart item row instead. Both changes shipped in the same Aug 4 stable release, which is why the two failures arrived together.

The spec now asserts against the order details table, which is the checkout's source of truth for what the reader will be charged.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Set `SITE_URL` to a site provisioned with WooCommerce.
3. Run `npx playwright test donations.spec.ts --project="With Woo in Desktop Chrome"`.
4. The test passes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Verified against the staging E2E site on both `With Woo in Desktop Chrome` and `With Woo in Mobile Chrome`.
