### PR TITLE
chore(tooling): explain how to fix a missing-dev-deps n test-php run

### DIFF
--- a/bin/_common.sh
+++ b/bin/_common.sh
@@ -48,6 +48,44 @@ lo0_alias_exists() {
     ifconfig lo0 2>/dev/null | awk -v ip="$1" '$1 == "inet" && $2 == ip { found = 1 } END { exit !found }'
 }
 
+# Whether a project's vendor/ was installed with its dev dependencies.
+#
+# `n env up` provisions vendor/ with --no-dev (see ensure-vendor.sh): enough to
+# activate a plugin, but without PHPUnit or the Yoast polyfills the WordPress
+# test bootstrap requires. Both kinds of install write vendor/autoload.php, so
+# its presence says nothing about whether the tests can run — composer's own
+# record of which install produced the directory, installed.json's top-level
+# "dev" flag, is what separates them.
+#
+# Read without a JSON parser: this is sourced on the host, in the containers and
+# in CI, and no single parser is present in all three. Two things make the
+# plain-text read safe. The value must be a bare boolean alone on its line,
+# which skips the `"dev": "Development related task"` entries real packages
+# carry in their metadata; and of the lines surviving that, the last is the
+# top-level flag, because composer writes it after the packages array closes.
+# Leading whitespace is not matched, so re-indenting the file changes nothing.
+#
+# The two unhappy paths answer differently, on purpose:
+#
+# - No readable installed.json means nothing was installed here, so the tests
+#   cannot run whatever else is true. Report absent and let the caller explain
+#   how to fix it.
+# - A file that exists but yields no recognisable flag means composer wrote a
+#   shape this function does not know — a format change, say. Report present.
+#   Guessing "absent" there would block every project at once, with no way past
+#   it; reporting present costs only a return to the bootstrap error this guard
+#   was added to replace, for whoever hits it first.
+project_has_dev_deps() {
+    local installed="$1/vendor/composer/installed.json"
+    [ -r "$installed" ] || return 1
+
+    local flag
+    flag=$(grep -E '^[[:space:]]*"dev": *(true|false),?$' "$installed" | tail -1)
+    [ -n "$flag" ] || return 0
+
+    [[ "$flag" == *true* ]]
+}
+
 # Logging helpers — mirror the colored output used by bin/site-setup.sh.
 NP_RED='\033[0;31m'
 NP_GREEN='\033[0;32m'

--- a/bin/test-php.sh
+++ b/bin/test-php.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+source /var/scripts/_common.sh
+# _common.sh derives NABSPATH from its own location, which in here is /var — not
+# a workspace root. repos.sh's host-only helpers key off NABSPATH being unset in
+# the container to fail visibly rather than probe /var/repos/..., so hand that
+# invariant back: keep the value only if it points at a real workspace.
+[ -f "${NABSPATH:-}/n" ] || unset NABSPATH
 source /var/scripts/repos.sh
 source /var/scripts/resolve-project-path.sh
 
@@ -30,7 +36,26 @@ case "$MYSQL_DATABASE" in
 	wordpress_*) TEST_DB_NAME="wp_tests_${MYSQL_DATABASE#wordpress_}" ;;
 esac
 
-echo "Running tests for $(basename "$PROJECT_DIR") (test database: $TEST_DB_NAME)"
+PROJECT_NAME=$(basename "$PROJECT_DIR")
+
+# Left to itself the WordPress test bootstrap fails on the missing Yoast
+# polyfills and advises setting WP_RUN_CORE_TESTS and running
+# `composer update -W` — correct guidance for someone testing WordPress core,
+# and a dead end for someone whose env simply has not been built yet. Name the
+# command that actually provisions dev dependencies instead.
+if [ -f "$PROJECT_DIR/composer.json" ] && ! project_has_dev_deps "$PROJECT_DIR"; then
+	echo "$PROJECT_NAME has no dev dependencies installed, so the WordPress test" >&2
+	echo "bootstrap cannot load the PHPUnit polyfills it requires." >&2
+	echo >&2
+	echo "Install them with either command, then re-run this one:" >&2
+	echo "  cd $PROJECT_DIR && n composer install" >&2
+	echo "      the composer dependencies on their own" >&2
+	echo "  n build $PROJECT_NAME" >&2
+	echo "      the same, plus the JS build" >&2
+	exit 1
+fi
+
+echo "Running tests for $PROJECT_NAME (test database: $TEST_DB_NAME)"
 cd "$PROJECT_DIR"
 bin/install-wp-tests.sh "$TEST_DB_NAME" root $MYSQL_ROOT_PASSWORD $MYSQL_HOST latest 2> /dev/null
 echo "Running: phpunit ${@:2}"

--- a/bin/tests/test-project-has-dev-deps.sh
+++ b/bin/tests/test-project-has-dev-deps.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# test-project-has-dev-deps.sh
+#
+# Self-proving spec for project_has_dev_deps (_common.sh): a vendor/ is judged
+# by composer's record of how it was installed, never by vendor/autoload.php.
+#
+# `n env up` provisions vendor/ with --no-dev, which is all plugin activation
+# needs but leaves out PHPUnit and the Yoast polyfills. That install writes
+# vendor/autoload.php exactly as a full one does, so autoload.php cannot tell
+# the two apart — only installed.json's top-level "dev" flag can. Reading the
+# wrong signal sends `n test-php` into the WordPress bootstrap, which fails on
+# the missing polyfills and advises setting WP_RUN_CORE_TESTS and running
+# `composer update -W` — neither of which provisions anything.
+#
+# Run: bash bin/tests/test-project-has-dev-deps.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../_common.sh
+. "$SCRIPT_DIR/../_common.sh"
+
+WORK=$(mktemp -d -t dev-deps-XXXXXX)
+trap 'rm -rf "$WORK"' EXIT
+
+# A project whose vendor/ looks installed in every way a caller might check —
+# autoload.php present, packages listed — and differs only in the dev flag.
+#
+# The packages array carries two decoys ahead of the top-level flag. The string
+# one is real: package metadata in this workspace already contains
+# `"dev": "Development related task"`, so a reader that accepts a string value
+# is wrong today. The nested boolean is prophylactic — no package here ships one
+# yet, and it is what pins the `tail -1`. Keep it: without it nothing proves the
+# last match is the one that counts.
+make_project() {
+	local name="$1" dev="$2"
+	local dir="$WORK/$name"
+	mkdir -p "$dir/vendor/composer"
+	echo '{}' > "$dir/composer.json"
+	echo '<?php // autoloader' > "$dir/vendor/autoload.php"
+	cat > "$dir/vendor/composer/installed.json" <<JSON
+{
+    "packages": [
+        {
+            "name": "vendor/decoy",
+            "scripts": {
+                "dev": "Development related task"
+            },
+            "extra": {
+                "dev": true
+            }
+        }
+    ],
+    "dev": $dev,
+    "dev-package-names": []
+}
+JSON
+	echo "$dir"
+}
+
+failures=0
+assert_dev_deps() {
+	local dir="$1" want="$2" desc="$3" got
+	if project_has_dev_deps "$dir"; then got=present; else got=absent; fi
+	if [[ "$got" == "$want" ]]; then
+		echo "  ok: $desc"
+	else
+		echo "  FAIL: $desc — want $want, got $got"
+		failures=$((failures + 1))
+	fi
+}
+
+echo "project_has_dev_deps:"
+
+full=$(make_project full true)
+assert_dev_deps "$full" present "a full install reads present"
+
+# The case the guard exists for, and the reason autoload.php is not the signal:
+# this project is byte-for-byte a working plugin apart from the dev flag. It
+# also pins the decoys — a nested `"dev": true` sits above the top-level false.
+runtime=$(make_project runtime false)
+assert_dev_deps "$runtime" absent "a --no-dev install reads absent despite vendor/autoload.php and a nested dev:true"
+
+# The two unhappy paths, which deliberately answer in opposite directions.
+
+# Nothing installed: the tests cannot run, so block and let the caller explain.
+mkdir -p "$WORK/vendorless"
+echo '{}' > "$WORK/vendorless/composer.json"
+assert_dev_deps "$WORK/vendorless" absent "a project with no vendor/ at all reads absent"
+
+# A record whose flag this function cannot find — the shape a composer format
+# change would take. Reporting absent here would block every project at once
+# with no way past it, so an unrecognised file reads present and the run
+# proceeds. Flip this assertion and you have chosen the opposite trade.
+mkdir -p "$WORK/unrecognised/vendor/composer"
+echo '{ "packages": [' > "$WORK/unrecognised/vendor/composer/installed.json"
+assert_dev_deps "$WORK/unrecognised" present "an installed.json with no readable flag reads present, so one format change cannot block everyone"
+
+if [[ "$failures" -gt 0 ]]; then
+	echo "$failures assertion(s) failed"
+	exit 1
+fi
+echo "All assertions passed."


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`n env up` provisions each project's `vendor/` with `--no-dev` — all plugin activation needs, and deliberately fast. Dev dependencies come from `n build` / `n ci-build`.

Run `n test-php` on a fresh env before building it and you land in the WordPress test bootstrap instead, which fails on the missing PHPUnit polyfills and advises setting `WP_RUN_CORE_TESTS` and running `composer update -W`. Sound for someone testing WordPress core, a dead end here.

`n test-php` now checks first, and when the dev dependencies are absent names both commands that install them:

```
newspack-plugin has no dev dependencies installed, so the WordPress test
bootstrap cannot load the PHPUnit polyfills it requires.

Install them with either command, then re-run this one:
  cd /newspack-plugins/newspack-plugin && n composer install
      the composer dependencies on their own
  n build newspack-plugin
      the same, plus the JS build
```

Both kinds of install write `vendor/autoload.php`, so the check reads composer's own record of which one ran.

One deliberate asymmetry: no readable `installed.json` blocks, but a file that exists without a recognisable flag reports **present**. A composer format change should degrade to today's behaviour for whoever hits it first, not block every project at once.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Create an environment: `n env create devdeps --worktree newspack-plugin:main`.
3. Start it: `n env up devdeps`. Do not build it.
4. Go to the plugin: `cd worktrees/main/plugins/newspack-plugin`.
5. Run `n test-php`.
6. Confirm the output names `n composer install` and `n build`, and does not mention `WP_RUN_CORE_TESTS`.
7. Run `n composer install`.
8. Run `n test-php` again. Confirm the suite runs.
9. Run `bash bin/tests/test-project-has-dev-deps.sh`. Confirm all assertions pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Both shell specs pass. The predicate was checked against all 14 real `installed.json` files in the workspace and agreed with an authoritative JSON parse on every one, and the guard was driven end to end in a container in both directions.
