### PR TITLE
build(deps): drop the duplicated pnpm override key

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,8 +78,7 @@
 			"@typescript-eslint/parser": "8.61.0",
 			"prettier": "npm:wp-prettier@^3.0.3",
 			"react": "18.3.1",
-			"react-dom": "18.3.1",
-			"@wordpress/stylelint-config>@wordpress/theme": "^0.16.0"
+			"react-dom": "18.3.1"
 		},
 		"patchedDependencies": {
 			"multi-semantic-release": "patches/multi-semantic-release.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,6 @@ overrides:
   prettier: npm:wp-prettier@^3.0.3
   react: 18.3.1
   react-dom: 18.3.1
-  '@wordpress/stylelint-config>@wordpress/theme': ^0.16.0
 
 patchedDependencies:
   multi-semantic-release:


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)? — n/a: no code, two manifest lines
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`pnpm install --frozen-lockfile` currently fails on `main`, so every JS, build and bundle job dies:

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at "pnpm-lock.yaml" is broken: duplicated mapping key (14:3)
```

`@wordpress/stylelint-config>@wordpress/theme` appears twice in `pnpm.overrides` — in `pnpm-lock.yaml`, and less visibly in `package.json`, where JSON parsers keep the last of a duplicate key and report nothing. This drops the second occurrence in each; both were byte-identical to the first, so nothing changes behaviourally.

Neither side wrote a duplicate. #757 added the override on `main`, #839 added the same override on its branch, and the merge-base had neither. The squash kept both insertions because they land on different lines — textually conflict-free, semantically a duplicate key. #839's own CI was green, `Install deps` included; the defect exists only in the merge result.

It stayed hidden because that commit's post-merge run was cancelled while pending when a newer push entered the same concurrency group, and the run that did complete changed no packages, so every package job skipped.

`release` and `alpha` are unaffected.

### How to test the changes in this Pull Request:

1. On `main`, run `pnpm install --frozen-lockfile` — fails with the error above.
2. On this branch, run the same command — completes (15.4s locally).
3. `node -e "console.log(Object.keys(require('./package.json').pnpm.overrides).length)"` prints `6` on both, since the duplicate was already collapsing silently.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them? — above.
* [x] Have you written new tests for your changes, as applicable? — n/a: the repo's own `Install deps` job is the test, and it fails on `main` today.
* [x] Have you successfully run tests with your changes locally? — yes, and the failure was reproduced first.
