### PR TITLE
fix(subscriptions): require Audience Management for the Subscriptions screen (NPPD-1899)

### DIFF
--- a/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-commerce.php
+++ b/plugins/newspack-plugin/includes/subscriber-commerce/class-subscriber-commerce.php
@@ -47,19 +47,22 @@ class Subscriber_Commerce {
 	/**
 	 * Whether subscriber-commerce rules are enforced at all.
 	 *
-	 * Two things stand enforcement down, and the admin stays reachable through
-	 * both so a publisher can keep authoring rules:
+	 * Two things stand enforcement down, and they differ in what the publisher can
+	 * still do about it:
 	 *
 	 * While WooCommerce Memberships is active it owns purchase restriction and
 	 * member discounts, and enforcing ours on top would double-apply on a site
-	 * mid-migration.
+	 * mid-migration. The admin stays reachable throughout, because configuring
+	 * the rules first and deactivating Memberships afterwards is the migration.
 	 *
 	 * Without Audience Management there is nowhere to send a reader who is
 	 * refused. Registration, sign-in, account emails and My Account all belong
 	 * to it, so a blocked purchase would leave the reader at a notice naming a
 	 * subscription they have no way to buy. Content gates go inert in the same
 	 * state ({@see Content_Gate::is_gating_active()}), and subscriber-commerce
-	 * matches them rather than half-working alongside.
+	 * matches them rather than half-working alongside. Here the admin closes too:
+	 * the Subscriptions screen shows the Audience Management prerequisite instead
+	 * of its tabs, so there is nothing to author until the dependency is met.
 	 *
 	 * @return bool
 	 */

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php
@@ -497,25 +497,26 @@ class Audience_Subscriptions extends Wizard {
 
 		parent::enqueue_scripts_and_styles();
 		wp_enqueue_script( 'newspack-wizards' );
-		wp_localize_script(
-			'newspack-wizards',
-			'newspackAudienceSubscriptions',
-			[
-				'tabs'                     => self::get_tabs(),
-				'memberships_url'          => admin_url( 'edit.php?post_type=wc_membership_plan' ),
-				'memberships_active'       => Memberships::is_active(),
-				'primary_product'          => $primary_product ? $primary_product->get_id() : '',
-				'eligible_products'        => array_map(
-					function ( $product ) {
-						return [
-							'id'    => $product->get_id(),
-							'title' => $product->get_title(),
-						];
-					},
-					Subscriptions_Tiers::get_tier_eligible_products()
-				),
-				'upgrade_subscription_url' => Subscriptions_Tiers::get_upgrade_subscription_url(),
-			] + $this->get_audience_management_script_data()
-		);
+		$data = [
+			'tabs'                     => self::get_tabs(),
+			'memberships_url'          => admin_url( 'edit.php?post_type=wc_membership_plan' ),
+			'memberships_active'       => Memberships::is_active(),
+			'primary_product'          => $primary_product ? $primary_product->get_id() : '',
+			'eligible_products'        => array_map(
+				function ( $product ) {
+					return [
+						'id'    => $product->get_id(),
+						'title' => $product->get_title(),
+					];
+				},
+				Subscriptions_Tiers::get_tier_eligible_products()
+			),
+			'upgrade_subscription_url' => Subscriptions_Tiers::get_upgrade_subscription_url(),
+		];
+		// array_merge, not `+`: the trait's keys have to win a collision. With `+`
+		// a key added to the array above would silently shadow the prerequisite
+		// state and unblock the screen.
+		$data = array_merge( $data, $this->get_audience_management_script_data() );
+		wp_localize_script( 'newspack-wizards', 'newspackAudienceSubscriptions', $data );
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php
@@ -18,6 +18,8 @@ defined( 'ABSPATH' ) || exit;
  * being wired in here, so a tab can ship without touching the shell.
  */
 class Audience_Subscriptions extends Wizard {
+	use Wizards\Traits\Audience_Management_Dependency;
+
 	/**
 	 * Admin page slug.
 	 *
@@ -513,7 +515,7 @@ class Audience_Subscriptions extends Wizard {
 					Subscriptions_Tiers::get_tier_eligible_products()
 				),
 				'upgrade_subscription_url' => Subscriptions_Tiers::get_upgrade_subscription_url(),
-			]
+			] + $this->get_audience_management_script_data()
 		);
 	}
 }

--- a/plugins/newspack-plugin/includes/wizards/traits/trait-audience-management-dependency.php
+++ b/plugins/newspack-plugin/includes/wizards/traits/trait-audience-management-dependency.php
@@ -14,8 +14,11 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Trait Audience_Management_Dependency
  *
- * Audience Management is a hard prerequisite for the wizards that surface the
- * content gate editor (Audience Access Control and Premium Newsletters).
+ * Audience Management is a hard prerequisite for the wizards that depend on it:
+ * the two that surface the content gate editor (Audience Access Control and
+ * Premium Newsletters), and Subscriptions, whose subscriber-commerce features
+ * are enforced only while it is on
+ * ({@see \Newspack\Subscriber_Commerce::is_enforcement_active()}).
  * Everything a gate hands the reader off to is gated on it: reader
  * registration, magic link login, account emails, session hydration and My
  * Account. A gate enforced without Audience Management locks readers out and
@@ -27,8 +30,8 @@ defined( 'ABSPATH' ) || exit;
  * other half of that — it keeps the publisher from authoring new gating that
  * would do nothing, and points them at the setting that makes it work.
  *
- * Shared by both surfaces so the dependency cannot be enforced on one and
- * forgotten on the other.
+ * Shared by every such surface so the dependency cannot be enforced on one and
+ * forgotten on the next.
  */
 trait Audience_Management_Dependency {
 	/**

--- a/plugins/newspack-plugin/src/wizards/audience/components/audience-management-required.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/components/audience-management-required.test.js
@@ -21,7 +21,7 @@ import { render, screen } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import AudienceManagementRequired, { redirectWithoutAudienceManagement, requireAudienceManagement } from '../../components/audience-management-required';
+import AudienceManagementRequired, { redirectWithoutAudienceManagement, requireAudienceManagement } from './audience-management-required';
 
 // The real @wordpress/components cannot load in jsdom (its data-store side effects throw
 // at import), so pass through only what the prerequisite state renders. ExternalLink and
@@ -34,7 +34,7 @@ jest.mock( '@wordpress/components', () => {
 	};
 } );
 
-jest.mock( '../../../../../packages/components/src', () => {
+jest.mock( '../../../../packages/components/src', () => {
 	const React = require( 'react' );
 	return {
 		Grid: ( { children } ) => React.createElement( 'div', null, children ),
@@ -46,7 +46,7 @@ jest.mock( '../../../../../packages/components/src', () => {
 	};
 } );
 
-jest.mock( '../../../../../packages/components/src/proxied-imports/router', () => {
+jest.mock( '../../../../packages/components/src/proxied-imports/router', () => {
 	const React = require( 'react' );
 	return {
 		__esModule: true,
@@ -69,6 +69,8 @@ const setAudienceManagement = enabled => {
 
 const Section = () => <div>the real section</div>;
 
+const getConfig = () => window.newspackAudienceContentGates;
+
 const GATES_COPY = 'Access Control needs accounts, sign-in, and account emails. Audience Management provides them.';
 
 describe( 'requireAudienceManagement (NPPD-1846)', () => {
@@ -82,7 +84,7 @@ describe( 'requireAudienceManagement (NPPD-1846)', () => {
 	] )( 'replaces the section with the prerequisite state when the flag is %s', ( _label, value ) => {
 		setAudienceManagement( value );
 
-		const Guarded = requireAudienceManagement( Section, { description: GATES_COPY } );
+		const Guarded = requireAudienceManagement( Section, { description: GATES_COPY, getConfig } );
 		render( <Guarded /> );
 
 		expect( screen.getByText( PREREQUISITE_HEADING ) ).toBeInTheDocument();
@@ -94,7 +96,7 @@ describe( 'requireAudienceManagement (NPPD-1846)', () => {
 	it( 'renders the section untouched when Audience Management is on', () => {
 		setAudienceManagement( '1' );
 
-		const Guarded = requireAudienceManagement( Section, { description: GATES_COPY } );
+		const Guarded = requireAudienceManagement( Section, { description: GATES_COPY, getConfig } );
 		render( <Guarded /> );
 
 		expect( screen.getByText( 'the real section' ) ).toBeInTheDocument();
@@ -105,7 +107,7 @@ describe( 'requireAudienceManagement (NPPD-1846)', () => {
 		setAudienceManagement( '1' );
 		const PropSpy = ( { label } ) => <div>{ label }</div>;
 
-		const Guarded = requireAudienceManagement( PropSpy, { description: GATES_COPY } );
+		const Guarded = requireAudienceManagement( PropSpy, { description: GATES_COPY, getConfig } );
 		render( <Guarded label="forwarded" /> );
 
 		expect( screen.getByText( 'forwarded' ) ).toBeInTheDocument();
@@ -116,7 +118,7 @@ describe( 'requireAudienceManagement (NPPD-1846)', () => {
 	it( 'renders the copy the guarded screen supplied', () => {
 		setAudienceManagement( '' );
 
-		const Guarded = requireAudienceManagement( Section, { description: 'Premium newsletters need accounts.' } );
+		const Guarded = requireAudienceManagement( Section, { description: 'Premium newsletters need accounts.', getConfig } );
 		render( <Guarded /> );
 
 		expect( screen.getByText( 'Premium newsletters need accounts.' ) ).toBeInTheDocument();
@@ -141,7 +143,7 @@ describe( 'redirectWithoutAudienceManagement (NPPD-1846)', () => {
 	] )( 'redirects to the landing route when the flag is %s', ( _label, value ) => {
 		setAudienceManagement( value );
 
-		const Guarded = redirectWithoutAudienceManagement( Section, '/content-gates' );
+		const Guarded = redirectWithoutAudienceManagement( Section, '/content-gates', getConfig );
 		render( <Guarded /> );
 
 		expect( screen.getByTestId( 'redirect' ) ).toHaveAttribute( 'data-to', '/content-gates' );
@@ -153,7 +155,7 @@ describe( 'redirectWithoutAudienceManagement (NPPD-1846)', () => {
 	it( 'renders the section untouched when Audience Management is on', () => {
 		setAudienceManagement( '1' );
 
-		const Guarded = redirectWithoutAudienceManagement( Section, '/content-gates' );
+		const Guarded = redirectWithoutAudienceManagement( Section, '/content-gates', getConfig );
 		render( <Guarded /> );
 
 		expect( screen.getByText( 'the real section' ) ).toBeInTheDocument();
@@ -169,8 +171,8 @@ describe( 'every gate-editing wizard section is guarded (NPPD-1846)', () => {
 	const path = require( 'path' );
 
 	const ROUTERS = [
-		[ 'Access Control', path.join( __dirname, 'index.js' ), 7 ],
-		[ 'Premium Newsletters', path.join( __dirname, '../../../newsletters/views/premium-newsletters/index.js' ), 2 ],
+		[ 'Access Control', path.join( __dirname, '../views/content-gates/index.js' ), 7 ],
+		[ 'Premium Newsletters', path.join( __dirname, '../../newsletters/views/premium-newsletters/index.js' ), 2 ],
 	];
 
 	it.each( ROUTERS )( '%s guards every section renderer', ( _name, routerPath, expectedSections ) => {

--- a/plugins/newspack-plugin/src/wizards/audience/components/audience-management-required.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/components/audience-management-required.tsx
@@ -13,14 +13,32 @@ import { people } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { Button, Grid, SectionHeader } from '../../../../../packages/components/src';
-import Router from '../../../../../packages/components/src/proxied-imports/router';
-import { hasAudienceManagement } from './utils';
+import { Button, Grid, SectionHeader } from '../../../../packages/components/src';
+import Router from '../../../../packages/components/src/proxied-imports/router';
 
 const { Redirect } = Router;
 
-const AudienceManagementRequired = ( { isNewsletter = false }: { isNewsletter?: boolean } ) => {
-	const audienceManagementUrl = window.newspackAudienceContentGates?.audience_management_url || '';
+type AudienceManagementConfig = {
+	audience_management_enabled?: string | boolean;
+	audience_management_url?: string;
+};
+
+/**
+ * Whether Audience Management is enabled, read from a wizard's localized config.
+ *
+ * Every screen that depends on Audience Management localizes the two keys the
+ * `Audience_Management_Dependency` PHP trait supplies, so the bag it lives in is
+ * the caller's to name.
+ *
+ * `wp_localize_script()` stringifies the PHP boolean, so the value arrives as
+ * '1' when on and '' when off - which is why this is a truthiness check and not
+ * a comparison against `true`.
+ */
+export const hasAudienceManagement = ( config: AudienceManagementConfig | undefined = window.newspackAudienceContentGates ) =>
+	Boolean( config?.audience_management_enabled );
+
+const AudienceManagementRequired = ( { description, setupUrl = '' }: { description: string; setupUrl?: string } ) => {
+	const audienceManagementUrl = setupUrl;
 
 	return (
 		<Grid columns={ 4 } noMargin>
@@ -28,17 +46,7 @@ const AudienceManagementRequired = ( { isNewsletter = false }: { isNewsletter?: 
 				<SectionHeader
 					icon={ people }
 					title={ __( 'Set up Audience Management first', 'newspack-plugin' ) }
-					description={
-						isNewsletter
-							? __(
-									'Premium newsletters need accounts, sign-in, and account emails. Audience Management provides them.',
-									'newspack-plugin'
-							  )
-							: __(
-									'Access Control needs accounts, sign-in, and account emails. Audience Management provides them.',
-									'newspack-plugin'
-							  )
-					}
+					description={ description }
 					pageHeader
 					noMargin
 				/>
@@ -79,12 +87,13 @@ const AudienceManagementRequired = ( { isNewsletter = false }: { isNewsletter?: 
  * that changes identity between renders remounts the section subtree and discards
  * in-progress editor state.
  */
-export const requireAudienceManagement = < P extends object >(
-	Section: React.ComponentType< P >,
-	{ isNewsletter = false }: { isNewsletter?: boolean } = {}
-) => {
+export const requireAudienceManagement = < P extends object >( Section: React.ComponentType< P >, { description }: { description: string } ) => {
 	const Guarded = ( props: P ) =>
-		hasAudienceManagement() ? <Section { ...props } /> : <AudienceManagementRequired isNewsletter={ isNewsletter } />;
+		hasAudienceManagement() ? (
+			<Section { ...props } />
+		) : (
+			<AudienceManagementRequired description={ description } setupUrl={ window.newspackAudienceContentGates?.audience_management_url || '' } />
+		);
 	// Named so the guarded sections are distinguishable in React DevTools
 	// rather than all reading as `Anonymous`.
 	Guarded.displayName = `RequireAudienceManagement(${ Section.displayName || Section.name || 'Section' })`;

--- a/plugins/newspack-plugin/src/wizards/audience/components/audience-management-required.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/components/audience-management-required.tsx
@@ -1,6 +1,12 @@
 /**
- * Audience Management prerequisite state, shown in place of a gate-editing screen
- * when Audience Management is not set up.
+ * Audience Management prerequisite state, shown in place of a screen that depends
+ * on it when it is not set up.
+ *
+ * Shared by every such screen — the two gate editors (Access Control, Premium
+ * Newsletters) and Subscriptions, whose dependency runs through
+ * `Subscriber_Commerce::is_enforcement_active()` rather than through gating. The
+ * copy, the setup destination and the config bag to read are all the caller's,
+ * so adding a fourth consumer needs no change here.
  */
 
 /**
@@ -18,8 +24,12 @@ import Router from '../../../../packages/components/src/proxied-imports/router';
 
 const { Redirect } = Router;
 
+// Access Control is where the prerequisite is documented for every surface, so it
+// is the default destination rather than a per-screen choice.
+const DEFAULT_LEARN_MORE_URL = 'https://help.newspack.com/access-control/';
+
 type AudienceManagementConfig = {
-	audience_management_enabled?: string | boolean;
+	audience_management_enabled?: string;
 	audience_management_url?: string;
 };
 
@@ -30,16 +40,26 @@ type AudienceManagementConfig = {
  * `Audience_Management_Dependency` PHP trait supplies, so the bag it lives in is
  * the caller's to name.
  *
+ * The config is required rather than defaulted. A default would fire on an
+ * explicitly passed `undefined` too, so a screen whose own bag failed to
+ * localize would silently read a different screen's answer and unblock itself —
+ * a fail-open hidden inside a guard.
+ *
  * `wp_localize_script()` stringifies the PHP boolean, so the value arrives as
  * '1' when on and '' when off - which is why this is a truthiness check and not
  * a comparison against `true`.
  */
-export const hasAudienceManagement = ( config: AudienceManagementConfig | undefined = window.newspackAudienceContentGates ) =>
-	Boolean( config?.audience_management_enabled );
+export const hasAudienceManagement = ( config: AudienceManagementConfig | undefined ) => Boolean( config?.audience_management_enabled );
 
-const AudienceManagementRequired = ( { description, setupUrl = '' }: { description: string; setupUrl?: string } ) => {
-	const audienceManagementUrl = setupUrl;
-
+const AudienceManagementRequired = ( {
+	description,
+	setupUrl = '',
+	learnMoreUrl = DEFAULT_LEARN_MORE_URL,
+}: {
+	description: string;
+	setupUrl?: string;
+	learnMoreUrl?: string;
+} ) => {
 	return (
 		<Grid columns={ 4 } noMargin>
 			<VStack data-start="2" data-end="4" spacing={ 8 }>
@@ -53,15 +73,12 @@ const AudienceManagementRequired = ( { description, setupUrl = '' }: { descripti
 				<VStack alignment="center" spacing={ 4 }>
 					{ /* Rendered only with a real destination: a primary CTA pointing at href=""
 					     reloads this same screen, which is worse than offering no button. */ }
-					{ audienceManagementUrl && (
-						<Button variant="primary" href={ audienceManagementUrl }>
+					{ setupUrl && (
+						<Button variant="primary" href={ setupUrl }>
 							{ __( 'Set up Audience Management', 'newspack-plugin' ) }
 						</Button>
 					) }
-					{ /* Points at the Access Control doc rather than the Audience Management one:
-					     the prerequisite is being added there, and that page is where the original
-					     support question started. */ }
-					<ExternalLink href="https://help.newspack.com/access-control/">{ __( 'Learn more', 'newspack-plugin' ) }</ExternalLink>
+					<ExternalLink href={ learnMoreUrl }>{ __( 'Learn more', 'newspack-plugin' ) }</ExternalLink>
 				</VStack>
 			</VStack>
 		</Grid>
@@ -87,13 +104,20 @@ const AudienceManagementRequired = ( { description, setupUrl = '' }: { descripti
  * that changes identity between renders remounts the section subtree and discards
  * in-progress editor state.
  */
-export const requireAudienceManagement = < P extends object >( Section: React.ComponentType< P >, { description }: { description: string } ) => {
-	const Guarded = ( props: P ) =>
-		hasAudienceManagement() ? (
+export const requireAudienceManagement = < P extends object >(
+	Section: React.ComponentType< P >,
+	{ description, getConfig }: { description: string; getConfig: () => AudienceManagementConfig | undefined }
+) => {
+	const Guarded = ( props: P ) => {
+		// Read at render, not at module scope: these wrappers are built while the
+		// bundle evaluates, before `wp_localize_script()` has necessarily run.
+		const config = getConfig();
+		return hasAudienceManagement( config ) ? (
 			<Section { ...props } />
 		) : (
-			<AudienceManagementRequired description={ description } setupUrl={ window.newspackAudienceContentGates?.audience_management_url || '' } />
+			<AudienceManagementRequired description={ description } setupUrl={ config?.audience_management_url || '' } />
 		);
+	};
 	// Named so the guarded sections are distinguishable in React DevTools
 	// rather than all reading as `Anonymous`.
 	Guarded.displayName = `RequireAudienceManagement(${ Section.displayName || Section.name || 'Section' })`;
@@ -110,8 +134,12 @@ export const requireAudienceManagement = < P extends object >( Section: React.Co
  *
  * Same module-scope requirement as `requireAudienceManagement()`.
  */
-export const redirectWithoutAudienceManagement = < P extends object >( Section: React.ComponentType< P >, redirectTo: string ) => {
-	const Guarded = ( props: P ) => ( hasAudienceManagement() ? <Section { ...props } /> : <Redirect to={ redirectTo } /> );
+export const redirectWithoutAudienceManagement = < P extends object >(
+	Section: React.ComponentType< P >,
+	redirectTo: string,
+	getConfig: () => AudienceManagementConfig | undefined
+) => {
+	const Guarded = ( props: P ) => ( hasAudienceManagement( getConfig() ) ? <Section { ...props } /> : <Redirect to={ redirectTo } /> );
 	Guarded.displayName = `RedirectWithoutAudienceManagement(${ Section.displayName || Section.name || 'Section' })`;
 	return Guarded;
 };

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/audience-management-prerequisite.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/audience-management-prerequisite.test.js
@@ -21,7 +21,7 @@ import { render, screen } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import AudienceManagementRequired, { redirectWithoutAudienceManagement, requireAudienceManagement } from './audience-management-required';
+import AudienceManagementRequired, { redirectWithoutAudienceManagement, requireAudienceManagement } from '../../components/audience-management-required';
 
 // The real @wordpress/components cannot load in jsdom (its data-store side effects throw
 // at import), so pass through only what the prerequisite state renders. ExternalLink and
@@ -69,6 +69,8 @@ const setAudienceManagement = enabled => {
 
 const Section = () => <div>the real section</div>;
 
+const GATES_COPY = 'Access Control needs accounts, sign-in, and account emails. Audience Management provides them.';
+
 describe( 'requireAudienceManagement (NPPD-1846)', () => {
 	// '' is what wp_localize_script() sends for PHP false, and the absent key covers a
 	// site whose localized config predates this feature. Pinning the string rather than
@@ -80,7 +82,7 @@ describe( 'requireAudienceManagement (NPPD-1846)', () => {
 	] )( 'replaces the section with the prerequisite state when the flag is %s', ( _label, value ) => {
 		setAudienceManagement( value );
 
-		const Guarded = requireAudienceManagement( Section );
+		const Guarded = requireAudienceManagement( Section, { description: GATES_COPY } );
 		render( <Guarded /> );
 
 		expect( screen.getByText( PREREQUISITE_HEADING ) ).toBeInTheDocument();
@@ -92,7 +94,7 @@ describe( 'requireAudienceManagement (NPPD-1846)', () => {
 	it( 'renders the section untouched when Audience Management is on', () => {
 		setAudienceManagement( '1' );
 
-		const Guarded = requireAudienceManagement( Section );
+		const Guarded = requireAudienceManagement( Section, { description: GATES_COPY } );
 		render( <Guarded /> );
 
 		expect( screen.getByText( 'the real section' ) ).toBeInTheDocument();
@@ -103,33 +105,25 @@ describe( 'requireAudienceManagement (NPPD-1846)', () => {
 		setAudienceManagement( '1' );
 		const PropSpy = ( { label } ) => <div>{ label }</div>;
 
-		const Guarded = requireAudienceManagement( PropSpy );
+		const Guarded = requireAudienceManagement( PropSpy, { description: GATES_COPY } );
 		render( <Guarded label="forwarded" /> );
 
 		expect( screen.getByText( 'forwarded' ) ).toBeInTheDocument();
 	} );
 
-	it( 'uses newsletter-specific copy for the Premium Newsletters surface', () => {
+	// The copy belongs to the screen, not to this component: three surfaces now
+	// depend on Audience Management and a boolean per surface does not scale.
+	it( 'renders the copy the guarded screen supplied', () => {
 		setAudienceManagement( '' );
 
-		const Guarded = requireAudienceManagement( Section, { isNewsletter: true } );
+		const Guarded = requireAudienceManagement( Section, { description: 'Premium newsletters need accounts.' } );
 		render( <Guarded /> );
 
-		expect( screen.getByText( /Premium newsletters need accounts/ ) ).toBeInTheDocument();
-	} );
-
-	it( 'uses Access Control copy by default', () => {
-		setAudienceManagement( '' );
-
-		render( <AudienceManagementRequired /> );
-
-		expect( screen.getByText( /Access Control needs accounts/ ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Premium newsletters need accounts.' ) ).toBeInTheDocument();
 	} );
 
 	it( 'omits the action rather than rendering a dead link when the URL is missing', () => {
-		window.newspackAudienceContentGates = { audience_management_enabled: '' };
-
-		render( <AudienceManagementRequired /> );
+		render( <AudienceManagementRequired description={ GATES_COPY } setupUrl="" /> );
 
 		expect( screen.getByText( PREREQUISITE_HEADING ) ).toBeInTheDocument();
 		expect( screen.queryByText( ACTION_LABEL ) ).not.toBeInTheDocument();

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/index.js
@@ -33,14 +33,17 @@ const ACCESS_CONTROL_INSTITUTIONS = [ ...ACCESS_CONTROL, { label: __( 'Instituti
 // renders. Only the landing route renders the prerequisite state; the rest redirect
 // to it, so the explanation lives in exactly one place.
 const GATES_ROUTE = '/content-gates';
+const getConfig = () => window.newspackAudienceContentGates;
+
 const GuardedContentGates = requireAudienceManagement( ContentGates, {
 	description: __( 'Access Control needs accounts, sign-in, and account emails. Audience Management provides them.', 'newspack-plugin' ),
+	getConfig,
 } );
-const GuardedEdit = redirectWithoutAudienceManagement( Edit, GATES_ROUTE );
-const GuardedCountdownBanner = redirectWithoutAudienceManagement( CountdownBanner, GATES_ROUTE );
-const GuardedContentGifting = redirectWithoutAudienceManagement( ContentGifting, GATES_ROUTE );
-const GuardedInstitutions = redirectWithoutAudienceManagement( Institutions, GATES_ROUTE );
-const GuardedInstitutionEdit = redirectWithoutAudienceManagement( InstitutionEdit, GATES_ROUTE );
+const GuardedEdit = redirectWithoutAudienceManagement( Edit, GATES_ROUTE, getConfig );
+const GuardedCountdownBanner = redirectWithoutAudienceManagement( CountdownBanner, GATES_ROUTE, getConfig );
+const GuardedContentGifting = redirectWithoutAudienceManagement( ContentGifting, GATES_ROUTE, getConfig );
+const GuardedInstitutions = redirectWithoutAudienceManagement( Institutions, GATES_ROUTE, getConfig );
+const GuardedInstitutionEdit = redirectWithoutAudienceManagement( InstitutionEdit, GATES_ROUTE, getConfig );
 
 const AudienceContentGates = ( props, ref ) => {
 	const { updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/index.js
@@ -16,7 +16,7 @@ import { forwardRef } from '@wordpress/element';
  */
 import { Wizard, withWizard } from '../../../../../packages/components/src';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
-import { redirectWithoutAudienceManagement, requireAudienceManagement } from './audience-management-required';
+import { redirectWithoutAudienceManagement, requireAudienceManagement } from '../../components/audience-management-required';
 import ContentGates from './content-gates';
 import Edit from './edit';
 import CountdownBanner from './edit/countdown-banner';
@@ -33,7 +33,9 @@ const ACCESS_CONTROL_INSTITUTIONS = [ ...ACCESS_CONTROL, { label: __( 'Instituti
 // renders. Only the landing route renders the prerequisite state; the rest redirect
 // to it, so the explanation lives in exactly one place.
 const GATES_ROUTE = '/content-gates';
-const GuardedContentGates = requireAudienceManagement( ContentGates );
+const GuardedContentGates = requireAudienceManagement( ContentGates, {
+	description: __( 'Access Control needs accounts, sign-in, and account emails. Audience Management provides them.', 'newspack-plugin' ),
+} );
 const GuardedEdit = redirectWithoutAudienceManagement( Edit, GATES_ROUTE );
 const GuardedCountdownBanner = redirectWithoutAudienceManagement( CountdownBanner, GATES_ROUTE );
 const GuardedContentGifting = redirectWithoutAudienceManagement( ContentGifting, GATES_ROUTE );

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/utils.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/utils.tsx
@@ -28,21 +28,6 @@ export function getEditGateLayoutUrl( gateId: number, gateMode: string ) {
 }
 
 /**
- * Whether Audience Management is set up, i.e. whether the gate-editing screens
- * may be used at all.
- *
- * Audience Management is a hard prerequisite for content gating - see the
- * `Audience_Management_Dependency` PHP trait for why. The `requireAudienceManagement`
- * router wrapper is the caller; the rule lives here so the wire format below is
- * encoded in exactly one place.
- *
- * `wp_localize_script()` stringifies the PHP boolean, so the value arrives as
- * '1' when on and '' when off - which is why this is a truthiness check and not
- * a comparison against `true`.
- */
-export const hasAudienceManagement = () => Boolean( window.newspackAudienceContentGates?.audience_management_enabled );
-
-/**
  * Whether a gate actually meters, i.e. it grants at least one free view.
  *
  * Metering switched on with 0 free views gates every reader on their first view, so

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/audience-management-prerequisite.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/audience-management-prerequisite.test.js
@@ -20,11 +20,16 @@ import AudienceSubscriptions from './index';
 
 const PREREQUISITE_HEADING = 'Set up Audience Management first';
 
+// The Wizard mock below renders whatever sections it is handed, so these tests pin
+// which sections reach it, not how routing resolves. Route enumeration is not
+// needed here the way it is for the gate editors: the screen replaces the whole
+// section list rather than guarding each renderer, and the one remaining section
+// is registered non-exact at '/', so no sub-route can slip past it.
+
 jest.mock( '@wordpress/components', () => {
 	const React = require( 'react' );
 	return {
 		__experimentalVStack: ( { children } ) => React.createElement( 'div', null, children ),
-		__experimentalHStack: ( { children } ) => React.createElement( 'div', null, children ),
 		ExternalLink: ( { children, href } ) => React.createElement( 'a', { href }, children ),
 	};
 } );
@@ -49,7 +54,12 @@ jest.mock( '../../../../../packages/components/src', () => {
 	};
 } );
 
-jest.mock( '../../../wizards-tab', () => ( { children } ) => children );
+jest.mock(
+	'../../../wizards-tab',
+	() =>
+		( { children } ) =>
+			children
+);
 
 // One registered tab, so a screen that did NOT stand down would render it and
 // the assertions below would fail for the right reason.

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/audience-management-prerequisite.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/audience-management-prerequisite.test.js
@@ -1,0 +1,99 @@
+/**
+ * The Subscriptions screen stands down as a whole without Audience Management.
+ *
+ * Enforcement for both subscriber-commerce features is gated on Audience
+ * Management, so a publisher configuring either one here would be authoring
+ * rules that do nothing. Blocking tab by tab was the alternative and is worse:
+ * Configuration alone still works, but a screen with one live tab and two
+ * prerequisite notices reads as broken rather than as a dependency.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import AudienceSubscriptions from './index';
+
+const PREREQUISITE_HEADING = 'Set up Audience Management first';
+
+jest.mock( '@wordpress/components', () => {
+	const React = require( 'react' );
+	return {
+		__experimentalVStack: ( { children } ) => React.createElement( 'div', null, children ),
+		__experimentalHStack: ( { children } ) => React.createElement( 'div', null, children ),
+		ExternalLink: ( { children, href } ) => React.createElement( 'a', { href }, children ),
+	};
+} );
+
+// Wizard is replaced by a renderer for the sections it was handed: what matters
+// here is which sections reach it, not how it draws them.
+jest.mock( '../../../../../packages/components/src', () => {
+	const React = require( 'react' );
+	return {
+		Button: ( { children, href } ) => React.createElement( 'a', { href }, children ),
+		Grid: ( { children } ) => React.createElement( 'div', null, children ),
+		Notice: ( { children } ) => React.createElement( 'div', null, children ),
+		SectionHeader: ( { title, description } ) =>
+			React.createElement( 'div', null, React.createElement( 'h2', null, title ), React.createElement( 'p', null, description ) ),
+		Wizard: ( { sections } ) =>
+			React.createElement(
+				'div',
+				null,
+				sections.map( section => React.createElement( 'div', { key: section.path }, React.createElement( section.render ) ) )
+			),
+		withWizard: component => component,
+	};
+} );
+
+jest.mock( '../../../wizards-tab', () => ( { children } ) => children );
+
+// One registered tab, so a screen that did NOT stand down would render it and
+// the assertions below would fail for the right reason.
+jest.mock( './tabs', () => ( {
+	getTab: () => ( {
+		render: () => require( 'react' ).createElement( 'div', null, 'Configuration tab' ),
+	} ),
+} ) );
+
+const setUpScreen = audienceManagementEnabled => {
+	window.newspackAudienceSubscriptions = {
+		tabs: [ { slug: 'configuration', label: 'Configuration', path: '/' } ],
+		audience_management_enabled: audienceManagementEnabled,
+		audience_management_url: 'https://example.test/wp-admin/admin.php?page=newspack-audience',
+	};
+};
+
+describe( 'Subscriptions screen without Audience Management', () => {
+	it( 'replaces every tab with the prerequisite state', () => {
+		setUpScreen( '' );
+
+		render( <AudienceSubscriptions /> );
+
+		expect( screen.getByText( PREREQUISITE_HEADING ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Configuration tab' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'points the publisher at the setup flow', () => {
+		setUpScreen( '' );
+
+		render( <AudienceSubscriptions /> );
+
+		expect( screen.getByText( 'Set up Audience Management' ) ).toHaveAttribute(
+			'href',
+			'https://example.test/wp-admin/admin.php?page=newspack-audience'
+		);
+	} );
+
+	it( 'renders the registered tabs once Audience Management is on', () => {
+		setUpScreen( '1' );
+
+		render( <AudienceSubscriptions /> );
+
+		expect( screen.getByText( 'Configuration tab' ) ).toBeInTheDocument();
+		expect( screen.queryByText( PREREQUISITE_HEADING ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/index.tsx
@@ -23,30 +23,48 @@ import type { SubscriptionsTab } from './types';
 
 const HEADER_TEXT = __( 'Audience Management / Subscriptions', 'newspack-plugin' );
 
+// Built at module scope: `Wizard` renders `section.render` as a component type, so
+// rebuilding it per render would remount the subtree and drop focus.
+const PREREQUISITE_SECTION = {
+	label: __( 'Subscriptions', 'newspack-plugin' ),
+	// `Wizard` registers section routes non-exact, so a bookmarked tab route lands
+	// here rather than on an empty Switch. That is what makes the stand-down
+	// deep-link safe without a per-route redirect.
+	path: '/',
+	breadcrumbs: [ { label: __( 'Audience Management', 'newspack-plugin' ) }, { label: __( 'Subscriptions', 'newspack-plugin' ) } ],
+	render: () => (
+		<AudienceManagementRequired
+			description={ __(
+				'The Subscriptions screen needs accounts, sign-in, and account emails. Audience Management provides them.',
+				'newspack-plugin'
+			) }
+			setupUrl={ window.newspackAudienceSubscriptions?.audience_management_url || '' }
+		/>
+	),
+};
+
 function AudienceSubscriptions( _props: Record< string, unknown >, ref: React.ForwardedRef< HTMLDivElement > ) {
-	const tabs: SubscriptionsTab[] = window.newspackAudienceSubscriptions.tabs || [];
+	const config = window.newspackAudienceSubscriptions;
 
 	// The whole screen stands down without Audience Management, rather than a tab
 	// at a time. Subscriber-only products and subscriber discounts are enforced
 	// only while it is on ({@see Newspack\Subscriber_Commerce::is_enforcement_active()}),
-	// and configuring either one here would do nothing. The Configuration tab
-	// would still work on its own, but this screen is one feature to a publisher,
-	// and a half-blocked one reads as broken rather than as a prerequisite.
-	const audienceManagement = window.newspackAudienceSubscriptions;
-	const prerequisiteSection = {
-		label: __( 'Subscriptions', 'newspack-plugin' ),
-		path: '/',
-		breadcrumbs: [ { label: __( 'Audience Management', 'newspack-plugin' ) }, { label: __( 'Subscriptions', 'newspack-plugin' ) } ],
-		render: () => (
-			<AudienceManagementRequired
-				description={ __(
-					'Subscriptions needs accounts, sign-in, and account emails. Audience Management provides them.',
-					'newspack-plugin'
-				) }
-				setupUrl={ audienceManagement?.audience_management_url || '' }
-			/>
-		),
-	};
+	// so configuring either one would do nothing.
+	//
+	// The Configuration tab is the accepted cost of that: its primary-tier setting
+	// still drives the front-end upgrade modal, which does not depend on Audience
+	// Management, so blocking the screen puts that setting out of reach too. One
+	// live tab beside two prerequisite notices reads as broken rather than as a
+	// dependency, so the screen is treated as one feature.
+	//
+	// Returning early rather than adding an arm to the ternary below keeps the tab
+	// lookup off the blocked path, and leaves that ternary's comment with the
+	// fallback it actually describes.
+	if ( ! hasAudienceManagement( config ) ) {
+		return <Wizard headerText={ HEADER_TEXT } sections={ [ PREREQUISITE_SECTION ] } requiredPlugins={ [ 'woocommerce' ] } ref={ ref } />;
+	}
+
+	const tabs: SubscriptionsTab[] = config.tabs || [];
 
 	const sections = tabs
 		.map( tab => {
@@ -76,9 +94,7 @@ function AudienceSubscriptions( _props: Record< string, unknown >, ref: React.Fo
 	// how a list ends up empty — so fall back to a single section carrying a
 	// notice. Routed through Wizard rather than returned on its own, it keeps the
 	// header, breadcrumbs and admin chrome, and the forwarded ref stays attached.
-	const displayedSections = ! hasAudienceManagement( audienceManagement )
-		? [ prerequisiteSection ]
-		: sections.length
+	const displayedSections = sections.length
 		? sections
 		: [
 				{

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/index.tsx
@@ -17,6 +17,7 @@ import { forwardRef } from '@wordpress/element';
  */
 import { Notice, Wizard, withWizard } from '../../../../../packages/components/src';
 import WizardsTab from '../../../wizards-tab';
+import AudienceManagementRequired, { hasAudienceManagement } from '../../components/audience-management-required';
 import { getTab } from './tabs';
 import type { SubscriptionsTab } from './types';
 
@@ -24,6 +25,28 @@ const HEADER_TEXT = __( 'Audience Management / Subscriptions', 'newspack-plugin'
 
 function AudienceSubscriptions( _props: Record< string, unknown >, ref: React.ForwardedRef< HTMLDivElement > ) {
 	const tabs: SubscriptionsTab[] = window.newspackAudienceSubscriptions.tabs || [];
+
+	// The whole screen stands down without Audience Management, rather than a tab
+	// at a time. Subscriber-only products and subscriber discounts are enforced
+	// only while it is on ({@see Newspack\Subscriber_Commerce::is_enforcement_active()}),
+	// and configuring either one here would do nothing. The Configuration tab
+	// would still work on its own, but this screen is one feature to a publisher,
+	// and a half-blocked one reads as broken rather than as a prerequisite.
+	const audienceManagement = window.newspackAudienceSubscriptions;
+	const prerequisiteSection = {
+		label: __( 'Subscriptions', 'newspack-plugin' ),
+		path: '/',
+		breadcrumbs: [ { label: __( 'Audience Management', 'newspack-plugin' ) }, { label: __( 'Subscriptions', 'newspack-plugin' ) } ],
+		render: () => (
+			<AudienceManagementRequired
+				description={ __(
+					'Subscriptions needs accounts, sign-in, and account emails. Audience Management provides them.',
+					'newspack-plugin'
+				) }
+				setupUrl={ audienceManagement?.audience_management_url || '' }
+			/>
+		),
+	};
 
 	const sections = tabs
 		.map( tab => {
@@ -53,7 +76,9 @@ function AudienceSubscriptions( _props: Record< string, unknown >, ref: React.Fo
 	// how a list ends up empty — so fall back to a single section carrying a
 	// notice. Routed through Wizard rather than returned on its own, it keeps the
 	// header, breadcrumbs and admin chrome, and the forwarded ref stays attached.
-	const displayedSections = sections.length
+	const displayedSections = ! hasAudienceManagement( audienceManagement )
+		? [ prerequisiteSection ]
+		: sections.length
 		? sections
 		: [
 				{

--- a/plugins/newspack-plugin/src/wizards/newsletters/views/premium-newsletters/index.js
+++ b/plugins/newspack-plugin/src/wizards/newsletters/views/premium-newsletters/index.js
@@ -21,8 +21,13 @@ import PremiumNewslettersList from './premium-newsletters-list';
 import Edit from '../../../audience/views/content-gates/edit';
 import { redirectWithoutAudienceManagement, requireAudienceManagement } from '../../../audience/components/audience-management-required';
 
+// Premium Newsletters localizes into the content-gates bag, which it shares with
+// the Access Control screen.
+const getConfig = () => window.newspackAudienceContentGates;
+
 const REQUIRES_AUDIENCE_MANAGEMENT = {
 	description: __( 'Premium newsletters need accounts, sign-in, and account emails. Audience Management provides them.', 'newspack-plugin' ),
+	getConfig,
 };
 
 const ROOT = [ { label: __( 'Newsletters', 'newspack-plugin' ) } ];
@@ -33,7 +38,7 @@ const PREMIUM_BREADCRUMBS = [ ...ROOT, { label: __( 'Premium', 'newspack-plugin'
 // redirects to it.
 const GATES_ROUTE = '/content-gates';
 const GuardedPremiumNewslettersList = requireAudienceManagement( PremiumNewslettersList, REQUIRES_AUDIENCE_MANAGEMENT );
-const GuardedEdit = redirectWithoutAudienceManagement( Edit, GATES_ROUTE );
+const GuardedEdit = redirectWithoutAudienceManagement( Edit, GATES_ROUTE, getConfig );
 
 const PremiumNewsletters = ( props, ref ) => {
 	const { updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );

--- a/plugins/newspack-plugin/src/wizards/newsletters/views/premium-newsletters/index.js
+++ b/plugins/newspack-plugin/src/wizards/newsletters/views/premium-newsletters/index.js
@@ -19,9 +19,11 @@ import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/w
 import { PREMIUM_NEWSLETTERS_WIZARD_SLUG, BASE_HEADER_TEXT } from './consts';
 import PremiumNewslettersList from './premium-newsletters-list';
 import Edit from '../../../audience/views/content-gates/edit';
-import { redirectWithoutAudienceManagement, requireAudienceManagement } from '../../../audience/views/content-gates/audience-management-required';
+import { redirectWithoutAudienceManagement, requireAudienceManagement } from '../../../audience/components/audience-management-required';
 
-const REQUIRES_AUDIENCE_MANAGEMENT = { isNewsletter: true };
+const REQUIRES_AUDIENCE_MANAGEMENT = {
+	description: __( 'Premium newsletters need accounts, sign-in, and account emails. Audience Management provides them.', 'newspack-plugin' ),
+};
 
 const ROOT = [ { label: __( 'Newsletters', 'newspack-plugin' ) } ];
 const PREMIUM_BREADCRUMBS = [ ...ROOT, { label: __( 'Premium', 'newspack-plugin' ) } ];

--- a/plugins/newspack-plugin/src/wizards/types/window.d.ts
+++ b/plugins/newspack-plugin/src/wizards/types/window.d.ts
@@ -75,6 +75,8 @@ declare global {
 				title: string;
 			}>;
 			upgrade_subscription_url: string;
+			audience_management_enabled?: string;
+			audience_management_url?: string;
 		};
 		newspackAudienceIntegrations: {
 			integrations_settings_enabled: boolean;
@@ -91,7 +93,7 @@ declare global {
 			// Audience Management is a prerequisite for content gates. Only ever the
 			// string wp_localize_script() produced ('1' on, '' off) - nothing writes a
 			// real boolean back, so typing it wider would invite a `=== true` that can
-			// never hold. Read it via hasAudienceManagement() in content-gates/utils.
+			// never hold. Read it via hasAudienceManagement() in audience/components/audience-management-required.
 			//
 			// Optional because both keys are absent on a page whose localized config
 			// predates this feature, which the readers already handle: hasAudienceManagement()

--- a/plugins/newspack-plugin/tests/unit-tests/wizards/class-audience-management-dependency-test.php
+++ b/plugins/newspack-plugin/tests/unit-tests/wizards/class-audience-management-dependency-test.php
@@ -277,4 +277,41 @@ class Audience_Management_Dependency_Test extends WP_UnitTestCase {
 		// where wp_localize_script() would stringify an integer 0 to the truthy '0'.
 		$this->assertFalse( $disabled['audience_management_enabled'] );
 	}
+
+	/**
+	 * The Subscriptions screen carries the trait's keys into its own localized
+	 * config, which is what its blocked state renders from.
+	 *
+	 * Its JS spec builds `newspackAudienceSubscriptions` itself, so nothing on
+	 * that side would notice the wizard dropping the trait or shadowing its keys —
+	 * both suites would stay green while the screen rendered unblocked.
+	 *
+	 * `enqueue_scripts_and_styles()` gates on `filter_input( INPUT_GET, … )`,
+	 * which reads the SAPI's request data and cannot be faked from a test, so the
+	 * merge direction is pinned by reading the source. The rest is structural.
+	 */
+	public function test_subscriptions_wizard_carries_the_prerequisite_into_its_config() {
+		$subscriptions_wizard = new \Newspack\Audience_Subscriptions();
+
+		$this->assertContains(
+			\Newspack\Wizards\Traits\Audience_Management_Dependency::class,
+			class_uses( $subscriptions_wizard ),
+			'The Subscriptions screen depends on Audience Management, so it uses the shared trait.'
+		);
+
+		$script_data = $subscriptions_wizard->get_audience_management_script_data();
+		$this->assertArrayHasKey( 'audience_management_enabled', $script_data );
+		$this->assertArrayHasKey( 'audience_management_url', $script_data );
+
+		// array_merge, not `+`: the trait has to win a key collision, or a key added
+		// to the wizard's own config could shadow the prerequisite and unblock the
+		// screen. The two operators differ only in that direction.
+		$reflected_enqueue = new \ReflectionMethod( $subscriptions_wizard, 'enqueue_scripts_and_styles' );
+		$wizard_source     = file_get_contents( $reflected_enqueue->getFileName() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		$this->assertMatchesRegularExpression(
+			'/array_merge\(\s*\$data,\s*\$this->get_audience_management_script_data\(\)\s*\)/',
+			$wizard_source,
+			'The trait wins a key collision, so the prerequisite cannot be shadowed.'
+		);
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Subscriptions screen let a publisher configure subscriber-only products and subscriber discounts while Audience Management was off, even though #909 means neither is enforced in that state. It now shows the same prerequisite screen Access Control and Premium Newsletters use, following NPPD-1846.

![Subscriptions screen with Audience Management off](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/19/zze7ti37-subscriptions-am-off.png)

The whole screen stands down rather than a tab at a time. Configuration alone would still work without Audience Management, since subscription tiers run on WooCommerce's own account and switch flow. One live tab beside two prerequisite notices reads as broken rather than as a dependency, so the screen is treated as one feature.

This is the component's third consumer, so it moves to `audience/components` and is generalised: the copy is a prop instead of an `isNewsletter` boolean, and the setup URL is a prop instead of one screen's localized global.

### How to test the changes in this Pull Request:

1. Check out this branch and run `n build newspack-plugin`.
2. Activate WooCommerce and the Newspack plugin.
3. Add `define( 'NEWSPACK_CONTENT_GATES', true );` to `wp-config.php`.
4. Enable Audience Management.
5. Go to Audience > Subscriptions. The Configuration tab renders.
6. Disable Audience Management, then reload the page.
7. The tabs are replaced by the "Set up Audience Management first" screen.
8. Click "Set up Audience Management". The Audience Management setup screen opens.
9. Go to Audience > Access Control. It shows the same prerequisite screen as before this change.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
