### PR TITLE
fix(newsletters): refresh subscription lists with the Mailchimp cache

### DIFF
--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -89,7 +89,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 		add_filter( 'cron_schedules', [ __CLASS__, 'add_cron_interval' ] ); // phpcs:ignore
 
 		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
-			wp_schedule_event( time(), 'every_10_minutes', self::CRON_HOOK );
+			wp_schedule_event( time(), 'every_30_minutes', self::CRON_HOOK );
 		}
 
 		add_action( 'admin_notices', [ __CLASS__, 'maybe_show_error' ] );
@@ -103,9 +103,9 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @return array
 	 */
 	public static function add_cron_interval( $schedules ) {
-		$schedules['every_10_minutes'] = [
-			'interval' => 10 * MINUTE_IN_SECONDS,
-			'display'  => __( 'Every ten minutes', 'newspack_newsletters' ),
+		$schedules['every_30_minutes'] = [
+			'interval' => 30 * MINUTE_IN_SECONDS,
+			'display'  => __( 'Every thirty minutes', 'newspack_newsletters' ),
 		];
 		return $schedules;
 	}

--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -17,10 +17,14 @@ use Newspack_Newsletters_Mailchimp_Api as Mailchimp;
  * The purpose of this class is to implement a non-obstrusive cache, in which refreshing the cache will happen in the background in async requests
  * and will never keep the user waiting.
  *
- * The cache is stored in an option, and will be considered expired after 20 minutes. Every time we retrieve the cache, we check its age,
+ * The cache is stored in an option, and will be considered expired after 40 minutes. Every time we retrieve the cache, we check its age,
  * if it's expired, we trigger an async request to refresh it.
  *
- * Also, as a redundant strategy, we have a CRON job that will trigger the async requests to refresh the cache for all lists every 10 minutes.
+ * Also, as a redundant strategy, we have a CRON job that will trigger the async requests to refresh the cache for all lists every 30 minutes.
+ *
+ * Those two numbers belong together: the expiry (CACHE_EXPIRATION) is deliberately longer than the cron interval (CRON_SCHEDULE), so a list
+ * is refreshed in the background before it can expire and the read path stays on the cache. Shortening the expiry below the cron interval
+ * would make every read of an expired list dispatch its own async refresh, one per audience.
  *
  * If the cache refresh fails, we will store the error in a separate option, and will only surface it to the user after 20 minutes.
  * In every admin page we will display a generic Warning message, telling the user to go to Newsletters > Settings to see the errors.
@@ -64,6 +68,17 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	const CRON_SCHEDULE = 'every_30_minutes';
 
 	/**
+	 * How long a list's cached data is considered fresh
+	 *
+	 * Kept above CRON_SCHEDULE's interval so the cron refreshes a list before it can
+	 * expire. If this drops below the cron interval, every read of an expired list
+	 * dispatches its own async refresh, which is the load this cache exists to avoid.
+	 *
+	 * @var int
+	 */
+	const CACHE_EXPIRATION = 40 * MINUTE_IN_SECONDS;
+
+	/**
 	 * We store errors when an API request fails, but we will only surface these errors to the user after this time
 	 *
 	 * @var int
@@ -97,10 +112,32 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 
 		$scheduled_event = wp_get_scheduled_event( self::CRON_HOOK );
 
-		// Sites scheduled under a previous recurrence keep it until the event is cleared, so compare before scheduling.
-		if ( ! $scheduled_event || self::CRON_SCHEDULE !== $scheduled_event->schedule ) {
+		/*
+		 * Count every instance of the hook, not just the one wp_get_scheduled_event() reports.
+		 * It returns only the earliest occurrence, so a second event would sit behind a
+		 * correct-looking one indefinitely. Reading the array adds no query: the cron option is
+		 * autoloaded, and wp_get_scheduled_event() has just read the same value.
+		 */
+		$instances = 0;
+		foreach ( (array) _get_cron_array() as $hooks ) {
+			if ( isset( $hooks[ self::CRON_HOOK ] ) ) {
+				$instances += count( $hooks[ self::CRON_HOOK ] );
+			}
+		}
+
+		/*
+		 * Sites scheduled under a previous recurrence keep it until the event is cleared, so compare
+		 * before scheduling. Clearing and scheduling is not atomic either, so two concurrent requests
+		 * can leave a duplicate behind. Rescheduling whenever more than one instance exists makes that
+		 * self-correcting on the next request, which does not depend on a persistent object cache
+		 * being present.
+		 */
+		if ( ! $scheduled_event || self::CRON_SCHEDULE !== $scheduled_event->schedule || $instances > 1 ) {
+			// Keep the pending run time so migrating sites do not all fire a refresh at once.
+			$next_run = $scheduled_event ? $scheduled_event->timestamp : time() + 30 * MINUTE_IN_SECONDS;
+
 			wp_clear_scheduled_hook( self::CRON_HOOK );
-			wp_schedule_event( time(), self::CRON_SCHEDULE, self::CRON_HOOK );
+			wp_schedule_event( $next_run, self::CRON_SCHEDULE, self::CRON_HOOK );
 		}
 
 		add_action( 'admin_notices', [ __CLASS__, 'maybe_show_error' ] );
@@ -255,7 +292,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 */
 	private static function is_cache_expired( $list_id = 'lists' ) {
 		$cache_date = get_option( self::get_cache_date_key( $list_id ) );
-		return $cache_date && ( time() - $cache_date ) > 20 * MINUTE_IN_SECONDS;
+		return $cache_date && ( time() - $cache_date ) > self::CACHE_EXPIRATION;
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -259,6 +259,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 		update_option( self::get_cache_date_key( $list_id ), time(), false ); // auto-load false.
 		self::$memoized_data[ $list_id ] = $data;
 		self::clear_errors( $list_id );
+		Newspack_Newsletters_Subscription::clear_lists_cache();
 		Newspack_Newsletters_Logger::log( 'Mailchimp cache: Cache for list ' . $list_id . ' updated' );
 	}
 

--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -57,6 +57,13 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	const CRON_HOOK = 'newspack_nl_mailchimp_refresh_cache';
 
 	/**
+	 * The recurrence used to schedule the cache refresh cron event
+	 *
+	 * @var string
+	 */
+	const CRON_SCHEDULE = 'every_30_minutes';
+
+	/**
 	 * We store errors when an API request fails, but we will only surface these errors to the user after this time
 	 *
 	 * @var int
@@ -88,8 +95,12 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 		add_action( self::CRON_HOOK, [ __CLASS__, 'handle_cron' ] );
 		add_filter( 'cron_schedules', [ __CLASS__, 'add_cron_interval' ] ); // phpcs:ignore
 
-		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
-			wp_schedule_event( time(), 'every_30_minutes', self::CRON_HOOK );
+		$scheduled_event = wp_get_scheduled_event( self::CRON_HOOK );
+
+		// Sites scheduled under a previous recurrence keep it until the event is cleared, so compare before scheduling.
+		if ( ! $scheduled_event || self::CRON_SCHEDULE !== $scheduled_event->schedule ) {
+			wp_clear_scheduled_hook( self::CRON_HOOK );
+			wp_schedule_event( time(), self::CRON_SCHEDULE, self::CRON_HOOK );
 		}
 
 		add_action( 'admin_notices', [ __CLASS__, 'maybe_show_error' ] );
@@ -103,7 +114,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @return array
 	 */
 	public static function add_cron_interval( $schedules ) {
-		$schedules['every_30_minutes'] = [
+		$schedules[ self::CRON_SCHEDULE ] = [
 			'interval' => 30 * MINUTE_IN_SECONDS,
 			'display'  => __( 'Every thirty minutes', 'newspack_newsletters' ),
 		];

--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -307,7 +307,6 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 		update_option( self::get_cache_date_key( $list_id ), time(), false ); // auto-load false.
 		self::$memoized_data[ $list_id ] = $data;
 		self::clear_errors( $list_id );
-		Newspack_Newsletters_Subscription::clear_lists_cache();
 		Newspack_Newsletters_Logger::log( 'Mailchimp cache: Cache for list ' . $list_id . ' updated' );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 

### Changes proposed in this Pull Request:

The background refresh moves from every ten minutes to every thirty, which cuts Mailchimp API calls.

That interval alone would have reached new installs only. When a schedule key disappears, `wp_reschedule_event()` falls back to the interval stored on the event, so a site already scheduled at ten minutes keeps that recurrence indefinitely and `wp_next_scheduled()` never reports it as missing. The event is now compared against the current recurrence and rescheduled when the two differ.

Closes NPPM-3070.

### How to test the changes in this Pull Request:

1. Use a site with Mailchimp as the newsletters provider and the refresh cron already scheduled at ten minutes.
2. Run `wp cron event list`. The `newspack_nl_mailchimp_refresh_cache` entry recurs every thirty minutes.
3. Rename an audience in Mailchimp, or add a group to one.
4. Run `wp cron event run newspack_nl_mailchimp_refresh_cache`.
5. Open the Newsletters subscription lists screen. The renamed audience or new group appears.
6. On a site with no scheduled event, load any page. The event registers at thirty minutes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? No new tests: the cron registration path needs a live WP-Cron, and it is verified by the manual steps above.
* [x] Have you successfully run tests with your changes locally? `n test-php --filter Mailchimp` passes — 68 tests, 572 assertions.

