### PR TITLE
perf(content-gate): memoize the active-gate check per request

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-block-visibility.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-block-visibility.php
@@ -404,11 +404,29 @@ class Block_Visibility {
 	private static $strip_cache = [];
 
 	/**
+	 * Per-request cache of has_active_gates() results, keyed by "{blog_id}:{md5(gate_ids)}".
+	 *
+	 * The blog id is in the key because gate ids are per-site post ids, so a
+	 * switch_to_blog() mid-request would otherwise answer for the wrong site.
+	 *
+	 * Not flushed when a gate is written. The only reader is the render path, which
+	 * returns early under is_admin(), and the gate-editing endpoints return gate data
+	 * rather than rendered post content -- so no request both writes a gate and renders
+	 * a block gated by it. A caller that breaks that assumption needs an invalidation
+	 * hook here, the way Content_Gate flushes its own cache on save_post and the
+	 * post-meta writes.
+	 *
+	 * @var bool[]
+	 */
+	private static $active_gates_cache = [];
+
+	/**
 	 * Reset the per-request caches. Used in unit tests only.
 	 */
 	public static function reset_cache_for_tests() {
-		self::$rules_match_cache = [];
-		self::$strip_cache       = [];
+		self::$rules_match_cache  = [];
+		self::$strip_cache        = [];
+		self::$active_gates_cache = [];
 	}
 
 	/**
@@ -451,13 +469,22 @@ class Block_Visibility {
 	 * @return bool
 	 */
 	private static function has_active_gates( $gate_ids ) {
+		$cache_key = get_current_blog_id() . ':' . md5( wp_json_encode( $gate_ids ) );
+		if ( isset( self::$active_gates_cache[ $cache_key ] ) ) {
+			return self::$active_gates_cache[ $cache_key ];
+		}
+
+		$has_active = false;
 		foreach ( $gate_ids as $gate_id ) {
 			$gate = Content_Gate::get_gate( $gate_id );
 			if ( ! \is_wp_error( $gate ) && 'publish' === $gate['status'] ) {
-				return true;
+				$has_active = true;
+				break;
 			}
 		}
-		return false;
+
+		self::$active_gates_cache[ $cache_key ] = $has_active;
+		return $has_active;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/content-gate/class-block-visibility.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-block-visibility.php
@@ -469,7 +469,13 @@ class Block_Visibility {
 	 * @return bool
 	 */
 	private static function has_active_gates( $gate_ids ) {
-		$cache_key = get_current_blog_id() . ':' . md5( wp_json_encode( $gate_ids ) );
+		// Normalized because the answer does not depend on order or repetition, but the
+		// caller's list does: the ids arrive from a block attribute in editor order, and
+		// array_filter() preserves keys, so dropping a zero would otherwise encode as an
+		// object rather than a list and key differently again.
+		$ids = array_values( array_unique( array_map( 'intval', $gate_ids ) ) );
+		sort( $ids, SORT_NUMERIC );
+		$cache_key = get_current_blog_id() . ':' . implode( ',', $ids );
 		if ( isset( self::$active_gates_cache[ $cache_key ] ) ) {
 			return self::$active_gates_cache[ $cache_key ];
 		}

--- a/plugins/newspack-plugin/includes/content-gate/class-block-visibility.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-block-visibility.php
@@ -404,7 +404,14 @@ class Block_Visibility {
 	private static $strip_cache = [];
 
 	/**
-	 * Per-request cache of has_active_gates() results, keyed by "{blog_id}:{md5(gate_ids)}".
+	 * Per-request cache of has_active_gates() results, keyed by
+	 * "{blog_id}:{sorted, de-duplicated gate ids}".
+	 *
+	 * "Cache" here is a static array that lives for one request and is gone when the
+	 * request ends -- the same sense the other two caches in this class use. This
+	 * class writes nothing that outlives a request: no wp_cache_*, no transient, no
+	 * option. So a stale entry cannot reach a later request, and the invalidation
+	 * question below is only about the one it was written in.
 	 *
 	 * The blog id is in the key because gate ids are per-site post ids, so a
 	 * switch_to_blog() mid-request would otherwise answer for the wrong site.

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-block-visibility.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-block-visibility.php
@@ -865,4 +865,54 @@ class Newspack_Test_Block_Visibility extends WP_UnitTestCase {
 			'Gate reconstructions must not grow with the number of block renders.'
 		);
 	}
+
+	/**
+	 * Gate mode: the active-gate check keys on the gate set, not the order it is
+	 * written in.
+	 */
+	public function test_gate_mode_active_gate_check_ignores_gate_id_order() {
+		// Draft gates so has_active_gates() returns false and the rule evaluation
+		// never runs, leaving the active-gate check as the only gate reader.
+		$gate_a  = $this->make_gate( true, 'draft' );
+		$gate_b  = $this->make_gate( true, 'draft' );
+		$fetches = 0;
+
+		$counter = function ( $value, $object_id, $meta_key ) use ( &$fetches, $gate_a, $gate_b ) {
+			if ( 'gate_priority' === $meta_key && in_array( (int) $object_id, [ (int) $gate_a, (int) $gate_b ], true ) ) {
+				++$fetches;
+			}
+			return $value;
+		};
+		add_filter( 'get_post_metadata', $counter, 10, 3 );
+
+		wp_set_current_user( 0 );
+		Block_Visibility::reset_cache_for_tests();
+
+		$forward = $this->make_block(
+			'core/group',
+			[
+				'newspackAccessControlMode'    => 'gate',
+				'newspackAccessControlGateIds' => [ $gate_a, $gate_b ],
+			]
+		);
+		$reverse = $this->make_block(
+			'core/group',
+			[
+				'newspackAccessControlMode'    => 'gate',
+				'newspackAccessControlGateIds' => [ $gate_b, $gate_a ],
+			]
+		);
+
+		Block_Visibility::filter_render_block( '<div>members</div>', $forward );
+		$after_forward = $fetches;
+		Block_Visibility::filter_render_block( '<div>members</div>', $reverse );
+
+		remove_filter( 'get_post_metadata', $counter, 10 );
+
+		$this->assertSame(
+			$after_forward,
+			$fetches,
+			'The same gate set in a different order must reuse the cached result.'
+		);
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-block-visibility.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-block-visibility.php
@@ -821,4 +821,48 @@ class Newspack_Test_Block_Visibility extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'KEEP', $out );
 		$this->assertNotEmpty( parse_blocks( $out ), 'Output is re-parseable.' );
 	}
+
+	/**
+	 * Gate mode: the active-gate check resolves a gate once per request, however
+	 * many blocks render against it.
+	 */
+	public function test_gate_mode_active_gate_check_does_not_refetch_per_render() {
+		$gate_id = $this->make_gate();
+		$fetches = 0;
+
+		// Content_Gate::get_gate() reads gate_priority exactly once per call, so this
+		// counts gate reconstructions. get_post_metadata fires ahead of the meta cache,
+		// so the count reflects calls rather than cache misses.
+		$counter = function ( $value, $object_id, $meta_key ) use ( &$fetches, $gate_id ) {
+			if ( 'gate_priority' === $meta_key && (int) $object_id === (int) $gate_id ) {
+				++$fetches;
+			}
+			return $value;
+		};
+		add_filter( 'get_post_metadata', $counter, 10, 3 );
+
+		wp_set_current_user( 0 );
+		Block_Visibility::reset_cache_for_tests();
+
+		$block = $this->make_block(
+			'core/group',
+			[
+				'newspackAccessControlMode'    => 'gate',
+				'newspackAccessControlGateIds' => [ $gate_id ],
+			]
+		);
+
+		Block_Visibility::filter_render_block( '<div>members</div>', $block );
+		$after_first = $fetches;
+		Block_Visibility::filter_render_block( '<div>members</div>', $block );
+		Block_Visibility::filter_render_block( '<div>members</div>', $block );
+
+		remove_filter( 'get_post_metadata', $counter, 10 );
+
+		$this->assertSame(
+			$after_first,
+			$fetches,
+			'Gate reconstructions must not grow with the number of block renders.'
+		);
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`Block_Visibility::has_active_gates()` rebuilt every gate it checked, on every block render. It calls `Content_Gate::get_gate()` per gate id, which reassembles the gate from `get_post()` plus several meta reads, and nothing memoized it. That result is now cached for the rest of the request.

The cost tracks the number of rendered blocks rather than the number of distinct gates: a REST collection read repeats the reconstruction once per gated block on the page. Three renders of one gated block dropped from four reconstructions to two, and the count no longer grows with the number of renders.

The cache key carries the blog id alongside the gate ids, because gate ids are per-site post ids and a `switch_to_blog()` would otherwise answer for the wrong site.

There is no invalidation hook. The only reader is the render path, which returns early under `is_admin()`, and the gate-editing endpoints return gate data rather than rendered post content, so no request both writes a gate and renders a block gated by it. The docblock records that assumption so a caller who breaks it knows what to add; `Content_Gate` already flushes its own `get_gates()` cache on `save_post` and the post-meta writes if that becomes necessary.

Closes NPPM-3161 (https://linear.app/a8c/issue/NPPM-3161), a follow-up raised in review on #813.

### How to test the changes in this Pull Request:

1. From `plugins/newspack-plugin`, run `n test-php --filter Newspack_Test_Block_Visibility`. 40 tests pass, including `test_gate_mode_active_gate_check_does_not_refetch_per_render`.
2. Confirm the new test can fail. Return `true` directly from the loop in `has_active_gates()` and drop the cache write, then re-run that filter. It reports 4 gate reconstructions against an expected 2.
3. On an env, publish a public post with a `core/group` block gated by a published gate, wrapping a marker string. Logged out, load the permalink. The marker is absent. Log in as a reader who satisfies the gate, and it appears. This is unchanged by the PR and is the control.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? — `test_gate_mode_active_gate_check_does_not_refetch_per_render` asserts the invariant (fetches after one render equal fetches after three) rather than a fixed count, so it holds both before and after #813 lands.
* [x] Have you successfully run tests with your changes locally? — full `newspack-plugin` suite: 3064 tests, 8980 assertions, 0 failures, 9 pre-existing environmental skips. `phpcs` clean against the root ruleset.
