### PR TITLE
ci(phpunit): fetch the test suite over HTTPS with timeouts and retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,6 +379,18 @@ jobs:
           fi
           echo "WordPress $WP_TESTS_TAG"
 
+          # The two sources tag releases differently: wordpress.org names its
+          # core tarball with the version as published ("7.1"), while
+          # wordpress-develop tags are always three-part ("7.1.0"). They agree
+          # once a patch ships, so the develop tag 404s only between an x.y.0
+          # release and its first patch -- a window this job would otherwise
+          # spend entirely red. Derive the tag rather than sharing the variable.
+          WP_DEVELOP_TAG="$WP_TESTS_TAG"
+          case "$WP_DEVELOP_TAG" in
+            *.*.*) ;;
+            *) WP_DEVELOP_TAG="$WP_DEVELOP_TAG.0" ;;
+          esac
+
           # The tarball's top-level directory is "wordpress/". Extract to
           # $WP_CORE_DIR's parent and strip that prefix so files land at
           # $WP_CORE_DIR directly. Avoids the "mv: same file" failure when
@@ -397,10 +409,10 @@ jobs:
           # guarded fetch replaces both checkouts and the apt install.
           echo "Fetching the phpunit test library..."
           rm -rf "$WP_TESTS_DIR/includes" "$WP_TESTS_DIR/data"
-          fetch "https://github.com/WordPress/wordpress-develop/archive/refs/tags/$WP_TESTS_TAG.tar.gz" \
+          fetch "https://github.com/WordPress/wordpress-develop/archive/refs/tags/$WP_DEVELOP_TAG.tar.gz" \
             | tar xz --strip-components=3 -C "$WP_TESTS_DIR" \
-                "wordpress-develop-$WP_TESTS_TAG/tests/phpunit/includes" \
-                "wordpress-develop-$WP_TESTS_TAG/tests/phpunit/data"
+                "wordpress-develop-$WP_DEVELOP_TAG/tests/phpunit/includes" \
+                "wordpress-develop-$WP_DEVELOP_TAG/tests/phpunit/data"
           # A silently-empty test library fails later as a cryptic "class
           # WP_UnitTestCase not found", so assert the bootstrap actually landed.
           if [ ! -f "$WP_TESTS_DIR/includes/bootstrap.php" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,6 +350,11 @@ jobs:
           fi
       - name: Install WordPress test suite
         if: steps.check.outputs.has_tests == 'true'
+        # Below the job budget on purpose. A transfer slow enough to keep
+        # retrying but never trip the speed limit can burn --max-time on every
+        # attempt, and hitting the job timeout instead reports as a cancelled
+        # job that names no step. Failing here names this step.
+        timeout-minutes: 15
         run: |
           # Every fetch below is a stall risk, and an unguarded one used to wedge
           # here with no output naming the URL it was on. curl aborts a transfer
@@ -359,7 +364,7 @@ jobs:
             curl --fail --location --silent --show-error \
               --connect-timeout 15 --max-time 300 \
               --speed-limit 1024 --speed-time 30 \
-              --retry 5 --retry-delay 5 --retry-all-errors "$@"
+              --retry 5 --retry-delay 5 --retry-max-time 300 --retry-all-errors "$@"
           }
 
           mkdir -p "$WP_TESTS_DIR"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,11 @@ jobs:
     needs: changed-packages
     if: needs.changed-packages.outputs.any == 'true' && needs.changed-packages.outputs.php-matrix != '{"include":[]}'
     runs-on: ubuntu-latest
+    # A stalled fetch in "Install WordPress test suite" used to hold a runner
+    # until the 6-hour default timeout killed it, with the PR's check reading
+    # as still-running the whole time. This job normally finishes in 3-6
+    # minutes, so 20 is slack for a slow runner and nothing more.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.changed-packages.outputs.php-matrix) }}
@@ -346,25 +351,57 @@ jobs:
       - name: Install WordPress test suite
         if: steps.check.outputs.has_tests == 'true'
         run: |
-          # svn isn't on ubuntu-latest runners by default; the WP develop
-          # repo's phpunit test library is published over svn.
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq subversion
-          # Download WP core and test library.
+          # Every fetch below is a stall risk, and an unguarded one used to wedge
+          # here with no output naming the URL it was on. curl aborts a transfer
+          # that drops under 1KB/s for 30s and retries it, and each fetch
+          # announces itself so a log tail identifies the culprit.
+          fetch() {
+            curl --fail --location --silent --show-error \
+              --connect-timeout 15 --max-time 300 \
+              --speed-limit 1024 --speed-time 30 \
+              --retry 5 --retry-delay 5 --retry-all-errors "$@"
+          }
+
           mkdir -p "$WP_TESTS_DIR"
-          WP_TESTS_TAG=$(curl -s "https://api.wordpress.org/core/version-check/1.7/" | jq -r '.offers[0].version')
+
+          echo "Resolving the current WordPress version..."
+          WP_TESTS_TAG=$(fetch "https://api.wordpress.org/core/version-check/1.7/" | jq -r '.offers[0].version')
+          # An empty or null version would build URLs like wordpress-null.tar.gz,
+          # whose 404 surfaces as a confusing tar error several lines later.
+          if [ -z "$WP_TESTS_TAG" ] || [ "$WP_TESTS_TAG" = "null" ]; then
+            echo "Could not resolve a WordPress version from api.wordpress.org"
+            exit 1
+          fi
+          echo "WordPress $WP_TESTS_TAG"
 
           # The tarball's top-level directory is "wordpress/". Extract to
           # $WP_CORE_DIR's parent and strip that prefix so files land at
           # $WP_CORE_DIR directly. Avoids the "mv: same file" failure when
           # $WP_CORE_DIR happens to be /tmp/wordpress.
+          echo "Fetching WordPress core..."
           rm -rf "$WP_CORE_DIR"
           mkdir -p "$WP_CORE_DIR"
-          curl -s "https://wordpress.org/wordpress-$WP_TESTS_TAG.tar.gz" \
+          fetch "https://wordpress.org/wordpress-$WP_TESTS_TAG.tar.gz" \
             | tar xz --strip-components=1 -C "$WP_CORE_DIR"
 
-          svn co --quiet "https://develop.svn.wordpress.org/tags/$WP_TESTS_TAG/tests/phpunit/includes/" "$WP_TESTS_DIR/includes"
-          svn co --quiet "https://develop.svn.wordpress.org/tags/$WP_TESTS_TAG/tests/phpunit/data/" "$WP_TESTS_DIR/data"
+          # The phpunit test library used to arrive via two `svn co` calls against
+          # develop.svn.wordpress.org. svn has no timeout of its own and those
+          # checkouts are what hung; it also had to be apt-installed on every run,
+          # since ubuntu-latest carries no subversion. The wordpress-develop tag
+          # holds the same tree and comes over the same HTTPS as core above, so one
+          # guarded fetch replaces both checkouts and the apt install.
+          echo "Fetching the phpunit test library..."
+          rm -rf "$WP_TESTS_DIR/includes" "$WP_TESTS_DIR/data"
+          fetch "https://github.com/WordPress/wordpress-develop/archive/refs/tags/$WP_TESTS_TAG.tar.gz" \
+            | tar xz --strip-components=3 -C "$WP_TESTS_DIR" \
+                "wordpress-develop-$WP_TESTS_TAG/tests/phpunit/includes" \
+                "wordpress-develop-$WP_TESTS_TAG/tests/phpunit/data"
+          # A silently-empty test library fails later as a cryptic "class
+          # WP_UnitTestCase not found", so assert the bootstrap actually landed.
+          if [ ! -f "$WP_TESTS_DIR/includes/bootstrap.php" ]; then
+            echo "The phpunit test library is missing $WP_TESTS_DIR/includes/bootstrap.php"
+            exit 1
+          fi
 
           # Write wp-tests-config.php.
           cat > "$WP_TESTS_DIR/wp-tests-config.php" << 'WPCFG'

--- a/plugins/newspack-plugin/.ci-probe-nppm-3175
+++ b/plugins/newspack-plugin/.ci-probe-nppm-3175
@@ -1,4 +1,0 @@
-Temporary. Exists only to put newspack-plugin in this PR's package matrix so the
-PHPUnit job runs and exercises the rewritten "Install WordPress test suite" step.
-A ci.yml-only diff detects no packages, so the job is otherwise skipped entirely.
-Reverted before merge.

--- a/plugins/newspack-plugin/.ci-probe-nppm-3175
+++ b/plugins/newspack-plugin/.ci-probe-nppm-3175
@@ -1,0 +1,4 @@
+Temporary. Exists only to put newspack-plugin in this PR's package matrix so the
+PHPUnit job runs and exercises the rewritten "Install WordPress test suite" step.
+A ci.yml-only diff detects no packages, so the job is otherwise skipped entirely.
+Reverted before merge.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)? — n/a in the usual sense: this is a GitHub Actions workflow with no PHP or JS, so PHPCS does not cover it. The step body is clean under `shellcheck -S warning`.
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? — no duplicate. One open PR also touches this file: #861 (adds a shellcheck job), whose hunk is at the end of the file, roughly 170 lines below either of these. No textual overlap.

### Changes proposed in this Pull Request:

A PHPUnit job that stalls now fails in 20 minutes instead of holding a runner for six hours, and the step most likely to stall no longer uses a transport that cannot time out.

The `Install WordPress test suite` step fetches WordPress core and the phpunit test library. Until now, no call in it had a timeout, and two of them were `svn co` against `develop.svn.wordpress.org`. When one stalled, the job sat until GitHub's six-hour default killed it, and the PR's PHPUnit check read as still-running for the duration. On 2026-08-18 two jobs ran the full 21616 seconds before being killed. On 2026-08-19, #880 held a pending required check for 5h50m, and a re-run of the same job stalled again 43 minutes in.

It hits a fraction of jobs rather than all of them: in one run on 2026-08-19, 8 of 13 PHPUnit jobs finished normally while 5 sat on the same step.

Four changes, all in the `php-test` job of `.github/workflows/ci.yml`:

**A job timeout.** `timeout-minutes: 20`. The job normally finishes in 3 to 6 minutes, so this is slack for a slow runner rather than a new constraint. It also converts a stall from a pending check, which reads as "still working", into a failure someone notices.

**One transport instead of two.** The two `svn co` calls are replaced by a single fetch of the `wordpress-develop` tag tarball over the same HTTPS that already fetches core. svn carries no timeout of its own, which is why a stall there is unbounded. This also drops the `apt-get update` and `apt-get install subversion` that ran on every job, since svn was needed only for those checkouts.

**Guarded fetches.** Every call now goes through one `fetch()` helper: `--connect-timeout 15 --max-time 300 --speed-limit 1024 --speed-time 30 --retry 5 --retry-delay 5 --retry-all-errors`. The speed-limit pair is what handles the failure seen here — a transfer that drops below 1KB/s for 30 seconds is aborted and retried, rather than held open indefinitely.

**Two assertions and a progress line per fetch.** A null version from `api.wordpress.org` used to build a URL like `wordpress-null.tar.gz`, whose 404 surfaced as a confusing tar error several lines later; it now fails at the point of the problem. A test library that arrives empty used to fail much later as "class WP_UnitTestCase not found"; the step now checks for `includes/bootstrap.php`. And each fetch announces itself, so the next stall names the URL it was on. Today's log gives no such clue, which is why this took a while to place.

Closes NPPM-3175.

### How to test the changes in this Pull Request:

1. Extract the `run:` block of the `Install WordPress test suite` step into a file.
2. Run it against a scratch location on Linux: `WP_TESTS_DIR=/tmp/wp-tests-smoke WP_CORE_DIR=/tmp/wp-core-smoke bash install-step.sh`. Expect it to finish in about 80 seconds.
3. Check what it produced. `/tmp/wp-tests-smoke/includes/bootstrap.php` exists, `includes` holds 57 files, `data` holds 844, and `/tmp/wp-core-smoke/wp-includes/version.php` exists.
4. Confirm the source swap is content-identical, not merely equivalent. For a file in the new tarball, compare it against the svn tag it used to come from: `curl -sSL "https://develop.svn.wordpress.org/tags/7.0.4/tests/phpunit/includes/bootstrap.php" | md5sum` against `md5sum /tmp/wp-tests-smoke/includes/bootstrap.php`. The two match.
5. Simulate the stall this exists for. Point a fetch at a listener that accepts the connection and then sends nothing, and confirm curl gives up rather than hanging. Each attempt aborts after about 30 seconds with `curl: (28) Operation too slow. Less than 1024 bytes/sec transferred the last 30 seconds`, and the whole fetch exhausts its retries and exits 28 after **206 seconds** measured, against `--max-time 300` for a single attempt and six hours before this change. Three fetches stalling in the same job is roughly 10 minutes, inside the 20-minute job timeout.

Note on what CI can show here. A PR that touches only `.github/workflows/ci.yml` changes no workspace package, so `changed-packages` emits an empty `php-matrix` and the `php-test` job does not run on this PR at all. The checks below therefore say nothing about this change.

So it was exercised separately. A throwaway commit touching `newspack-plugin` (`5e8c7cc6`) put that package in the matrix, and `PHPUnit / newspack` ran the rewritten step on `ubuntu-latest`: it resolved the version, fetched core and the test library in 5 seconds total, and the suite passed in 97 seconds. Neither new assertion fired, so `api.wordpress.org` returned a version and `includes/bootstrap.php` landed. `PHPCS / newspack` and `Build ZIP / newspack` also passed on that commit. The probe is reverted in `34bdcfe7` and the net diff is `ci.yml` only.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them? — above.
* [x] Have you written new tests for your changes, as applicable? — not applicable: this is a workflow file, and the repo has no harness for executing workflow steps. Verified instead by extracting the step body and running it on Linux with GNU tar 1.34, as in the steps above.
* [x] Have you successfully run tests with your changes locally? — yes, the extraction above, plus `shellcheck -S warning` and a YAML parse of the whole file.

**Base branch.** `release`, so it reaches the open hotfix PRs that are hitting this now, and lands on `main` and `alpha` with the next post-release sync. The install step is identical on both branches, so it applies either way if you would rather it went to `main` first.

