### PR TITLE
fix(subscriber-commerce): require Audience Management for enforcement (NPPD-1899)

### DIFF
--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-commerce.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-commerce.php
@@ -47,14 +47,24 @@ class Subscriber_Commerce {
 	/**
 	 * Whether subscriber-commerce rules are enforced at all.
 	 *
+	 * Two things stand enforcement down, and the admin stays reachable through
+	 * both so a publisher can keep authoring rules:
+	 *
 	 * While WooCommerce Memberships is active it owns purchase restriction and
 	 * member discounts, and enforcing ours on top would double-apply on a site
-	 * mid-migration — so every subscriber-commerce feature stands down.
+	 * mid-migration.
+	 *
+	 * Without Audience Management there is nowhere to send a reader who is
+	 * refused. Registration, sign-in, account emails and My Account all belong
+	 * to it, so a blocked purchase would leave the reader at a notice naming a
+	 * subscription they have no way to buy. Content gates go inert in the same
+	 * state ({@see Content_Gate::is_gating_active()}), and subscriber-commerce
+	 * matches them rather than half-working alongside.
 	 *
 	 * @return bool
 	 */
 	public static function is_enforcement_active(): bool {
-		$active = self::is_admin_available() && ! Memberships::is_active();
+		$active = self::is_admin_available() && Reader_Activation::is_enabled() && ! Memberships::is_active();
 
 		/**
 		 * Filters whether subscriber-commerce rules (subscriber-only products,

--- a/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/subscriber-commerce.php
+++ b/plugins/newspack-plugin/tests/unit-tests/subscriber-commerce/subscriber-commerce.php
@@ -33,6 +33,7 @@ class Test_Subscriber_Commerce extends \WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		remove_all_filters( 'newspack_subscriber_commerce_enforcement_active' );
+		remove_all_filters( 'newspack_reader_activation_enabled' );
 		parent::tear_down();
 	}
 
@@ -68,6 +69,26 @@ class Test_Subscriber_Commerce extends \WP_UnitTestCase {
 	public function test_enforcement_is_active_without_memberships() {
 		$this->enable_gates();
 		$this->assertTrue( Subscriber_Commerce::is_enforcement_active() );
+	}
+
+	/**
+	 * Audience Management is a prerequisite for enforcement, matching the way
+	 * content gates go inert without it (NPPD-1846).
+	 *
+	 * Everything the reader is sent to when a purchase is refused — the
+	 * subscription, registration, sign-in — belongs to Audience Management. With
+	 * it off, blocking the purchase strands the reader at a notice pointing
+	 * somewhere that cannot be reached.
+	 *
+	 * The admin stays reachable so the publisher can still author rules, which is
+	 * the same split is_admin_available() already draws for Memberships.
+	 */
+	public function test_enforcement_stands_down_without_audience_management() {
+		$this->enable_gates();
+		add_filter( 'newspack_reader_activation_enabled', '__return_false' );
+
+		$this->assertFalse( Subscriber_Commerce::is_enforcement_active() );
+		$this->assertTrue( Subscriber_Commerce::is_admin_available() );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds Audience Management to the prerequisites for subscriber-commerce enforcement, so subscriber-only products and subscriber discounts behave the way content gates already do.

`Subscriber_Commerce::is_enforcement_active()` checked the `NEWSPACK_CONTENT_GATES` constant, WooCommerce, and Memberships being inactive. It did not check `Reader_Activation::is_enabled()`, while `Content_Gate::is_gating_active()` does. With Audience Management off, a reader could be refused a purchase and shown a notice naming a subscription, with registration, sign-in, and My Account all inert behind it.

`is_admin_available()` is deliberately unchanged, so the admin screens stay reachable and rules can still be authored. That is the same split the guard already draws for Memberships.

Raised in review on #743. Follows the precedent set by NPPD-1846.

The guard has no callers on `main` yet, so this takes effect when #743 or #760 merges.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Run `n test-php --group subscriber-commerce` in `plugins/newspack-plugin`. All tests pass.
3. Activate WooCommerce and the Newspack plugin on a test site.
4. Add `define( 'NEWSPACK_CONTENT_GATES', true );` to `wp-config.php`.
5. Enable Audience Management. `Subscriber_Commerce::is_enforcement_active()` returns `true`.
6. Disable Audience Management. The method returns `false`.
7. Check `Subscriber_Commerce::is_admin_available()` in both states. It returns `true` each time.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
