### PR TITLE
fix(content-distribution): filter caller-supplied content on insert

### DIFF
--- a/plugins/newspack-network/includes/content-distribution/class-api.php
+++ b/plugins/newspack-network/includes/content-distribution/class-api.php
@@ -325,10 +325,10 @@ class API {
 	 *
 	 * Applies what core would clean for such a caller, directly rather than by
 	 * running the filter chain, so this does not depend on global filter
-	 * registration: block custom CSS and kses over `content`/`raw_content`, and
-	 * kses over `title` and `excerpt` in core's own two contexts. (Core also puts
-	 * wp_filter_global_styles_post on `content_save_pre`; it acts only on
-	 * global-styles JSON, which a distributed post never carries.)
+	 * registration. Over `content`/`raw_content` that is core's whole
+	 * `content_save_pre` set for this caller: the block custom-CSS strip (8), the
+	 * global-styles sanitizer (9), and kses (10). Over `title` and `excerpt` it is
+	 * kses in core's own two contexts.
 	 *
 	 * Title and excerpt are filtered twice — here, and again by core's
 	 * `title_save_pre`/`excerpt_save_pre`, which this route never removes. Both
@@ -378,12 +378,20 @@ class API {
 
 			$value = $payload['post_data'][ $field ];
 
-			// Core's order: the custom-CSS strip runs at priority 8, kses at 10.
+			// Core's content_save_pre order for such a caller: custom-CSS strip
+			// at 8, the global-styles sanitizer at 9, kses at 10.
 			if ( $strip_css ) {
 				$value = self::strip_block_custom_css( $value );
 			}
 
 			if ( $filter_html ) {
+				// A wp_global_styles post carries theme JSON in post_content, and
+				// kses does not clean the CSS inside it — wp_filter_global_styles_post
+				// does. This route does not restrict post_type, so a caller can send
+				// that JSON here. The function slash-wraps its own output; this input
+				// is unslashed until wp_slash( $postarr ), so unwrap it back. It is a
+				// passthrough for anything that is not global-styles JSON.
+				$value = wp_unslash( wp_filter_global_styles_post( wp_slash( $value ) ) );
 				$value = wp_kses_post( $value );
 			}
 

--- a/plugins/newspack-network/includes/content-distribution/class-api.php
+++ b/plugins/newspack-network/includes/content-distribution/class-api.php
@@ -312,6 +312,41 @@ class API {
 	}
 
 	/**
+	 * Hold the caller-supplied post type to the network's allowlist.
+	 *
+	 * `post_type` comes from the payload and reaches wp_insert_post() unchecked,
+	 * and wp_insert_post() does no post-type authorization of its own. Filtering
+	 * the content does not cover this: types like `wp_template`, `wp_navigation`
+	 * and `wp_global_styles` change how the site renders rather than carrying
+	 * article content, so a clean payload is still the wrong thing to create.
+	 *
+	 * Outgoing_Post::__construct() already refuses anything outside this list, so
+	 * this is the same rule applied to the receiving end. Scoped to this route:
+	 * distribution over Data Events does not pass through here.
+	 *
+	 * @param mixed $payload The incoming payload.
+	 *
+	 * @return WP_Error|null An error to return to the caller, or null to proceed.
+	 */
+	private static function check_incoming_post_type( mixed $payload ): ?WP_Error {
+		if ( ! is_array( $payload ) || ! isset( $payload['post_data']['post_type'] ) ) {
+			return null;
+		}
+
+		$post_type = $payload['post_data']['post_type'];
+		if ( ! is_string( $post_type ) || in_array( $post_type, Content_Distribution_Class::get_distributed_post_types(), true ) ) {
+			return null;
+		}
+
+		return new WP_Error(
+			'invalid_post_type',
+			/* translators: unsupported post type for content distribution */
+			sprintf( __( 'Post type %s is not supported as a distributed incoming post.', 'newspack-network' ), $post_type ),
+			[ 'status' => 400 ]
+		);
+	}
+
+	/**
 	 * Hold caller-supplied content to the caller's own capabilities.
 	 *
 	 * This route's payload is composed in the browser rather than by a peer site,
@@ -427,7 +462,14 @@ class API {
 	 * @return WP_REST_Response|WP_Error The REST response or error.
 	 */
 	public static function insert_post( $request ): WP_REST_Response|WP_Error {
-		$payload = self::filter_incoming_content( $request->get_param( 'payload' ) );
+		$payload = $request->get_param( 'payload' );
+
+		$post_type_error = self::check_incoming_post_type( $payload );
+		if ( $post_type_error ) {
+			return $post_type_error;
+		}
+
+		$payload = self::filter_incoming_content( $payload );
 
 		try {
 			$incoming_post = new Incoming_Post( $payload );

--- a/plugins/newspack-network/includes/content-distribution/class-api.php
+++ b/plugins/newspack-network/includes/content-distribution/class-api.php
@@ -323,19 +323,25 @@ class API {
 	 * Data Event carrying network credentials and never passes through here, so
 	 * it keeps storing content verbatim — see test_event_path_content_is_not_filtered.
 	 *
-	 * Covers the two things core cleans on `content_save_pre` for such a caller:
-	 * HTML through kses, and block custom CSS. Those are applied directly rather
-	 * than by running the chain, so this guard does not depend on global filter
-	 * registration. That reasoning covers `content` and `raw_content` only —
-	 * `title` and `excerpt` are left to core's own `title_save_pre` and
-	 * `excerpt_save_pre`, which this path never removes, so they do still depend
-	 * on it.
+	 * Applies what core would clean for such a caller, directly rather than by
+	 * running the filter chain, so this does not depend on global filter
+	 * registration: block custom CSS and kses over `content`/`raw_content`, and
+	 * kses over `title` and `excerpt` in core's own two contexts. (Core also puts
+	 * wp_filter_global_styles_post on `content_save_pre`; it acts only on
+	 * global-styles JSON, which a distributed post never carries.)
+	 *
+	 * Title and excerpt are filtered twice — here, and again by core's
+	 * `title_save_pre`/`excerpt_save_pre`, which this route never removes. Both
+	 * passes are idempotent, so the stored value is the same either way. The
+	 * reason to filter them here at all is the persisted payload, below.
 	 *
 	 * Load-bearing: this mutates the payload BEFORE Incoming_Post is constructed,
 	 * so the copy persisted to PAYLOAD_META is the filtered one. Re-linking an
-	 * unlinked post replays that stored payload through insert() with
-	 * `content_save_pre` still removed and no route filtering, so persisting a
-	 * pristine payload here would reopen the hole through that path.
+	 * unlinked post replays that stored payload through insert(), with
+	 * `content_save_pre` still removed and no route filtering — and a caller
+	 * holding unfiltered_html at that moment has no title or excerpt filters of
+	 * their own either. Persisting a pristine payload would reopen the hole
+	 * through that path, for every field.
 	 *
 	 * The cost of that choice, on legitimate content: the filtered copy is also the
 	 * merge base `get_payload_from_partial()` merges later updates over, so where a
@@ -382,6 +388,24 @@ class API {
 			}
 
 			$payload['post_data'][ $field ] = $value;
+		}
+
+		// Mirrors core's other two kses registrations for this caller:
+		// title_save_pre => wp_filter_kses, which scopes the tag set by context,
+		// and excerpt_save_pre => wp_filter_post_kses. Custom CSS is deliberately
+		// not stripped here — neither field is block content, and core does not
+		// strip it there either.
+		if ( $filter_html ) {
+			foreach ( [
+				'title'   => 'title_save_pre',
+				'excerpt' => 'post',
+			] as $field => $context ) {
+				if ( ! isset( $payload['post_data'][ $field ] ) || ! is_string( $payload['post_data'][ $field ] ) ) {
+					continue;
+				}
+
+				$payload['post_data'][ $field ] = wp_kses( $payload['post_data'][ $field ], $context );
+			}
 		}
 
 		return $payload;

--- a/plugins/newspack-network/includes/content-distribution/class-api.php
+++ b/plugins/newspack-network/includes/content-distribution/class-api.php
@@ -245,6 +245,149 @@ class API {
 	}
 
 	/**
+	 * Remove block custom CSS from post content.
+	 *
+	 * Core has `wp_strip_custom_css_from_blocks()`, but only since WordPress 7.0,
+	 * and guarding on its existence would gate on feature availability rather than
+	 * on safety: content stored on an older site keeps the attribute, and it starts
+	 * rendering the day that site upgrades. Stripping it ourselves closes that
+	 * window and keeps one code path under test. Matches core's output where no
+	 * block carries custom CSS, including the untouched-bytes case; once something
+	 * is stripped this re-serializes the document while core splices only the
+	 * attribute it changed, so siblings written in non-canonical form normalize.
+	 *
+	 * @param string $content Post content.
+	 *
+	 * @return string The content with any block custom CSS removed.
+	 */
+	private static function strip_block_custom_css( string $content ): string {
+		// Deliberately not gated on has_blocks(). That tests for the exact literal
+		// '<!-- wp:', while WP_Block_Parser accepts extra whitespace or a newline
+		// after the opener, so a guard here skips content the parser still reads as
+		// a block — and the kses pass that follows then normalizes the delimiter
+		// back to canonical form with the attribute intact. Core carries the same
+		// guard; this is the one place we deliberately differ from it. The $removed
+		// check below already returns the original bytes when nothing was stripped,
+		// so the guard bought nothing.
+		$removed = false;
+		$blocks  = self::remove_custom_css_attribute( parse_blocks( $content ), $removed );
+
+		// Return the original bytes when there was nothing to strip, so this does not
+		// needlessly re-serialize markup it had no reason to touch. Note the stored
+		// payload is the FILTERED copy, not the sender's original — see the note on
+		// filter_incoming_content(), which that safety depends on.
+		if ( ! $removed ) {
+			return $content;
+		}
+
+		return serialize_blocks( $blocks );
+	}
+
+	/**
+	 * Recursively drop the `style.css` attribute from parsed blocks.
+	 *
+	 * @param array $blocks  Parsed blocks.
+	 * @param bool  $removed Set to true when any custom CSS was found and removed.
+	 *
+	 * @return array The blocks, without custom CSS.
+	 */
+	private static function remove_custom_css_attribute( array $blocks, bool &$removed ): array {
+		foreach ( $blocks as $index => $block ) {
+			if ( isset( $block['attrs']['style']['css'] ) ) {
+				unset( $blocks[ $index ]['attrs']['style']['css'] );
+				$removed = true;
+
+				// Match core: an emptied style attribute is removed, not left behind.
+				if ( empty( $blocks[ $index ]['attrs']['style'] ) ) {
+					unset( $blocks[ $index ]['attrs']['style'] );
+				}
+			}
+
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$blocks[ $index ]['innerBlocks'] = self::remove_custom_css_attribute( $block['innerBlocks'], $removed );
+			}
+		}
+
+		return $blocks;
+	}
+
+	/**
+	 * Hold caller-supplied content to the caller's own capabilities.
+	 *
+	 * This route's payload is composed in the browser rather than by a peer site,
+	 * and Incoming_Post::insert() stores content with kses disabled, which is only
+	 * defensible for trusted-node content. So content is filtered here, against the
+	 * requesting user's own capabilities.
+	 *
+	 * Scoped deliberately to this route. Distribution between sites arrives as a
+	 * Data Event carrying network credentials and never passes through here, so
+	 * it keeps storing content verbatim — see test_event_path_content_is_not_filtered.
+	 *
+	 * Covers the two things core cleans on `content_save_pre` for such a caller:
+	 * HTML through kses, and block custom CSS. Those are applied directly rather
+	 * than by running the chain, so this guard does not depend on global filter
+	 * registration. That reasoning covers `content` and `raw_content` only —
+	 * `title` and `excerpt` are left to core's own `title_save_pre` and
+	 * `excerpt_save_pre`, which this path never removes, so they do still depend
+	 * on it.
+	 *
+	 * Load-bearing: this mutates the payload BEFORE Incoming_Post is constructed,
+	 * so the copy persisted to PAYLOAD_META is the filtered one. Re-linking an
+	 * unlinked post replays that stored payload through insert() with
+	 * `content_save_pre` still removed and no route filtering, so persisting a
+	 * pristine payload here would reopen the hole through that path.
+	 *
+	 * The cost of that choice, on legitimate content: the filtered copy is also the
+	 * merge base `get_payload_from_partial()` merges later updates over, so where a
+	 * low-privilege caller degrades content, subsequent partial updates re-apply the
+	 * degraded copy. Only a full re-distribution from the origin heals it.
+	 *
+	 * @param mixed $payload The incoming payload.
+	 *
+	 * @return mixed The payload, with content filtered where the caller requires it.
+	 */
+	private static function filter_incoming_content( mixed $payload ): mixed {
+		if ( ! is_array( $payload ) || empty( $payload['post_data'] ) || ! is_array( $payload['post_data'] ) ) {
+			return $payload;
+		}
+
+		// Checked separately because core gates them separately: it registers the
+		// custom-CSS strip for callers without edit_css and kses for callers without
+		// unfiltered_html. Both meta caps resolve to the same primitive by default,
+		// but map_meta_cap is a filter and a plugin can diverge them, so mirroring
+		// core's two gates keeps this correct either way.
+		$strip_css   = ! current_user_can( 'edit_css' );
+		$filter_html = ! current_user_can( 'unfiltered_html' );
+
+		if ( ! $strip_css && ! $filter_html ) {
+			return $payload;
+		}
+
+		// Both fields can reach post_content: get_post_content() returns 'content'
+		// unless 'raw_content' carries blocks, in which case that is what is stored.
+		foreach ( [ 'content', 'raw_content' ] as $field ) {
+			if ( ! isset( $payload['post_data'][ $field ] ) || ! is_string( $payload['post_data'][ $field ] ) ) {
+				continue;
+			}
+
+			$value = $payload['post_data'][ $field ];
+
+			// Core's order: the custom-CSS strip runs at priority 8, kses at 10.
+			if ( $strip_css ) {
+				$value = self::strip_block_custom_css( $value );
+			}
+
+			if ( $filter_html ) {
+				$value = wp_kses_post( $value );
+			}
+
+			$payload['post_data'][ $field ] = $value;
+		}
+
+		return $payload;
+	}
+
+	/**
 	 * Insert a post given an Outgoing_Post payload.
 	 *
 	 * @param WP_REST_Request $request The REST request object.
@@ -252,7 +395,7 @@ class API {
 	 * @return WP_REST_Response|WP_Error The REST response or error.
 	 */
 	public static function insert_post( $request ): WP_REST_Response|WP_Error {
-		$payload = $request->get_param( 'payload' );
+		$payload = self::filter_incoming_content( $request->get_param( 'payload' ) );
 
 		try {
 			$incoming_post = new Incoming_Post( $payload );

--- a/plugins/newspack-network/includes/content-distribution/class-api.php
+++ b/plugins/newspack-network/includes/content-distribution/class-api.php
@@ -329,7 +329,17 @@ class API {
 	 * @return WP_Error|null An error to return to the caller, or null to proceed.
 	 */
 	private static function check_incoming_post_type( mixed $payload ): ?WP_Error {
-		if ( ! is_array( $payload ) || ! isset( $payload['post_data']['post_type'] ) ) {
+		if ( ! is_array( $payload ) || ! isset( $payload['post_data'] ) || ! is_array( $payload['post_data'] ) ) {
+			return null;
+		}
+
+		// array_key_exists rather than isset, so an explicit null is judged rather
+		// than read as absent. The two are not equivalent on a partial payload:
+		// get_payload_from_partial() array_merges this over the stored payload, so a
+		// null overwrites the stored type and wp_insert_post() falls back to its own
+		// default. That silently turns an existing page into a post. A genuinely
+		// omitted key still passes, which is what a partial payload relies on.
+		if ( ! array_key_exists( 'post_type', $payload['post_data'] ) ) {
 			return null;
 		}
 

--- a/plugins/newspack-network/includes/content-distribution/class-api.php
+++ b/plugins/newspack-network/includes/content-distribution/class-api.php
@@ -334,14 +334,21 @@ class API {
 		}
 
 		$post_type = $payload['post_data']['post_type'];
-		if ( ! is_string( $post_type ) || in_array( $post_type, Content_Distribution_Class::get_distributed_post_types(), true ) ) {
+
+		// Only a string on the list gets through. A non-string is refused rather
+		// than passed along: it cannot be on the list, and letting it reach
+		// wp_insert_post() defers the same problem to a worse place.
+		if ( is_string( $post_type ) && in_array( $post_type, Content_Distribution_Class::get_distributed_post_types(), true ) ) {
 			return null;
 		}
 
 		return new WP_Error(
 			'invalid_post_type',
-			/* translators: unsupported post type for content distribution */
-			sprintf( __( 'Post type %s is not supported as a distributed incoming post.', 'newspack-network' ), $post_type ),
+			sprintf(
+				/* translators: unsupported post type for content distribution */
+				__( 'Post type %s is not supported as a distributed incoming post.', 'newspack-network' ),
+				is_string( $post_type ) ? $post_type : gettype( $post_type )
+			),
 			[ 'status' => 400 ]
 		);
 	}
@@ -422,8 +429,9 @@ class API {
 			if ( $filter_html ) {
 				// A wp_global_styles post carries theme JSON in post_content, and
 				// kses does not clean the CSS inside it — wp_filter_global_styles_post
-				// does. This route does not restrict post_type, so a caller can send
-				// that JSON here. The function slash-wraps its own output; this input
+				// does. This runs on content regardless of post type, so the same JSON
+				// sent as the body of an allowed type is cleaned too. The function
+				// slash-wraps its own output; this input
 				// is unslashed until wp_slash( $postarr ), so unwrap it back. It is a
 				// passthrough for anything that is not global-styles JSON.
 				$value = wp_unslash( wp_filter_global_styles_post( wp_slash( $value ) ) );

--- a/plugins/newspack-network/includes/content-distribution/class-api.php
+++ b/plugins/newspack-network/includes/content-distribution/class-api.php
@@ -349,10 +349,23 @@ class API {
 		// than read as absent. The two are not equivalent on a partial payload:
 		// get_payload_from_partial() array_merges this over the stored payload, so a
 		// null overwrites the stored type and wp_insert_post() falls back to its own
-		// default. That silently turns an existing page into a post. A genuinely
-		// omitted key still passes, which is what a partial payload relies on.
+		// default. That silently turns an existing page into a post.
+		//
+		// A genuinely omitted key passes only on a partial payload, which is the one
+		// shape that legitimately carries just the fields it is changing. On a full
+		// payload the field is required: insert() hands it to
+		// use_block_editor_for_post_type() before anything else validates it, so the
+		// omission surfaces as a PHP warning rather than as this route's 400.
 		if ( ! array_key_exists( 'post_type', $payload['post_data'] ) ) {
-			return null;
+			if ( ! empty( $payload['partial'] ) ) {
+				return null;
+			}
+
+			return new WP_Error(
+				'invalid_post_type',
+				__( 'The payload must carry a post type unless it is a partial update.', 'newspack-network' ),
+				[ 'status' => 400 ]
+			);
 		}
 
 		$post_type = $payload['post_data']['post_type'];

--- a/plugins/newspack-network/includes/content-distribution/class-api.php
+++ b/plugins/newspack-network/includes/content-distribution/class-api.php
@@ -353,9 +353,15 @@ class API {
 		//
 		// A genuinely omitted key passes only on a partial payload, which is the one
 		// shape that legitimately carries just the fields it is changing. On a full
-		// payload the field is required: insert() hands it to
-		// use_block_editor_for_post_type() before anything else validates it, so the
-		// omission surfaces as a PHP warning rather than as this route's 400.
+		// payload the field is required: insert() reads it straight out of the
+		// payload before anything else validates it, so the omission surfaces as a
+		// PHP warning rather than as this route's 400.
+		//
+		// Requiring fields stops at post_type deliberately. insert() dereferences
+		// several other fields just as unguarded — title, slug, content, timestamps
+		// and more — but post_type is the one whose value decides what the caller is
+		// authorized to create, via the allowlist below. This is that check's
+		// precondition, not payload-shape validation.
 		if ( ! array_key_exists( 'post_type', $payload['post_data'] ) ) {
 			if ( ! empty( $payload['partial'] ) ) {
 				return null;
@@ -408,11 +414,13 @@ class API {
 	 * kses in core's own two contexts.
 	 *
 	 * Deliberately not reproduced: `convert_invalid_entities` (10) and `balanceTags`
-	 * (50). Both are ungated, so they are not part of holding a caller to their own
-	 * capabilities, and `remove_all_filters()` dropped them for every caller before
-	 * this change too. The cost is that content stored through this route is less
-	 * normalized than the same content saved in the editor, on a site with
-	 * `use_balanceTags` enabled.
+	 * (50). Neither is capability-gated, so they are not part of holding a caller to
+	 * their own capabilities, and `remove_all_filters()` dropped them for every
+	 * caller before this change too. The cost is that content stored through this
+	 * route is less normalized than the same content saved in the editor: CP1252
+	 * numeric entities survive verbatim on every site, and unbalanced tags survive
+	 * where `use_balanceTags` is enabled — only `balanceTags()` is gated on that
+	 * option.
 	 *
 	 * Title and excerpt are filtered twice — here, and again by core's
 	 * `title_save_pre`/`excerpt_save_pre`, which this route never removes. Both

--- a/plugins/newspack-network/includes/content-distribution/class-api.php
+++ b/plugins/newspack-network/includes/content-distribution/class-api.php
@@ -389,10 +389,17 @@ class API {
 	 *
 	 * Applies what core would clean for such a caller, directly rather than by
 	 * running the filter chain, so this does not depend on global filter
-	 * registration. Over `content`/`raw_content` that is core's whole
+	 * registration. Over `content`/`raw_content` that is core's capability-gated
 	 * `content_save_pre` set for this caller: the block custom-CSS strip (8), the
 	 * global-styles sanitizer (9), and kses (10). Over `title` and `excerpt` it is
 	 * kses in core's own two contexts.
+	 *
+	 * Deliberately not reproduced: `convert_invalid_entities` (10) and `balanceTags`
+	 * (50). Both are ungated, so they are not part of holding a caller to their own
+	 * capabilities, and `remove_all_filters()` dropped them for every caller before
+	 * this change too. The cost is that content stored through this route is less
+	 * normalized than the same content saved in the editor, on a site with
+	 * `use_balanceTags` enabled.
 	 *
 	 * Title and excerpt are filtered twice — here, and again by core's
 	 * `title_save_pre`/`excerpt_save_pre`, which this route never removes. Both

--- a/plugins/newspack-network/includes/content-distribution/class-api.php
+++ b/plugins/newspack-network/includes/content-distribution/class-api.php
@@ -329,8 +329,20 @@ class API {
 	 * @return WP_Error|null An error to return to the caller, or null to proceed.
 	 */
 	private static function check_incoming_post_type( mixed $payload ): ?WP_Error {
-		if ( ! is_array( $payload ) || ! isset( $payload['post_data'] ) || ! is_array( $payload['post_data'] ) ) {
+		if ( ! is_array( $payload ) || ! isset( $payload['post_data'] ) ) {
 			return null;
+		}
+
+		// A present-but-not-array post_data is refused rather than passed along.
+		// get_payload_error() only tests it for emptiness, and insert() then indexes
+		// it, which is an uncaught TypeError on PHP 8. Returning early here would
+		// read as validation while letting that through.
+		if ( ! is_array( $payload['post_data'] ) ) {
+			return new WP_Error(
+				'invalid_post_data',
+				__( 'The payload post data must be an object.', 'newspack-network' ),
+				[ 'status' => 400 ]
+			);
 		}
 
 		// array_key_exists rather than isset, so an explicit null is judged rather

--- a/plugins/newspack-network/includes/content-distribution/class-incoming-post.php
+++ b/plugins/newspack-network/includes/content-distribution/class-incoming-post.php
@@ -803,13 +803,14 @@ class Incoming_Post {
 				if ( is_array( $content_save_pre_filters ) ) {
 					foreach ( $content_save_pre_filters as $priority => $callbacks ) {
 						foreach ( $callbacks as $callback ) {
-							// Reconcile rather than overwrite. A callback inside the try may
-							// have removed one of these on purpose — core does exactly that
-							// when the current user is switched to one holding
-							// unfiltered_html — and re-adding it blindly would undo that.
-							if ( false === has_filter( 'content_save_pre', $callback['function'] ) ) {
-								add_filter( 'content_save_pre', $callback['function'], $priority, $callback['accepted_args'] );
-							}
+							// Restores the snapshot exactly, including a callback registered
+							// at more than one priority. A has_filter() guard was tried here
+							// and reverted: has_filter() reports only the first priority a
+							// callback sits at, so the second registration was silently
+							// dropped. It also could not do what it was meant to — the hook
+							// is already empty by this point, so a filter removed deliberately
+							// inside the try is indistinguishable from the ones removed above.
+							add_filter( 'content_save_pre', $callback['function'], $priority, $callback['accepted_args'] );
 						}
 					}
 				}

--- a/plugins/newspack-network/includes/content-distribution/class-incoming-post.php
+++ b/plugins/newspack-network/includes/content-distribution/class-incoming-post.php
@@ -810,6 +810,19 @@ class Incoming_Post {
 							// dropped. It also could not do what it was meant to — the hook
 							// is already empty by this point, so a filter removed deliberately
 							// inside the try is indistinguishable from the ones removed above.
+							//
+							// Known limit: the snapshot belongs to whoever was current when
+							// it was taken. If a callback inside the try switched the current
+							// user to one holding unfiltered_html, core's kses_init on
+							// set_current_user drops kses, and this puts it back — leaving
+							// that user over-filtered for the rest of the request. It does not
+							// self-heal, because kses_init only removes filters, so a later
+							// switch back to the same user changes nothing. Left as is:
+							// nothing in this plugin switches users during a save, and
+							// over-filtering is the safe direction. Reconciling would mean
+							// re-running kses_init and wp_custom_css_kses_init after the
+							// restore, which would also discard any unrelated
+							// content_save_pre callback another plugin added inside the try.
 							add_filter( 'content_save_pre', $callback['function'], $priority, $callback['accepted_args'] );
 						}
 					}

--- a/plugins/newspack-network/includes/content-distribution/class-incoming-post.php
+++ b/plugins/newspack-network/includes/content-distribution/class-incoming-post.php
@@ -773,17 +773,46 @@ class Incoming_Post {
 			 */
 			do_action( 'newspack_network_incoming_post_before_save', $post_data, $this->post, $this->get_original_site_url() );
 
-			// Remove filters that may alter content updates.
+			// Remove filters that may alter content updates. Captured and restored
+			// below: the removal is global, so leaving it in place would silently
+			// disable kses for every later post save in the same request.
+			// Copy the callbacks array, not the WP_Hook object: remove_all_filters()
+			// empties that same object, so holding the object would restore nothing.
+			$content_save_pre_filters = isset( $GLOBALS['wp_filter']['content_save_pre'] )
+				? $GLOBALS['wp_filter']['content_save_pre']->callbacks
+				: null;
 			remove_all_filters( 'content_save_pre' );
 
 			// wp_insert_post()/wp_update_post() expect slashed data and unslash it
 			// internally. Serialized block markup carries literal backslashes in
 			// attribute JSON escapes (backslash-u003c for `<` etc.), which an
 			// unslashed insert would strip, corrupting block attributes.
-			if ( $this->ID ) {
-				$post_id = wp_update_post( wp_slash( $postarr ), true );
-			} else {
-				$post_id = wp_insert_post( wp_slash( $postarr ), true );
+			try {
+				if ( $this->ID ) {
+					$post_id = wp_update_post( wp_slash( $postarr ), true );
+				} else {
+					$post_id = wp_insert_post( wp_slash( $postarr ), true );
+				}
+			} finally {
+				// A throwing callback on wp_insert_post_data or save_post would
+				// otherwise leave content unfiltered for the rest of the request,
+				// for every later save, not just this one. One deliberate effect:
+				// the attachment insert in upload_thumbnail() below now runs with
+				// the filters back, so its EXIF-derived post_content is cleaned the
+				// way a normal media upload would be.
+				if ( is_array( $content_save_pre_filters ) ) {
+					foreach ( $content_save_pre_filters as $priority => $callbacks ) {
+						foreach ( $callbacks as $callback ) {
+							// Reconcile rather than overwrite. A callback inside the try may
+							// have removed one of these on purpose — core does exactly that
+							// when the current user is switched to one holding
+							// unfiltered_html — and re-adding it blindly would undo that.
+							if ( false === has_filter( 'content_save_pre', $callback['function'] ) ) {
+								add_filter( 'content_save_pre', $callback['function'], $priority, $callback['accepted_args'] );
+							}
+						}
+					}
+				}
 			}
 
 			if ( is_wp_error( $post_id ) ) {

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
@@ -899,4 +899,74 @@ class TestApi extends \WP_UnitTestCase {
 			);
 		}
 	}
+
+	/**
+	 * The route must refuse a post type the network does not distribute.
+	 *
+	 * The payload's post_type reaches wp_insert_post() unchecked, and that
+	 * function does no post-type authorization. Types like wp_template and
+	 * wp_navigation change how the site renders, so filtering their content
+	 * is not enough.
+	 *
+	 * @group content-distribution-api
+	 */
+	public function test_insert_refuses_a_post_type_outside_the_allowlist() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'author' ] ) );
+		kses_init();
+
+		foreach ( [ 'wp_template', 'wp_navigation', 'wp_global_styles' ] as $post_type ) {
+			$response = rest_get_server()->dispatch(
+				$this->make_insert_request_with( [ 'post_type' => $post_type ] )
+			);
+
+			$this->assertSame( 400, $response->get_status(), "The route must refuse $post_type." );
+			$this->assertSame(
+				'invalid_post_type',
+				$response->as_error()->get_error_code(),
+				"Refusing $post_type must report why, not fail incidentally."
+			);
+			$this->assertSame(
+				0,
+				count(
+					get_posts(
+						[
+							'post_type'   => $post_type,
+							'post_status' => 'any',
+						] 
+					) 
+				),
+				"Nothing of type $post_type may be created."
+			);
+		}
+	}
+
+	/**
+	 * The allowlist must not cost the types the network does distribute.
+	 *
+	 * The list is filterable, so this asserts against whatever the install
+	 * allows rather than a hard-coded set.
+	 *
+	 * @group content-distribution-api
+	 */
+	public function test_insert_still_accepts_a_distributed_post_type() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'author' ] ) );
+		kses_init();
+
+		foreach ( Content_Distribution_Class::get_distributed_post_types() as $post_type ) {
+			if ( ! post_type_exists( $post_type ) ) {
+				continue;
+			}
+
+			$response = rest_get_server()->dispatch(
+				$this->make_insert_request_with( [ 'post_type' => $post_type ] )
+			);
+
+			$this->assertSame( 200, $response->get_status(), "A distributed type must still insert ($post_type)." );
+			$this->assertSame(
+				$post_type,
+				get_post_field( 'post_type', $response->get_data()['post_id'] ),
+				"The post must be created as $post_type."
+			);
+		}
+	}
 }

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
@@ -262,4 +262,466 @@ class TestApi extends \WP_UnitTestCase {
 			'The payload hash must be stored on a successful dispatch.'
 		);
 	}
+
+	/**
+	 * Build an /insert request carrying the given content.
+	 *
+	 * @param string $content     The rendered content.
+	 * @param string $raw_content The block-serialized content.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function make_insert_request( $content, $raw_content = 'plain text, no blocks' ) {
+		$payload = get_sample_payload( 'https://origin.test', get_bloginfo( 'url' ) );
+
+		$payload['post_data']['content']       = $content;
+		$payload['post_data']['raw_content']   = $raw_content;
+		$payload['post_data']['thumbnail_url'] = ''; // Avoid a sideload attempt in tests.
+
+		$request = new WP_REST_Request( 'POST', '/newspack-network/v1/content-distribution/insert' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( [ 'payload' => $payload ] ) );
+
+		return $request;
+	}
+
+	/**
+	 * Dispatch an /insert request and return the stored post content.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return string The stored post_content.
+	 */
+	private function insert_and_get_content( $request ) {
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status(), 'The insert request should succeed.' );
+
+		return get_post_field( 'post_content', $response->get_data()['post_id'] );
+	}
+
+	/**
+	 * The 'author' role holds the distribute capability but not
+	 * 'unfiltered_html', so content arriving through /insert must be filtered
+	 * the same way it would be if that user wrote the post by hand.
+	 */
+	public function test_insert_strips_unsafe_html_for_author() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'author' ] ) );
+
+		$content = $this->insert_and_get_content(
+			$this->make_insert_request( '<script>alert(1)</script>hello' )
+		);
+
+		$this->assertStringNotContainsString(
+			'<script>',
+			$content,
+			'An author must not be able to store a raw script tag through /insert.'
+		);
+		$this->assertStringContainsString( 'hello', $content, 'The safe part of the content must survive.' );
+	}
+
+	/**
+	 * An editor holds 'unfiltered_html', so their content is stored as-is.
+	 * This is what keeps Story Budget pulls working for editors and above.
+	 */
+	public function test_insert_preserves_unsafe_html_for_editor() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'editor' ] ) );
+
+		// The whole test rests on the editor holding unfiltered_html, which is a
+		// single-site fact: multisite and DISALLOW_UNFILTERED_HTML deny it to
+		// everyone below super admin. Skip there rather than fail — the fix is
+		// behaving correctly on those installs, it just filters everyone.
+		if ( ! current_user_can( 'unfiltered_html' ) ) {
+			$this->markTestSkipped( 'This install denies unfiltered_html to editors; the route filters every role there.' );
+		}
+
+		$content = $this->insert_and_get_content(
+			$this->make_insert_request( '<script>alert(1)</script>hello' )
+		);
+
+		$this->assertStringContainsString(
+			'<script>',
+			$content,
+			'An editor holds unfiltered_html, so their content must not be filtered.'
+		);
+	}
+
+	/**
+	 * Filtering must not disturb ordinary block markup: block delimiters are
+	 * HTML comments, which kses preserves.
+	 */
+	public function test_insert_preserves_ordinary_block_markup_for_author() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'author' ] ) );
+
+		$blocks = '<!-- wp:paragraph --><p>Hello <strong>world</strong></p><!-- /wp:paragraph -->';
+
+		$content = $this->insert_and_get_content(
+			$this->make_insert_request( '<p>Hello <strong>world</strong></p>', $blocks )
+		);
+
+		$this->assertStringContainsString( 'wp:paragraph', $content, 'Block delimiters must survive filtering.' );
+		$this->assertStringContainsString( '<strong>world</strong>', $content, 'Inline markup must survive filtering.' );
+	}
+
+	/**
+	 * The scoping guard. Distribution between sites arrives as a Data Event,
+	 * not through /insert, and carries network credentials. That path must
+	 * keep storing content verbatim, or every network loses its embeds.
+	 *
+	 * If this test fails, the filtering has been pushed down into
+	 * Incoming_Post::insert() and is no longer scoped to the REST route.
+	 */
+	public function test_event_path_content_is_not_filtered() {
+		$payload = get_sample_payload( 'https://origin.test', get_bloginfo( 'url' ) );
+
+		$payload['post_data']['content']       = '<script>alert(1)</script>hello';
+		$payload['post_data']['raw_content']   = 'plain text, no blocks';
+		$payload['post_data']['thumbnail_url'] = '';
+
+		$incoming_post = new Incoming_Post( $payload );
+		$post_id       = $incoming_post->insert();
+
+		$this->assertNotWPError( $post_id, 'The event path insert should succeed.' );
+		$this->assertStringContainsString(
+			'<script>',
+			get_post_field( 'post_content', $post_id ),
+			'Content arriving on the event path must not be filtered.'
+		);
+	}
+
+	/**
+	 * Inserting disables kses globally for the rest of the request. It must put
+	 * the filters back, or an unrelated save later in the same request stores
+	 * unfiltered content. Nothing in the current after-save chain writes a post,
+	 * so this guards the next thing that does.
+	 */
+	public function test_insert_restores_content_filters() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'author' ] ) );
+		kses_init();
+
+		$this->assertNotFalse(
+			has_filter( 'content_save_pre', 'wp_filter_post_kses' ),
+			'Precondition: kses must be filtering content for this user before the insert.'
+		);
+
+		$this->insert_and_get_content( $this->make_insert_request( 'safe content' ) );
+
+		// Assert the priority, not just presence: the restore loop's whole job is
+		// reproducing priority and accepted_args, and a presence-only check passes
+		// even if everything came back at priority 10.
+		$this->assertSame(
+			10,
+			has_filter( 'content_save_pre', 'wp_filter_post_kses' ),
+			'The insert must restore kses at its original priority.'
+		);
+		$this->assertSame(
+			9,
+			has_filter( 'content_save_pre', 'wp_filter_global_styles_post' ),
+			'The insert must restore the other content_save_pre callbacks too, not just kses.'
+		);
+		if ( function_exists( 'wp_strip_custom_css_from_blocks' ) ) {
+			$this->assertSame(
+				8,
+				has_filter( 'content_save_pre', 'wp_strip_custom_css_from_blocks' ),
+				'Priority 8 is the custom-CSS sink this fix also covers, so pin it explicitly.'
+			);
+		}
+
+		$later_post = wp_insert_post(
+			[
+				'post_title'   => 'Saved after the insert',
+				'post_content' => '<script>alert(1)</script>hello',
+				'post_status'  => 'draft',
+			]
+		);
+
+		$this->assertStringNotContainsString(
+			'<script>',
+			get_post_field( 'post_content', $later_post ),
+			'A later save in the same request must still be filtered.'
+		);
+	}
+
+	/**
+	 * The cost of filtering, pinned deliberately rather than left to be
+	 * discovered. An author pulling a story that carries a Custom HTML block
+	 * gets the block's body dropped, because `iframe` is not in the kses
+	 * post allowlist. The block delimiter survives as an empty shell, with no
+	 * notice in the response.
+	 *
+	 * An author cannot hand-write an iframe either, so this matches what they
+	 * would get writing the post themselves. Editors and above keep the embed
+	 * (see test_insert_preserves_unsafe_html_for_editor).
+	 */
+	public function test_insert_drops_custom_html_block_body_for_author() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'author' ] ) );
+
+		$embed = '<!-- wp:html --><iframe src="https://example.test/chart/1/"></iframe><!-- /wp:html -->';
+
+		$content = $this->insert_and_get_content( $this->make_insert_request( '<p>Story</p>', $embed ) );
+
+		$this->assertStringNotContainsString( '<iframe', $content, 'kses drops iframes; the embed body does not survive.' );
+		$this->assertStringContainsString( 'wp:html', $content, 'The block delimiter itself survives, so the loss is silent.' );
+	}
+
+	/**
+	 * Block custom CSS is the second sink inside post content. Core strips it on
+	 * a normal save for anyone without edit_css, which maps to unfiltered_html,
+	 * so a caller who cannot add it by hand must not get it through this route.
+	 */
+	public function test_insert_strips_block_custom_css_for_author() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'author' ] ) );
+
+		// className carries \u002d escapes, so a surviving attribute forces the
+		// re-encode branch of wp_strip_custom_css_from_blocks() and pins the
+		// wp_slash/wp_unslash round trip. Without it both assertions below pass
+		// even with that wrapping removed.
+		$attrs  = serialize_block_attributes(
+			[
+				'className' => 'a--b',
+				'style'     => [ 'css' => 'body{display:none}' ],
+			]
+		);
+		$blocks = '<!-- wp:paragraph ' . $attrs . ' --><p>Story</p><!-- /wp:paragraph -->';
+
+		$content = $this->insert_and_get_content( $this->make_insert_request( '<p>Story</p>', $blocks ) );
+
+		$this->assertStringNotContainsString( '"css"', $content, 'An author must not be able to store block custom CSS.' );
+		$this->assertStringContainsString( 'a\u002d\u002db', $content, 'Escaped attribute JSON must survive the slash round trip intact.' );
+		$this->assertStringContainsString( '<p>Story</p>', $content, 'The block body itself must survive.' );
+	}
+
+	/**
+	 * The other side of it: an editor holds unfiltered_html, so their custom CSS
+	 * is stored, exactly as it would be on a normal save.
+	 */
+	public function test_insert_preserves_block_custom_css_for_editor() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'editor' ] ) );
+
+		if ( ! current_user_can( 'unfiltered_html' ) ) {
+			$this->markTestSkipped( 'This install denies unfiltered_html to editors; the route filters every role there.' );
+		}
+
+		$attrs  = serialize_block_attributes(
+			[
+				'className' => 'a--b',
+				'style'     => [ 'css' => 'body{display:none}' ],
+			]
+		);
+		$blocks = '<!-- wp:paragraph ' . $attrs . ' --><p>Story</p><!-- /wp:paragraph -->';
+
+		$content = $this->insert_and_get_content( $this->make_insert_request( '<p>Story</p>', $blocks ) );
+
+		$this->assertStringContainsString( '"css"', $content, 'An editor holds unfiltered_html, so their custom CSS is kept.' );
+	}
+
+	/**
+	 * The strip is ours rather than core's, so its recursion needs pinning: custom
+	 * CSS on a nested block must go too, not just on a top-level one.
+	 */
+	public function test_insert_strips_block_custom_css_from_nested_blocks_for_author() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'author' ] ) );
+
+		$attrs  = serialize_block_attributes( [ 'style' => [ 'css' => 'body{display:none}' ] ] );
+		$blocks = '<!-- wp:group --><div><!-- wp:paragraph ' . $attrs . ' --><p>Inner</p><!-- /wp:paragraph --></div><!-- /wp:group -->';
+
+		$content = $this->insert_and_get_content( $this->make_insert_request( '<p>Inner</p>', $blocks ) );
+
+		$this->assertStringNotContainsString( '"css"', $content, 'Custom CSS on a nested block must be stripped too.' );
+		$this->assertStringContainsString( 'wp:group', $content, 'The surrounding block structure must survive.' );
+		$this->assertStringContainsString( '<p>Inner</p>', $content, 'The inner block body must survive.' );
+	}
+
+	/**
+	 * The strip is ours rather than core's, so the claim that it behaves like
+	 * core's needs a test rather than an assertion. Core returns the content
+	 * untouched when no block carries custom CSS; a naive round trip would
+	 * normalize attribute JSON the sender wrote by hand.
+	 *
+	 * Scope of the claim, because two of these cases do strip and still assert
+	 * equality: they agree because their inputs are canonical single-attribute
+	 * blocks, not because equality holds after a strip in general. It does not.
+	 * Core splices only the attribute it changed while this re-serializes the
+	 * document, so a non-canonically-written sibling alongside a stripped block
+	 * normalizes and the two diverge. Matching core there would mean
+	 * reimplementing its token scanner for a property get_post_content() discards.
+	 */
+	public function test_block_custom_css_strip_matches_core() {
+		if ( ! function_exists( 'wp_strip_custom_css_from_blocks' ) ) {
+			$this->markTestSkipped( 'Core comparison requires WordPress 7.0.' );
+		}
+
+		$css = serialize_block_attributes( [ 'style' => [ 'css' => 'body{display:none}' ] ] );
+
+		$cases = [
+			'non-canonical attributes, no custom CSS' => '<!-- wp:paragraph {"align": "left"} --><p>Hi</p><!-- /wp:paragraph -->',
+			'canonical attributes, no custom CSS'     => '<!-- wp:paragraph {"align":"left"} --><p>Hi</p><!-- /wp:paragraph -->',
+			'no attributes at all'                    => '<!-- wp:paragraph --><p>Hi</p><!-- /wp:paragraph -->',
+			'not block content'                       => '<p>plain <a href="https://example.test?a=1&b=2">link</a></p>',
+			'custom CSS present'                      => '<!-- wp:paragraph ' . $css . ' --><p>Hi</p><!-- /wp:paragraph -->',
+			'custom CSS nested'                       => '<!-- wp:group --><div><!-- wp:paragraph ' . $css . ' --><p>In</p><!-- /wp:paragraph --></div><!-- /wp:group -->',
+		];
+
+		$method = new \ReflectionMethod( API::class, 'strip_block_custom_css' );
+
+		foreach ( $cases as $label => $content ) {
+			$this->assertSame(
+				wp_unslash( wp_strip_custom_css_from_blocks( wp_slash( $content ) ) ),
+				$method->invoke( null, $content ),
+				"Our strip must match core's output: $label."
+			);
+		}
+	}
+
+	/**
+	 * The widest claim this change makes is that the cleanup is not an author-only
+	 * concern: multisite, and any site defining DISALLOW_UNFILTERED_HTML, denies
+	 * unfiltered_html to everyone below super admin, so an administrator pulling a
+	 * story loses the same markup an author would.
+	 *
+	 * The two editor tests skip in that configuration rather than covering it, so
+	 * this forces the denial through map_meta_cap and asserts the positive. Without
+	 * it the claim rests on reading core rather than on anything the suite runs.
+	 */
+	public function test_insert_filters_for_a_caller_denied_unfiltered_html_by_the_install() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->assertTrue(
+			current_user_can( 'unfiltered_html' ),
+			'Precondition: an administrator holds unfiltered_html before the install denies it.'
+		);
+
+		// What multisite and DISALLOW_UNFILTERED_HTML both do, via the same filter
+		// core routes them through.
+		add_filter(
+			'map_meta_cap',
+			function ( $caps, $cap ) {
+				return 'unfiltered_html' === $cap ? [ 'do_not_allow' ] : $caps;
+			},
+			10,
+			2
+		);
+
+		$this->assertFalse( current_user_can( 'unfiltered_html' ), 'The filter must deny the capability.' );
+
+		$content = $this->insert_and_get_content( $this->make_insert_request( '<script>alert(1)</script>hello' ) );
+
+		$this->assertStringNotContainsString(
+			'<script>',
+			$content,
+			'An administrator on an install that denies unfiltered_html is filtered like anyone else.'
+		);
+	}
+
+	/**
+	 * Re-linking replays the stored payload through insert() with `content_save_pre`
+	 * still removed and no route filtering. That is safe only because the payload
+	 * persisted at insert time was already filtered.
+	 *
+	 * If someone ever changes the route to persist the caller's original payload,
+	 * every other test still passes and this one fails, which is the point.
+	 */
+	public function test_relinking_replays_the_filtered_payload() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'author' ] ) );
+
+		$response = rest_get_server()->dispatch( $this->make_insert_request( '<script>alert(1)</script>hello' ) );
+		$this->assertSame( 200, $response->get_status() );
+		$post_id = $response->get_data()['post_id'];
+
+		$incoming_post = new Incoming_Post( $post_id );
+		$incoming_post->set_unlinked( true );
+		$incoming_post->set_unlinked( false );
+
+		$this->assertStringNotContainsString(
+			'<script>',
+			get_post_field( 'post_content', $post_id ),
+			'Re-linking must not restore markup the route filtered out.'
+		);
+	}
+
+	/**
+	 * Core gates the two transformations on two different capabilities: the
+	 * custom-CSS strip on `edit_css`, kses on `unfiltered_html`. They resolve to
+	 * the same primitive by default, but `map_meta_cap` is a filter, so a plugin
+	 * can diverge them. These two cases pin that each gate acts on its own.
+	 */
+	public function test_custom_css_is_stripped_when_only_edit_css_is_denied() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		add_filter(
+			'map_meta_cap',
+			function ( $caps, $cap ) {
+				return 'edit_css' === $cap ? [ 'do_not_allow' ] : $caps;
+			},
+			10,
+			2
+		);
+
+		$this->assertFalse( current_user_can( 'edit_css' ), 'Precondition: edit_css denied.' );
+		$this->assertTrue( current_user_can( 'unfiltered_html' ), 'Precondition: unfiltered_html still held.' );
+
+		$attrs  = serialize_block_attributes( [ 'style' => [ 'css' => 'body{display:none}' ] ] );
+		$blocks = '<!-- wp:paragraph ' . $attrs . ' --><p>Story</p><!-- /wp:paragraph -->';
+
+		$content = $this->insert_and_get_content(
+			$this->make_insert_request( '<script>alert(1)</script>Story', $blocks )
+		);
+
+		$this->assertStringNotContainsString( '"css"', $content, 'Custom CSS goes when edit_css is denied.' );
+		$this->assertStringContainsString( 'wp:paragraph', $content, 'The block itself survives.' );
+	}
+
+	/**
+	 * The inverse: HTML is filtered when only `unfiltered_html` is denied, and
+	 * custom CSS is kept because `edit_css` is still held.
+	 */
+	public function test_html_is_filtered_when_only_unfiltered_html_is_denied() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		add_filter(
+			'map_meta_cap',
+			function ( $caps, $cap ) {
+				return 'unfiltered_html' === $cap ? [ 'do_not_allow' ] : $caps;
+			},
+			10,
+			2
+		);
+
+		$this->assertFalse( current_user_can( 'unfiltered_html' ), 'Precondition: unfiltered_html denied.' );
+		$this->assertTrue( current_user_can( 'edit_css' ), 'Precondition: edit_css still held.' );
+
+		$attrs  = serialize_block_attributes( [ 'style' => [ 'css' => 'body{display:none}' ] ] );
+		$blocks = '<!-- wp:paragraph ' . $attrs . ' --><p>Story</p><!-- /wp:paragraph -->';
+
+		$content = $this->insert_and_get_content(
+			$this->make_insert_request( '<p>Story</p>', $blocks )
+		);
+
+		$this->assertStringContainsString( '"css"', $content, 'Custom CSS stays when edit_css is held.' );
+	}
+
+	/**
+	 * `has_blocks()` matches the exact literal `<!-- wp:`, but WP_Block_Parser
+	 * accepts extra whitespace or a newline after the opener. Gating the strip on
+	 * `has_blocks()` therefore skipped content the parser still reads as a block,
+	 * carrying its custom CSS through. Raised in review on PR #924.
+	 */
+	public function test_insert_strips_custom_css_from_non_canonical_block_delimiters() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'author' ] ) );
+
+		$attrs = serialize_block_attributes( [ 'style' => [ 'css' => 'body{display:none}' ] ] );
+
+		foreach (
+			[
+				'extra spaces' => '<!--   wp:paragraph ' . $attrs . ' --><p>Story</p><!-- /wp:paragraph -->',
+				'newline'      => "<!--\nwp:paragraph " . $attrs . ' --><p>Story</p><!-- /wp:paragraph -->',
+			] as $label => $blocks
+		) {
+			$this->assertFalse( has_blocks( $blocks ), "Precondition: has_blocks() misses this form ($label)." );
+
+			$content = $this->insert_and_get_content( $this->make_insert_request( '<p>Story</p>', $blocks ) );
+
+			$this->assertStringNotContainsString( '"css"', $content, "Custom CSS must be stripped despite the delimiter form ($label)." );
+		}
+	}
 }

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
@@ -755,4 +755,113 @@ class TestApi extends \WP_UnitTestCase {
 			$this->assertStringNotContainsString( '"css"', $content, "Custom CSS must be stripped despite the delimiter form ($label)." );
 		}
 	}
+
+	/**
+	 * Build an /insert request whose payload carries the given post_data overrides.
+	 *
+	 * @param array $overrides post_data fields to set.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function make_insert_request_with( array $overrides ) {
+		$payload = get_sample_payload( 'https://origin.test', get_bloginfo( 'url' ) );
+
+		$payload['post_data']['thumbnail_url'] = ''; // Avoid a sideload attempt in tests.
+		$payload['post_data']                  = array_merge( $payload['post_data'], $overrides );
+
+		$request = new WP_REST_Request( 'POST', '/newspack-network/v1/content-distribution/insert' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( [ 'payload' => $payload ] ) );
+
+		return $request;
+	}
+
+	/**
+	 * Re-linking must not write a title or excerpt the caller could not have saved.
+	 *
+	 * Core cleans title and excerpt on the way in, so the insert itself is safe
+	 * even without this fix. The exposure is the replay: re-linking an unlinked
+	 * post feeds the stored payload back through insert(), and a caller holding
+	 * unfiltered_html at that moment has no filters of their own. Unless the
+	 * payload was filtered before it was persisted, that replay writes the
+	 * original markup.
+	 *
+	 * @group content-distribution-api
+	 */
+	public function test_relinking_does_not_restore_an_unfiltered_title_or_excerpt() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'author' ] ) );
+		kses_init();
+
+		$request = $this->make_insert_request_with(
+			[
+				'title'   => '<script>alert(1)</script>Headline',
+				'excerpt' => '<script>alert(2)</script>Standfirst',
+			]
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status(), 'The insert request should succeed.' );
+		$post_id = $response->get_data()['post_id'];
+
+		$this->assertStringNotContainsString(
+			'<script>',
+			get_post_field( 'post_title', $post_id ),
+			'Precondition: core cleans the title on the way in.'
+		);
+
+		// An editor re-links the post. They hold unfiltered_html, so nothing of
+		// core's is registered to clean the payload on the way back through.
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+		kses_init();
+
+		( new Incoming_Post( $post_id ) )->set_unlinked( false );
+
+		$this->assertStringNotContainsString(
+			'<script>',
+			get_post_field( 'post_title', $post_id ),
+			'Re-linking must not restore the unfiltered title.'
+		);
+		$this->assertStringNotContainsString(
+			'<script>',
+			get_post_field( 'post_excerpt', $post_id ),
+			'Re-linking must not restore the unfiltered excerpt.'
+		);
+	}
+
+	/**
+	 * Filtering the title must cost nothing on ordinary headlines.
+	 *
+	 * This pass runs on top of core's own title_save_pre rather than instead of
+	 * it, and the copy it writes becomes the merge base later partial updates are
+	 * applied over. So anything it degrades would compound across every update.
+	 * Each case must come out exactly as core alone would have stored it.
+	 *
+	 * @group content-distribution-api
+	 */
+	public function test_filtering_leaves_an_ordinary_headline_untouched() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'author' ] ) );
+		kses_init();
+
+		$headlines = [
+			'ampersand'     => 'Fire & Rain',
+			'entity'        => 'Fire &amp; Rain',
+			'curly quotes'  => "The \u{201C}Big\u{201D} Story",
+			'apostrophe'    => "Council\u{2019}s vote",
+			'em dash'       => "Budget \u{2014} at last",
+			'non-ascii'     => "Se\u{00F1}or caf\u{00E9}",
+			'inline markup' => 'Council <b>votes</b> [Update]',
+			'percent'       => 'Up 50% in Q3',
+		];
+
+		foreach ( $headlines as $label => $headline ) {
+			$response = rest_get_server()->dispatch( $this->make_insert_request_with( [ 'title' => $headline ] ) );
+			$this->assertSame( 200, $response->get_status(), "The insert request should succeed ($label)." );
+
+			$this->assertSame(
+				wp_kses( $headline, 'title_save_pre' ),
+				get_post_field( 'post_title', $response->get_data()['post_id'] ),
+				"The stored title must match what core alone would have stored ($label)."
+			);
+		}
+	}
 }

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
@@ -321,6 +321,41 @@ class TestApi extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A wp_global_styles post keeps its theme customization in post_content as
+	 * JSON, and the CSS inside it is cleaned by wp_filter_global_styles_post,
+	 * not by kses. Core runs that filter for a caller without unfiltered_html;
+	 * since this route puts no allowlist on post_type, the same JSON can arrive
+	 * here, so the filter has to run here too.
+	 *
+	 * @group content-distribution-api
+	 */
+	public function test_insert_sanitizes_global_styles_json_for_author() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'author' ] ) );
+		kses_init();
+
+		$theme_json = wp_json_encode(
+			[
+				'isGlobalStylesUserThemeJSON' => true,
+				'version'                     => 2,
+				'styles'                      => [ 'css' => 'body{display:none}' ],
+			]
+		);
+
+		$content = $this->insert_and_get_content( $this->make_insert_request( $theme_json ) );
+
+		$this->assertStringNotContainsString(
+			'display:none',
+			$content,
+			'The unsafe CSS carried in the theme JSON must be removed on the way in.'
+		);
+		$this->assertStringNotContainsString(
+			'"css"',
+			$content,
+			'wp_filter_global_styles_post drops the css property, which kses would have left in place.'
+		);
+	}
+
+	/**
 	 * An editor holds 'unfiltered_html', so their content is stored as-is.
 	 * This is what keeps Story Budget pulls working for editors and above.
 	 */

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
@@ -443,6 +443,37 @@ class TestApi extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A callback registered at more than one priority must come back at all of them.
+	 *
+	 * This pins the bug in a has_filter() guard: has_filter() reports only the
+	 * first priority a callback sits at, so a presence check restores one
+	 * registration and silently drops the rest.
+	 *
+	 * @group content-distribution-api
+	 */
+	public function test_insert_restores_a_callback_registered_at_several_priorities() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'author' ] ) );
+		kses_init();
+
+		// strval() returns the content unchanged, so this measures the restore
+		// without altering what gets stored.
+		add_filter( 'content_save_pre', 'strval', 3, 1 );
+		add_filter( 'content_save_pre', 'strval', 30, 1 );
+
+		$this->insert_and_get_content( $this->make_insert_request( 'safe content' ) );
+
+		$callbacks = $GLOBALS['wp_filter']['content_save_pre']->callbacks;
+
+		// Read the priority buckets directly. has_filter() would answer 3 for both
+		// assertions and pass even with the priority-30 registration gone.
+		$this->assertArrayHasKey( 'strval', $callbacks[3] ?? [], 'The lower-priority registration must be restored.' );
+		$this->assertArrayHasKey( 'strval', $callbacks[30] ?? [], 'The higher-priority registration must be restored too.' );
+
+		remove_filter( 'content_save_pre', 'strval', 3 );
+		remove_filter( 'content_save_pre', 'strval', 30 );
+	}
+
+	/**
 	 * The cost of filtering, pinned deliberately rather than left to be
 	 * discovered. An author pulling a story that carries a Custom HTML block
 	 * gets the block's body dropped, because `iframe` is not in the kses

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
@@ -1071,12 +1071,49 @@ class TestApi extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * A partial update must not be able to change an existing post's type.
+	 * A full payload must carry a post type.
+	 *
+	 * The omission is allowed only for a partial update. On a full payload the
+	 * value reaches use_block_editor_for_post_type() inside insert() before
+	 * anything validates it, so without this the caller gets a PHP warning
+	 * instead of this route's 400.
+	 *
+	 * @group content-distribution-api
+	 */
+	public function test_insert_refuses_a_full_payload_with_no_post_type() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'author' ] ) );
+		kses_init();
+
+		$payload = get_sample_payload( 'https://origin.test', get_bloginfo( 'url' ) );
+		$payload['post_data']['thumbnail_url'] = '';
+		unset( $payload['post_data']['post_type'] );
+
+		$request = new WP_REST_Request( 'POST', '/newspack-network/v1/content-distribution/insert' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( [ 'payload' => $payload ] ) );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status(), 'A full payload with no post type must be refused.' );
+		$this->assertSame(
+			'invalid_post_type',
+			$response->as_error()->get_error_code(),
+			'It must be refused by this route, not by an incidental failure downstream.'
+		);
+	}
+
+	/**
+	 * A partial update must not be able to null out an existing post's type.
 	 *
 	 * The merge in get_payload_from_partial() applies the incoming post_data over
 	 * the stored payload, and array_merge lets an explicit null overwrite. Left
 	 * unchecked, that null reaches wp_insert_post(), which falls back to its own
 	 * default and converts a page into a post while returning 200.
+	 *
+	 * Scoped to null deliberately. A partial carrying a different but allowed type
+	 * still changes the stored type, because this guard tests membership of the
+	 * list rather than agreement with the post being updated. Closing that needs
+	 * the resolved post, which the route does not have — tracked on NPPM-3189.
 	 *
 	 * @group content-distribution-api
 	 */

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
@@ -977,6 +977,42 @@ class TestApi extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A post_data that is present but not an object must be refused.
+	 *
+	 * Nothing downstream validates its shape: get_payload_error() tests only that
+	 * it is non-empty, and insert() then indexes it, which is an uncaught
+	 * TypeError on PHP 8 rather than a handled error response.
+	 *
+	 * @group content-distribution-api
+	 */
+	public function test_insert_refuses_a_post_data_that_is_not_an_object() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'author' ] ) );
+		kses_init();
+
+		foreach ( [
+			'string' => 'not-an-object',
+			'int'    => 7,
+			'bool'   => true,
+		] as $label => $post_data ) {
+			$payload              = get_sample_payload( 'https://origin.test', get_bloginfo( 'url' ) );
+			$payload['post_data'] = $post_data;
+
+			$request = new WP_REST_Request( 'POST', '/newspack-network/v1/content-distribution/insert' );
+			$request->set_header( 'Content-Type', 'application/json' );
+			$request->set_body( wp_json_encode( [ 'payload' => $payload ] ) );
+
+			$response = rest_get_server()->dispatch( $request );
+
+			$this->assertSame( 400, $response->get_status(), "A $label post_data must be refused." );
+			$this->assertSame(
+				'invalid_post_data',
+				$response->as_error()->get_error_code(),
+				"A $label post_data must be refused by name, not by an incidental failure."
+			);
+		}
+	}
+
+	/**
 	 * A partial update must not be able to change an existing post's type.
 	 *
 	 * The merge in get_payload_from_partial() applies the incoming post_data over

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
@@ -440,6 +440,13 @@ class TestApi extends \WP_UnitTestCase {
 			'Precondition: kses must be filtering content for this user before the insert.'
 		);
 
+		// A callback with a non-default accepted_args, because every reachable core
+		// registration on this hook uses the default of 1 — asserting against those
+		// passes even when the restore drops the argument. strval() returns the
+		// content unchanged, and WP_Hook hands it only the one argument the filter
+		// call carries, whatever accepted_args says.
+		add_filter( 'content_save_pre', 'strval', 22, 2 );
+
 		$this->insert_and_get_content( $this->make_insert_request( 'safe content' ) );
 
 		// Assert the priority, not just presence: a presence-only check passes even
@@ -454,12 +461,13 @@ class TestApi extends \WP_UnitTestCase {
 			has_filter( 'content_save_pre', 'wp_filter_global_styles_post' ),
 			'The insert must restore the other content_save_pre callbacks too, not just kses.'
 		);
-		// accepted_args is restored too, and nothing else here would notice: a loop
-		// that passed a literal 1 would satisfy every assertion above, then break any
-		// callback registered with more than one argument for the rest of the request.
+		// accepted_args is restored too, and nothing else here would notice: a
+		// restore that passed a literal 1, or dropped the argument for its default,
+		// would satisfy every assertion above, then break any callback registered
+		// with more than one argument for the rest of the request.
 		$this->assertSame(
-			1,
-			$GLOBALS['wp_filter']['content_save_pre']->callbacks[10]['wp_filter_post_kses']['accepted_args'],
+			2,
+			$GLOBALS['wp_filter']['content_save_pre']->callbacks[22]['strval']['accepted_args'],
 			'The restore must reproduce accepted_args, not just the priority.'
 		);
 
@@ -1019,6 +1027,27 @@ class TestApi extends \WP_UnitTestCase {
 				"A $label post_data must be refused by name, not by an incidental failure."
 			);
 		}
+
+		// null is deliberately not in the set above: it fails the isset() in
+		// check_incoming_post_type(), so it never reaches the shape guard. It is
+		// refused a layer down instead, by the constructor's emptiness check, under
+		// that path's own code — asserted here so the shape stays covered without
+		// implying the guard sees it.
+		$payload              = get_sample_payload( 'https://origin.test', get_bloginfo( 'url' ) );
+		$payload['post_data'] = null;
+
+		$request = new WP_REST_Request( 'POST', '/newspack-network/v1/content-distribution/insert' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( [ 'payload' => $payload ] ) );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status(), 'A null post_data must still be refused.' );
+		$this->assertSame(
+			'invalid_payload',
+			$response->as_error()->get_error_code(),
+			'A null post_data is refused by the constructor, not by the shape guard it never reaches.'
+		);
 	}
 
 	/**
@@ -1073,10 +1102,10 @@ class TestApi extends \WP_UnitTestCase {
 	/**
 	 * A full payload must carry a post type.
 	 *
-	 * The omission is allowed only for a partial update. On a full payload the
-	 * value reaches use_block_editor_for_post_type() inside insert() before
-	 * anything validates it, so without this the caller gets a PHP warning
-	 * instead of this route's 400.
+	 * The omission is allowed only for a partial update. On a full payload,
+	 * insert() reads the value straight out of the payload before anything
+	 * validates it, so without this the caller gets a PHP warning instead of
+	 * this route's 400.
 	 *
 	 * @group content-distribution-api
 	 */
@@ -1085,7 +1114,6 @@ class TestApi extends \WP_UnitTestCase {
 		kses_init();
 
 		$payload = get_sample_payload( 'https://origin.test', get_bloginfo( 'url' ) );
-		$payload['post_data']['thumbnail_url'] = '';
 		unset( $payload['post_data']['post_type'] );
 
 		$request = new WP_REST_Request( 'POST', '/newspack-network/v1/content-distribution/insert' );

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
@@ -442,9 +442,8 @@ class TestApi extends \WP_UnitTestCase {
 
 		$this->insert_and_get_content( $this->make_insert_request( 'safe content' ) );
 
-		// Assert the priority, not just presence: the restore loop's whole job is
-		// reproducing priority and accepted_args, and a presence-only check passes
-		// even if everything came back at priority 10.
+		// Assert the priority, not just presence: a presence-only check passes even
+		// if everything came back at priority 10.
 		$this->assertSame(
 			10,
 			has_filter( 'content_save_pre', 'wp_filter_post_kses' ),
@@ -455,6 +454,15 @@ class TestApi extends \WP_UnitTestCase {
 			has_filter( 'content_save_pre', 'wp_filter_global_styles_post' ),
 			'The insert must restore the other content_save_pre callbacks too, not just kses.'
 		);
+		// accepted_args is restored too, and nothing else here would notice: a loop
+		// that passed a literal 1 would satisfy every assertion above, then break any
+		// callback registered with more than one argument for the rest of the request.
+		$this->assertSame(
+			1,
+			$GLOBALS['wp_filter']['content_save_pre']->callbacks[10]['wp_filter_post_kses']['accepted_args'],
+			'The restore must reproduce accepted_args, not just the priority.'
+		);
+
 		if ( function_exists( 'wp_strip_custom_css_from_blocks' ) ) {
 			$this->assertSame(
 				8,
@@ -954,9 +962,10 @@ class TestApi extends \WP_UnitTestCase {
 		wp_set_current_user( $this->factory->user->create( [ 'role' => 'author' ] ) );
 		kses_init();
 
-		// null is absent rather than invalid: it fails isset(), so the payload is
-		// treated as not carrying a post type at all and wp_insert_post() applies
-		// its own default of 'post', which is on the list.
+		// null is not in this set because it is judged, not skipped: the guard uses
+		// array_key_exists, so a present key is checked whatever its value. The
+		// sibling test below covers it. Only a genuinely omitted key passes, which
+		// is what a partial payload relies on.
 		foreach ( [
 			'array' => [ 'post' ],
 			'int'   => 5,
@@ -1010,6 +1019,55 @@ class TestApi extends \WP_UnitTestCase {
 				"A $label post_data must be refused by name, not by an incidental failure."
 			);
 		}
+	}
+
+	/**
+	 * A partial update that omits post_type must still be accepted.
+	 *
+	 * This is the branch the guard exists to leave alone. A partial payload
+	 * legitimately carries only the fields it is changing, so an absent post_type
+	 * has to pass and the stored type has to survive the merge. It is the path most
+	 * likely to break a site that works today, and the one a rejection guard is
+	 * most likely to catch by accident.
+	 *
+	 * @group content-distribution-api
+	 */
+	public function test_partial_update_that_omits_post_type_is_accepted() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'author' ] ) );
+		kses_init();
+
+		$created = rest_get_server()->dispatch(
+			$this->make_insert_request_with(
+				[
+					'post_type' => 'page',
+					'title'     => 'A page',
+				]
+			)
+		);
+		$this->assertSame( 200, $created->get_status(), 'Precondition: a page inserts cleanly.' );
+		$post_id = $created->get_data()['post_id'];
+
+		$payload              = get_sample_payload( 'https://origin.test', get_bloginfo( 'url' ) );
+		$payload['partial']   = true;
+		$payload['post_data'] = [ 'title' => 'Updated by a partial that carries no post type' ];
+
+		$request = new WP_REST_Request( 'POST', '/newspack-network/v1/content-distribution/insert' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( [ 'payload' => $payload ] ) );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status(), 'A partial that omits post_type must be accepted.' );
+		$this->assertSame(
+			'page',
+			get_post_field( 'post_type', $post_id ),
+			'The stored post type must survive a partial update that does not carry one.'
+		);
+		$this->assertSame(
+			'Updated by a partial that carries no post type',
+			get_post_field( 'post_title', $post_id ),
+			'The partial must still apply the field it did carry.'
+		);
 	}
 
 	/**

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
@@ -933,8 +933,8 @@ class TestApi extends \WP_UnitTestCase {
 						[
 							'post_type'   => $post_type,
 							'post_status' => 'any',
-						] 
-					) 
+						]
+					)
 				),
 				"Nothing of type $post_type may be created."
 			);
@@ -995,7 +995,7 @@ class TestApi extends \WP_UnitTestCase {
 				[
 					'post_type' => 'page',
 					'title'     => 'A page',
-				] 
+				]
 			)
 		);
 		$this->assertSame( 200, $created->get_status(), 'Precondition: a page inserts cleanly.' );

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
@@ -323,9 +323,10 @@ class TestApi extends \WP_UnitTestCase {
 	/**
 	 * A wp_global_styles post keeps its theme customization in post_content as
 	 * JSON, and the CSS inside it is cleaned by wp_filter_global_styles_post,
-	 * not by kses. Core runs that filter for a caller without unfiltered_html;
-	 * since this route puts no allowlist on post_type, the same JSON can arrive
-	 * here, so the filter has to run here too.
+	 * not by kses. Core runs that filter for a caller without unfiltered_html.
+	 * The post-type allowlist does not cover this: the same JSON sent as the
+	 * body of an allowed type still needs the filter, so it runs on content
+	 * regardless of type.
 	 *
 	 * @group content-distribution-api
 	 */
@@ -936,6 +937,41 @@ class TestApi extends \WP_UnitTestCase {
 					) 
 				),
 				"Nothing of type $post_type may be created."
+			);
+		}
+	}
+
+	/**
+	 * A post type that is not a string must be refused, not waved through.
+	 *
+	 * The allowlist can only match strings, so a guard that skips non-strings
+	 * lets malformed input past the check entirely and defers the problem to
+	 * wp_insert_post().
+	 *
+	 * @group content-distribution-api
+	 */
+	public function test_insert_refuses_a_non_string_post_type() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'author' ] ) );
+		kses_init();
+
+		// null is absent rather than invalid: it fails isset(), so the payload is
+		// treated as not carrying a post type at all and wp_insert_post() applies
+		// its own default of 'post', which is on the list.
+		foreach ( [
+			'array' => [ 'post' ],
+			'int'   => 5,
+			'bool'  => true,
+			'float' => 1.5,
+		] as $label => $post_type ) {
+			$response = rest_get_server()->dispatch(
+				$this->make_insert_request_with( [ 'post_type' => $post_type ] )
+			);
+
+			$this->assertSame( 400, $response->get_status(), "A $label post_type must be refused." );
+			$this->assertSame(
+				'invalid_post_type',
+				$response->as_error()->get_error_code(),
+				"A $label post_type must be refused by the allowlist, not incidentally."
 			);
 		}
 	}

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
@@ -977,6 +977,53 @@ class TestApi extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A partial update must not be able to change an existing post's type.
+	 *
+	 * The merge in get_payload_from_partial() applies the incoming post_data over
+	 * the stored payload, and array_merge lets an explicit null overwrite. Left
+	 * unchecked, that null reaches wp_insert_post(), which falls back to its own
+	 * default and converts a page into a post while returning 200.
+	 *
+	 * @group content-distribution-api
+	 */
+	public function test_partial_update_cannot_null_out_an_existing_post_type() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'author' ] ) );
+		kses_init();
+
+		$created = rest_get_server()->dispatch(
+			$this->make_insert_request_with(
+				[
+					'post_type' => 'page',
+					'title'     => 'A page',
+				] 
+			)
+		);
+		$this->assertSame( 200, $created->get_status(), 'Precondition: a page inserts cleanly.' );
+		$post_id = $created->get_data()['post_id'];
+		$this->assertSame( 'page', get_post_field( 'post_type', $post_id ), 'Precondition: it is stored as a page.' );
+
+		$payload              = get_sample_payload( 'https://origin.test', get_bloginfo( 'url' ) );
+		$payload['partial']   = true;
+		$payload['post_data'] = [
+			'post_type' => null,
+			'title'     => 'Updated',
+		];
+
+		$request = new WP_REST_Request( 'POST', '/newspack-network/v1/content-distribution/insert' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( [ 'payload' => $payload ] ) );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status(), 'An explicit null post type must be refused.' );
+		$this->assertSame(
+			'page',
+			get_post_field( 'post_type', $post_id ),
+			'The stored post must still be a page.'
+		);
+	}
+
+	/**
 	 * The allowlist must not cost the types the network does distribute.
 	 *
 	 * The list is filterable, so this asserts against whatever the install


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Content arriving at the content-distribution import route now gets the same cleanup the caller would get saving the post by hand. The route is open to anyone holding `newspack_network_distribute`, which the plugin grants to `administrator`, `editor`, and `author` by default (an admin can change the set), so the cleanup applies to callers without `unfiltered_html`.

It covers both things WordPress cleans on a normal save for such a caller: the HTML itself, through `wp_kses_post()`, and custom CSS attached to blocks.

The change also restores the `content_save_pre` filters that `Incoming_Post::insert()` removes, so they are in place for the rest of the request rather than only up to the insert.

**Who is affected.** For callers who cannot publish raw HTML, the route now drops markup their role does not permit, with no notice in the response. That is more than authors: on multisite, and anywhere `DISALLOW_UNFILTERED_HTML` is defined, `map_meta_cap()` denies the capability to everyone below super admin, so the cleanup applies to every role there.

Scheduled distribution between networked sites is unchanged. It arrives through `Network_Post_Updated` rather than this route, and a test pins that separation so a later change doesn't collapse it.

Reference NPPM-3059.

### How to test the changes in this Pull Request:

Run `n test-php --group content-distribution-api` from `plugins/newspack-network`; all pass on this branch. Reverting only the two source files while keeping this branch's tests turns the added cases red, which is the regression check.

Fourteen of the twenty-three are new here. They cover the cleanup itself; the two paths that must not change, being callers who can publish raw HTML and scheduled distribution; block markup surviving intact; the filter restore at its original priorities; equivalence with core's own implementation; the cost named above, both the markup a caller loses and the case where the install denies the capability to every role; and that re-linking an unlinked post replays the filtered copy rather than the original. `make_insert_request()` builds the request, over `get_sample_payload()` from `tests/unit-tests/content-distribution/util.php`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<details>
<summary>Notes for reviewers</summary>

**The filtering is applied directly, not through `content_save_pre`.** `filter_incoming_content()` calls `wp_kses_post()` and the custom-CSS strip itself rather than running core's save-time chain. That is deliberate: a security guard should not depend on global filter registration, which any plugin can clear with `kses_remove_filters()`. It does mean the coverage is ours to justify rather than core's to provide, which *Why those two and not more* and *Both content fields are covered* below set out.

**Why those two and not more.** For a caller without `unfiltered_html`, core puts three callbacks on `content_save_pre` that alter content: the custom-CSS strip at 8, `wp_filter_global_styles_post` at 9, and `wp_filter_post_kses` at 10. Priority 9 is a no-op unless the content decodes as JSON carrying `isGlobalStylesUserThemeJSON`, which the post types reaching this route cannot produce. So 8 and 10 are the two that apply.

**Bare `wp_kses_post()` rather than `wp_filter_post_kses()`** because REST parameters arrive unslashed; `Incoming_Post::insert()` applies `wp_slash()` later, at the point of the write.

**Where the filtering sits.** In `API::insert_post()`, before `Incoming_Post` is constructed, rather than inside `Incoming_Post::insert()`. The route is the only entry point with an authenticated human caller; the scheduled-distribution path has no current user and must store content verbatim. Filtering at the route also means the copy stored alongside the post is the filtered one.

**The gate is the requesting user**, which is the only identity on the request the site establishes for itself. Fuller reasoning on NPPM-3059.

**Four payload fields are covered.** Over `content` and `raw_content` — either can reach `post_content`, depending on whether `raw_content` carries blocks — the pass mirrors core's full `content_save_pre` cleanup for this caller: the block custom-CSS strip, the global-styles sanitizer, and kses. `title` and `excerpt` are held to the same capabilities with kses in core's own two contexts; they are filtered here as well as by core's `title_save_pre` / `excerpt_save_pre`, which this path never removes, and the pass is idempotent, so an ordinary headline stores exactly as core alone would store it.

**The custom-CSS strip is ours rather than core's.** `wp_strip_custom_css_from_blocks()` exists only in WordPress 7.0+, so depending on it would make the guard conditional on the WordPress version. Ours returns the original bytes when no block carries custom CSS, matching core's early return. That matters for the payload copy stored alongside the post (the `newspack_network_post_payload` meta), which is written as handed over, so a needless re-serialization would be baked in permanently. `test_block_custom_css_strip_matches_core` pins that against core for the cases where nothing is stripped. Once something is stripped the two diverge by design: core splices only the attribute it changed while this re-serializes the document, so a sibling block written in non-canonical form normalizes. That is moot for `post_content`, which `get_post_content()` re-serializes anyway.

**The restore** touches `Incoming_Post::insert()`, so it applies on both paths, not just this route. The callbacks array is copied by value, because `remove_all_filters()` empties the same `WP_Hook` object and holding the object would restore nothing. A `finally` re-adds them, so a throwing `save_post` callback cannot skip it. A test asserts they come back at their original priorities.
</details>

