### PR TITLE
fix(accessibility): stop duplicate statement pages appearing (NEWS-2948)

### DIFF
--- a/plugins/newspack-plugin/includes/advanced-settings/class-accessibility-statement-page.php
+++ b/plugins/newspack-plugin/includes/advanced-settings/class-accessibility-statement-page.php
@@ -10,40 +10,131 @@ namespace Newspack;
 /**
  * Accessibility Statement Page class.
  */
-class Accessibility_Statement_Page {
+final class Accessibility_Statement_Page {
+
+	/**
+	 * Option holding the ID of the page the site uses.
+	 */
+	const OPTION_NAME = 'newspack_accessibility_statement_page_id';
+
+	/**
+	 * Where the page ID used to live. Theme mods are per theme, so every theme
+	 * and style variation kept its own, and a site lost the page each time it
+	 * switched. Still read until the upgrade has run, and still written on
+	 * create, so a plugin rolled back to before this change finds the page
+	 * where it looks for it instead of making a second one.
+	 */
+	const LEGACY_THEME_MOD = 'accessibility_statement_page_id';
+
+	/**
+	 * Marks the upgrade as done so the theme scan runs once per site, including
+	 * on sites that turn out to have nothing to migrate. Autoloaded, so the
+	 * debug reset clears it together with the pointer rather than leaving a
+	 * site that believes it has already migrated and has nothing to show.
+	 */
+	const MIGRATION_FLAG = 'newspack_accessibility_statement_migrated';
+
+	/**
+	 * The slug reserved for the page.
+	 */
+	const PAGE_SLUG = 'accessibility-statement';
 
 	/**
 	 * Add hooks.
 	 */
-	public static function init() {
+	public static function init(): void {
 		// Register REST routes.
-		add_action( 'rest_api_init', [ __CLASS__, 'register_rest_routes' ] );
+		add_action( 'rest_api_init', [ __CLASS__, 'register_rest_routes' ], 10 );
+		add_action( 'admin_init', [ __CLASS__, 'migrate_legacy_theme_mod' ], 10 );
 		// Add post status to accessibility statement page.
 		add_filter( 'display_post_states', [ __CLASS__, 'post_status' ], 10, 2 );
 	}
 
 	/**
-	 * Create an accessibility statement page.
+	 * Get the ID of the page the site uses, whether or not it still exists.
 	 *
-	 * @param bool $force_create Whether to force creation of a new page even if theme_mod exists.
-	 * @return array|null|WP_Error The created page data, null if it has been trashed or deleted, or error.
+	 * Falls back to the legacy theme mod when no usable page is stored. That
+	 * covers the window between the plugin updating and the next admin request,
+	 * which on an auto-updating site can be days, and it covers a page an older
+	 * version created while the plugin was rolled back.
+	 *
+	 * @return int The stored page ID, which may point at a page that has since
+	 *             been trashed or deleted, or 0 if no pointer was ever stored.
 	 */
-	public static function create_page( $force_create = false ) {
-		// Check if page ID is stored in theme_mods.
-		$page_id = get_theme_mod( 'accessibility_statement_page_id' );
-		if ( $page_id && ! $force_create ) {
-			$page = get_post( $page_id );
-			// Check if page exists and is either published or draft.
-			if ( $page && 'page' === $page->post_type && in_array( get_post_status( $page->ID ), [ 'publish', 'draft' ] ) ) {
-				$page_data = [
-					'editUrl' => get_edit_post_link( $page->ID, 'raw' ),
-					'status'  => get_post_status( $page->ID ),
-					'pageUrl' => get_permalink( $page->ID ),
-				];
-				return $page_data;
-			}
-			// If page doesn't exist or is in trash, return null but keep the ID stored.
+	public static function get_page_id(): int {
+		$page_id = (int) get_option( self::OPTION_NAME, 0 );
+		if ( $page_id && self::usable_page( $page_id ) ) {
+			return $page_id;
+		}
+
+		$legacy_id = (int) get_theme_mod( self::LEGACY_THEME_MOD );
+		if ( $legacy_id && self::usable_page( $legacy_id ) ) {
+			return $legacy_id;
+		}
+
+		return $page_id;
+	}
+
+	/**
+	 * Get the stored page, if it is still there to be used.
+	 *
+	 * @return \WP_Post|null The page, or null if none is stored, it has been
+	 *                       deleted, or it sits in the trash.
+	 */
+	private static function get_stored_page(): ?\WP_Post {
+		$page_id = self::get_page_id();
+		if ( ! $page_id ) {
 			return null;
+		}
+
+		return self::usable_page( $page_id );
+	}
+
+	/**
+	 * Resolve a page ID to a page the site can still use.
+	 *
+	 * @param int $page_id The page ID.
+	 * @return \WP_Post|null The page, or null if it is gone, trashed, or not a page.
+	 */
+	private static function usable_page( int $page_id ): ?\WP_Post {
+		$page = get_post( $page_id );
+		if ( ! $page || 'page' !== $page->post_type || 'trash' === $page->post_status ) {
+			return null;
+		}
+
+		return $page;
+	}
+
+	/**
+	 * Shape a page for the wizard and the theme.
+	 *
+	 * @param \WP_Post $page The page.
+	 * @return array{editUrl: ?string, pageUrl: string|false, status: string, title: string} The page data.
+	 */
+	private static function page_data( \WP_Post $page ): array {
+		return [
+			'editUrl' => get_edit_post_link( $page->ID, 'raw' ),
+			'pageUrl' => get_permalink( $page->ID ),
+			'status'  => $page->post_status,
+			'title'   => get_the_title( $page->ID ),
+		];
+	}
+
+	/**
+	 * Create an accessibility statement page, unless the site already has one.
+	 *
+	 * Idempotent against a stored pointer, which is what a repeat click hits.
+	 * Two genuinely simultaneous requests can still each insert: WordPress has
+	 * no atomic option claim, and a second request's write is invisible to this
+	 * one anyway, because the first miss is cached for the rest of the request.
+	 *
+	 * @return array{editUrl: ?string, pageUrl: string|false, status: string, title: string}|\WP_Error
+	 *         The page data, or an error if it could not be created.
+	 */
+	public static function create_page(): array|\WP_Error {
+		$existing = self::get_stored_page();
+		if ( $existing ) {
+			return self::page_data( $existing );
 		}
 
 		// Get the Accessibility Statement boilerplate content.
@@ -51,87 +142,181 @@ class Accessibility_Statement_Page {
 		require __DIR__ . '/class-accessibility-statement-boilerplate.php';
 		$page_content = ob_get_clean();
 
-		// If no page ID is stored, create a new page.
 		$page_id = wp_insert_post(
 			[
 				'post_title'   => __( 'Accessibility Statement', 'newspack-plugin' ),
-				'post_name'    => 'accessibility-statement',
+				'post_name'    => self::PAGE_SLUG,
 				'post_status'  => 'draft',
 				'post_type'    => 'page',
 				'post_content' => $page_content,
-			]
+			],
+			true
 		);
 
 		if ( is_wp_error( $page_id ) ) {
 			return $page_id;
 		}
 
-		// Save the page ID.
-		set_theme_mod( 'accessibility_statement_page_id', $page_id );
+		update_option( self::OPTION_NAME, $page_id, true );
+		set_theme_mod( self::LEGACY_THEME_MOD, $page_id );
 
-		$page_data = [
-			'editUrl' => get_edit_post_link( $page_id, 'raw' ),
-			'status'  => 'draft',
-			'pageUrl' => get_permalink( $page_id ),
-		];
-		return $page_data;
+		$page = self::usable_page( $page_id );
+		if ( ! $page ) {
+			return new \WP_Error(
+				'newspack_accessibility_statement_page_missing',
+				esc_html__( 'The accessibility statement page could not be created.', 'newspack-plugin' )
+			);
+		}
+
+		return self::page_data( $page );
 	}
 
 	/**
 	 * Get accessibility statement page data.
 	 * The function to actually output the link lives in the Classic Theme.
 	 *
+	 * Reading never creates the page. The classic theme footer calls this on
+	 * every front-end render, so a write here reaches logged-out visitors.
+	 *
 	 * TODO: Create a block for the Block Theme that outputs the format we need there.
 	 *
-	 * @return array|false The page data or false if not set.
+	 * @return array{editUrl: ?string, pageUrl: string|false, status: string, title: string}|false
+	 *         The page data, or false if the site has no usable page.
 	 */
-	public static function get_page() {
-		$page_id = get_theme_mod( 'accessibility_statement_page_id' );
-		if ( ! $page_id ) {
-			// If no page ID exists, create a new page.
-			$result = self::create_page();
-			if ( ! is_wp_error( $result ) ) {
-				return $result;
+	public static function get_page(): array|false {
+		$page = self::get_stored_page();
+
+		return $page ? self::page_data( $page ) : false;
+	}
+
+	/**
+	 * Move the page ID from theme mods to a site-wide option.
+	 *
+	 * @return void
+	 */
+	public static function migrate_legacy_theme_mod(): void {
+		// admin_init also fires on admin-ajax.php and admin-post.php, both
+		// reachable logged out. Anonymous requests should not pay for the scan.
+		if ( wp_doing_ajax() || ! is_user_logged_in() ) {
+			return;
+		}
+
+		if ( (int) get_option( self::OPTION_NAME, 0 ) ) {
+			return;
+		}
+
+		if ( get_option( self::MIGRATION_FLAG ) ) {
+			// Rolling the plugin back and forward again leaves a pointer on the
+			// active theme, worth adopting without repeating the whole scan.
+			$legacy_id = (int) get_theme_mod( self::LEGACY_THEME_MOD );
+			$legacy    = $legacy_id ? get_post( $legacy_id ) : null;
+			if ( $legacy && 'page' === $legacy->post_type ) {
+				update_option( self::OPTION_NAME, $legacy_id, true );
 			}
-			return false;
+			return;
 		}
 
-		$page = get_post( $page_id );
-		if ( ! $page || 'page' !== $page->post_type || 'trash' === get_post_status( $page->ID ) ) {
-			// If page doesn't exist, isn't a page, or is in trash, return false but keep theme_mod.
-			return false;
+		$page_id = self::find_legacy_page_id();
+		if ( $page_id ) {
+			update_option( self::OPTION_NAME, $page_id, true );
+			// The page may have come from a theme that is no longer active;
+			// a rolled-back plugin only looks at the active one.
+			set_theme_mod( self::LEGACY_THEME_MOD, $page_id );
+		} elseif ( get_theme_mod( self::LEGACY_THEME_MOD ) ) {
+			remove_theme_mod( self::LEGACY_THEME_MOD );
 		}
 
-		$page_data = [
-			'editUrl' => get_edit_post_link( $page->ID, 'raw' ),
-			'pageUrl' => get_permalink( $page->ID ),
-			'status'  => get_post_status( $page->ID ),
-			'title'   => get_the_title( $page->ID ),
-		];
-		return $page_data;
+		// Recorded last: a request that dies inside the scan should retry on the
+		// next one rather than abandon the site's page for good.
+		update_option( self::MIGRATION_FLAG, 1, true );
+	}
+
+	/**
+	 * Find the page a site stored before the ID moved to an option.
+	 *
+	 * A published page wins over a draft: where a site accumulated duplicates,
+	 * the published one is the statement the publisher maintains. A trashed page
+	 * is still worth pointing at, so restoring it brings the link back rather
+	 * than the pointer being lost for good.
+	 *
+	 * @return int The page ID, or 0 if none was found.
+	 */
+	private static function find_legacy_page_id(): int {
+		$candidates = [];
+		foreach ( self::legacy_page_ids() as $page_id ) {
+			$page = get_post( $page_id );
+			if ( $page && 'page' === $page->post_type ) {
+				$candidates[] = $page;
+			}
+		}
+
+		foreach ( $candidates as $page ) {
+			if ( 'publish' === $page->post_status ) {
+				return $page->ID;
+			}
+		}
+
+		foreach ( $candidates as $page ) {
+			if ( 'trash' !== $page->post_status ) {
+				return $page->ID;
+			}
+		}
+
+		return $candidates ? $candidates[0]->ID : 0;
+	}
+
+	/**
+	 * Every page ID a theme's mods point at, active theme or not.
+	 *
+	 * Read from the options table rather than through wp_get_themes(): mods are
+	 * keyed by stylesheet and survive the theme being deleted, so enumerating
+	 * installed themes would miss exactly the sites that switched away and
+	 * tidied up. Runs once per site, behind the migration flag.
+	 *
+	 * @return int[]
+	 */
+	private static function legacy_page_ids(): array {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$option_names = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s ORDER BY option_name",
+				$wpdb->esc_like( 'theme_mods_' ) . '%'
+			)
+		);
+
+		$page_ids = [ (int) get_theme_mod( self::LEGACY_THEME_MOD ) ];
+		foreach ( (array) $option_names as $option_name ) {
+			$mods       = get_option( $option_name );
+			$page_ids[] = is_array( $mods ) ? (int) ( $mods[ self::LEGACY_THEME_MOD ] ?? 0 ) : 0;
+		}
+
+		return array_unique( array_filter( $page_ids ) );
 	}
 
 	/**
 	 * Register REST API endpoints.
+	 *
+	 * @return void
 	 */
-	public static function register_rest_routes() {
+	public static function register_rest_routes(): void {
 		register_rest_route(
 			'newspack/v1',
 			'/wizard/newspack-settings/accessibility-statement',
 			[
-				'methods'             => 'POST',
-				'callback'            => [ __CLASS__, 'api_create_page' ],
-				'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
-			]
-		);
-
-		register_rest_route(
-			'newspack/v1',
-			'/wizard/newspack-settings/accessibility-statement',
-			[
-				'methods'             => 'GET',
-				'callback'            => [ __CLASS__, 'api_get_page' ],
-				'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
+				[
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => [ __CLASS__, 'api_get_page' ],
+					'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
+					'args'                => [],
+				],
+				[
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => [ __CLASS__, 'api_create_page' ],
+					'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
+					'args'                => [],
+				],
 			]
 		);
 	}
@@ -139,12 +324,10 @@ class Accessibility_Statement_Page {
 	/**
 	 * API callback for creating accessibility statement page.
 	 *
-	 * @param WP_REST_Request $request The request object.
-	 * @return WP_REST_Response|WP_Error Response object.
+	 * @return \WP_REST_Response|\WP_Error Response object.
 	 */
-	public static function api_create_page( $request ) {
-		$force_create = $request->get_param( 'force_create' ) === 'true';
-		$result = self::create_page( $force_create );
+	public static function api_create_page(): \WP_REST_Response|\WP_Error {
+		$result = self::create_page();
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
@@ -154,19 +337,27 @@ class Accessibility_Statement_Page {
 	/**
 	 * API callback for getting accessibility statement page.
 	 *
-	 * @return WP_REST_Response Response object.
+	 * Where there is no page, the response says whether the site has never
+	 * created one ('none') or created one that has since gone ('missing'), so
+	 * the wizard can explain which of the two the publisher is looking at.
+	 *
+	 * @return \WP_REST_Response|\WP_Error Response object.
 	 */
-	public static function api_get_page() {
+	public static function api_get_page(): \WP_REST_Response|\WP_Error {
 		$page_data = self::get_page();
-		return rest_ensure_response( $page_data );
+		if ( $page_data ) {
+			return rest_ensure_response( $page_data );
+		}
+
+		return rest_ensure_response( [ 'status' => self::get_page_id() ? 'missing' : 'none' ] );
 	}
 
 	/**
 	 * Check capabilities for using API.
 	 *
-	 * @return bool|WP_Error
+	 * @return bool|\WP_Error
 	 */
-	public static function api_permissions_check() {
+	public static function api_permissions_check(): bool|\WP_Error {
 		if ( ! current_user_can( 'edit_pages' ) ) {
 			return new \WP_Error(
 				'newspack_rest_forbidden',
@@ -180,13 +371,16 @@ class Accessibility_Statement_Page {
 	/**
 	 * Add post status to accessibility statement page.
 	 *
-	 * @param array   $post_states The post states.
-	 * @param WP_Post $post The post object.
+	 * @param mixed $post_states The post states, normally an array.
+	 * @param mixed $post The post object, normally a WP_Post.
 	 * @return array The post states.
 	 */
-	public static function post_status( $post_states, $post ) {
-		$page_id = get_theme_mod( 'accessibility_statement_page_id' );
-		if ( $page_id === $post->ID ) {
+	public static function post_status( $post_states, $post = null ): array {
+		if ( ! is_array( $post_states ) ) {
+			$post_states = [];
+		}
+
+		if ( $post instanceof \WP_Post && $post->ID === self::get_page_id() ) {
 			$post_states['accessibility_statement'] = __( 'Accessibility Statement', 'newspack-plugin' );
 		}
 		return $post_states;

--- a/plugins/newspack-plugin/includes/advanced-settings/class-accessibility-statement-page.php
+++ b/plugins/newspack-plugin/includes/advanced-settings/class-accessibility-statement-page.php
@@ -273,10 +273,10 @@ final class Accessibility_Statement_Page {
 
 		$page_id = self::find_legacy_page_id();
 		if ( $page_id ) {
-			self::store_page_id( $page_id );
-			// The page may have come from a theme that is no longer active;
-			// a rolled-back plugin only looks at the active one.
-			set_theme_mod( self::LEGACY_THEME_MOD, $page_id );
+			// The page may have come from a theme that is no longer active; a
+			// rolled-back plugin only looks at the active one, so the breadcrumb
+			// has to name the page the site ends up on, not the one found here.
+			set_theme_mod( self::LEGACY_THEME_MOD, self::store_page_id( $page_id ) );
 		} elseif ( get_theme_mod( self::LEGACY_THEME_MOD ) ) {
 			remove_theme_mod( self::LEGACY_THEME_MOD );
 		}
@@ -298,16 +298,27 @@ final class Accessibility_Statement_Page {
 	 * write. That narrows the window to the re-read itself rather than closing
 	 * it; no option API can do better, and the cost lands once per site.
 	 *
+	 * All three option cache entries go, not just the two the autoloaded row
+	 * uses: an autoload optimiser can leave the row out of `alloptions`, and the
+	 * per-option entry would then serve this request's own miss back to us.
+	 *
 	 * @param int $page_id The page ID to store.
-	 * @return void
+	 * @return int The page ID the site points at, which is not the one passed in
+	 *             when another request got there first.
 	 */
-	private static function store_page_id( int $page_id ): void {
+	private static function store_page_id( int $page_id ): int {
+		wp_cache_delete( self::OPTION_NAME, 'options' );
 		wp_cache_delete( 'notoptions', 'options' );
 		wp_cache_delete( 'alloptions', 'options' );
 
-		if ( ! (int) get_option( self::OPTION_NAME, 0 ) ) {
-			update_option( self::OPTION_NAME, $page_id, true );
+		$stored = (int) get_option( self::OPTION_NAME, 0 );
+		if ( $stored ) {
+			return $stored;
 		}
+
+		update_option( self::OPTION_NAME, $page_id, true );
+
+		return $page_id;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/advanced-settings/class-accessibility-statement-page.php
+++ b/plugins/newspack-plugin/includes/advanced-settings/class-accessibility-statement-page.php
@@ -48,6 +48,10 @@ final class Accessibility_Statement_Page {
 	 * at a deleted page would otherwise go back to the database on every call,
 	 * which on the Pages list table is once per row.
 	 *
+	 * The blog ID is part of the key because this is a plain static: page IDs
+	 * repeat across a network, so without it a switch_to_blog() could be handed
+	 * another site's page.
+	 *
 	 * @var array{key: string, id: int, page: \WP_Post|null}|null
 	 */
 	private static ?array $resolved = null;
@@ -83,7 +87,7 @@ final class Accessibility_Statement_Page {
 	private static function resolve(): array {
 		$page_id   = (int) get_option( self::OPTION_NAME, 0 );
 		$legacy_id = (int) get_theme_mod( self::LEGACY_THEME_MOD );
-		$key       = $page_id . ':' . $legacy_id;
+		$key       = get_current_blog_id() . ':' . $page_id . ':' . $legacy_id;
 
 		if ( self::$resolved && $key === self::$resolved['key'] ) {
 			return self::$resolved;
@@ -262,18 +266,14 @@ final class Accessibility_Statement_Page {
 			$legacy_id = (int) get_theme_mod( self::LEGACY_THEME_MOD );
 			$legacy    = $legacy_id ? get_post( $legacy_id ) : null;
 			if ( $legacy && 'page' === $legacy->post_type ) {
-				add_option( self::OPTION_NAME, $legacy_id, '', true );
+				self::store_page_id( $legacy_id );
 			}
 			return;
 		}
 
 		$page_id = self::find_legacy_page_id();
 		if ( $page_id ) {
-			// add_option, not update_option: the decision to write was made
-			// before a multi-query scan, and a create_page() that landed in the
-			// gap must keep its pointer rather than be sent back to an older
-			// page. Core's INSERT ... ON DUPLICATE KEY leaves the row alone.
-			add_option( self::OPTION_NAME, $page_id, '', true );
+			self::store_page_id( $page_id );
 			// The page may have come from a theme that is no longer active;
 			// a rolled-back plugin only looks at the active one.
 			set_theme_mod( self::LEGACY_THEME_MOD, $page_id );
@@ -284,6 +284,30 @@ final class Accessibility_Statement_Page {
 		// Recorded last: a request that dies inside the scan should retry on the
 		// next one rather than abandon the site's page for good.
 		update_option( self::MIGRATION_FLAG, 1, true );
+	}
+
+	/**
+	 * Store the pointer, unless another request stored one while we were looking.
+	 *
+	 * The decision to write is made before a lookup that costs several queries,
+	 * so a create_page() can land in the gap, and its page is the one the site
+	 * should keep. add_option() cannot make that call here: the miss this request
+	 * already cached leaves the option in `notoptions`, which is exactly the case
+	 * where add_option() skips its own existence check and overwrites. Dropping
+	 * the two cache entries first is what makes the re-read see a concurrent
+	 * write. That narrows the window to the re-read itself rather than closing
+	 * it; no option API can do better, and the cost lands once per site.
+	 *
+	 * @param int $page_id The page ID to store.
+	 * @return void
+	 */
+	private static function store_page_id( int $page_id ): void {
+		wp_cache_delete( 'notoptions', 'options' );
+		wp_cache_delete( 'alloptions', 'options' );
+
+		if ( ! (int) get_option( self::OPTION_NAME, 0 ) ) {
+			update_option( self::OPTION_NAME, $page_id, true );
+		}
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/advanced-settings/class-accessibility-statement-page.php
+++ b/plugins/newspack-plugin/includes/advanced-settings/class-accessibility-statement-page.php
@@ -22,7 +22,10 @@ final class Accessibility_Statement_Page {
 	 * and style variation kept its own, and a site lost the page each time it
 	 * switched. Still read until the upgrade has run, and still written on
 	 * create, so a plugin rolled back to before this change finds the page
-	 * where it looks for it instead of making a second one.
+	 * where it looks for it instead of making a second one. Both the write and
+	 * the read only ever see the active theme, so the breadcrumb covers a
+	 * rollback on a site that has not switched theme since; rolling forward
+	 * re-adopts from the option either way.
 	 */
 	const LEGACY_THEME_MOD = 'accessibility_statement_page_id';
 
@@ -40,14 +43,68 @@ final class Accessibility_Statement_Page {
 	const PAGE_SLUG = 'accessibility-statement';
 
 	/**
+	 * What the stored pointer resolved to this request, keyed by the values it
+	 * was resolved from. get_post() caches a hit but not a miss, so a pointer
+	 * at a deleted page would otherwise go back to the database on every call,
+	 * which on the Pages list table is once per row.
+	 *
+	 * @var array{key: string, id: int, page: \WP_Post|null}|null
+	 */
+	private static ?array $resolved = null;
+
+	/**
 	 * Add hooks.
 	 */
 	public static function init(): void {
 		// Register REST routes.
 		add_action( 'rest_api_init', [ __CLASS__, 'register_rest_routes' ], 10 );
 		add_action( 'admin_init', [ __CLASS__, 'migrate_legacy_theme_mod' ], 10 );
+		// Trashing, restoring or deleting the page changes what the pointer
+		// resolves to without changing the pointer itself.
+		add_action( 'clean_post_cache', [ __CLASS__, 'forget_resolved_page' ], 10 );
 		// Add post status to accessibility statement page.
 		add_filter( 'display_post_states', [ __CLASS__, 'post_status' ], 10, 2 );
+	}
+
+	/**
+	 * Drop the resolved pointer so the next read looks it up again.
+	 *
+	 * @return void
+	 */
+	public static function forget_resolved_page(): void {
+		self::$resolved = null;
+	}
+
+	/**
+	 * Resolve the stored pointer to an ID and, where it still exists, a page.
+	 *
+	 * @return array{key: string, id: int, page: \WP_Post|null}
+	 */
+	private static function resolve(): array {
+		$page_id   = (int) get_option( self::OPTION_NAME, 0 );
+		$legacy_id = (int) get_theme_mod( self::LEGACY_THEME_MOD );
+		$key       = $page_id . ':' . $legacy_id;
+
+		if ( self::$resolved && $key === self::$resolved['key'] ) {
+			return self::$resolved;
+		}
+
+		$page = $page_id ? self::usable_page( $page_id ) : null;
+		if ( ! $page && $legacy_id ) {
+			$legacy = self::usable_page( $legacy_id );
+			if ( $legacy ) {
+				$page_id = $legacy_id;
+				$page    = $legacy;
+			}
+		}
+
+		self::$resolved = [
+			'key'  => $key,
+			'id'   => $page_id,
+			'page' => $page,
+		];
+
+		return self::$resolved;
 	}
 
 	/**
@@ -58,21 +115,17 @@ final class Accessibility_Statement_Page {
 	 * which on an auto-updating site can be days, and it covers a page an older
 	 * version created while the plugin was rolled back.
 	 *
+	 * That fallback reads the active theme only, and skips a trashed page,
+	 * where the upgrade scan reads every theme's mods and keeps a trashed page
+	 * on purpose. So a site that switched theme before updating has no link
+	 * until the upgrade runs; widening the fallback would put a scan of every
+	 * theme's mods on every front-end render.
+	 *
 	 * @return int The stored page ID, which may point at a page that has since
 	 *             been trashed or deleted, or 0 if no pointer was ever stored.
 	 */
 	public static function get_page_id(): int {
-		$page_id = (int) get_option( self::OPTION_NAME, 0 );
-		if ( $page_id && self::usable_page( $page_id ) ) {
-			return $page_id;
-		}
-
-		$legacy_id = (int) get_theme_mod( self::LEGACY_THEME_MOD );
-		if ( $legacy_id && self::usable_page( $legacy_id ) ) {
-			return $legacy_id;
-		}
-
-		return $page_id;
+		return self::resolve()['id'];
 	}
 
 	/**
@@ -82,12 +135,7 @@ final class Accessibility_Statement_Page {
 	 *                       deleted, or it sits in the trash.
 	 */
 	private static function get_stored_page(): ?\WP_Post {
-		$page_id = self::get_page_id();
-		if ( ! $page_id ) {
-			return null;
-		}
-
-		return self::usable_page( $page_id );
+		return self::resolve()['page'];
 	}
 
 	/**
@@ -196,8 +244,11 @@ final class Accessibility_Statement_Page {
 	 */
 	public static function migrate_legacy_theme_mod(): void {
 		// admin_init also fires on admin-ajax.php and admin-post.php, both
-		// reachable logged out. Anonymous requests should not pay for the scan.
-		if ( wp_doing_ajax() || ! is_user_logged_in() ) {
+		// reachable logged out, and every logged-in reader reaches the admin
+		// through their profile. Only a user who could create the page pays for
+		// the scan and its writes; the legacy fallback in get_page_id() covers
+		// the site until one of them shows up.
+		if ( wp_doing_ajax() || ! current_user_can( 'edit_pages' ) ) {
 			return;
 		}
 
@@ -211,14 +262,18 @@ final class Accessibility_Statement_Page {
 			$legacy_id = (int) get_theme_mod( self::LEGACY_THEME_MOD );
 			$legacy    = $legacy_id ? get_post( $legacy_id ) : null;
 			if ( $legacy && 'page' === $legacy->post_type ) {
-				update_option( self::OPTION_NAME, $legacy_id, true );
+				add_option( self::OPTION_NAME, $legacy_id, '', true );
 			}
 			return;
 		}
 
 		$page_id = self::find_legacy_page_id();
 		if ( $page_id ) {
-			update_option( self::OPTION_NAME, $page_id, true );
+			// add_option, not update_option: the decision to write was made
+			// before a multi-query scan, and a create_page() that landed in the
+			// gap must keep its pointer rather than be sent back to an older
+			// page. Core's INSERT ... ON DUPLICATE KEY leaves the row alone.
+			add_option( self::OPTION_NAME, $page_id, '', true );
 			// The page may have come from a theme that is no longer active;
 			// a rolled-back plugin only looks at the active one.
 			set_theme_mod( self::LEGACY_THEME_MOD, $page_id );
@@ -309,13 +364,11 @@ final class Accessibility_Statement_Page {
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => [ __CLASS__, 'api_get_page' ],
 					'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
-					'args'                => [],
 				],
 				[
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => [ __CLASS__, 'api_create_page' ],
 					'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
-					'args'                => [],
 				],
 			]
 		);
@@ -337,9 +390,12 @@ final class Accessibility_Statement_Page {
 	/**
 	 * API callback for getting accessibility statement page.
 	 *
-	 * Where there is no page, the response says whether the site has never
-	 * created one ('none') or created one that has since gone ('missing'), so
-	 * the wizard can explain which of the two the publisher is looking at.
+	 * Where there is no page, the response carries a `reason` instead of the
+	 * page: whether the site has never created one ('none') or created one that
+	 * has since gone ('missing'), so the wizard can explain which of the two the
+	 * publisher is looking at. It is its own key because `status` is a post
+	 * status, and a client testing `status` against these two names would
+	 * misread any post status registered under either.
 	 *
 	 * @return \WP_REST_Response|\WP_Error Response object.
 	 */
@@ -349,7 +405,7 @@ final class Accessibility_Statement_Page {
 			return rest_ensure_response( $page_data );
 		}
 
-		return rest_ensure_response( [ 'status' => self::get_page_id() ? 'missing' : 'none' ] );
+		return rest_ensure_response( [ 'reason' => self::get_page_id() ? 'missing' : 'none' ] );
 	}
 
 	/**
@@ -371,16 +427,16 @@ final class Accessibility_Statement_Page {
 	/**
 	 * Add post status to accessibility statement page.
 	 *
+	 * Core always passes an array and a WP_Post. Another plugin calling the
+	 * filter with something else gets it back untouched, rather than having
+	 * whatever earlier filters contributed replaced with an empty array.
+	 *
 	 * @param mixed $post_states The post states, normally an array.
 	 * @param mixed $post The post object, normally a WP_Post.
-	 * @return array The post states.
+	 * @return mixed The post states.
 	 */
-	public static function post_status( $post_states, $post = null ): array {
-		if ( ! is_array( $post_states ) ) {
-			$post_states = [];
-		}
-
-		if ( $post instanceof \WP_Post && $post->ID === self::get_page_id() ) {
+	public static function post_status( $post_states, $post = null ) {
+		if ( is_array( $post_states ) && $post instanceof \WP_Post && $post->ID === self::get_page_id() ) {
 			$post_states['accessibility_statement'] = __( 'Accessibility Statement', 'newspack-plugin' );
 		}
 		return $post_states;

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -335,7 +335,7 @@ class Content_Gate {
 			return;
 		}
 		// Never on Accessibility Statement page.
-		if ( $post->ID === get_theme_mod( 'accessibility_statement_page_id' ) ) {
+		if ( $post->ID === Accessibility_Statement_Page::get_page_id() ) {
 			return;
 		}
 

--- a/plugins/newspack-plugin/includes/wizards/class-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/class-wizard.php
@@ -225,7 +225,7 @@ abstract class Wizard {
 		wp_register_script(
 			'newspack-wizards',
 			Newspack::plugin_url() . '/dist/wizards.js',
-			$this->get_script_dependencies(),
+			$this->get_script_dependencies( [ 'wp-a11y' ] ),
 			Newspack::asset_version( 'wizards' ),
 			true
 		);

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.test.tsx
@@ -1,0 +1,43 @@
+// @jest-environment jsdom
+
+/**
+ * Internal dependencies
+ */
+import { isPage } from './accessibility-statement';
+
+type Response = Parameters< typeof isPage >[ 0 ];
+
+// The guard decides whether the wizard renders the page card or an empty state.
+// Throwing here rejects into the fetch hook's catch, which leaves the fetching
+// flag set and the Create button disabled with nothing on screen to explain it,
+// so it has to stay total for anything the endpoint could hand back.
+describe( 'isPage', () => {
+	it( 'accepts a page payload', () => {
+		expect(
+			isPage( {
+				editUrl: 'https://example.com/wp-admin/post.php?post=1&action=edit',
+				pageUrl: 'https://example.com/accessibility-statement/',
+				status: 'publish',
+				title: 'Accessibility Statement',
+			} )
+		).toBe( true );
+	} );
+
+	it( 'rejects a reason payload', () => {
+		expect( isPage( { reason: 'none' } ) ).toBe( false );
+		expect( isPage( { reason: 'missing' } ) ).toBe( false );
+	} );
+
+	it( 'accepts a page whose status happens to read like a reason', () => {
+		expect( isPage( { editUrl: null, pageUrl: false, status: 'none', title: 'Draft' } ) ).toBe( true );
+	} );
+
+	it( 'returns false rather than throwing on values the types rule out', () => {
+		const notResponses = [ undefined, null, '', 'missing', 0, 42, true ];
+
+		notResponses.forEach( value => {
+			expect( () => isPage( value as unknown as Response ) ).not.toThrow();
+			expect( isPage( value as unknown as Response ) ).toBe( false );
+		} );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
@@ -8,6 +8,7 @@
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 import { ExternalLink } from '@wordpress/components';
+import { speak } from '@wordpress/a11y';
 import { Button, Card, Notice, SectionHeader } from '../../../../../../packages/components/src';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
 
@@ -16,83 +17,93 @@ interface AccessibilityStatementProps {
 }
 
 type PageData = {
-	editUrl: string;
+	editUrl: string | null;
 	status: string;
-	pageUrl: string;
+	pageUrl: string | false;
+	title: string;
 };
 
+/**
+ * Where no page exists, the server says whether the site has never created one
+ * ( 'none' ) or created one that has since gone ( 'missing' ).
+ */
+type PageResponse = PageData | { status: 'none' | 'missing' };
+
+const isPage = ( response: PageResponse ): response is PageData =>
+	Boolean( response?.status ) && response.status !== 'none' && response.status !== 'missing';
+
 export default function AccessibilityStatement( { isFetching }: AccessibilityStatementProps ) {
-	const { wizardApiFetch } = useWizardApiFetch( 'newspack-settings/advanced-settings/accessibility-statement' );
+	const { wizardApiFetch, errorMessage, resetError } = useWizardApiFetch( 'newspack-settings/advanced-settings/accessibility-statement' );
 	const [ localIsFetching, setLocalIsFetching ] = useState( false );
 	const [ localPageData, setLocalPageData ] = useState< PageData | null >( null );
+	const [ isPageMissing, setIsPageMissing ] = useState( false );
 
-	// Function to fetch fresh data
-	const fetchFreshData = () => {
-		setLocalIsFetching( true );
-		wizardApiFetch(
-			{
-				path: `/newspack/v1/wizard/newspack-settings/accessibility-statement`,
-				method: 'GET',
-			},
-			{
-				onSuccess: response => {
-					if ( response && response.editUrl && response.status && response.status !== 'trash' ) {
-						setLocalPageData( response );
-					} else {
-						setLocalPageData( null );
-					}
-					setLocalIsFetching( false );
-				},
-				onError: () => {
-					setLocalPageData( null );
-					setLocalIsFetching( false );
-				},
-			}
-		);
+	const applyResponse = ( response: PageResponse, announce = false ) => {
+		// A retry that succeeds must clear the notice the failure left behind.
+		resetError();
+		if ( isPage( response ) ) {
+			setLocalPageData( response );
+			setIsPageMissing( false );
+		} else {
+			setLocalPageData( null );
+			setIsPageMissing( response?.status === 'missing' );
+		}
+		setLocalIsFetching( false );
+		if ( announce ) {
+			speak( __( 'Accessibility statement page created.', 'newspack-plugin' ) );
+		}
 	};
 
-	// Only fetch on mount
+	const handleError = ( error: { message?: string } ) => {
+		setLocalPageData( null );
+		setIsPageMissing( false );
+		setLocalIsFetching( false );
+		// The notice is a plain div, so nothing else announces the failure.
+		speak( error?.message ?? __( 'Something went wrong.', 'newspack-plugin' ), 'assertive' );
+	};
+
 	useEffect( () => {
-		if ( ! localPageData ) {
-			fetchFreshData();
-		}
+		setLocalIsFetching( true );
+		wizardApiFetch< PageResponse >(
+			{
+				path: '/newspack/v1/wizard/newspack-settings/accessibility-statement',
+				method: 'GET',
+			},
+			{ onSuccess: applyResponse, onError: handleError }
+		).catch( () => {} );
 	}, [] );
 
 	const createPage = () => {
 		setLocalIsFetching( true );
-		wizardApiFetch(
+		wizardApiFetch< PageResponse >(
 			{
 				path: '/newspack/v1/wizard/newspack-settings/accessibility-statement',
 				method: 'POST',
-				data: {
-					force_create: 'true', // Force creation of a new page
-				},
+				// The POST answers with the page, so it can refresh the cached
+				// GET rather than leaving a stale "no page" behind it.
+				updateCacheMethods: [ 'GET' ],
 			},
 			{
-				onSuccess: response => {
-					if ( response && response.editUrl && response.status ) {
-						setLocalPageData( response );
-					} else {
-						setLocalPageData( null );
-					}
-					fetchFreshData();
-				},
-				onError: () => {
-					setLocalPageData( null );
-					setLocalIsFetching( false );
-				},
+				onSuccess: response => applyResponse( response, true ),
+				onError: handleError,
 			}
-		);
+		).catch( () => {} );
 	};
 
 	const getStatusMessage = () => {
+		if ( errorMessage ) {
+			return { type: 'error', message: errorMessage };
+		}
+
 		if ( ! localPageData ) {
 			return {
 				type: 'warning',
-				message: __(
-					'Your accessibility statement page has been moved to trash or deleted. Click "Create Page" to create a new one.',
-					'newspack-plugin'
-				),
+				message: isPageMissing
+					? __(
+							'Your accessibility statement page has been moved to trash or deleted. Click "Create Page" to create a new one.',
+							'newspack-plugin'
+					  )
+					: __( 'You do not have an accessibility statement page yet. Click "Create Page" to add one.', 'newspack-plugin' ),
 			};
 		}
 
@@ -102,21 +113,11 @@ export default function AccessibilityStatement( { isFetching }: AccessibilitySta
 					type: 'success',
 					message: __( 'Your accessibility statement page is published.', 'newspack-plugin' ),
 				};
-			case 'draft':
-			case 'pending':
-				return {
-					type: 'warning',
-					message: __(
-						'Your accessibility statement page is not yet published. Please review and make edits before publishing.',
-						'newspack-plugin'
-					),
-				};
-			case 'trash':
 			default:
 				return {
 					type: 'warning',
 					message: __(
-						'Your accessibility statement page has been moved to trash. Click "Create Page" to create a new one.',
+						'Your accessibility statement page is not yet published. Please review and make edits before publishing.',
 						'newspack-plugin'
 					),
 				};
@@ -131,13 +132,27 @@ export default function AccessibilityStatement( { isFetching }: AccessibilitySta
 		switch ( localPageData.status ) {
 			case 'publish':
 				return __( 'Edit Page', 'newspack-plugin' );
-			case 'draft':
-			case 'pending':
-				return __( 'Edit and Publish Page', 'newspack-plugin' );
-			case 'trash':
 			default:
-				return __( 'Create Page', 'newspack-plugin' );
+				return __( 'Edit and Publish Page', 'newspack-plugin' );
 		}
+	};
+
+	// A page the user cannot edit has no edit URL, and Create would only hand
+	// back the page they already cannot open.
+	const renderAction = () => {
+		if ( localPageData ) {
+			return localPageData.editUrl ? (
+				<Button variant="secondary" isSmall href={ localPageData.editUrl }>
+					{ getButtonText() }
+				</Button>
+			) : null;
+		}
+
+		return (
+			<Button variant="secondary" isSmall onClick={ createPage } disabled={ isFetching || localIsFetching }>
+				{ getButtonText() }
+			</Button>
+		);
 	};
 
 	const statusInfo = getStatusMessage();
@@ -153,18 +168,15 @@ export default function AccessibilityStatement( { isFetching }: AccessibilitySta
 						'newspack-plugin'
 					) }
 				/>
-				{ localPageData && localPageData.status !== 'trash' ? (
-					<Button variant="secondary" isSmall href={ localPageData.editUrl }>
-						{ getButtonText() }
-					</Button>
-				) : (
-					<Button variant="secondary" isSmall onClick={ createPage } disabled={ isFetching || localIsFetching }>
-						{ getButtonText() }
-					</Button>
-				) }
+				{ renderAction() }
 			</Card>
 
-			<Notice isSuccess={ statusInfo.type === 'success' } isWarning={ statusInfo.type === 'warning' } noticeText={ statusInfo.message } />
+			<Notice
+				isError={ statusInfo.type === 'error' }
+				isSuccess={ statusInfo.type === 'success' }
+				isWarning={ statusInfo.type === 'warning' }
+				noticeText={ statusInfo.message }
+			/>
 
 			<p>
 				{ __(

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
@@ -31,7 +31,7 @@ type PageData = {
  */
 type PageResponse = PageData | { reason: 'none' | 'missing' };
 
-const isPage = ( response: PageResponse ): response is PageData => Boolean( response ) && ! ( 'reason' in response );
+const isPage = ( response: PageResponse ): response is PageData => typeof response === 'object' && response !== null && ! ( 'reason' in response );
 
 export default function AccessibilityStatement( { isFetching }: AccessibilityStatementProps ) {
 	const { wizardApiFetch, errorMessage, resetError } = useWizardApiFetch( 'newspack-settings/advanced-settings/accessibility-statement' );

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 import { ExternalLink } from '@wordpress/components';
 import { speak } from '@wordpress/a11y';
+import { decodeEntities } from '@wordpress/html-entities';
 import { Button, Card, Notice, SectionHeader } from '../../../../../../packages/components/src';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
 
@@ -24,13 +25,13 @@ type PageData = {
 };
 
 /**
- * Where no page exists, the server says whether the site has never created one
- * ( 'none' ) or created one that has since gone ( 'missing' ).
+ * Where no page exists, the server sends a reason in place of the page: whether
+ * the site has never created one ( 'none' ) or created one that has since gone
+ * ( 'missing' ).
  */
-type PageResponse = PageData | { status: 'none' | 'missing' };
+type PageResponse = PageData | { reason: 'none' | 'missing' };
 
-const isPage = ( response: PageResponse ): response is PageData =>
-	Boolean( response?.status ) && response.status !== 'none' && response.status !== 'missing';
+const isPage = ( response: PageResponse ): response is PageData => Boolean( response ) && ! ( 'reason' in response );
 
 export default function AccessibilityStatement( { isFetching }: AccessibilityStatementProps ) {
 	const { wizardApiFetch, errorMessage, resetError } = useWizardApiFetch( 'newspack-settings/advanced-settings/accessibility-statement' );
@@ -46,7 +47,7 @@ export default function AccessibilityStatement( { isFetching }: AccessibilitySta
 			setIsPageMissing( false );
 		} else {
 			setLocalPageData( null );
-			setIsPageMissing( response?.status === 'missing' );
+			setIsPageMissing( response?.reason === 'missing' );
 		}
 		setLocalIsFetching( false );
 		if ( announce ) {
@@ -58,8 +59,9 @@ export default function AccessibilityStatement( { isFetching }: AccessibilitySta
 		setLocalPageData( null );
 		setIsPageMissing( false );
 		setLocalIsFetching( false );
-		// The notice is a plain div, so nothing else announces the failure.
-		speak( error?.message ?? __( 'Something went wrong.', 'newspack-plugin' ), 'assertive' );
+		// The notice is a plain div, so nothing else announces the failure. It
+		// renders the message decoded, so announce the decoded text too.
+		speak( decodeEntities( error?.message ?? __( 'Something went wrong.', 'newspack-plugin' ) ), 'assertive' );
 	};
 
 	useEffect( () => {

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
@@ -31,7 +31,8 @@ type PageData = {
  */
 type PageResponse = PageData | { reason: 'none' | 'missing' };
 
-const isPage = ( response: PageResponse ): response is PageData => typeof response === 'object' && response !== null && ! ( 'reason' in response );
+export const isPage = ( response: PageResponse ): response is PageData =>
+	typeof response === 'object' && response !== null && ! ( 'reason' in response );
 
 export default function AccessibilityStatement( { isFetching }: AccessibilityStatementProps ) {
 	const { wizardApiFetch, errorMessage, resetError } = useWizardApiFetch( 'newspack-settings/advanced-settings/accessibility-statement' );

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/theme-mods.d.ts
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/theme-mods.d.ts
@@ -126,13 +126,6 @@ interface AdvancedSettings {
 	newspack_image_credits_placeholder: number | null;
 	newspack_image_credits_auto_populate: boolean;
 
-	// Accessibility Statement.
-	accessibility_statement_page?: {
-		editUrl: string;
-		status: string;
-		pageUrl: string;
-	};
-
 	// Post Date.
 	post_time_ago: boolean;
 	post_time_ago_cut_off: number;

--- a/plugins/newspack-plugin/tests/unit-tests/accessibility-statement-page.php
+++ b/plugins/newspack-plugin/tests/unit-tests/accessibility-statement-page.php
@@ -1,0 +1,578 @@
+<?php
+/**
+ * Test_Accessibility_Statement_Page class.
+ *
+ * @package Newspack
+ */
+
+use Newspack\Accessibility_Statement_Page;
+
+/**
+ * Class Test_Accessibility_Statement_Page
+ *
+ * @group accessibility-statement
+ */
+class Test_Accessibility_Statement_Page extends WP_UnitTestCase {
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		delete_option( Accessibility_Statement_Page::OPTION_NAME );
+		delete_option( Accessibility_Statement_Page::MIGRATION_FLAG );
+		remove_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD );
+	}
+
+	/**
+	 * Count every accessibility statement page on the site, trash included.
+	 *
+	 * `post_status => any` omits statuses flagged as internal, and trash is one
+	 * of them, so the statuses are listed out.
+	 *
+	 * @return int
+	 */
+	private function count_pages() {
+		return count(
+			get_posts(
+				[
+					'post_type'      => 'page',
+					'post_status'    => array_keys( get_post_stati() ),
+					'posts_per_page' => 100,
+					'title'          => 'Accessibility Statement',
+					'fields'         => 'ids',
+				]
+			)
+		);
+	}
+
+	/**
+	 * Make a page that stands in for one a site created before this upgrade.
+	 *
+	 * @param string $status Post status.
+	 * @return int The page ID.
+	 */
+	private function make_page( $status = 'draft' ) {
+		return $this->factory()->post->create(
+			[
+				'post_type'   => 'page',
+				'post_status' => $status,
+				'post_title'  => 'Accessibility Statement',
+			]
+		);
+	}
+
+	/**
+	 * The stylesheet of a theme that is installed but not active.
+	 *
+	 * @return string
+	 */
+	private function inactive_stylesheet() {
+		$inactive = array_values( array_diff( array_keys( wp_get_themes() ), [ get_stylesheet() ] ) );
+		$this->assertNotEmpty( $inactive, 'Needs a second installed theme to test against.' );
+
+		return $inactive[0];
+	}
+
+	/**
+	 * Reading the page must never write one. This is the front-end footer's
+	 * entry point, so a write here runs on every render, for logged-out
+	 * visitors included.
+	 */
+	public function test_get_page_does_not_create_anything() {
+		$before = $this->count_pages();
+
+		$this->assertFalse( Accessibility_Statement_Page::get_page() );
+		$this->assertSame( $before, $this->count_pages() );
+	}
+
+	/**
+	 * Repeated reads must stay free of side effects.
+	 */
+	public function test_repeated_reads_create_nothing() {
+		$before = $this->count_pages();
+
+		for ( $i = 0; $i < 5; $i++ ) {
+			Accessibility_Statement_Page::get_page();
+		}
+
+		$this->assertSame( $before, $this->count_pages() );
+	}
+
+	/**
+	 * A stored page is returned with the fields the wizard and theme read.
+	 */
+	public function test_get_page_returns_the_stored_page() {
+		$created = Accessibility_Statement_Page::create_page();
+		$page    = Accessibility_Statement_Page::get_page();
+
+		$this->assertIsArray( $page );
+		$this->assertSame( 'draft', $page['status'] );
+		$this->assertSame( $created['editUrl'], $page['editUrl'] );
+		$this->assertNotEmpty( $page['pageUrl'] );
+		$this->assertSame( 'Accessibility Statement', $page['title'] );
+	}
+
+	/**
+	 * A trashed page reads as absent, and reading it still writes nothing.
+	 */
+	public function test_get_page_returns_false_when_the_stored_page_is_trashed() {
+		Accessibility_Statement_Page::create_page();
+		wp_trash_post( get_option( Accessibility_Statement_Page::OPTION_NAME ) );
+
+		$before = $this->count_pages();
+
+		$this->assertFalse( Accessibility_Statement_Page::get_page() );
+		$this->assertSame( $before, $this->count_pages() );
+	}
+
+	/**
+	 * Creating stores the pointer and yields exactly one draft.
+	 */
+	public function test_create_page_creates_a_single_draft() {
+		$before = $this->count_pages();
+		$result = Accessibility_Statement_Page::create_page();
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'draft', $result['status'] );
+		$this->assertSame( $before + 1, $this->count_pages() );
+
+		$page_id = get_option( Accessibility_Statement_Page::OPTION_NAME );
+		$this->assertSame( 'page', get_post_type( $page_id ) );
+		$this->assertNotEmpty( get_post( $page_id )->post_content );
+	}
+
+	/**
+	 * A second create hands back the page that already exists, rather than
+	 * adding another.
+	 */
+	public function test_create_page_returns_the_existing_page_instead_of_a_duplicate() {
+		$first  = Accessibility_Statement_Page::create_page();
+		$before = $this->count_pages();
+		$second = Accessibility_Statement_Page::create_page();
+
+		$this->assertSame( $first['editUrl'], $second['editUrl'] );
+		$this->assertSame( $before, $this->count_pages() );
+	}
+
+	/**
+	 * A published page is equally protected from being replaced.
+	 */
+	public function test_create_page_does_not_replace_a_published_page() {
+		Accessibility_Statement_Page::create_page();
+		$page_id = get_option( Accessibility_Statement_Page::OPTION_NAME );
+		wp_update_post(
+			[
+				'ID'          => $page_id,
+				'post_status' => 'publish',
+			]
+		);
+
+		$before = $this->count_pages();
+		$result = Accessibility_Statement_Page::create_page();
+
+		$this->assertSame( $before, $this->count_pages() );
+		$this->assertSame( 'publish', $result['status'] );
+		$this->assertSame( $page_id, get_option( Accessibility_Statement_Page::OPTION_NAME ) );
+	}
+
+	/**
+	 * Once the stored page is gone, creating gives the site a fresh one, and
+	 * the trashed original stays where the publisher left it.
+	 */
+	public function test_create_page_replaces_a_trashed_page() {
+		Accessibility_Statement_Page::create_page();
+		$trashed_id = get_option( Accessibility_Statement_Page::OPTION_NAME );
+		wp_trash_post( $trashed_id );
+
+		$before = $this->count_pages();
+		$result = Accessibility_Statement_Page::create_page();
+		$new_id = get_option( Accessibility_Statement_Page::OPTION_NAME );
+
+		$this->assertIsArray( $result );
+		$this->assertNotEquals( $trashed_id, $new_id );
+		$this->assertSame( 'draft', get_post_status( $new_id ) );
+		$this->assertSame( 'trash', get_post_status( $trashed_id ) );
+		$this->assertSame( $before + 1, $this->count_pages() );
+	}
+
+	/**
+	 * The pointer is site-wide, so changing theme or style variation keeps it.
+	 */
+	public function test_the_stored_page_survives_a_theme_switch() {
+		$created = Accessibility_Statement_Page::create_page();
+		$before  = $this->count_pages();
+
+		switch_theme( $this->inactive_stylesheet() );
+
+		$page = Accessibility_Statement_Page::get_page();
+
+		$this->assertIsArray( $page );
+		$this->assertSame( $created['editUrl'], $page['editUrl'] );
+		$this->assertSame( $before, $this->count_pages() );
+	}
+
+	/**
+	 * Before the upgrade has run, the page is still found through the theme
+	 * mod. Without this, a site loses its footer link and its content-gate
+	 * exemption for the whole window between updating and the next admin request.
+	 */
+	public function test_the_legacy_theme_mod_is_read_before_migration_runs() {
+		$page_id = $this->make_page( 'publish' );
+		set_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD, $page_id );
+
+		$this->assertSame( $page_id, Accessibility_Statement_Page::get_page_id() );
+
+		$page = Accessibility_Statement_Page::get_page();
+		$this->assertIsArray( $page );
+		$this->assertSame( 'publish', $page['status'] );
+	}
+
+	/**
+	 * The ID the content gate compares against is an integer, so its strict
+	 * comparison with a post ID holds.
+	 */
+	public function test_the_stored_id_is_an_integer_for_the_content_gate() {
+		$page_id = $this->make_page();
+		set_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD, (string) $page_id );
+		Accessibility_Statement_Page::migrate_legacy_theme_mod();
+
+		$stored = Accessibility_Statement_Page::get_page_id();
+
+		$this->assertIsInt( $stored );
+		$this->assertTrue( get_post( $page_id )->ID === $stored );
+	}
+
+	/**
+	 * Sites that stored the pointer as a theme mod keep their existing page.
+	 * The legacy mod is deliberately left in place, so rolling the plugin back
+	 * finds the page where the old code looks for it.
+	 */
+	public function test_a_legacy_theme_mod_is_adopted() {
+		$page_id = $this->make_page();
+		set_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD, $page_id );
+
+		$before = $this->count_pages();
+		Accessibility_Statement_Page::migrate_legacy_theme_mod();
+
+		$this->assertSame( $page_id, (int) get_option( Accessibility_Statement_Page::OPTION_NAME ) );
+		$this->assertSame( $page_id, (int) get_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD ) );
+		$this->assertSame( $before, $this->count_pages() );
+
+		$page = Accessibility_Statement_Page::get_page();
+		$this->assertIsArray( $page );
+		$this->assertSame( get_permalink( $page_id ), $page['pageUrl'] );
+	}
+
+	/**
+	 * A site that switched theme after creating its page left the ID behind in
+	 * the mods of the theme it was using at the time, so migration has to look
+	 * past the active theme to find it.
+	 */
+	public function test_a_theme_mod_from_an_inactive_theme_is_adopted() {
+		$page_id  = $this->make_page();
+		$inactive = $this->inactive_stylesheet();
+
+		update_option(
+			'theme_mods_' . $inactive,
+			[ Accessibility_Statement_Page::LEGACY_THEME_MOD => $page_id ]
+		);
+
+		$before = $this->count_pages();
+		Accessibility_Statement_Page::migrate_legacy_theme_mod();
+
+		$this->assertSame( $page_id, Accessibility_Statement_Page::get_page_id() );
+		$this->assertSame( $before, $this->count_pages() );
+
+		delete_option( 'theme_mods_' . $inactive );
+	}
+
+	/**
+	 * Where a site accumulated duplicates across themes, the published page is
+	 * the statement the publisher actually maintains.
+	 */
+	public function test_a_published_candidate_wins_over_a_draft() {
+		$draft     = $this->make_page();
+		$published = $this->make_page( 'publish' );
+		$inactive  = $this->inactive_stylesheet();
+
+		set_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD, $draft );
+		update_option(
+			'theme_mods_' . $inactive,
+			[ Accessibility_Statement_Page::LEGACY_THEME_MOD => $published ]
+		);
+
+		Accessibility_Statement_Page::migrate_legacy_theme_mod();
+
+		$this->assertSame( $published, Accessibility_Statement_Page::get_page_id() );
+
+		delete_option( 'theme_mods_' . $inactive );
+	}
+
+	/**
+	 * A theme mod pointing at a trashed page is skipped, and the scan carries
+	 * on to the other themes rather than giving up.
+	 */
+	public function test_a_trashed_candidate_falls_through_to_another_theme() {
+		$trashed  = $this->make_page();
+		$usable   = $this->make_page();
+		$inactive = $this->inactive_stylesheet();
+		wp_trash_post( $trashed );
+
+		set_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD, $trashed );
+		update_option(
+			'theme_mods_' . $inactive,
+			[ Accessibility_Statement_Page::LEGACY_THEME_MOD => $usable ]
+		);
+
+		Accessibility_Statement_Page::migrate_legacy_theme_mod();
+
+		$this->assertSame( $usable, Accessibility_Statement_Page::get_page_id() );
+
+		delete_option( 'theme_mods_' . $inactive );
+	}
+
+	/**
+	 * Deleting a theme leaves its mods stranded in the options table, where an
+	 * installed-theme scan cannot reach them. Reading the options table directly
+	 * still finds the page, so the publisher is not invited to duplicate it.
+	 */
+	public function test_a_theme_mod_from_a_deleted_theme_is_adopted() {
+		$page_id = $this->make_page( 'publish' );
+		update_option(
+			'theme_mods_a-theme-that-is-no-longer-installed',
+			[ Accessibility_Statement_Page::LEGACY_THEME_MOD => $page_id ]
+		);
+
+		$before = $this->count_pages();
+		Accessibility_Statement_Page::migrate_legacy_theme_mod();
+
+		$this->assertSame( $page_id, Accessibility_Statement_Page::get_page_id() );
+		$this->assertSame( $before, $this->count_pages() );
+
+		delete_option( 'theme_mods_a-theme-that-is-no-longer-installed' );
+	}
+
+	/**
+	 * A site with no pointer anywhere must not adopt an unrelated page that
+	 * happens to sit at the reserved slug.
+	 */
+	public function test_an_unrelated_page_at_the_slug_is_not_adopted() {
+		$this->factory()->post->create(
+			[
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Our accessibility commitments',
+				'post_name'   => Accessibility_Statement_Page::PAGE_SLUG,
+			]
+		);
+
+		Accessibility_Statement_Page::migrate_legacy_theme_mod();
+
+		$this->assertSame( 0, Accessibility_Statement_Page::get_page_id() );
+		$this->assertFalse( Accessibility_Statement_Page::get_page() );
+	}
+
+	/**
+	 * A page sitting in the trash when the upgrade runs keeps its pointer, so
+	 * restoring it brings the link back instead of the site being told it never
+	 * had a page and invited to create a second one.
+	 */
+	public function test_a_trashed_page_keeps_its_pointer_through_migration() {
+		$page_id = $this->make_page( 'publish' );
+		set_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD, $page_id );
+		wp_trash_post( $page_id );
+
+		$before = $this->count_pages();
+		Accessibility_Statement_Page::migrate_legacy_theme_mod();
+
+		$this->assertSame( $page_id, Accessibility_Statement_Page::get_page_id() );
+		$this->assertFalse( Accessibility_Statement_Page::get_page() );
+		$this->assertSame( 'missing', Accessibility_Statement_Page::api_get_page()->get_data()['status'] );
+
+		wp_untrash_post( $page_id );
+		wp_update_post(
+			[
+				'ID'          => $page_id,
+				'post_status' => 'publish',
+			]
+		);
+
+		$page = Accessibility_Statement_Page::get_page();
+		$this->assertIsArray( $page );
+		$this->assertSame( 'publish', $page['status'] );
+		$this->assertSame( $before, $this->count_pages() );
+	}
+
+	/**
+	 * Creating leaves the legacy pointer behind too, so a plugin rolled back to
+	 * before this change finds the page instead of making another.
+	 */
+	public function test_create_page_leaves_a_rollback_breadcrumb() {
+		$result = Accessibility_Statement_Page::create_page();
+
+		$this->assertIsArray( $result );
+		$this->assertSame(
+			(int) get_option( Accessibility_Statement_Page::OPTION_NAME ),
+			(int) get_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD )
+		);
+	}
+
+	/**
+	 * A theme mod pointing at a page that no longer exists is not adopted, and
+	 * is cleared: get_post() does not cache a miss, so leaving it would send
+	 * every render, gate check and list-table row back to the database.
+	 */
+	public function test_a_theme_mod_pointing_at_a_deleted_page_is_ignored() {
+		set_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD, 999999 );
+
+		$before = $this->count_pages();
+		Accessibility_Statement_Page::migrate_legacy_theme_mod();
+
+		$this->assertSame( 0, Accessibility_Statement_Page::get_page_id() );
+		$this->assertFalse( get_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD ) );
+		$this->assertSame( $before, $this->count_pages() );
+	}
+
+	/**
+	 * A page that still exists beats a stored pointer that no longer resolves,
+	 * which is the state a rollback leaves behind when the publisher deleted
+	 * the original and the older plugin made a replacement.
+	 */
+	public function test_a_live_legacy_page_beats_a_stored_pointer_that_is_gone() {
+		$deleted     = $this->make_page();
+		$replacement = $this->make_page( 'publish' );
+		update_option( Accessibility_Statement_Page::OPTION_NAME, $deleted );
+		wp_delete_post( $deleted, true );
+		set_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD, $replacement );
+
+		$this->assertSame( $replacement, Accessibility_Statement_Page::get_page_id() );
+
+		$page = Accessibility_Statement_Page::get_page();
+		$this->assertIsArray( $page );
+		$this->assertSame( 'publish', $page['status'] );
+	}
+
+	/**
+	 * The post-state filter tolerates a caller that passes something other than
+	 * a post object, rather than fatalling the posts list screen.
+	 */
+	public function test_post_state_tolerates_an_unexpected_argument() {
+		Accessibility_Statement_Page::create_page();
+
+		$this->assertSame( [], Accessibility_Statement_Page::post_status( [], 123 ) );
+		$this->assertSame( [], Accessibility_Statement_Page::post_status( null, null ) );
+	}
+
+	/**
+	 * Migration must not overwrite a pointer the site already has.
+	 */
+	public function test_migration_leaves_an_existing_pointer_alone() {
+		Accessibility_Statement_Page::create_page();
+		$page_id = (int) get_option( Accessibility_Statement_Page::OPTION_NAME );
+		set_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD, 999999 );
+
+		Accessibility_Statement_Page::migrate_legacy_theme_mod();
+
+		$this->assertSame( $page_id, (int) get_option( Accessibility_Statement_Page::OPTION_NAME ) );
+	}
+
+	/**
+	 * Rolling the plugin back and forward again leaves a pointer on the active
+	 * theme. It is adopted rather than ignored, or the wizard would offer to
+	 * create a second page beside the one the rollback just made.
+	 */
+	public function test_a_pointer_written_after_migration_is_adopted() {
+		Accessibility_Statement_Page::migrate_legacy_theme_mod();
+		$this->assertSame( 0, Accessibility_Statement_Page::get_page_id() );
+
+		$page_id = $this->make_page( 'publish' );
+		set_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD, $page_id );
+
+		$this->assertSame( $page_id, Accessibility_Statement_Page::get_page_id() );
+
+		Accessibility_Statement_Page::migrate_legacy_theme_mod();
+		$this->assertSame( $page_id, (int) get_option( Accessibility_Statement_Page::OPTION_NAME ) );
+	}
+
+	/**
+	 * A pointer left behind for a page that has since been deleted is still
+	 * ignored, so the site is not left claiming a page it does not have.
+	 */
+	public function test_a_pointer_at_a_deleted_page_stays_ignored_after_migration() {
+		Accessibility_Statement_Page::migrate_legacy_theme_mod();
+		set_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD, 999999 );
+
+		$this->assertSame( 0, Accessibility_Statement_Page::get_page_id() );
+		$this->assertFalse( Accessibility_Statement_Page::get_page() );
+	}
+
+	/**
+	 * The completion flag is recorded even when there was nothing to adopt, and
+	 * is autoloaded so the debug reset sweeps it along with the pointer.
+	 */
+	public function test_the_migration_flag_is_recorded_and_autoloaded() {
+		Accessibility_Statement_Page::migrate_legacy_theme_mod();
+
+		$this->assertNotFalse( get_option( Accessibility_Statement_Page::MIGRATION_FLAG ) );
+		$this->assertArrayHasKey(
+			Accessibility_Statement_Page::MIGRATION_FLAG,
+			wp_load_alloptions()
+		);
+	}
+
+	/**
+	 * Adopting a page from an inactive theme leaves the breadcrumb on the
+	 * active one, where a rolled-back plugin looks for it.
+	 */
+	public function test_migration_leaves_a_rollback_breadcrumb() {
+		$page_id  = $this->make_page( 'publish' );
+		$inactive = $this->inactive_stylesheet();
+		update_option(
+			'theme_mods_' . $inactive,
+			[ Accessibility_Statement_Page::LEGACY_THEME_MOD => $page_id ]
+		);
+
+		Accessibility_Statement_Page::migrate_legacy_theme_mod();
+
+		$this->assertSame( $page_id, (int) get_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD ) );
+
+		delete_option( 'theme_mods_' . $inactive );
+	}
+
+	/**
+	 * The wizard needs to tell a site that never had a page from one whose page
+	 * was deleted, because the two need different copy.
+	 */
+	public function test_api_response_separates_never_created_from_deleted() {
+		$never = Accessibility_Statement_Page::api_get_page();
+		$this->assertSame( 'none', $never->get_data()['status'] );
+
+		Accessibility_Statement_Page::create_page();
+		wp_delete_post( get_option( Accessibility_Statement_Page::OPTION_NAME ), true );
+
+		$deleted = Accessibility_Statement_Page::api_get_page();
+		$this->assertSame( 'missing', $deleted->get_data()['status'] );
+	}
+
+	/**
+	 * The admin list marks the page the site actually uses.
+	 */
+	public function test_post_state_marks_the_stored_page() {
+		Accessibility_Statement_Page::create_page();
+		$page_id = (int) get_option( Accessibility_Statement_Page::OPTION_NAME );
+		$other   = $this->factory()->post->create( [ 'post_type' => 'page' ] );
+
+		$this->assertArrayHasKey(
+			'accessibility_statement',
+			Accessibility_Statement_Page::post_status( [], get_post( $page_id ) )
+		);
+		$this->assertArrayNotHasKey(
+			'accessibility_statement',
+			Accessibility_Statement_Page::post_status( [], get_post( $other ) )
+		);
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/accessibility-statement-page.php
+++ b/plugins/newspack-plugin/tests/unit-tests/accessibility-statement-page.php
@@ -90,19 +90,6 @@ class Test_Accessibility_Statement_Page extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Repeated reads must stay free of side effects.
-	 */
-	public function test_repeated_reads_create_nothing() {
-		$before = $this->count_pages();
-
-		for ( $i = 0; $i < 5; $i++ ) {
-			Accessibility_Statement_Page::get_page();
-		}
-
-		$this->assertSame( $before, $this->count_pages() );
-	}
-
-	/**
 	 * A stored page is returned with the fields the wizard and theme read.
 	 */
 	public function test_get_page_returns_the_stored_page() {
@@ -232,21 +219,6 @@ class Test_Accessibility_Statement_Page extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The ID the content gate compares against is an integer, so its strict
-	 * comparison with a post ID holds.
-	 */
-	public function test_the_stored_id_is_an_integer_for_the_content_gate() {
-		$page_id = $this->make_page();
-		set_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD, (string) $page_id );
-		Accessibility_Statement_Page::migrate_legacy_theme_mod();
-
-		$stored = Accessibility_Statement_Page::get_page_id();
-
-		$this->assertIsInt( $stored );
-		$this->assertTrue( get_post( $page_id )->ID === $stored );
-	}
-
-	/**
 	 * Sites that stored the pointer as a theme mod keep their existing page.
 	 * The legacy mod is deliberately left in place, so rolling the plugin back
 	 * finds the page where the old code looks for it.
@@ -265,29 +237,6 @@ class Test_Accessibility_Statement_Page extends WP_UnitTestCase {
 		$page = Accessibility_Statement_Page::get_page();
 		$this->assertIsArray( $page );
 		$this->assertSame( get_permalink( $page_id ), $page['pageUrl'] );
-	}
-
-	/**
-	 * A site that switched theme after creating its page left the ID behind in
-	 * the mods of the theme it was using at the time, so migration has to look
-	 * past the active theme to find it.
-	 */
-	public function test_a_theme_mod_from_an_inactive_theme_is_adopted() {
-		$page_id  = $this->make_page();
-		$inactive = $this->inactive_stylesheet();
-
-		update_option(
-			'theme_mods_' . $inactive,
-			[ Accessibility_Statement_Page::LEGACY_THEME_MOD => $page_id ]
-		);
-
-		$before = $this->count_pages();
-		Accessibility_Statement_Page::migrate_legacy_theme_mod();
-
-		$this->assertSame( $page_id, Accessibility_Statement_Page::get_page_id() );
-		$this->assertSame( $before, $this->count_pages() );
-
-		delete_option( 'theme_mods_' . $inactive );
 	}
 
 	/**
@@ -391,7 +340,7 @@ class Test_Accessibility_Statement_Page extends WP_UnitTestCase {
 
 		$this->assertSame( $page_id, Accessibility_Statement_Page::get_page_id() );
 		$this->assertFalse( Accessibility_Statement_Page::get_page() );
-		$this->assertSame( 'missing', Accessibility_Statement_Page::api_get_page()->get_data()['status'] );
+		$this->assertSame( 'missing', Accessibility_Statement_Page::api_get_page()->get_data()['reason'] );
 
 		wp_untrash_post( $page_id );
 		wp_update_post(
@@ -457,14 +406,16 @@ class Test_Accessibility_Statement_Page extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The post-state filter tolerates a caller that passes something other than
-	 * a post object, rather than fatalling the posts list screen.
+	 * A caller passing something other than an array gets it back untouched,
+	 * so another plugin's misuse of the filter costs it the states it had
+	 * collected rather than fatalling the posts list screen.
 	 */
-	public function test_post_state_tolerates_an_unexpected_argument() {
+	public function test_post_state_leaves_an_unexpected_argument_alone() {
 		Accessibility_Statement_Page::create_page();
 
 		$this->assertSame( [], Accessibility_Statement_Page::post_status( [], 123 ) );
-		$this->assertSame( [], Accessibility_Statement_Page::post_status( null, null ) );
+		$this->assertSame( 'sticky', Accessibility_Statement_Page::post_status( 'sticky', null ) );
+		$this->assertNull( Accessibility_Statement_Page::post_status( null, null ) );
 	}
 
 	/**
@@ -549,13 +500,40 @@ class Test_Accessibility_Statement_Page extends WP_UnitTestCase {
 	 */
 	public function test_api_response_separates_never_created_from_deleted() {
 		$never = Accessibility_Statement_Page::api_get_page();
-		$this->assertSame( 'none', $never->get_data()['status'] );
+		$this->assertSame( 'none', $never->get_data()['reason'] );
 
 		Accessibility_Statement_Page::create_page();
 		wp_delete_post( get_option( Accessibility_Statement_Page::OPTION_NAME ), true );
 
 		$deleted = Accessibility_Statement_Page::api_get_page();
-		$this->assertSame( 'missing', $deleted->get_data()['status'] );
+		$this->assertSame( 'missing', $deleted->get_data()['reason'] );
+		$this->assertArrayNotHasKey( 'status', $deleted->get_data() );
+	}
+
+	/**
+	 * Only a user who could create the page pays for the scan and its writes.
+	 * Every logged-in reader reaches admin_init through their profile screen,
+	 * and this change exists to keep reader-facing requests read-only.
+	 */
+	public function test_migration_waits_for_a_user_who_could_create_the_page() {
+		$page_id = $this->make_page( 'publish' );
+		set_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD, $page_id );
+
+		foreach ( [ 0, $this->factory()->user->create( [ 'role' => 'subscriber' ] ) ] as $user_id ) {
+			wp_set_current_user( $user_id );
+			Accessibility_Statement_Page::migrate_legacy_theme_mod();
+
+			$this->assertFalse( get_option( Accessibility_Statement_Page::OPTION_NAME ) );
+			$this->assertFalse( get_option( Accessibility_Statement_Page::MIGRATION_FLAG ) );
+		}
+
+		// The page is still found meanwhile, through the legacy theme mod.
+		$this->assertSame( $page_id, Accessibility_Statement_Page::get_page_id() );
+
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		Accessibility_Statement_Page::migrate_legacy_theme_mod();
+
+		$this->assertSame( $page_id, (int) get_option( Accessibility_Statement_Page::OPTION_NAME ) );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/accessibility-statement-page.php
+++ b/plugins/newspack-plugin/tests/unit-tests/accessibility-statement-page.php
@@ -406,9 +406,10 @@ class Test_Accessibility_Statement_Page extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A caller passing something other than an array gets it back untouched,
-	 * so another plugin's misuse of the filter costs it the states it had
-	 * collected rather than fatalling the posts list screen.
+	 * Core always passes an array. A caller that passes something else gets it
+	 * back untouched, so this filter is not what drops whatever earlier filters
+	 * had collected. Core still fatals on count() further down, which is where
+	 * that caller's bug belongs.
 	 */
 	public function test_post_state_leaves_an_unexpected_argument_alone() {
 		Accessibility_Statement_Page::create_page();
@@ -534,6 +535,22 @@ class Test_Accessibility_Statement_Page extends WP_UnitTestCase {
 		Accessibility_Statement_Page::migrate_legacy_theme_mod();
 
 		$this->assertSame( $page_id, (int) get_option( Accessibility_Statement_Page::OPTION_NAME ) );
+	}
+
+	/**
+	 * A pointer row left holding a falsy value still gets adopted. The guard
+	 * before the scan reads it as "no pointer", so the write afterwards has to
+	 * agree, or the flag is recorded and the site can never adopt at all.
+	 */
+	public function test_a_falsy_stored_pointer_does_not_block_adoption() {
+		$page_id = $this->make_page( 'publish' );
+		update_option( Accessibility_Statement_Page::OPTION_NAME, 0 );
+		set_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD, $page_id );
+
+		Accessibility_Statement_Page::migrate_legacy_theme_mod();
+
+		$this->assertSame( $page_id, (int) get_option( Accessibility_Statement_Page::OPTION_NAME ) );
+		$this->assertSame( $page_id, Accessibility_Statement_Page::get_page_id() );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/accessibility-statement-page.php
+++ b/plugins/newspack-plugin/tests/unit-tests/accessibility-statement-page.php
@@ -554,6 +554,42 @@ class Test_Accessibility_Statement_Page extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A pointer stored while the scan was running wins. The decision to write is
+	 * made before the scan starts, so a create_page() landing in that gap would
+	 * otherwise be sent back to the older page, and the rollback breadcrumb with
+	 * it. This is the branch the cache deletes in store_page_id() exist for.
+	 */
+	public function test_a_pointer_stored_during_the_scan_is_not_overwritten() {
+		global $wpdb;
+
+		$legacy     = $this->make_page();
+		$concurrent = $this->make_page( 'publish' );
+		set_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD, $legacy );
+
+		// Fires part-way through the scan. Writing straight to the table leaves
+		// this request's cached miss in place, exactly as another process would.
+		$store_competing_pointer = function ( $mods ) use ( $wpdb, $concurrent ) {
+			$wpdb->replace( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+				$wpdb->options,
+				[
+					'option_name'  => Accessibility_Statement_Page::OPTION_NAME,
+					'option_value' => $concurrent,
+					'autoload'     => 'on',
+				]
+			);
+			return $mods;
+		};
+
+		$filter = 'option_theme_mods_' . get_stylesheet();
+		add_filter( $filter, $store_competing_pointer );
+		Accessibility_Statement_Page::migrate_legacy_theme_mod();
+		remove_filter( $filter, $store_competing_pointer );
+
+		$this->assertSame( $concurrent, (int) get_option( Accessibility_Statement_Page::OPTION_NAME ) );
+		$this->assertSame( $concurrent, (int) get_theme_mod( Accessibility_Statement_Page::LEGACY_THEME_MOD ) );
+	}
+
+	/**
 	 * The admin list marks the page the site actually uses.
 	 */
 	public function test_post_state_marks_the_stored_page() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Reading the accessibility statement page created one. `get_page()` made a draft whenever no page ID was stored, and the classic theme footer calls it on every front-end render, so ordinary visits and 404s minted pages. The ID also lived in a theme mod, which every theme and style variation keeps its own copy of, so each switch started the count again. Sites ended up with a pile of identical drafts nobody asked for.

**Reading is now a pure lookup.** Creation happens only on the explicit POST, and hands back the existing page instead of a second one. The ID moved to a site-wide option, adopted on upgrade from whatever a theme mod was holding, including a theme that has since been deleted. That old pointer stays readable until the upgrade runs, and again if the plugin is rolled back, so a published statement keeps its footer link and its content-gate exemption throughout. Both the read and the write only see the active theme, so that cover applies to a site still on the theme that stored the ID; one that had already switched gets its link back when the upgrade runs. Widening the fallback would put a scan of every theme's mods on every front-end render, which is a worse trade than the gap it closes.

The wizard now separates a page that was deleted from one that was never created. That first state was unreachable before, because loading the screen created the page.

![Advanced Settings: the new empty state, reading You do not have an accessibility statement page yet](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/19/ofa12whi-news-2948-a11y-empty-state-v2.png)

Closes NEWS-2948.

### How to test the changes in this Pull Request:

1. Activate a classic Newspack theme. This puts the footer call in play.
2. Open Newspack > Settings > Advanced Settings and create the page. Pages shows one draft.
3. Switch to another style variation, for example `newspack-scott`.
4. Load a front-end page, then a URL that 404s. Pages still shows one draft.
5. Load the front end while logged out. Pages still shows one draft.
6. Reopen Advanced Settings. The card still points at the same page.
7. Publish the page. The footer link appears in the site footer.
8. Trash the page, then reopen Advanced Settings. The notice says it was trashed.
9. Click Create Page. Exactly one new draft appears.
10. Delete both `newspack_accessibility_statement_*` options, and permanently delete every accessibility statement page the steps above made, trash included. Each theme still holds a mod pointing at one of them, and those are only followed to a page that still exists, so deleting the pages is what leaves the site with no pointer at all.
11. Reload Advanced Settings. The notice now says no page exists yet, rather than claiming one was trashed.
12. For the upgrade path, delete those options again and set the `accessibility_statement_page_id` theme mod to a published page's ID.
13. Load the front end logged out. The footer link is there before any admin visit.
14. Log in as a subscriber and open `/wp-admin/profile.php`. Neither option is written: the upgrade waits for someone who could create the page, and the footer link keeps working meanwhile.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Sites that already collected duplicates keep them. The upgrade adopts one page, preferring a published one, and leaves the rest alone rather than deleting publisher content on update, so support should expect to tell affected publishers to bin the extras.

The `force_create` parameter is gone from the POST endpoint. It existed only to bypass the guard this PR makes reliable.

Where the GET finds no page it now answers with a `reason` of `none` or `missing`, rather than putting either word in `status`. `status` stays a post status, so a client cannot mistake a post status registered under one of those names for an absent page. The wizard is the only consumer, and the classic theme reads `get_page()`, which still returns `false`.

