### PR TITLE
fix(network): distribute dynamic galleries as resolved images

### DIFF
--- a/plugins/newspack-network/includes/content-distribution/blocks/class-block-processor.php
+++ b/plugins/newspack-network/includes/content-distribution/blocks/class-block-processor.php
@@ -76,15 +76,16 @@ class Block_Processor {
 	/**
 	 * Process an outgoing block.
 	 *
-	 * @param array $block The block to process.
+	 * @param array $block   The block to process.
+	 * @param int   $post_id The ID of the post being distributed.
 	 *
 	 * @return array The processed block.
 	 */
-	public function process_outgoing_block( $block ) {
+	public function process_outgoing_block( $block, $post_id = 0 ) {
 		if ( ! is_callable( $this->outgoing_callback ) ) {
 			return $block;
 		}
-		return call_user_func( $this->outgoing_callback, $block );
+		return call_user_func( $this->outgoing_callback, $block, $post_id );
 	}
 
 	/**

--- a/plugins/newspack-network/includes/content-distribution/blocks/class-blocks.php
+++ b/plugins/newspack-network/includes/content-distribution/blocks/class-blocks.php
@@ -27,6 +27,7 @@ class Blocks {
 		// Register block processors.
 		self::register_block_processor( 'jetpack/slideshow', [ __CLASS__, 'process_jetpack_galleries' ] );
 		self::register_block_processor( 'jetpack/tiled-gallery', [ __CLASS__, 'process_jetpack_galleries' ] );
+		self::register_block_processor( 'core/gallery', [ __CLASS__, 'process_dynamic_gallery' ] );
 	}
 
 	/**
@@ -60,11 +61,25 @@ class Blocks {
 	/**
 	 * Process an outgoing block.
 	 *
-	 * @param array $block The block to process.
+	 * Recurses into inner blocks so a block nested inside a Group, Columns or
+	 * similar container is processed too. Without this, a gallery only gets
+	 * handled when it sits at the top level of the post.
+	 *
+	 * @param array $block   The block to process.
+	 * @param int   $post_id The ID of the post being distributed.
 	 *
 	 * @return array The processed block.
 	 */
-	public static function process_outgoing_block( $block ) {
+	public static function process_outgoing_block( $block, $post_id = 0 ) {
+		if ( ! empty( $block['innerBlocks'] ) ) {
+			$block['innerBlocks'] = array_map(
+				function ( $inner_block ) use ( $post_id ) {
+					return self::process_outgoing_block( $inner_block, $post_id );
+				},
+				$block['innerBlocks']
+			);
+		}
+
 		$block_name = $block['blockName'];
 
 		$processors = self::get_block_processors( $block_name );
@@ -73,7 +88,7 @@ class Blocks {
 		}
 
 		foreach ( $processors as $processor ) {
-			$block = $processor->process_outgoing_block( $block );
+			$block = $processor->process_outgoing_block( $block, $post_id );
 		}
 		return $block;
 	}
@@ -120,5 +135,98 @@ class Blocks {
 	public static function process_jetpack_galleries( $block ) {
 		unset( $block['attrs']['ids'] );
 		return $block;
+	}
+
+	/**
+	 * Flatten a dynamic gallery into ordinary image blocks for distribution.
+	 *
+	 * A gallery in dynamic mode stores no image IDs. It stores the instruction
+	 * "show the images attached to this post", which core resolves at render time
+	 * against whichever post is being rendered. That instruction travels intact,
+	 * but it means something different on a node, where the only attached image is
+	 * the sideloaded featured image. The gallery then arrives showing a single
+	 * unrelated image, or nothing at all, with no error either way.
+	 *
+	 * Resolving the images here, on the origin, leaves the block in the same shape
+	 * an ordinary gallery is saved in, which already distributes correctly. The
+	 * node's copy stops following new attachments, which matches how every other
+	 * edit reaches a node: on the next sync.
+	 *
+	 * @param array $block   The block to process.
+	 * @param int   $post_id The ID of the post being distributed.
+	 *
+	 * @return array The processed block.
+	 */
+	public static function process_dynamic_gallery( $block, $post_id = 0 ) {
+		if ( empty( $block['attrs']['dynamicContent'] ) ) {
+			return $block;
+		}
+
+		// Dynamic galleries arrived in WordPress 7.1. Leave the block alone on older versions.
+		if ( ! function_exists( 'block_core_gallery_resolve_dynamic_source' ) ) {
+			return $block;
+		}
+
+		$post_id = $post_id ? $post_id : get_the_ID();
+		if ( ! $post_id ) {
+			return $block;
+		}
+
+		$attachment_ids = block_core_gallery_resolve_dynamic_source(
+			$block['attrs']['dynamicContent'],
+			new \WP_Block( $block, [ 'postId' => $post_id ] )
+		);
+		if ( empty( $attachment_ids ) ) {
+			return $block;
+		}
+
+		$size_slug = $block['attrs']['sizeSlug'] ?? 'large';
+		$link_to   = $block['attrs']['linkTo'] ?? 'none';
+
+		$images = [];
+		foreach ( $attachment_ids as $attachment_id ) {
+			$url = wp_get_attachment_image_url( $attachment_id, $size_slug );
+			if ( ! $url ) {
+				continue;
+			}
+			$images[] = sprintf(
+				"<!-- wp:image %1\$s -->\n<figure class=\"wp-block-image size-%2\$s\"><img src=\"%3\$s\" alt=\"%4\$s\" class=\"wp-image-%5\$d\"/></figure>\n<!-- /wp:image -->",
+				wp_json_encode(
+					[
+						'id'              => (int) $attachment_id,
+						'sizeSlug'        => $size_slug,
+						'linkDestination' => $link_to,
+					]
+				),
+				esc_attr( $size_slug ),
+				esc_url( $url ),
+				esc_attr( (string) get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ),
+				(int) $attachment_id
+			);
+		}
+
+		if ( empty( $images ) ) {
+			return $block;
+		}
+
+		$attrs = $block['attrs'];
+		unset( $attrs['dynamicContent'] );
+
+		// Keep the gallery's own wrapper so its classes and layout survive.
+		$figure_open = '<figure class="wp-block-gallery has-nested-images columns-default is-cropped">';
+		if ( ! empty( $block['innerHTML'] ) && preg_match( '/<figure[^>]*>/', $block['innerHTML'], $matches ) ) {
+			$figure_open = $matches[0];
+		}
+
+		$markup = sprintf(
+			"<!-- wp:gallery %1\$s -->\n%2\$s\n%3\$s\n</figure>\n<!-- /wp:gallery -->",
+			wp_json_encode( (object) $attrs ),
+			$figure_open,
+			implode( "\n", $images )
+		);
+
+		$parsed = parse_blocks( $markup );
+
+		return $parsed[0] ?? $block;
 	}
 }

--- a/plugins/newspack-network/includes/content-distribution/blocks/class-blocks.php
+++ b/plugins/newspack-network/includes/content-distribution/blocks/class-blocks.php
@@ -7,6 +7,8 @@
 
 namespace Newspack_Network\Content_Distribution;
 
+use Newspack_Network\Debugger;
+
 /**
  * Blocks class.
  */
@@ -148,9 +150,24 @@ class Blocks {
 	 * unrelated image, or nothing at all, with no error either way.
 	 *
 	 * Resolving the images here, on the origin, leaves the block in the same shape
-	 * an ordinary gallery is saved in, which already distributes correctly. The
-	 * node's copy stops following new attachments, which matches how every other
-	 * edit reaches a node: on the next sync.
+	 * an ordinary gallery is saved in, which already distributes correctly.
+	 *
+	 * The image and wrapper construction mirrors core's own dynamic render
+	 * (`block_core_gallery_render_dynamic_image()` and the `dynamicContent` branch
+	 * of `block_core_gallery_render()`), reusing core's helpers so links, captions,
+	 * aspect ratio and responsive markup match what the origin renders. Blocks are
+	 * built as arrays and left for `serialize_blocks()` to encode, so attribute
+	 * values never pass through a hand-written block-comment delimiter.
+	 *
+	 * Two caveats worth knowing:
+	 *
+	 * - The node's copy is static. Attaching a new image on the origin does not by
+	 *   itself resync the post, so the node updates on the next save of the post,
+	 *   not on the upload.
+	 * - When nothing resolves, the block is flattened to an empty gallery rather
+	 *   than shipped as-is. Passing the dynamic instruction through would let the
+	 *   node resolve it against its own attachments, which is the bug this exists
+	 *   to prevent.
 	 *
 	 * @param array $block   The block to process.
 	 * @param int   $post_id The ID of the post being distributed.
@@ -162,71 +179,198 @@ class Blocks {
 			return $block;
 		}
 
-		// Dynamic galleries arrived in WordPress 7.1. Leave the block alone on older versions.
-		if ( ! function_exists( 'block_core_gallery_resolve_dynamic_source' ) ) {
+		// Dynamic galleries arrived with the WordPress 7.1 gallery block. Leave the
+		// block untouched on older versions, where nothing can resolve it anyway.
+		if (
+			! function_exists( 'block_core_gallery_resolve_dynamic_source' ) ||
+			! function_exists( 'block_core_gallery_dynamic_image_link_attributes' )
+		) {
 			return $block;
 		}
 
-		$post_id = $post_id ? $post_id : get_the_ID();
 		if ( ! $post_id ) {
-			return $block;
+			Debugger::log( 'Dynamic gallery: no post ID given, flattening to an empty gallery.' );
+			return self::flatten_gallery( $block, [] );
 		}
 
 		$attachment_ids = block_core_gallery_resolve_dynamic_source(
 			$block['attrs']['dynamicContent'],
 			new \WP_Block( $block, [ 'postId' => $post_id ] )
 		);
+
 		if ( empty( $attachment_ids ) ) {
-			return $block;
+			Debugger::log( sprintf( 'Dynamic gallery on post %d resolved no images.', $post_id ) );
+			return self::flatten_gallery( $block, [] );
 		}
 
-		$size_slug = $block['attrs']['sizeSlug'] ?? 'large';
-		$link_to   = $block['attrs']['linkTo'] ?? 'none';
+		// The source query only fetched IDs, which skips WP_Query's cache priming,
+		// and each image below reads the attachment post and its meta. Warm both in
+		// one pair of queries rather than paying two per attachment.
+		if ( count( $attachment_ids ) > 1 ) {
+			_prime_post_caches( $attachment_ids, false, true );
+		}
 
-		$images = [];
+		// Distribute origin URLs rather than the origin's image CDN, matching every
+		// other media URL this plugin puts on the wire.
+		add_filter( 'jetpack_photon_override_image_downsize', '__return_true' );
+
+		$image_blocks = [];
 		foreach ( $attachment_ids as $attachment_id ) {
-			$url = wp_get_attachment_image_url( $attachment_id, $size_slug );
-			if ( ! $url ) {
-				continue;
+			$image_block = self::build_gallery_image_block( $attachment_id, $block['attrs'] );
+			if ( $image_block ) {
+				$image_blocks[] = $image_block;
 			}
-			$images[] = sprintf(
-				"<!-- wp:image %1\$s -->\n<figure class=\"wp-block-image size-%2\$s\"><img src=\"%3\$s\" alt=\"%4\$s\" class=\"wp-image-%5\$d\"/></figure>\n<!-- /wp:image -->",
-				wp_json_encode(
-					[
-						'id'              => (int) $attachment_id,
-						'sizeSlug'        => $size_slug,
-						'linkDestination' => $link_to,
-					]
-				),
-				esc_attr( $size_slug ),
-				esc_url( $url ),
-				esc_attr( (string) get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ),
-				(int) $attachment_id
-			);
 		}
 
-		if ( empty( $images ) ) {
-			return $block;
+		remove_filter( 'jetpack_photon_override_image_downsize', '__return_true' );
+
+		if ( empty( $image_blocks ) ) {
+			Debugger::log( sprintf( 'Dynamic gallery on post %d resolved %d images, none of which produced markup.', $post_id, count( $attachment_ids ) ) );
 		}
 
+		return self::flatten_gallery( $block, $image_blocks );
+	}
+
+	/**
+	 * Build the flattened gallery block around a list of image blocks.
+	 *
+	 * Mirrors the wrapper core builds for a dynamic gallery: the gallery-specific
+	 * classes from `save.js`, plus the block-support classes and styles (align,
+	 * colors, border, spacing, anchor) that a static gallery carries in its saved
+	 * markup. Layout classes are deliberately left out, since the layout render
+	 * filter adds those on the node exactly as it does on the origin.
+	 *
+	 * @param array $block        The original dynamic gallery block.
+	 * @param array $image_blocks The image blocks to nest, possibly empty.
+	 *
+	 * @return array The flattened gallery block.
+	 */
+	private static function flatten_gallery( $block, $image_blocks ) {
 		$attrs = $block['attrs'];
 		unset( $attrs['dynamicContent'] );
 
-		// Keep the gallery's own wrapper so its classes and layout survive.
-		$figure_open = '<figure class="wp-block-gallery has-nested-images columns-default is-cropped">';
-		if ( ! empty( $block['innerHTML'] ) && preg_match( '/<figure[^>]*>/', $block['innerHTML'], $matches ) ) {
-			$figure_open = $matches[0];
+		$classes  = 'wp-block-gallery has-nested-images';
+		$classes .= isset( $attrs['columns'] ) ? ' columns-' . (int) $attrs['columns'] : ' columns-default';
+		if ( $attrs['imageCrop'] ?? true ) {
+			$classes .= ' is-cropped';
 		}
 
-		$markup = sprintf(
-			"<!-- wp:gallery %1\$s -->\n%2\$s\n%3\$s\n</figure>\n<!-- /wp:gallery -->",
-			wp_json_encode( (object) $attrs ),
-			$figure_open,
-			implode( "\n", $images )
+		$wrapper = self::get_block_wrapper_attributes( $block, $classes );
+
+		// In dynamic mode `save.js` persists at most the gallery caption, so the
+		// block's own inner HTML is that `<figcaption>` or nothing. Core appends it
+		// after the images, and drops it when there are no images to caption.
+		$caption = $image_blocks ? trim( $block['innerHTML'] ?? '' ) : '';
+
+		$opening       = sprintf( '<figure %s>', $wrapper );
+		$closing       = $caption . '</figure>';
+		$inner_content = array_merge(
+			[ $opening ],
+			array_fill( 0, count( $image_blocks ), null ),
+			[ $closing ]
 		);
 
-		$parsed = parse_blocks( $markup );
+		return [
+			'blockName'    => 'core/gallery',
+			'attrs'        => $attrs,
+			'innerBlocks'  => $image_blocks,
+			'innerHTML'    => $opening . $closing,
+			'innerContent' => $inner_content,
+		];
+	}
 
-		return $parsed[0] ?? $block;
+	/**
+	 * Build a single `core/image` block for a resolved gallery image.
+	 *
+	 * Deliberately mirrors `block_core_gallery_render_dynamic_image()`, stopping
+	 * short of rendering so the block can be nested instead.
+	 *
+	 * @param int   $attachment_id The image attachment ID.
+	 * @param array $attributes    The gallery block attributes.
+	 *
+	 * @return array|null The image block, or null when no markup could be built.
+	 */
+	private static function build_gallery_image_block( $attachment_id, $attributes ) {
+		$size_slug    = $attributes['sizeSlug'] ?? 'large';
+		$aspect_ratio = $attributes['aspectRatio'] ?? 'auto';
+
+		$img_attr = [ 'class' => 'wp-image-' . $attachment_id ];
+		if ( $aspect_ratio && 'auto' !== $aspect_ratio ) {
+			$img_attr['style'] = safecss_filter_attr( sprintf( 'aspect-ratio:%s;object-fit:cover;', $aspect_ratio ) );
+		}
+
+		$image_markup = wp_get_attachment_image( $attachment_id, $size_slug, false, $img_attr );
+		if ( ! $image_markup ) {
+			return null;
+		}
+
+		$image_attributes = array_merge(
+			[
+				'id'       => $attachment_id,
+				'data-id'  => (string) $attachment_id,
+				'sizeSlug' => $size_slug,
+			],
+			block_core_gallery_dynamic_image_link_attributes( $attachment_id, $attributes )
+		);
+
+		if ( $aspect_ratio && 'auto' !== $aspect_ratio ) {
+			$image_attributes['aspectRatio'] = $aspect_ratio;
+			$image_attributes['scale']       = 'cover';
+		}
+
+		if ( ! empty( $image_attributes['href'] ) ) {
+			$image_markup = sprintf(
+				'<a href="%1$s"%2$s%3$s>%4$s</a>',
+				esc_url( $image_attributes['href'] ),
+				isset( $image_attributes['linkTarget'] ) ? ' target="' . esc_attr( $image_attributes['linkTarget'] ) . '"' : '',
+				isset( $image_attributes['rel'] ) ? ' rel="' . esc_attr( $image_attributes['rel'] ) . '"' : '',
+				$image_markup
+			);
+		}
+
+		$attachment = get_post( $attachment_id );
+		$caption    = $attachment ? $attachment->post_excerpt : '';
+		if ( '' !== $caption ) {
+			$image_markup .= sprintf( '<figcaption class="wp-element-caption">%s</figcaption>', wp_kses_post( $caption ) );
+		}
+
+		$figure = sprintf(
+			'<figure class="wp-block-image size-%1$s">%2$s</figure>',
+			esc_attr( $size_slug ),
+			$image_markup
+		);
+
+		return [
+			'blockName'    => 'core/image',
+			'attrs'        => $image_attributes,
+			'innerBlocks'  => [],
+			'innerHTML'    => $figure,
+			'innerContent' => [ $figure ],
+		];
+	}
+
+	/**
+	 * Get the block-support wrapper attributes for a block outside of a render.
+	 *
+	 * `get_block_wrapper_attributes()` reads the block being rendered from
+	 * `WP_Block_Supports`, which is only set during a render. Distribution runs
+	 * outside one, so point it at this block and put back whatever was there.
+	 *
+	 * @param array  $block   The block whose supports should be applied.
+	 * @param string $classes Additional classes for the wrapper.
+	 *
+	 * @return string The wrapper attributes.
+	 */
+	private static function get_block_wrapper_attributes( $block, $classes ) {
+		if ( ! class_exists( '\WP_Block_Supports' ) || ! function_exists( 'get_block_wrapper_attributes' ) ) {
+			return sprintf( 'class="%s"', esc_attr( $classes ) );
+		}
+
+		$previous                            = \WP_Block_Supports::$block_to_render;
+		\WP_Block_Supports::$block_to_render = $block;
+		$attributes                          = get_block_wrapper_attributes( [ 'class' => $classes ] );
+		\WP_Block_Supports::$block_to_render = $previous;
+
+		return $attributes ? $attributes : sprintf( 'class="%s"', esc_attr( $classes ) );
 	}
 }

--- a/plugins/newspack-network/includes/content-distribution/blocks/class-blocks.php
+++ b/plugins/newspack-network/includes/content-distribution/blocks/class-blocks.php
@@ -67,6 +67,9 @@ class Blocks {
 	 * similar container is processed too. Without this, a gallery only gets
 	 * handled when it sits at the top level of the post.
 	 *
+	 * Processors must return one block per block. Returning a different count would
+	 * desynchronise the parent's `innerContent` null placeholders.
+	 *
 	 * @param array $block   The block to process.
 	 * @param int   $post_id The ID of the post being distributed.
 	 *
@@ -180,13 +183,17 @@ class Blocks {
 			return $block;
 		}
 
-		// Dynamic galleries arrived with the WordPress 7.1 gallery block. Leave the
-		// block untouched on older versions, where nothing can resolve it anyway.
+		// Dynamic galleries arrived with the WordPress 7.1 gallery block. Reaching
+		// here without those functions means 7.1-authored content on an older core:
+		// a downgrade, an import or a migration. Nothing can resolve the images, but
+		// shipping the instruction would let the node resolve it against its own
+		// attachments, so strip it and let the gallery arrive empty.
 		if (
 			! function_exists( 'block_core_gallery_resolve_dynamic_source' ) ||
 			! function_exists( 'block_core_gallery_dynamic_image_link_attributes' )
 		) {
-			return $block;
+			Debugger::log( 'Dynamic gallery found on a WordPress older than 7.1, flattening to an empty gallery.' );
+			return self::flatten_gallery( $block, [] );
 		}
 
 		if ( ! $post_id ) {
@@ -292,7 +299,9 @@ class Blocks {
 	 * @return array|null The image block, or null when no markup could be built.
 	 */
 	private static function build_gallery_image_block( $attachment_id, $attributes ) {
-		$size_slug = $attributes['sizeSlug'] ?? 'large';
+		$size_slug    = $attributes['sizeSlug'] ?? 'large';
+		$aspect_ratio = $attributes['aspectRatio'] ?? 'auto';
+		$has_ratio    = $aspect_ratio && 'auto' !== $aspect_ratio;
 
 		$url = wp_get_attachment_image_url( $attachment_id, $size_slug );
 		if ( ! $url ) {
@@ -307,6 +316,15 @@ class Blocks {
 			block_core_gallery_dynamic_image_link_attributes( $attachment_id, $attributes )
 		);
 
+		// The image block's save() derives the inline style from these two attributes,
+		// so they have to travel together. Attributes without the style, or the style
+		// without the attributes, puts save() out of step with the stored markup and
+		// the block fails validation on the node.
+		if ( $has_ratio ) {
+			$image_attributes['aspectRatio'] = $aspect_ratio;
+			$image_attributes['scale']       = 'cover';
+		}
+
 		// Build the `<img>` the way the image block *saves* it, not the way core
 		// renders it. `wp_get_attachment_image()` adds width, height, srcset, sizes,
 		// loading and decoding, which the block's `save()` never emits, so persisting
@@ -314,10 +332,13 @@ class Blocks {
 		// Those attributes are added at render time on the node, as they are for any
 		// other distributed image.
 		$image_markup = sprintf(
-			'<img src="%1$s" alt="%2$s" class="wp-image-%3$d"/>',
+			'<img src="%1$s" alt="%2$s" class="wp-image-%3$d"%4$s/>',
 			esc_url( $url ),
 			esc_attr( (string) get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ),
-			(int) $attachment_id
+			(int) $attachment_id,
+			$has_ratio
+				? ' style="' . esc_attr( safecss_filter_attr( sprintf( 'aspect-ratio:%s;object-fit:cover;', $aspect_ratio ) ) ) . '"'
+				: ''
 		);
 
 		if ( ! empty( $image_attributes['href'] ) ) {
@@ -370,8 +391,15 @@ class Blocks {
 
 		$previous                            = \WP_Block_Supports::$block_to_render;
 		\WP_Block_Supports::$block_to_render = $block;
-		$attributes                          = get_block_wrapper_attributes( [ 'class' => $classes ] );
-		\WP_Block_Supports::$block_to_render = $previous;
+
+		try {
+			$attributes = get_block_wrapper_attributes( [ 'class' => $classes ] );
+		} finally {
+			// Block supports call third-party callbacks, so restore the static even if
+			// one of them throws. Distribution runs a queue with no catch of its own,
+			// and leaving this set would outlive the block being processed.
+			\WP_Block_Supports::$block_to_render = $previous;
+		}
 
 		return $attributes ? $attributes : sprintf( 'class="%s"', esc_attr( $classes ) );
 	}

--- a/plugins/newspack-network/includes/content-distribution/blocks/class-blocks.php
+++ b/plugins/newspack-network/includes/content-distribution/blocks/class-blocks.php
@@ -153,11 +153,12 @@ class Blocks {
 	 * an ordinary gallery is saved in, which already distributes correctly.
 	 *
 	 * The image and wrapper construction mirrors core's own dynamic render
-	 * (`block_core_gallery_render_dynamic_image()` and the `dynamicContent` branch
-	 * of `block_core_gallery_render()`), reusing core's helpers so links, captions,
-	 * aspect ratio and responsive markup match what the origin renders. Blocks are
-	 * built as arrays and left for `serialize_blocks()` to encode, so attribute
-	 * values never pass through a hand-written block-comment delimiter.
+	 * (the `dynamicContent` branch of `block_core_gallery_render()`), reusing core's
+	 * link helper so links, the lightbox and captions match what the origin shows.
+	 * The markup itself is the shape the blocks *save* in, not the shape core
+	 * renders, since a node stores it and its editor validates it against `save()`.
+	 * Blocks are built as arrays and left for `serialize_blocks()` to encode, so
+	 * attribute values never pass through a hand-written block-comment delimiter.
 	 *
 	 * Two caveats worth knowing:
 	 *
@@ -291,32 +292,33 @@ class Blocks {
 	 * @return array|null The image block, or null when no markup could be built.
 	 */
 	private static function build_gallery_image_block( $attachment_id, $attributes ) {
-		$size_slug    = $attributes['sizeSlug'] ?? 'large';
-		$aspect_ratio = $attributes['aspectRatio'] ?? 'auto';
+		$size_slug = $attributes['sizeSlug'] ?? 'large';
 
-		$img_attr = [ 'class' => 'wp-image-' . $attachment_id ];
-		if ( $aspect_ratio && 'auto' !== $aspect_ratio ) {
-			$img_attr['style'] = safecss_filter_attr( sprintf( 'aspect-ratio:%s;object-fit:cover;', $aspect_ratio ) );
-		}
-
-		$image_markup = wp_get_attachment_image( $attachment_id, $size_slug, false, $img_attr );
-		if ( ! $image_markup ) {
+		$url = wp_get_attachment_image_url( $attachment_id, $size_slug );
+		if ( ! $url ) {
 			return null;
 		}
 
 		$image_attributes = array_merge(
 			[
-				'id'       => $attachment_id,
-				'data-id'  => (string) $attachment_id,
+				'id'       => (int) $attachment_id,
 				'sizeSlug' => $size_slug,
 			],
 			block_core_gallery_dynamic_image_link_attributes( $attachment_id, $attributes )
 		);
 
-		if ( $aspect_ratio && 'auto' !== $aspect_ratio ) {
-			$image_attributes['aspectRatio'] = $aspect_ratio;
-			$image_attributes['scale']       = 'cover';
-		}
+		// Build the `<img>` the way the image block *saves* it, not the way core
+		// renders it. `wp_get_attachment_image()` adds width, height, srcset, sizes,
+		// loading and decoding, which the block's `save()` never emits, so persisting
+		// them makes the block fail validation the moment an editor opens the post.
+		// Those attributes are added at render time on the node, as they are for any
+		// other distributed image.
+		$image_markup = sprintf(
+			'<img src="%1$s" alt="%2$s" class="wp-image-%3$d"/>',
+			esc_url( $url ),
+			esc_attr( (string) get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ),
+			(int) $attachment_id
+		);
 
 		if ( ! empty( $image_attributes['href'] ) ) {
 			$image_markup = sprintf(

--- a/plugins/newspack-network/includes/content-distribution/class-outgoing-post.php
+++ b/plugins/newspack-network/includes/content-distribution/class-outgoing-post.php
@@ -400,8 +400,11 @@ class Outgoing_Post {
 			return $this->post->post_content;
 		}
 
-		$blocks = array_map(
-			[ Blocks::class, 'process_outgoing_block' ],
+		$post_id = $this->post->ID;
+		$blocks  = array_map(
+			function ( $block ) use ( $post_id ) {
+				return Blocks::process_outgoing_block( $block, $post_id );
+			},
 			parse_blocks( $this->post->post_content )
 		);
 

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-dynamic-gallery.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-dynamic-gallery.php
@@ -159,12 +159,29 @@ class TestDynamicGallery extends \WP_UnitTestCase {
 	public function test_preserves_links_and_lightbox() {
 		$this->requires_dynamic_galleries();
 
-		$linked = $this->flatten( $this->dynamic_gallery( [ 'linkTo' => 'media' ] ) );
-		$this->assertSame( 3, substr_count( $linked, '<a href=' ), 'Linked galleries must keep their anchors.' );
+		$first = $this->attachment_ids[0];
+
+		$media = $this->flatten( $this->dynamic_gallery( [ 'linkTo' => 'media' ] ) );
+		$this->assertSame( 3, substr_count( $media, '<a href=' ), 'Linked galleries must keep their anchors.' );
+		$this->assertStringContainsString( 'href="' . esc_url( wp_get_attachment_url( $first ) ) . '"', $media, 'media must link to the file.' );
+
+		$attachment = $this->flatten( $this->dynamic_gallery( [ 'linkTo' => 'attachment' ] ) );
+		$this->assertStringContainsString( 'href="' . esc_url( get_attachment_link( $first ) ) . '"', $attachment, 'attachment must link to the attachment page.' );
+
+		$blank = $this->flatten(
+			$this->dynamic_gallery(
+				[
+					'linkTo'     => 'media',
+					'linkTarget' => '_blank',
+				] 
+			) 
+		);
+		$this->assertStringContainsString( 'target="_blank"', $blank );
+		$this->assertStringContainsString( 'rel="noopener"', $blank );
 
 		$lightbox = $this->flatten( $this->dynamic_gallery( [ 'linkTo' => 'lightbox' ] ) );
 		$this->assertStringNotContainsString( '"linkDestination":"lightbox"', $lightbox, 'lightbox is not a linkDestination value.' );
-		$this->assertStringContainsString( 'lightbox', $lightbox );
+		$this->assertStringContainsString( '"lightbox":{"enabled":true}', $lightbox, 'The lightbox must be switched on, not merely mentioned.' );
 	}
 
 	/**
@@ -262,5 +279,66 @@ class TestDynamicGallery extends \WP_UnitTestCase {
 		Blocks::reset_block_processors( 'core/separator' );
 
 		$this->assertSame( 4242, $seen );
+	}
+
+	/**
+	 * A cropped gallery keeps its ratio on the node.
+	 *
+	 * The image block's save() derives the inline style from the aspectRatio and
+	 * scale attributes, so the two have to travel together or the block fails
+	 * validation. Assert both, so they cannot come apart again.
+	 */
+	public function test_preserves_aspect_ratio() {
+		$this->requires_dynamic_galleries();
+
+		$output = $this->flatten( $this->dynamic_gallery( [ 'aspectRatio' => '16/9' ] ) );
+
+		$this->assertStringContainsString( '"aspectRatio":"16/9"', $output, 'The ratio must reach the image block attributes.' );
+		$this->assertStringContainsString( '"scale":"cover"', $output, 'scale travels with aspectRatio.' );
+		$this->assertSame( 3, substr_count( $output, 'style="aspect-ratio:16/9;object-fit:cover"' ), 'Every image needs the persisted style.' );
+	}
+
+	/**
+	 * An "auto" ratio adds nothing, which is what core saves for an uncropped gallery.
+	 */
+	public function test_auto_aspect_ratio_adds_nothing() {
+		$this->requires_dynamic_galleries();
+
+		$output = $this->flatten( $this->dynamic_gallery( [ 'aspectRatio' => 'auto' ] ) );
+
+		$this->assertStringNotContainsString( 'aspect-ratio:', $output );
+		$this->assertStringNotContainsString( '"scale"', $output );
+	}
+
+	/**
+	 * The recursion reaches a nested Jetpack gallery.
+	 *
+	 * This is the part of the change that reaches sites before they update to 7.1,
+	 * so unlike the gallery tests it has to run on every WordPress version.
+	 */
+	public function test_recursion_reaches_a_nested_jetpack_gallery() {
+		$markup = '<!-- wp:group --><div class="wp-block-group">'
+			. '<!-- wp:jetpack/tiled-gallery {"ids":[11,22,33]} --><div class="wp-block-jetpack-tiled-gallery"></div><!-- /wp:jetpack/tiled-gallery -->'
+			. '</div><!-- /wp:group -->';
+
+		$blocks = parse_blocks( $markup );
+		$output = serialize_blocks( [ Blocks::process_outgoing_block( $blocks[0], $this->post_id ) ] );
+
+		$this->assertStringNotContainsString( '"ids"', $output, 'Origin attachment IDs are meaningless on a node.' );
+		$this->assertStringContainsString( 'wp:jetpack/tiled-gallery', $output, 'The block itself must survive.' );
+	}
+
+	/**
+	 * Recursion must return one block per block, or the parent's innerContent
+	 * placeholders stop lining up with its inner blocks.
+	 */
+	public function test_recursion_preserves_block_structure() {
+		$markup = '<!-- wp:group --><div class="wp-block-group">'
+			. '<!-- wp:paragraph --><p>One</p><!-- /wp:paragraph -->'
+			. '<!-- wp:paragraph --><p>Two</p><!-- /wp:paragraph -->'
+			. '</div><!-- /wp:group -->';
+
+		$blocks = parse_blocks( $markup );
+		$this->assertSame( $markup, serialize_blocks( [ Blocks::process_outgoing_block( $blocks[0], $this->post_id ) ] ) );
 	}
 }

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-dynamic-gallery.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-dynamic-gallery.php
@@ -132,8 +132,8 @@ class TestDynamicGallery extends \WP_UnitTestCase {
 				[
 					'columns'   => 3,
 					'imageCrop' => false,
-				] 
-			) 
+				]
+			)
 		);
 
 		$this->assertStringContainsString( 'columns-3', $output, 'The column count must survive.' );

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-dynamic-gallery.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-dynamic-gallery.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * Class TestDynamicGallery
+ *
+ * @package Newspack_Network
+ */
+
+namespace Test\Content_Distribution;
+
+use Newspack_Network\Content_Distribution\Blocks;
+
+/**
+ * Test flattening of WordPress 7.1 dynamic galleries for distribution.
+ */
+class TestDynamicGallery extends \WP_UnitTestCase {
+
+	/**
+	 * The post the gallery images are attached to.
+	 *
+	 * @var int
+	 */
+	private $post_id;
+
+	/**
+	 * The attached image IDs.
+	 *
+	 * @var int[]
+	 */
+	private $attachment_ids = [];
+
+	/**
+	 * Set up a post with three attached images.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->post_id        = self::factory()->post->create();
+		$this->attachment_ids = [];
+
+		for ( $i = 0; $i < 3; $i++ ) {
+			$this->attachment_ids[] = self::factory()->attachment->create_object(
+				[
+					'file'           => "dg-{$i}.png",
+					'post_parent'    => $this->post_id,
+					'post_mime_type' => 'image/png',
+					'post_excerpt'   => "Caption {$i}",
+				]
+			);
+		}
+	}
+
+	/**
+	 * Skip when the WordPress under test predates dynamic galleries.
+	 *
+	 * The behaviour under test only exists from WordPress 7.1. Skipping loudly is
+	 * better than asserting nothing, so the gap is visible in the CI output.
+	 */
+	private function requires_dynamic_galleries() {
+		if ( ! function_exists( 'block_core_gallery_resolve_dynamic_source' ) ) {
+			$this->markTestSkipped( 'Dynamic galleries require WordPress 7.1 or later; this suite runs ' . get_bloginfo( 'version' ) . '.' );
+		}
+	}
+
+	/**
+	 * Build a dynamic gallery block, in the shape the editor saves it.
+	 *
+	 * @param array  $attrs      Extra gallery attributes.
+	 * @param string $inner_html Saved inner HTML, i.e. the gallery caption.
+	 *
+	 * @return array The parsed block.
+	 */
+	private function dynamic_gallery( $attrs = [], $inner_html = '' ) {
+		$attrs  = array_merge( [ 'dynamicContent' => [ 'source' => 'core/attached-media' ] ], $attrs );
+		$markup = '<!-- wp:gallery ' . serialize_block_attributes( $attrs ) . ' -->' . $inner_html . '<!-- /wp:gallery -->';
+		$blocks = parse_blocks( $markup );
+		return $blocks[0];
+	}
+
+	/**
+	 * Flatten a block and return it serialized.
+	 *
+	 * @param array $block The block.
+	 *
+	 * @return string The serialized block.
+	 */
+	private function flatten( $block ) {
+		return serialize_blocks( [ Blocks::process_outgoing_block( $block, $this->post_id ) ] );
+	}
+
+	/**
+	 * A dynamic gallery is replaced by the images attached to the post.
+	 */
+	public function test_resolves_attached_images() {
+		$this->requires_dynamic_galleries();
+
+		$output = $this->flatten( $this->dynamic_gallery() );
+
+		$this->assertStringNotContainsString( 'dynamicContent', $output, 'The dynamic instruction must not be distributed.' );
+		$this->assertSame( 3, substr_count( $output, '<!-- wp:image ' ), 'Every attached image should become an image block.' );
+
+		foreach ( $this->attachment_ids as $attachment_id ) {
+			$this->assertStringContainsString( 'wp-image-' . $attachment_id, $output );
+		}
+	}
+
+	/**
+	 * The flattened gallery no longer depends on the rendering post's attachments,
+	 * which is the whole point: a node has only the sideloaded featured image.
+	 */
+	public function test_renders_on_a_post_without_attachments() {
+		$this->requires_dynamic_galleries();
+
+		$output = $this->flatten( $this->dynamic_gallery() );
+		$node   = self::factory()->post->create( [ 'post_content' => $output ] );
+
+		$rendered = '';
+		foreach ( parse_blocks( get_post( $node )->post_content ) as $block ) {
+			$rendered .= render_block( $block );
+		}
+
+		$this->assertSame( 3, substr_count( $rendered, '<img ' ), 'All images should render where the post has none attached.' );
+	}
+
+	/**
+	 * Gallery settings that live on the wrapper survive.
+	 */
+	public function test_preserves_wrapper_settings() {
+		$this->requires_dynamic_galleries();
+
+		$output = $this->flatten(
+			$this->dynamic_gallery(
+				[
+					'columns'   => 3,
+					'imageCrop' => false,
+				] 
+			) 
+		);
+
+		$this->assertStringContainsString( 'columns-3', $output, 'The column count must survive.' );
+		$this->assertStringNotContainsString( 'is-cropped', $output, 'imageCrop false must not be cropped on the node.' );
+	}
+
+	/**
+	 * The gallery caption survives. It is a sourced attribute, so it lives only in
+	 * the block's inner HTML.
+	 */
+	public function test_preserves_gallery_caption() {
+		$this->requires_dynamic_galleries();
+
+		$caption = '<figcaption class="blocks-gallery-caption wp-element-caption">Scenes from the parade</figcaption>';
+		$output  = $this->flatten( $this->dynamic_gallery( [], $caption ) );
+
+		$this->assertStringContainsString( 'Scenes from the parade', $output );
+	}
+
+	/**
+	 * Linked galleries keep their links, and the lightbox keeps working.
+	 */
+	public function test_preserves_links_and_lightbox() {
+		$this->requires_dynamic_galleries();
+
+		$linked = $this->flatten( $this->dynamic_gallery( [ 'linkTo' => 'media' ] ) );
+		$this->assertSame( 3, substr_count( $linked, '<a href=' ), 'Linked galleries must keep their anchors.' );
+
+		$lightbox = $this->flatten( $this->dynamic_gallery( [ 'linkTo' => 'lightbox' ] ) );
+		$this->assertStringNotContainsString( '"linkDestination":"lightbox"', $lightbox, 'lightbox is not a linkDestination value.' );
+		$this->assertStringContainsString( 'lightbox', $lightbox );
+	}
+
+	/**
+	 * Attribute values cannot break out of the block comment delimiter.
+	 */
+	public function test_attribute_values_cannot_inject_markup() {
+		$this->requires_dynamic_galleries();
+
+		$payload = 'x"} --><img src=x onerror=alert(1)>';
+		$output  = $this->flatten( $this->dynamic_gallery( [ 'className' => $payload ] ) );
+
+		$this->assertStringNotContainsString( '<img src=x onerror', $output, 'Attribute values must not become markup.' );
+
+		$reparsed = parse_blocks( $output );
+		$this->assertSame( $payload, $reparsed[0]['attrs']['className'], 'The attribute must survive intact.' );
+		$this->assertCount( 3, $reparsed[0]['innerBlocks'], 'The block must not be corrupted.' );
+	}
+
+	/**
+	 * When nothing resolves, the dynamic instruction must not be distributed. A node
+	 * would resolve it against its own attachments, which is the bug being fixed.
+	 */
+	public function test_fails_closed_when_nothing_resolves() {
+		$this->requires_dynamic_galleries();
+
+		$empty  = self::factory()->post->create();
+		$output = serialize_blocks( [ Blocks::process_outgoing_block( $this->dynamic_gallery(), $empty ) ] );
+
+		$this->assertStringNotContainsString( 'dynamicContent', $output );
+		$this->assertStringNotContainsString( '<!-- wp:image ', $output );
+	}
+
+	/**
+	 * A gallery nested inside another block is processed too.
+	 */
+	public function test_flattens_a_nested_gallery() {
+		$this->requires_dynamic_galleries();
+
+		$markup = '<!-- wp:group --><div class="wp-block-group">'
+			. '<!-- wp:gallery ' . serialize_block_attributes( [ 'dynamicContent' => [ 'source' => 'core/attached-media' ] ] ) . ' /-->'
+			. '</div><!-- /wp:group -->';
+
+		$post_id = $this->post_id;
+		$output  = serialize_blocks(
+			array_map(
+				function ( $block ) use ( $post_id ) {
+					return Blocks::process_outgoing_block( $block, $post_id );
+				},
+				parse_blocks( $markup )
+			)
+		);
+
+		$this->assertStringNotContainsString( 'dynamicContent', $output );
+		$this->assertSame( 3, substr_count( $output, '<!-- wp:image ' ) );
+	}
+
+	/**
+	 * An ordinary gallery is left exactly as it is.
+	 */
+	public function test_leaves_an_ordinary_gallery_alone() {
+		$markup = '<!-- wp:gallery {"linkTo":"none"} --><figure class="wp-block-gallery has-nested-images">'
+			. '<!-- wp:image {"id":1} --><figure class="wp-block-image"><img src="http://example.org/a.png" class="wp-image-1"/></figure><!-- /wp:image -->'
+			. '</figure><!-- /wp:gallery -->';
+
+		$blocks = parse_blocks( $markup );
+		$this->assertSame( serialize_blocks( $blocks ), $this->flatten( $blocks[0] ) );
+	}
+
+	/**
+	 * Processing an already flattened gallery changes nothing further.
+	 */
+	public function test_is_idempotent() {
+		$this->requires_dynamic_galleries();
+
+		$once  = Blocks::process_outgoing_block( $this->dynamic_gallery(), $this->post_id );
+		$twice = Blocks::process_outgoing_block( $once, $this->post_id );
+
+		$this->assertSame( serialize_blocks( [ $once ] ), serialize_blocks( [ $twice ] ) );
+	}
+
+	/**
+	 * The post ID reaches a registered outgoing callback.
+	 */
+	public function test_post_id_reaches_the_callback() {
+		$seen = null;
+		Blocks::register_block_processor(
+			'core/separator',
+			function ( $block, $post_id ) use ( &$seen ) {
+				$seen = $post_id;
+				return $block;
+			}
+		);
+
+		Blocks::process_outgoing_block( parse_blocks( '<!-- wp:separator /-->' )[0], 4242 );
+		Blocks::reset_block_processors( 'core/separator' );
+
+		$this->assertSame( 4242, $seen );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

WordPress 7.1's dynamic gallery saves no image IDs. It saves "show the images attached to this post", which core resolves at render time against the post being rendered. That instruction distributes intact but means something different on a node, where the only attached image is the sideloaded featured image. The gallery arrives showing a single unrelated image, or nothing, with no error.

This resolves the images on the origin, so the block distributes in the same shape as an ordinary gallery.

The node's copy is static. Attaching an image on the origin does not resync on its own, so the node updates on the next save of the post.

Closes NEWS-2951.

### How to test the changes in this Pull Request:

1. On a hub, create a post and upload three images from inside the post so they attach.
2. Set a featured image that is not one of those three.
3. Delete the three Image blocks. The images stay attached to the post.
4. Add an empty Gallery block and click **Use attached images**.
5. Confirm the block offers **Detach Gallery**, which means it is in dynamic mode.
6. Publish, then distribute to a node from the Distribute sidebar.
7. Pull on the node and open the post. Expect the three original images.
8. Repeat without a featured image. Expect three images, where before there were none.
9. Distribute a post with an ordinary gallery. Expect no change.
10. Distribute a dynamic gallery nested inside a Group block. Expect three images.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

The new tests skip on WordPress below 7.1, which is what CI currently runs, so they report as skipped rather than passing.

`aspectRatio` does not travel: a gallery pinned to a ratio renders at natural ratios on the node.
