### PR TITLE
fix(newsletters): pixel open counts and disabled-tracking cleanup

### DIFF
--- a/plugins/newspack-newsletters/includes/tracking/class-pixel.php
+++ b/plugins/newspack-newsletters/includes/tracking/class-pixel.php
@@ -212,9 +212,10 @@ final class Pixel {
 
 			$newsletter_tracking_id = \get_post_meta( $newsletter_id, 'tracking_id', true );
 
-			// Bail if tracking ID mismatch.
+			// Skip mismatched events: one stale tracking ID must not drop the
+			// rest of the batch, whose lines are already consumed from the log.
 			if ( $newsletter_tracking_id !== $tracking_id ) {
-				return;
+				continue;
 			}
 
 			$pixel_seen = \get_post_meta( $newsletter_id, 'tracking_pixel_seen', true );

--- a/plugins/newspack-newsletters/includes/tracking/class-pixel.php
+++ b/plugins/newspack-newsletters/includes/tracking/class-pixel.php
@@ -296,8 +296,14 @@ final class Pixel {
 
 	/**
 	 * Schedule log processing.
+	 *
+	 * No-op while pixel tracking is off, so disabled sites don't keep a
+	 * minutely cron event alive for logs that are discarded anyway.
 	 */
 	public static function schedule_log_processing() {
+		if ( ! Admin::is_tracking_pixel_enabled() ) {
+			return;
+		}
 		if ( ! \wp_next_scheduled( 'newspack_newsletters_tracking_pixel_process_log' ) ) {
 			\wp_schedule_single_event( time() + 60, 'newspack_newsletters_tracking_pixel_process_log' );
 		}

--- a/plugins/newspack-newsletters/includes/tracking/class-pixel.php
+++ b/plugins/newspack-newsletters/includes/tracking/class-pixel.php
@@ -333,7 +333,7 @@ final class Pixel {
 		}
 		foreach ( [ 'newspack_newsletters_tracking_pixel_log_file', 'newspack_newsletters_tracking_pixel_previous_log_file' ] as $option ) {
 			$log_file = \get_option( $option );
-			if ( $log_file && file_exists( $log_file ) ) {
+			if ( self::is_pixel_log_file( $log_file ) ) {
 				unlink( $log_file );
 			}
 			\delete_option( $option );
@@ -341,6 +341,28 @@ final class Pixel {
 		// phpcs:enable WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
 		\delete_option( 'newspack_newsletters_pixel_log_offset' );
 		\wp_clear_scheduled_hook( 'newspack_newsletters_tracking_pixel_process_log' );
+	}
+
+	/**
+	 * Whether a path is one of the pixel log files this class creates: a
+	 * tempnam file named newspack_newsletters_pixel_log_* inside the uploads
+	 * directory. The teardown paths come from options, and a corrupted option
+	 * must not turn disabling tracking into deleting an arbitrary file.
+	 *
+	 * @param mixed $path Path stored in the option.
+	 *
+	 * @return bool
+	 */
+	private static function is_pixel_log_file( $path ) {
+		if ( ! is_string( $path ) || '' === $path || ! file_exists( $path ) ) {
+			return false;
+		}
+		if ( 0 !== strpos( basename( $path ), 'newspack_newsletters_pixel_log_' ) ) {
+			return false;
+		}
+		$real_path = realpath( $path );
+		$uploads   = realpath( \wp_get_upload_dir()['basedir'] );
+		return $real_path && $uploads && 0 === strpos( $real_path, \trailingslashit( $uploads ) );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/tracking/class-pixel.php
+++ b/plugins/newspack-newsletters/includes/tracking/class-pixel.php
@@ -44,6 +44,12 @@ final class Pixel {
 		\add_action( 'wp', [ __CLASS__, 'schedule_log_processing' ] );
 		\add_action( 'newspack_newsletters_tracking_pixel_process_log', [ __CLASS__, 'process_logs' ] );
 		\add_filter( 'newspack_newsletters_tracking_pixel_url', [ __CLASS__, 'log_pixel_url' ], 10, 4 );
+
+		// When pixel tracking is turned off, tear the pixel machinery down:
+		// the standalone pixel file keeps logging opens from previously sent
+		// emails, and with scheduling gated nothing would ever drain that log.
+		\add_action( 'add_option_newspack_newsletters_use_tracking_pixel', [ __CLASS__, 'maybe_teardown_pixel' ] );
+		\add_action( 'update_option_newspack_newsletters_use_tracking_pixel', [ __CLASS__, 'maybe_teardown_pixel' ] );
 	}
 
 	/**
@@ -307,6 +313,34 @@ final class Pixel {
 		if ( ! \wp_next_scheduled( 'newspack_newsletters_tracking_pixel_process_log' ) ) {
 			\wp_schedule_single_event( time() + 60, 'newspack_newsletters_tracking_pixel_process_log' );
 		}
+	}
+
+	/**
+	 * Remove the standalone pixel file, its logs and the scheduled processing
+	 * when pixel tracking is turned off. Historical emails keep requesting the
+	 * pixel; without the file those hits 404 instead of filling a log nothing
+	 * reads. Re-enabling self-heals: the next processing run recreates the
+	 * files via rotate_log_file().
+	 */
+	public static function maybe_teardown_pixel() {
+		if ( Admin::is_tracking_pixel_enabled() ) {
+			return;
+		}
+		// phpcs:disable WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
+		$pixel_file = WP_CONTENT_DIR . '/np-newsletters-pixel.php';
+		if ( file_exists( $pixel_file ) ) {
+			unlink( $pixel_file );
+		}
+		foreach ( [ 'newspack_newsletters_tracking_pixel_log_file', 'newspack_newsletters_tracking_pixel_previous_log_file' ] as $option ) {
+			$log_file = \get_option( $option );
+			if ( $log_file && file_exists( $log_file ) ) {
+				unlink( $log_file );
+			}
+			\delete_option( $option );
+		}
+		// phpcs:enable WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
+		\delete_option( 'newspack_newsletters_pixel_log_offset' );
+		\wp_clear_scheduled_hook( 'newspack_newsletters_tracking_pixel_process_log' );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/tests/test-tracking.php
+++ b/plugins/newspack-newsletters/tests/test-tracking.php
@@ -510,4 +510,23 @@ class Newsletters_Tracking_Test extends WP_UnitTestCase {
 		// Clean up.
 		wp_clear_scheduled_hook( 'newspack_newsletters_tracking_pixel_process_log' );
 	}
+
+	/**
+	 * Turning pixel tracking off removes the standalone pixel file, its logs and
+	 * the scheduled processing, so nothing keeps logging into a file nothing reads.
+	 */
+	public function test_disabling_pixel_tracking_tears_down_pixel_machinery() {
+		update_option( 'newspack_newsletters_use_tracking_pixel', 1 );
+		Pixel::process_logs(); // Bootstraps the standalone pixel file and log file.
+
+		$pixel_file = WP_CONTENT_DIR . '/np-newsletters-pixel.php';
+		$this->assertFileExists( $pixel_file );
+		$this->assertNotEmpty( get_option( 'newspack_newsletters_tracking_pixel_log_file' ) );
+
+		update_option( 'newspack_newsletters_use_tracking_pixel', 0 );
+
+		$this->assertFileDoesNotExist( $pixel_file );
+		$this->assertFalse( get_option( 'newspack_newsletters_tracking_pixel_log_file' ) );
+		$this->assertFalse( wp_next_scheduled( 'newspack_newsletters_tracking_pixel_process_log' ) );
+	}
 }

--- a/plugins/newspack-newsletters/tests/test-tracking.php
+++ b/plugins/newspack-newsletters/tests/test-tracking.php
@@ -529,4 +529,25 @@ class Newsletters_Tracking_Test extends WP_UnitTestCase {
 		$this->assertFalse( get_option( 'newspack_newsletters_tracking_pixel_log_file' ) );
 		$this->assertFalse( wp_next_scheduled( 'newspack_newsletters_tracking_pixel_process_log' ) );
 	}
+
+	/**
+	 * Teardown only deletes files that look like pixel logs: a corrupted option
+	 * must not turn disabling tracking into deleting an arbitrary path.
+	 */
+	public function test_teardown_ignores_non_log_paths_in_options() {
+		update_option( 'newspack_newsletters_use_tracking_pixel', 1 );
+
+		// phpcs:disable WordPressVIPMinimum.Functions.RestrictedFunctions
+		$unrelated = tempnam( sys_get_temp_dir(), 'unrelated_' );
+		update_option( 'newspack_newsletters_tracking_pixel_log_file', $unrelated );
+
+		update_option( 'newspack_newsletters_use_tracking_pixel', 0 );
+
+		$this->assertFileExists( $unrelated, 'A path that is not a pixel log must not be deleted.' );
+		$this->assertFalse( get_option( 'newspack_newsletters_tracking_pixel_log_file' ), 'The option is still cleared.' );
+
+		// Clean up.
+		unlink( $unrelated );
+		// phpcs:enable WordPressVIPMinimum.Functions.RestrictedFunctions
+	}
 }

--- a/plugins/newspack-newsletters/tests/test-tracking.php
+++ b/plugins/newspack-newsletters/tests/test-tracking.php
@@ -457,4 +457,33 @@ class Newsletters_Tracking_Test extends WP_UnitTestCase {
 		unlink( get_option( 'newspack_newsletters_tracking_pixel_log_file' ) );
 		// phpcs:enable WordPressVIPMinimum.Functions.RestrictedFunctions
 	}
+
+	/**
+	 * Test logs processing – a stale event must not abort the rest of the batch.
+	 */
+	public function test_process_logs_skips_mismatched_tracking_id() {
+		$stale_newsletter_id = $this->factory->post->create( [ 'post_type' => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ] );
+		$newsletter_id       = $this->factory->post->create( [ 'post_type' => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ] );
+		update_post_meta( $stale_newsletter_id, 'tracking_id', 'tracking_id_current' );
+		update_post_meta( $newsletter_id, 'tracking_id', 'tracking_id_2' );
+
+		// phpcs:disable WordPressVIPMinimum.Functions.RestrictedFunctions
+		// A stale event (old tracking ID) first, then valid events for another newsletter.
+		$log_file_path = tempnam( sys_get_temp_dir(), 'newspack_newsletters_pixel_log_' );
+		file_put_contents( $log_file_path, "$stale_newsletter_id|tracking_id_old|email_1@example.com" . PHP_EOL );
+		file_put_contents( $log_file_path, "$newsletter_id|tracking_id_2|email_2@example.com" . PHP_EOL, FILE_APPEND );
+		file_put_contents( $log_file_path, "$newsletter_id|tracking_id_2|email_3@example.com" . PHP_EOL, FILE_APPEND );
+		update_option( 'newspack_newsletters_tracking_pixel_log_file', $log_file_path );
+
+		Pixel::process_logs();
+
+		// The stale event is not counted.
+		$this->assertEmpty( get_post_meta( $stale_newsletter_id, 'tracking_pixel_seen', true ) );
+		// The events after it still are.
+		$this->assertEquals( 2, get_post_meta( $newsletter_id, 'tracking_pixel_seen', true ) );
+
+		// Clean up.
+		unlink( get_option( 'newspack_newsletters_tracking_pixel_log_file' ) );
+		// phpcs:enable WordPressVIPMinimum.Functions.RestrictedFunctions
+	}
 }

--- a/plugins/newspack-newsletters/tests/test-tracking.php
+++ b/plugins/newspack-newsletters/tests/test-tracking.php
@@ -486,4 +486,28 @@ class Newsletters_Tracking_Test extends WP_UnitTestCase {
 		unlink( get_option( 'newspack_newsletters_tracking_pixel_log_file' ) );
 		// phpcs:enable WordPressVIPMinimum.Functions.RestrictedFunctions
 	}
+
+	/**
+	 * Scheduling the log processing event respects the tracking setting.
+	 */
+	public function test_schedule_log_processing_respects_tracking_setting() {
+		wp_clear_scheduled_hook( 'newspack_newsletters_tracking_pixel_process_log' );
+
+		update_option( 'newspack_newsletters_use_tracking_pixel', 0 );
+		Pixel::schedule_log_processing();
+		$this->assertFalse(
+			wp_next_scheduled( 'newspack_newsletters_tracking_pixel_process_log' ),
+			'No log processing should be scheduled while pixel tracking is off.'
+		);
+
+		update_option( 'newspack_newsletters_use_tracking_pixel', 1 );
+		Pixel::schedule_log_processing();
+		$this->assertNotFalse(
+			wp_next_scheduled( 'newspack_newsletters_tracking_pixel_process_log' ),
+			'Log processing should be scheduled while pixel tracking is on.'
+		);
+
+		// Clean up.
+		wp_clear_scheduled_hook( 'newspack_newsletters_tracking_pixel_process_log' );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Open tracking counts newsletter opens by logging pixel hits and processing the log in batches every minute. Two fixes to that pipeline:

- A batched event whose tracking ID no longer matches its newsletter stopped the whole batch, so opens later in the same batch were never counted. Processing now skips that event and counts the rest.
- With open tracking turned off, front-end visits kept scheduling the minutely processing task, and the standalone pixel file kept logging opens from previously sent emails into a log whose events are discarded. Turning tracking off now removes the pixel file, its logs, and the scheduled event, and scheduling stops. Re-enabling recreates them on the next processing run.

### How to test the changes in this Pull Request:

1. With open tracking on (the default), visit the front end. `wp-content/np-newsletters-pixel.php` exists.
2. Run `wp cron event list`. The `newspack_newsletters_tracking_pixel_process_log` event is scheduled.
3. Send a test newsletter and open it. The newsletter's opens count increases within a couple of minutes.
4. Turn open tracking off (Engagement > Newsletters). The pixel file and the scheduled event are gone.
5. Request `wp-content/np-newsletters-pixel.php` directly. It returns 404.
6. Turn open tracking back on and visit the front end. The pixel file and scheduled event return within a minute.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

With tracking off, pixel requests from already-sent emails now return 404; their events were already discarded during processing, so this stops the logging, not the counting. The batch fix has no practical manual repro (it needs a stale tracking ID mid-batch) and is covered by the new unit tests.
