### PR TITLE
chore(release): merge in release newspack-network@2.22.1

### DIFF
--- a/.github/scripts/release-wporg.sh
+++ b/.github/scripts/release-wporg.sh
@@ -38,11 +38,35 @@ if [ ! -d "release/$WP_ORG_PLUGIN_NAME" ]; then
   exit 1
 fi
 
+# The version WordPress.org serves comes from the main plugin file's `Version:`
+# header: these plugins ship `Stable tag: trunk`, so readme.txt carries no
+# version at all and the header is the only marker an update check reads.
+# WP_ORG_PLUGIN_VERSION comes from package.json instead, and the two are
+# written by different halves of the release (semantic-release stamps the
+# header, finalize-package-versions.cjs commits package.json). Assert they
+# agree on the built artifact, so the value that decides what publishes is
+# checked rather than assumed.
+main_file=$( { grep -ilE '^[[:space:]]*\*?[[:space:]]*Plugin Name:' "release/$WP_ORG_PLUGIN_NAME"/*.php || true; } | head -n 1 )
+if [ -z "$main_file" ]; then
+  echo "::error::No plugin header found in release/$WP_ORG_PLUGIN_NAME. Cannot confirm the version WordPress.org would serve."
+  exit 1
+fi
+header_line=$( grep -m1 -iE '^[[:space:]]*\*?[[:space:]]*Version:' "$main_file" || true )
+header_version=$( printf '%s' "$header_line" | sed -E 's/.*[Vv]ersion:[[:space:]]*//; s/[[:space:]].*$//' )
+if [ "$header_version" != "$WP_ORG_PLUGIN_VERSION" ]; then
+  echo "::error::$main_file declares version '${header_version:-none}' but this deploy is publishing $WP_ORG_PLUGIN_VERSION. WordPress.org reads the header, so the artifact would go out mislabelled."
+  exit 1
+fi
+
 mkdir -p "$SVN_REPO_LOCAL_PATH" && cd "$SVN_REPO_LOCAL_PATH"
 
-# Skip if this version is already published.
+# Nothing is published when this version is already tagged on WordPress.org.
+# That is expected when re-running a deploy, and it is also the last guard
+# behind the workflow's version gate -- so it annotates the run rather than
+# passing quietly, because on any other run it means the build carried the
+# wrong version and the release never reached wordpress.org.
 if svn ls "$SVN_REPO_URL/tags/$SVN_TAG" > /dev/null 2>&1; then
-  echo "Tag $SVN_TAG already exists on WordPress.org. No deployment needed."
+  echo "::warning::Tag $SVN_TAG already exists on WordPress.org; nothing deployed. Expected on a re-run -- otherwise check that $SVN_TAG is the version this run released."
   exit 0
 fi
 

--- a/.github/workflows/_release-wporg.yml
+++ b/.github/workflows/_release-wporg.yml
@@ -21,6 +21,32 @@ on:
         required: false
         default: ''
         type: string
+      ref:
+        description: >-
+          Commit SHA (or branch) to build and publish. Callers should pass the
+          exact commit the release produced -- see the checkout step. Defaults
+          to the caller's branch tip.
+        required: false
+        default: ''
+        type: string
+      released-tags:
+        description: >-
+          Newline-separated `<pkg>@<version>` tags created by the release job
+          that called this workflow. Only meaningful with require-release.
+        required: false
+        default: ''
+        type: string
+      require-release:
+        description: >-
+          True when released-tags is the authoritative record of what this run
+          published -- i.e. called from release.yml. The gate then skips a
+          plugin absent from the list and fails on a version mismatch. False
+          (manual dispatch) deploys the resolved version as-is. Kept separate
+          from released-tags so an empty list reads as "nothing released"
+          rather than "not supplied".
+        required: false
+        default: false
+        type: boolean
     secrets:
       WP_ORG_USERNAME:
         required: true
@@ -34,40 +60,135 @@ jobs:
   release-wporg:
     name: Deploy to WordPress.org
     runs-on: ubuntu-latest
+    # This job only reads the repository and pushes to SVN; it never writes to
+    # GitHub. A job-level grant can only narrow the caller's, so declaring it
+    # here keeps the caller's write-scoped GITHUB_TOKEN and mintable OIDC token
+    # out of the environment that runs third-party install lifecycle scripts.
+    permissions:
+      contents: read
+    # One deploy at a time per plugin, across all callers: the manual escape
+    # hatch exists to be run while a release-triggered deploy may still be in
+    # flight, and two jobs running `svn checkout` / `svn ci` against the same
+    # plugin would race.
+    concurrency:
+      group: wporg-${{ inputs.plugin-name }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Build the exact commit that was released, NOT the default
+          # `github.sha`.
+          #
+          # `github.sha` is the commit that triggered the run, which never
+          # carries the released version: the bump is committed afterwards, by
+          # the release job's "Sync package.json versions" step. Resolving the
+          # version from it publishes the PREVIOUS release.
+          #
+          # A branch name is not enough either. `needs: release` guarantees the
+          # bump is pushed before this checkout, but the tip keeps moving --
+          # anything merged into `release` while the release job runs would be
+          # built and published under the released version number. So callers
+          # pass the SHA the release job ended on; the branch tip is only the
+          # fallback for a caller that has no SHA to give.
+          ref: ${{ inputs.ref != '' && inputs.ref || github.ref_name }}
+      - name: Resolve released version
+        # Read before the build: the gate below can then skip a no-op run
+        # without paying for install + build. `ubuntu-latest` ships node, so
+        # this does not need actions/setup-node.
+        #
+        # Assigned to a variable rather than inlined into `echo`, so a missing
+        # or unparseable package.json (a wrong plugin-path, a plugin move)
+        # fails here at the real cause instead of writing an empty version and
+        # surfacing one step later as a bogus "stale checkout" error.
+        id: ver
+        env:
+          PLUGIN_PATH: ${{ inputs.plugin-path }}
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./$PLUGIN_PATH/package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Check this plugin released in this run
+        # Second line of defence behind the pinned checkout above: given the
+        # release job's tag list, the resolved version must match the tag this
+        # run created.
+        #   - no tag for this plugin  -> nothing released, skip cleanly.
+        #   - tag at a different version -> the checkout is stale, fail loudly.
+        #   - tag at the resolved version -> deploy.
+        id: gate
+        env:
+          RELEASED_TAGS: ${{ inputs.released-tags }}
+          REQUIRE_RELEASE: ${{ inputs.require-release }}
+          PLUGIN_NAME: ${{ inputs.plugin-name }}
+          VERSION: ${{ steps.ver.outputs.version }}
+          DEPLOY_REF: ${{ inputs.ref != '' && inputs.ref || github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ "$REQUIRE_RELEASE" != "true" ]; then
+            # What the annotation is guarding is whether the commit being
+            # published is on the release branch -- not what the ref was
+            # called. An exact SHA is the most precise input there is, so
+            # comparing the ref string to "release" would warn on the safest
+            # case and stay quiet on a moving branch tip. Ask git instead.
+            release_head=$(git rev-parse --verify --quiet refs/remotes/origin/release || true)
+            sha=$(git rev-parse --short HEAD)
+            if [ -z "$release_head" ]; then
+              echo "::warning::Manual deploy; could not resolve origin/release to check '$DEPLOY_REF' against. Publishing $VERSION from $sha."
+            elif git merge-base --is-ancestor HEAD "$release_head"; then
+              echo "::notice::Manual deploy; publishing $VERSION from $sha, a commit on the release branch."
+            else
+              echo "::warning::Manual deploy; '$DEPLOY_REF' ($sha) is not on the release branch. Publishing $VERSION to wordpress.org from code that was never released."
+            fi
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          released=$(printf '%s\n' "$RELEASED_TAGS" | { grep -E "^${PLUGIN_NAME}@" || true; })
+          if [ -z "$released" ]; then
+            echo "::notice::$PLUGIN_NAME had no release in this run. Nothing to deploy."
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! printf '%s\n' "$released" | grep -qxF "${PLUGIN_NAME}@${VERSION}"; then
+            echo "::error::This run released [$(printf '%s' "$released" | tr '\n' ' ')] but the checked-out tree resolves to $VERSION. The checkout is stale -- refusing to deploy the wrong version."
+            exit 1
+          fi
+          echo "deploy=true" >> "$GITHUB_OUTPUT"
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        if: steps.gate.outputs.deploy == 'true'
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v4
+        if: steps.gate.outputs.deploy == 'true'
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
+        if: steps.gate.outputs.deploy == 'true'
         with:
           php-version: '8.3'
           tools: composer
       - name: Install JS dependencies
+        if: steps.gate.outputs.deploy == 'true'
         run: pnpm install --frozen-lockfile
       - name: Install PHP dependencies
+        if: steps.gate.outputs.deploy == 'true'
         run: composer install --no-dev --no-scripts
         working-directory: ${{ inputs.plugin-path }}
       - name: Build shared packages
+        if: steps.gate.outputs.deploy == 'true'
         run: pnpm run build:packages
       - name: Build plugin and release artifact
+        if: steps.gate.outputs.deploy == 'true'
         run: |
           pnpm --filter "{${{ inputs.plugin-path }}}" run --if-present build
           pnpm --filter "{${{ inputs.plugin-path }}}" run release:archive
-      - name: Resolve released version
-        id: ver
-        run: echo "version=$(node -p "require('./${{ inputs.plugin-path }}/package.json').version")" >> "$GITHUB_OUTPUT"
       - name: Install Subversion
         # ubuntu-latest no longer ships svn; the deploy script needs it (both
         # the already-published check and the commit).
+        if: steps.gate.outputs.deploy == 'true'
         run: sudo apt-get update && sudo apt-get install -y subversion
       - name: Deploy to WordPress.org
+        if: steps.gate.outputs.deploy == 'true'
         working-directory: ${{ inputs.plugin-path }}
         env:
           WP_ORG_USERNAME: ${{ secrets.WP_ORG_USERNAME }}

--- a/.github/workflows/release-wporg-manual.yml
+++ b/.github/workflows/release-wporg-manual.yml
@@ -1,0 +1,66 @@
+name: Deploy to WordPress.org (manual)
+
+# Escape hatch for the WP.org deploy, which normally runs only as part of a
+# release (release.yml). Use it when a published release did not reach the SVN
+# repo -- a failed deploy job, or a run whose deploy resolved the wrong version.
+#
+# It publishes whatever version the chosen ref carries in the plugin's
+# package.json. That ref defaults to `release`, and deliberately does NOT
+# follow the branch picker: GitHub pre-selects the repository's default branch
+# there, and `main` runs ahead of `release` at an identical version -- so a
+# default dispatch would otherwise push unreleased code to wordpress.org under
+# the released version number, straight to trunk, on every installed site's
+# next update check.
+#
+# `require-release: false` tells _release-wporg.yml's gate there is no released
+# tag list to check against, leaving the SVN already-published check as the
+# only guard: re-running for a version that is already live is a harmless
+# no-op, but a version that never reached SVN will publish.
+#
+# GitHub only shows the "Run workflow" button for workflows present on the
+# default branch, so this file must be synced to `main` before the button
+# appears. The branch picker still selects which copy of the workflow runs;
+# the `ref` input below is what decides which code is published.
+
+on:
+  workflow_dispatch:
+    inputs:
+      plugin:
+        description: 'Plugin to deploy (its package.json version on the chosen ref).'
+        required: true
+        type: choice
+        options:
+          - newspack-newsletters
+          - super-cool-ad-inserter
+          - republication-tracker-tool
+      ref:
+        description: 'Branch or commit SHA to publish. Leave as `release` unless you know otherwise.'
+        required: true
+        default: 'release'
+        type: string
+      wporg-slug:
+        description: 'WordPress.org slug, only if it differs from the plugin name.'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: WP.org / ${{ inputs.plugin }}
+    # The three wp.org-distributed plugins all live at plugins/<name>, and their
+    # directory name, package name and wp.org slug are identical -- so the path
+    # needs no lookup table, and wporg-slug above is the override for the day
+    # one of them diverges. Revisit if that ever stops being true.
+    uses: ./.github/workflows/_release-wporg.yml
+    with:
+      plugin-name: ${{ inputs.plugin }}
+      plugin-path: plugins/${{ inputs.plugin }}
+      wporg-slug: ${{ inputs.wporg-slug }}
+      ref: ${{ inputs.ref }}
+      require-release: false
+    secrets:
+      WP_ORG_USERNAME: ${{ secrets.WP_ORG_USERNAME }}
+      WP_ORG_PASSWORD: ${{ secrets.WP_ORG_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,16 @@ jobs:
     # alpha` sitting there sends it down the path that force-pushes alpha.
     outputs:
       release_needed: ${{ steps.plan.outputs.release_needed }}
+      # Newline-separated `<pkg>@<version>` tags created by this run. Narrows
+      # release_needed above from "this run released something" to "this run
+      # released THIS plugin", which is what the WP.org deploy jobs gate on.
+      # See the "Collect released tags" step.
+      released-tags: ${{ steps.released.outputs.tags }}
+      # The commit this job left the branch on -- the one carrying the released
+      # versions. The WP.org deploy jobs build that exact commit rather than the
+      # branch tip, which keeps moving. See the "Sync package.json versions"
+      # step and the checkout in _release-wporg.yml.
+      released-sha: ${{ steps.sync.outputs.sha }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -178,6 +188,43 @@ jobs:
           # auth 401s. Set it to the same secret so npm actually authenticates.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_OPTIONS: --max-old-space-size=12288
+      # Which packages actually published, as `<pkg>@<version>` tags. Same
+      # before/after tag diff notify-release.sh uses for its Slack summary,
+      # surfaced as a job output so the WP.org deploy jobs can gate on it:
+      # without it they cannot tell a plugin that had no release from one whose
+      # deploy silently resolved a stale version. Always runs, so a skipped
+      # release yields an empty list rather than a missing output.
+      #
+      # Every command here must fail loudly. An empty list is meaningful -- the
+      # deploy jobs read it as "this plugin had no release" and skip -- so a
+      # swallowed error would silently skip every WP.org deploy of a real
+      # release, which is the exact failure this gating exists to prevent.
+      # Hence no `|| true`, pipefail on, and both sides materialised as files
+      # rather than process substitutions (whose exit status bash discards).
+      #
+      # `--merged HEAD` restricts the diff to tags on this branch's history, so
+      # it measures what this run created rather than what appeared. The
+      # concurrency group is per-ref, so an alpha release runs alongside a
+      # stable one by design and tags into the same namespace, and
+      # semantic-release fetches tags on every invocation -- an alpha tag
+      # pushed while the release step ran would otherwise land in this list.
+      # The deploy gate would then find a tag for the plugin but no match at
+      # the stable version, and fail the run as a stale checkout, minutes after
+      # npm and GitHub had already published.
+      - name: Collect released tags
+        id: released
+        run: |
+          set -euo pipefail
+          sort "$RUNNER_TEMP/tags-before.txt" > "$RUNNER_TEMP/tags-before-sorted.txt"
+          git tag --merged HEAD | sort > "$RUNNER_TEMP/tags-after-sorted.txt"
+          new_tags=$(comm -13 "$RUNNER_TEMP/tags-before-sorted.txt" "$RUNNER_TEMP/tags-after-sorted.txt")
+          echo "Tags created by this run:"
+          echo "${new_tags:-(none)}"
+          {
+            echo 'tags<<RELEASED_TAGS_EOF'
+            echo "$new_tags"
+            echo 'RELEASED_TAGS_EOF'
+          } >> "$GITHUB_OUTPUT"
       # package.json is deliberately excluded from the @semantic-release/git
       # prepare commit: that keeps multi-semantic-release's concretized
       # workspace:* deps off the branch (they'd break the next
@@ -198,6 +245,7 @@ jobs:
       # colliding on version headers. The prerelease zip is built from the
       # working tree regardless, so nothing downstream needs this commit.
       - name: Sync package.json versions
+        id: sync
         if: ${{ github.ref_name == 'release' }}
         run: |
           node .github/scripts/finalize-package-versions.cjs
@@ -208,6 +256,12 @@ jobs:
             git pull --rebase origin "${GITHUB_REF_NAME}"
             git push origin "HEAD:${GITHUB_REF_NAME}"
           }
+          # Published after the push, so it names a commit that exists on the
+          # remote for the deploy jobs to check out. Pinning them to this SHA is
+          # what makes the deployed tree exactly the released one: the branch tip
+          # can move underneath them, and a version-only check cannot see that,
+          # since a code-only commit leaves every version untouched.
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       # Post a release-success summary to Slack: stable releases (release branch)
       # go to the a8c workspace, alpha releases to the Newspack workspace. Only
@@ -260,6 +314,9 @@ jobs:
     with:
       plugin-name: newspack-newsletters
       plugin-path: plugins/newspack-newsletters
+      ref: ${{ needs.release.outputs.released-sha }}
+      released-tags: ${{ needs.release.outputs.released-tags }}
+      require-release: true
     secrets:
       WP_ORG_USERNAME: ${{ secrets.WP_ORG_USERNAME }}
       WP_ORG_PASSWORD: ${{ secrets.WP_ORG_PASSWORD }}
@@ -272,6 +329,9 @@ jobs:
     with:
       plugin-name: super-cool-ad-inserter
       plugin-path: plugins/super-cool-ad-inserter
+      ref: ${{ needs.release.outputs.released-sha }}
+      released-tags: ${{ needs.release.outputs.released-tags }}
+      require-release: true
     secrets:
       WP_ORG_USERNAME: ${{ secrets.WP_ORG_USERNAME }}
       WP_ORG_PASSWORD: ${{ secrets.WP_ORG_PASSWORD }}
@@ -284,6 +344,9 @@ jobs:
     with:
       plugin-name: republication-tracker-tool
       plugin-path: plugins/republication-tracker-tool
+      ref: ${{ needs.release.outputs.released-sha }}
+      released-tags: ${{ needs.release.outputs.released-tags }}
+      require-release: true
     secrets:
       WP_ORG_USERNAME: ${{ secrets.WP_ORG_USERNAME }}
       WP_ORG_PASSWORD: ${{ secrets.WP_ORG_PASSWORD }}

--- a/plugins/newspack-network/CHANGELOG.md
+++ b/plugins/newspack-network/CHANGELOG.md
@@ -1,3 +1,10 @@
+## newspack-network [2.22.1](https://github.com/Automattic/newspack-workspace/compare/newspack-network@2.22.0...newspack-network@2.22.1) (2026-08-19)
+
+
+### Bug Fixes
+
+* **network:** distribute dynamic galleries as resolved images ([#918](https://github.com/Automattic/newspack-workspace/issues/918)) ([0e1d1a1](https://github.com/Automattic/newspack-workspace/commit/0e1d1a149e48ba2f6425477eea41164fc6b195d7))
+
 # newspack-network [2.22.0](https://github.com/Automattic/newspack-workspace/compare/newspack-network@2.21.2...newspack-network@2.22.0) (2026-08-17)
 
 

--- a/plugins/newspack-network/includes/content-distribution/blocks/class-block-processor.php
+++ b/plugins/newspack-network/includes/content-distribution/blocks/class-block-processor.php
@@ -76,15 +76,16 @@ class Block_Processor {
 	/**
 	 * Process an outgoing block.
 	 *
-	 * @param array $block The block to process.
+	 * @param array $block   The block to process.
+	 * @param int   $post_id The ID of the post being distributed.
 	 *
 	 * @return array The processed block.
 	 */
-	public function process_outgoing_block( $block ) {
+	public function process_outgoing_block( $block, $post_id = 0 ) {
 		if ( ! is_callable( $this->outgoing_callback ) ) {
 			return $block;
 		}
-		return call_user_func( $this->outgoing_callback, $block );
+		return call_user_func( $this->outgoing_callback, $block, $post_id );
 	}
 
 	/**

--- a/plugins/newspack-network/includes/content-distribution/blocks/class-blocks.php
+++ b/plugins/newspack-network/includes/content-distribution/blocks/class-blocks.php
@@ -7,6 +7,8 @@
 
 namespace Newspack_Network\Content_Distribution;
 
+use Newspack_Network\Debugger;
+
 /**
  * Blocks class.
  */
@@ -27,6 +29,7 @@ class Blocks {
 		// Register block processors.
 		self::register_block_processor( 'jetpack/slideshow', [ __CLASS__, 'process_jetpack_galleries' ] );
 		self::register_block_processor( 'jetpack/tiled-gallery', [ __CLASS__, 'process_jetpack_galleries' ] );
+		self::register_block_processor( 'core/gallery', [ __CLASS__, 'process_dynamic_gallery' ] );
 	}
 
 	/**
@@ -60,11 +63,28 @@ class Blocks {
 	/**
 	 * Process an outgoing block.
 	 *
-	 * @param array $block The block to process.
+	 * Recurses into inner blocks so a block nested inside a Group, Columns or
+	 * similar container is processed too. Without this, a gallery only gets
+	 * handled when it sits at the top level of the post.
+	 *
+	 * Processors must return one block per block. Returning a different count would
+	 * desynchronise the parent's `innerContent` null placeholders.
+	 *
+	 * @param array $block   The block to process.
+	 * @param int   $post_id The ID of the post being distributed.
 	 *
 	 * @return array The processed block.
 	 */
-	public static function process_outgoing_block( $block ) {
+	public static function process_outgoing_block( $block, $post_id = 0 ) {
+		if ( ! empty( $block['innerBlocks'] ) ) {
+			$block['innerBlocks'] = array_map(
+				function ( $inner_block ) use ( $post_id ) {
+					return self::process_outgoing_block( $inner_block, $post_id );
+				},
+				$block['innerBlocks']
+			);
+		}
+
 		$block_name = $block['blockName'];
 
 		$processors = self::get_block_processors( $block_name );
@@ -73,7 +93,7 @@ class Blocks {
 		}
 
 		foreach ( $processors as $processor ) {
-			$block = $processor->process_outgoing_block( $block );
+			$block = $processor->process_outgoing_block( $block, $post_id );
 		}
 		return $block;
 	}
@@ -120,5 +140,267 @@ class Blocks {
 	public static function process_jetpack_galleries( $block ) {
 		unset( $block['attrs']['ids'] );
 		return $block;
+	}
+
+	/**
+	 * Flatten a dynamic gallery into ordinary image blocks for distribution.
+	 *
+	 * A gallery in dynamic mode stores no image IDs. It stores the instruction
+	 * "show the images attached to this post", which core resolves at render time
+	 * against whichever post is being rendered. That instruction travels intact,
+	 * but it means something different on a node, where the only attached image is
+	 * the sideloaded featured image. The gallery then arrives showing a single
+	 * unrelated image, or nothing at all, with no error either way.
+	 *
+	 * Resolving the images here, on the origin, leaves the block in the same shape
+	 * an ordinary gallery is saved in, which already distributes correctly.
+	 *
+	 * The image and wrapper construction mirrors core's own dynamic render
+	 * (the `dynamicContent` branch of `block_core_gallery_render()`), reusing core's
+	 * link helper so links, the lightbox and captions match what the origin shows.
+	 * The markup itself is the shape the blocks *save* in, not the shape core
+	 * renders, since a node stores it and its editor validates it against `save()`.
+	 * Blocks are built as arrays and left for `serialize_blocks()` to encode, so
+	 * attribute values never pass through a hand-written block-comment delimiter.
+	 *
+	 * Two caveats worth knowing:
+	 *
+	 * - The node's copy is static. Attaching a new image on the origin does not by
+	 *   itself resync the post, so the node updates on the next save of the post,
+	 *   not on the upload.
+	 * - When nothing resolves, the block is flattened to an empty gallery rather
+	 *   than shipped as-is. Passing the dynamic instruction through would let the
+	 *   node resolve it against its own attachments, which is the bug this exists
+	 *   to prevent.
+	 *
+	 * @param array $block   The block to process.
+	 * @param int   $post_id The ID of the post being distributed.
+	 *
+	 * @return array The processed block.
+	 */
+	public static function process_dynamic_gallery( $block, $post_id = 0 ) {
+		if ( empty( $block['attrs']['dynamicContent'] ) ) {
+			return $block;
+		}
+
+		// Dynamic galleries arrived with the WordPress 7.1 gallery block. Reaching
+		// here without those functions means 7.1-authored content on an older core:
+		// a downgrade, an import or a migration. Nothing can resolve the images, but
+		// shipping the instruction would let the node resolve it against its own
+		// attachments, so strip it and let the gallery arrive empty.
+		if (
+			! function_exists( 'block_core_gallery_resolve_dynamic_source' ) ||
+			! function_exists( 'block_core_gallery_dynamic_image_link_attributes' )
+		) {
+			Debugger::log( 'Dynamic gallery found on a WordPress older than 7.1, flattening to an empty gallery.' );
+			return self::flatten_gallery( $block, [] );
+		}
+
+		if ( ! $post_id ) {
+			Debugger::log( 'Dynamic gallery: no post ID given, flattening to an empty gallery.' );
+			return self::flatten_gallery( $block, [] );
+		}
+
+		$attachment_ids = block_core_gallery_resolve_dynamic_source(
+			$block['attrs']['dynamicContent'],
+			new \WP_Block( $block, [ 'postId' => $post_id ] )
+		);
+
+		if ( empty( $attachment_ids ) ) {
+			Debugger::log( sprintf( 'Dynamic gallery on post %d resolved no images.', $post_id ) );
+			return self::flatten_gallery( $block, [] );
+		}
+
+		// The source query only fetched IDs, which skips WP_Query's cache priming,
+		// and each image below reads the attachment post and its meta. Warm both in
+		// one pair of queries rather than paying two per attachment.
+		if ( count( $attachment_ids ) > 1 ) {
+			_prime_post_caches( $attachment_ids, false, true );
+		}
+
+		// Distribute origin URLs rather than the origin's image CDN, matching every
+		// other media URL this plugin puts on the wire.
+		add_filter( 'jetpack_photon_override_image_downsize', '__return_true' );
+
+		$image_blocks = [];
+		foreach ( $attachment_ids as $attachment_id ) {
+			$image_block = self::build_gallery_image_block( $attachment_id, $block['attrs'] );
+			if ( $image_block ) {
+				$image_blocks[] = $image_block;
+			}
+		}
+
+		remove_filter( 'jetpack_photon_override_image_downsize', '__return_true' );
+
+		if ( empty( $image_blocks ) ) {
+			Debugger::log( sprintf( 'Dynamic gallery on post %d resolved %d images, none of which produced markup.', $post_id, count( $attachment_ids ) ) );
+		}
+
+		return self::flatten_gallery( $block, $image_blocks );
+	}
+
+	/**
+	 * Build the flattened gallery block around a list of image blocks.
+	 *
+	 * Mirrors the wrapper core builds for a dynamic gallery: the gallery-specific
+	 * classes from `save.js`, plus the block-support classes and styles (align,
+	 * colors, border, spacing, anchor) that a static gallery carries in its saved
+	 * markup. Layout classes are deliberately left out, since the layout render
+	 * filter adds those on the node exactly as it does on the origin.
+	 *
+	 * @param array $block        The original dynamic gallery block.
+	 * @param array $image_blocks The image blocks to nest, possibly empty.
+	 *
+	 * @return array The flattened gallery block.
+	 */
+	private static function flatten_gallery( $block, $image_blocks ) {
+		$attrs = $block['attrs'];
+		unset( $attrs['dynamicContent'] );
+
+		$classes  = 'wp-block-gallery has-nested-images';
+		$classes .= isset( $attrs['columns'] ) ? ' columns-' . (int) $attrs['columns'] : ' columns-default';
+		if ( $attrs['imageCrop'] ?? true ) {
+			$classes .= ' is-cropped';
+		}
+
+		$wrapper = self::get_block_wrapper_attributes( $block, $classes );
+
+		// In dynamic mode `save.js` persists at most the gallery caption, so the
+		// block's own inner HTML is that `<figcaption>` or nothing. Core appends it
+		// after the images, and drops it when there are no images to caption.
+		$caption = $image_blocks ? trim( $block['innerHTML'] ?? '' ) : '';
+
+		$opening       = sprintf( '<figure %s>', $wrapper );
+		$closing       = $caption . '</figure>';
+		$inner_content = array_merge(
+			[ $opening ],
+			array_fill( 0, count( $image_blocks ), null ),
+			[ $closing ]
+		);
+
+		return [
+			'blockName'    => 'core/gallery',
+			'attrs'        => $attrs,
+			'innerBlocks'  => $image_blocks,
+			'innerHTML'    => $opening . $closing,
+			'innerContent' => $inner_content,
+		];
+	}
+
+	/**
+	 * Build a single `core/image` block for a resolved gallery image.
+	 *
+	 * Deliberately mirrors `block_core_gallery_render_dynamic_image()`, stopping
+	 * short of rendering so the block can be nested instead.
+	 *
+	 * @param int   $attachment_id The image attachment ID.
+	 * @param array $attributes    The gallery block attributes.
+	 *
+	 * @return array|null The image block, or null when no markup could be built.
+	 */
+	private static function build_gallery_image_block( $attachment_id, $attributes ) {
+		$size_slug    = $attributes['sizeSlug'] ?? 'large';
+		$aspect_ratio = $attributes['aspectRatio'] ?? 'auto';
+		$has_ratio    = $aspect_ratio && 'auto' !== $aspect_ratio;
+
+		$url = wp_get_attachment_image_url( $attachment_id, $size_slug );
+		if ( ! $url ) {
+			return null;
+		}
+
+		$image_attributes = array_merge(
+			[
+				'id'       => (int) $attachment_id,
+				'sizeSlug' => $size_slug,
+			],
+			block_core_gallery_dynamic_image_link_attributes( $attachment_id, $attributes )
+		);
+
+		// The image block's save() derives the inline style from these two attributes,
+		// so they have to travel together. Attributes without the style, or the style
+		// without the attributes, puts save() out of step with the stored markup and
+		// the block fails validation on the node.
+		if ( $has_ratio ) {
+			$image_attributes['aspectRatio'] = $aspect_ratio;
+			$image_attributes['scale']       = 'cover';
+		}
+
+		// Build the `<img>` the way the image block *saves* it, not the way core
+		// renders it. `wp_get_attachment_image()` adds width, height, srcset, sizes,
+		// loading and decoding, which the block's `save()` never emits, so persisting
+		// them makes the block fail validation the moment an editor opens the post.
+		// Those attributes are added at render time on the node, as they are for any
+		// other distributed image.
+		$image_markup = sprintf(
+			'<img src="%1$s" alt="%2$s" class="wp-image-%3$d"%4$s/>',
+			esc_url( $url ),
+			esc_attr( (string) get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ),
+			(int) $attachment_id,
+			$has_ratio
+				? ' style="' . esc_attr( safecss_filter_attr( sprintf( 'aspect-ratio:%s;object-fit:cover;', $aspect_ratio ) ) ) . '"'
+				: ''
+		);
+
+		if ( ! empty( $image_attributes['href'] ) ) {
+			$image_markup = sprintf(
+				'<a href="%1$s"%2$s%3$s>%4$s</a>',
+				esc_url( $image_attributes['href'] ),
+				isset( $image_attributes['linkTarget'] ) ? ' target="' . esc_attr( $image_attributes['linkTarget'] ) . '"' : '',
+				isset( $image_attributes['rel'] ) ? ' rel="' . esc_attr( $image_attributes['rel'] ) . '"' : '',
+				$image_markup
+			);
+		}
+
+		$attachment = get_post( $attachment_id );
+		$caption    = $attachment ? $attachment->post_excerpt : '';
+		if ( '' !== $caption ) {
+			$image_markup .= sprintf( '<figcaption class="wp-element-caption">%s</figcaption>', wp_kses_post( $caption ) );
+		}
+
+		$figure = sprintf(
+			'<figure class="wp-block-image size-%1$s">%2$s</figure>',
+			esc_attr( $size_slug ),
+			$image_markup
+		);
+
+		return [
+			'blockName'    => 'core/image',
+			'attrs'        => $image_attributes,
+			'innerBlocks'  => [],
+			'innerHTML'    => $figure,
+			'innerContent' => [ $figure ],
+		];
+	}
+
+	/**
+	 * Get the block-support wrapper attributes for a block outside of a render.
+	 *
+	 * `get_block_wrapper_attributes()` reads the block being rendered from
+	 * `WP_Block_Supports`, which is only set during a render. Distribution runs
+	 * outside one, so point it at this block and put back whatever was there.
+	 *
+	 * @param array  $block   The block whose supports should be applied.
+	 * @param string $classes Additional classes for the wrapper.
+	 *
+	 * @return string The wrapper attributes.
+	 */
+	private static function get_block_wrapper_attributes( $block, $classes ) {
+		if ( ! class_exists( '\WP_Block_Supports' ) || ! function_exists( 'get_block_wrapper_attributes' ) ) {
+			return sprintf( 'class="%s"', esc_attr( $classes ) );
+		}
+
+		$previous                            = \WP_Block_Supports::$block_to_render;
+		\WP_Block_Supports::$block_to_render = $block;
+
+		try {
+			$attributes = get_block_wrapper_attributes( [ 'class' => $classes ] );
+		} finally {
+			// Block supports call third-party callbacks, so restore the static even if
+			// one of them throws. Distribution runs a queue with no catch of its own,
+			// and leaving this set would outlive the block being processed.
+			\WP_Block_Supports::$block_to_render = $previous;
+		}
+
+		return $attributes ? $attributes : sprintf( 'class="%s"', esc_attr( $classes ) );
 	}
 }

--- a/plugins/newspack-network/includes/content-distribution/class-outgoing-post.php
+++ b/plugins/newspack-network/includes/content-distribution/class-outgoing-post.php
@@ -400,8 +400,11 @@ class Outgoing_Post {
 			return $this->post->post_content;
 		}
 
-		$blocks = array_map(
-			[ Blocks::class, 'process_outgoing_block' ],
+		$post_id = $this->post->ID;
+		$blocks  = array_map(
+			function ( $block ) use ( $post_id ) {
+				return Blocks::process_outgoing_block( $block, $post_id );
+			},
 			parse_blocks( $this->post->post_content )
 		);
 

--- a/plugins/newspack-network/newspack-network.php
+++ b/plugins/newspack-network/newspack-network.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack Network
  * Description: The Newspack Network plugin.
- * Version: 2.22.0
+ * Version: 2.22.1
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPLv2 or later

--- a/plugins/newspack-network/package.json
+++ b/plugins/newspack-network/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack-network",
-	"version": "2.22.0",
+	"version": "2.22.1",
 	"description": "The Newspack Network plugin.",
 	"license": "GPL-2.0-or-later",
 	"repository": {

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-dynamic-gallery.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-dynamic-gallery.php
@@ -1,0 +1,344 @@
+<?php
+/**
+ * Class TestDynamicGallery
+ *
+ * @package Newspack_Network
+ */
+
+namespace Test\Content_Distribution;
+
+use Newspack_Network\Content_Distribution\Blocks;
+
+/**
+ * Test flattening of WordPress 7.1 dynamic galleries for distribution.
+ */
+class TestDynamicGallery extends \WP_UnitTestCase {
+
+	/**
+	 * The post the gallery images are attached to.
+	 *
+	 * @var int
+	 */
+	private $post_id;
+
+	/**
+	 * The attached image IDs.
+	 *
+	 * @var int[]
+	 */
+	private $attachment_ids = [];
+
+	/**
+	 * Set up a post with three attached images.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->post_id        = self::factory()->post->create();
+		$this->attachment_ids = [];
+
+		for ( $i = 0; $i < 3; $i++ ) {
+			$this->attachment_ids[] = self::factory()->attachment->create_object(
+				[
+					'file'           => "dg-{$i}.png",
+					'post_parent'    => $this->post_id,
+					'post_mime_type' => 'image/png',
+					'post_excerpt'   => "Caption {$i}",
+				]
+			);
+		}
+	}
+
+	/**
+	 * Skip when the WordPress under test predates dynamic galleries.
+	 *
+	 * The behaviour under test only exists from WordPress 7.1. Skipping loudly is
+	 * better than asserting nothing, so the gap is visible in the CI output.
+	 */
+	private function requires_dynamic_galleries() {
+		if ( ! function_exists( 'block_core_gallery_resolve_dynamic_source' ) ) {
+			$this->markTestSkipped( 'Dynamic galleries require WordPress 7.1 or later; this suite runs ' . get_bloginfo( 'version' ) . '.' );
+		}
+	}
+
+	/**
+	 * Build a dynamic gallery block, in the shape the editor saves it.
+	 *
+	 * @param array  $attrs      Extra gallery attributes.
+	 * @param string $inner_html Saved inner HTML, i.e. the gallery caption.
+	 *
+	 * @return array The parsed block.
+	 */
+	private function dynamic_gallery( $attrs = [], $inner_html = '' ) {
+		$attrs  = array_merge( [ 'dynamicContent' => [ 'source' => 'core/attached-media' ] ], $attrs );
+		$markup = '<!-- wp:gallery ' . serialize_block_attributes( $attrs ) . ' -->' . $inner_html . '<!-- /wp:gallery -->';
+		$blocks = parse_blocks( $markup );
+		return $blocks[0];
+	}
+
+	/**
+	 * Flatten a block and return it serialized.
+	 *
+	 * @param array $block The block.
+	 *
+	 * @return string The serialized block.
+	 */
+	private function flatten( $block ) {
+		return serialize_blocks( [ Blocks::process_outgoing_block( $block, $this->post_id ) ] );
+	}
+
+	/**
+	 * A dynamic gallery is replaced by the images attached to the post.
+	 */
+	public function test_resolves_attached_images() {
+		$this->requires_dynamic_galleries();
+
+		$output = $this->flatten( $this->dynamic_gallery() );
+
+		$this->assertStringNotContainsString( 'dynamicContent', $output, 'The dynamic instruction must not be distributed.' );
+		$this->assertSame( 3, substr_count( $output, '<!-- wp:image ' ), 'Every attached image should become an image block.' );
+
+		foreach ( $this->attachment_ids as $attachment_id ) {
+			$this->assertStringContainsString( 'wp-image-' . $attachment_id, $output );
+		}
+	}
+
+	/**
+	 * The flattened gallery no longer depends on the rendering post's attachments,
+	 * which is the whole point: a node has only the sideloaded featured image.
+	 */
+	public function test_renders_on_a_post_without_attachments() {
+		$this->requires_dynamic_galleries();
+
+		$output = $this->flatten( $this->dynamic_gallery() );
+		$node   = self::factory()->post->create( [ 'post_content' => $output ] );
+
+		$rendered = '';
+		foreach ( parse_blocks( get_post( $node )->post_content ) as $block ) {
+			$rendered .= render_block( $block );
+		}
+
+		$this->assertSame( 3, substr_count( $rendered, '<img ' ), 'All images should render where the post has none attached.' );
+	}
+
+	/**
+	 * Gallery settings that live on the wrapper survive.
+	 */
+	public function test_preserves_wrapper_settings() {
+		$this->requires_dynamic_galleries();
+
+		$output = $this->flatten(
+			$this->dynamic_gallery(
+				[
+					'columns'   => 3,
+					'imageCrop' => false,
+				]
+			)
+		);
+
+		$this->assertStringContainsString( 'columns-3', $output, 'The column count must survive.' );
+		$this->assertStringNotContainsString( 'is-cropped', $output, 'imageCrop false must not be cropped on the node.' );
+	}
+
+	/**
+	 * The gallery caption survives. It is a sourced attribute, so it lives only in
+	 * the block's inner HTML.
+	 */
+	public function test_preserves_gallery_caption() {
+		$this->requires_dynamic_galleries();
+
+		$caption = '<figcaption class="blocks-gallery-caption wp-element-caption">Scenes from the parade</figcaption>';
+		$output  = $this->flatten( $this->dynamic_gallery( [], $caption ) );
+
+		$this->assertStringContainsString( 'Scenes from the parade', $output );
+	}
+
+	/**
+	 * Linked galleries keep their links, and the lightbox keeps working.
+	 */
+	public function test_preserves_links_and_lightbox() {
+		$this->requires_dynamic_galleries();
+
+		$first = $this->attachment_ids[0];
+
+		$media = $this->flatten( $this->dynamic_gallery( [ 'linkTo' => 'media' ] ) );
+		$this->assertSame( 3, substr_count( $media, '<a href=' ), 'Linked galleries must keep their anchors.' );
+		$this->assertStringContainsString( 'href="' . esc_url( wp_get_attachment_url( $first ) ) . '"', $media, 'media must link to the file.' );
+
+		$attachment = $this->flatten( $this->dynamic_gallery( [ 'linkTo' => 'attachment' ] ) );
+		$this->assertStringContainsString( 'href="' . esc_url( get_attachment_link( $first ) ) . '"', $attachment, 'attachment must link to the attachment page.' );
+
+		$blank = $this->flatten(
+			$this->dynamic_gallery(
+				[
+					'linkTo'     => 'media',
+					'linkTarget' => '_blank',
+				] 
+			) 
+		);
+		$this->assertStringContainsString( 'target="_blank"', $blank );
+		$this->assertStringContainsString( 'rel="noopener"', $blank );
+
+		$lightbox = $this->flatten( $this->dynamic_gallery( [ 'linkTo' => 'lightbox' ] ) );
+		$this->assertStringNotContainsString( '"linkDestination":"lightbox"', $lightbox, 'lightbox is not a linkDestination value.' );
+		$this->assertStringContainsString( '"lightbox":{"enabled":true}', $lightbox, 'The lightbox must be switched on, not merely mentioned.' );
+	}
+
+	/**
+	 * Attribute values cannot break out of the block comment delimiter.
+	 */
+	public function test_attribute_values_cannot_inject_markup() {
+		$this->requires_dynamic_galleries();
+
+		$payload = 'x"} --><img src=x onerror=alert(1)>';
+		$output  = $this->flatten( $this->dynamic_gallery( [ 'className' => $payload ] ) );
+
+		$this->assertStringNotContainsString( '<img src=x onerror', $output, 'Attribute values must not become markup.' );
+
+		$reparsed = parse_blocks( $output );
+		$this->assertSame( $payload, $reparsed[0]['attrs']['className'], 'The attribute must survive intact.' );
+		$this->assertCount( 3, $reparsed[0]['innerBlocks'], 'The block must not be corrupted.' );
+	}
+
+	/**
+	 * When nothing resolves, the dynamic instruction must not be distributed. A node
+	 * would resolve it against its own attachments, which is the bug being fixed.
+	 */
+	public function test_fails_closed_when_nothing_resolves() {
+		$this->requires_dynamic_galleries();
+
+		$empty  = self::factory()->post->create();
+		$output = serialize_blocks( [ Blocks::process_outgoing_block( $this->dynamic_gallery(), $empty ) ] );
+
+		$this->assertStringNotContainsString( 'dynamicContent', $output );
+		$this->assertStringNotContainsString( '<!-- wp:image ', $output );
+	}
+
+	/**
+	 * A gallery nested inside another block is processed too.
+	 */
+	public function test_flattens_a_nested_gallery() {
+		$this->requires_dynamic_galleries();
+
+		$markup = '<!-- wp:group --><div class="wp-block-group">'
+			. '<!-- wp:gallery ' . serialize_block_attributes( [ 'dynamicContent' => [ 'source' => 'core/attached-media' ] ] ) . ' /-->'
+			. '</div><!-- /wp:group -->';
+
+		$post_id = $this->post_id;
+		$output  = serialize_blocks(
+			array_map(
+				function ( $block ) use ( $post_id ) {
+					return Blocks::process_outgoing_block( $block, $post_id );
+				},
+				parse_blocks( $markup )
+			)
+		);
+
+		$this->assertStringNotContainsString( 'dynamicContent', $output );
+		$this->assertSame( 3, substr_count( $output, '<!-- wp:image ' ) );
+	}
+
+	/**
+	 * An ordinary gallery is left exactly as it is.
+	 */
+	public function test_leaves_an_ordinary_gallery_alone() {
+		$markup = '<!-- wp:gallery {"linkTo":"none"} --><figure class="wp-block-gallery has-nested-images">'
+			. '<!-- wp:image {"id":1} --><figure class="wp-block-image"><img src="http://example.org/a.png" class="wp-image-1"/></figure><!-- /wp:image -->'
+			. '</figure><!-- /wp:gallery -->';
+
+		$blocks = parse_blocks( $markup );
+		$this->assertSame( serialize_blocks( $blocks ), $this->flatten( $blocks[0] ) );
+	}
+
+	/**
+	 * Processing an already flattened gallery changes nothing further.
+	 */
+	public function test_is_idempotent() {
+		$this->requires_dynamic_galleries();
+
+		$once  = Blocks::process_outgoing_block( $this->dynamic_gallery(), $this->post_id );
+		$twice = Blocks::process_outgoing_block( $once, $this->post_id );
+
+		$this->assertSame( serialize_blocks( [ $once ] ), serialize_blocks( [ $twice ] ) );
+	}
+
+	/**
+	 * The post ID reaches a registered outgoing callback.
+	 */
+	public function test_post_id_reaches_the_callback() {
+		$seen = null;
+		Blocks::register_block_processor(
+			'core/separator',
+			function ( $block, $post_id ) use ( &$seen ) {
+				$seen = $post_id;
+				return $block;
+			}
+		);
+
+		Blocks::process_outgoing_block( parse_blocks( '<!-- wp:separator /-->' )[0], 4242 );
+		Blocks::reset_block_processors( 'core/separator' );
+
+		$this->assertSame( 4242, $seen );
+	}
+
+	/**
+	 * A cropped gallery keeps its ratio on the node.
+	 *
+	 * The image block's save() derives the inline style from the aspectRatio and
+	 * scale attributes, so the two have to travel together or the block fails
+	 * validation. Assert both, so they cannot come apart again.
+	 */
+	public function test_preserves_aspect_ratio() {
+		$this->requires_dynamic_galleries();
+
+		$output = $this->flatten( $this->dynamic_gallery( [ 'aspectRatio' => '16/9' ] ) );
+
+		$this->assertStringContainsString( '"aspectRatio":"16/9"', $output, 'The ratio must reach the image block attributes.' );
+		$this->assertStringContainsString( '"scale":"cover"', $output, 'scale travels with aspectRatio.' );
+		$this->assertSame( 3, substr_count( $output, 'style="aspect-ratio:16/9;object-fit:cover"' ), 'Every image needs the persisted style.' );
+	}
+
+	/**
+	 * An "auto" ratio adds nothing, which is what core saves for an uncropped gallery.
+	 */
+	public function test_auto_aspect_ratio_adds_nothing() {
+		$this->requires_dynamic_galleries();
+
+		$output = $this->flatten( $this->dynamic_gallery( [ 'aspectRatio' => 'auto' ] ) );
+
+		$this->assertStringNotContainsString( 'aspect-ratio:', $output );
+		$this->assertStringNotContainsString( '"scale"', $output );
+	}
+
+	/**
+	 * The recursion reaches a nested Jetpack gallery.
+	 *
+	 * This is the part of the change that reaches sites before they update to 7.1,
+	 * so unlike the gallery tests it has to run on every WordPress version.
+	 */
+	public function test_recursion_reaches_a_nested_jetpack_gallery() {
+		$markup = '<!-- wp:group --><div class="wp-block-group">'
+			. '<!-- wp:jetpack/tiled-gallery {"ids":[11,22,33]} --><div class="wp-block-jetpack-tiled-gallery"></div><!-- /wp:jetpack/tiled-gallery -->'
+			. '</div><!-- /wp:group -->';
+
+		$blocks = parse_blocks( $markup );
+		$output = serialize_blocks( [ Blocks::process_outgoing_block( $blocks[0], $this->post_id ) ] );
+
+		$this->assertStringNotContainsString( '"ids"', $output, 'Origin attachment IDs are meaningless on a node.' );
+		$this->assertStringContainsString( 'wp:jetpack/tiled-gallery', $output, 'The block itself must survive.' );
+	}
+
+	/**
+	 * Recursion must return one block per block, or the parent's innerContent
+	 * placeholders stop lining up with its inner blocks.
+	 */
+	public function test_recursion_preserves_block_structure() {
+		$markup = '<!-- wp:group --><div class="wp-block-group">'
+			. '<!-- wp:paragraph --><p>One</p><!-- /wp:paragraph -->'
+			. '<!-- wp:paragraph --><p>Two</p><!-- /wp:paragraph -->'
+			. '</div><!-- /wp:group -->';
+
+		$blocks = parse_blocks( $markup );
+		$this->assertSame( $markup, serialize_blocks( [ Blocks::process_outgoing_block( $blocks[0], $this->post_id ) ] ) );
+	}
+}

--- a/plugins/newspack-plugin/CHANGELOG.md
+++ b/plugins/newspack-plugin/CHANGELOG.md
@@ -1,3 +1,10 @@
+## newspack [6.48.7](https://github.com/Automattic/newspack-workspace/compare/newspack@6.48.6...newspack@6.48.7) (2026-08-19)
+
+
+### Bug Fixes
+
+* **subscriptions:** enable legacy subscription product types once ([#819](https://github.com/Automattic/newspack-workspace/issues/819)) ([7d9e6c4](https://github.com/Automattic/newspack-workspace/commit/7d9e6c4b148db93a21d54a774081345127acba2b))
+
 ## newspack [6.48.6](https://github.com/Automattic/newspack-workspace/compare/newspack@6.48.5...newspack@6.48.6) (2026-08-19)
 
 

--- a/plugins/newspack-plugin/CHANGELOG.md
+++ b/plugins/newspack-plugin/CHANGELOG.md
@@ -1,3 +1,10 @@
+## newspack [6.48.6](https://github.com/Automattic/newspack-workspace/compare/newspack@6.48.5...newspack@6.48.6) (2026-08-19)
+
+
+### Bug Fixes
+
+* **reader-activation:** keep the initial list size from reverting to 2 ([#849](https://github.com/Automattic/newspack-workspace/issues/849)) ([24d8d43](https://github.com/Automattic/newspack-workspace/commit/24d8d4389c54f2e95860581226c8a57062eff5e8))
+
 ## newspack [6.48.5](https://github.com/Automattic/newspack-workspace/compare/newspack@6.48.4...newspack@6.48.5) (2026-08-19)
 
 

--- a/plugins/newspack-plugin/CHANGELOG.md
+++ b/plugins/newspack-plugin/CHANGELOG.md
@@ -1,3 +1,10 @@
+## newspack [6.48.8](https://github.com/Automattic/newspack-workspace/compare/newspack@6.48.7...newspack@6.48.8) (2026-08-19)
+
+
+### Bug Fixes
+
+* **content-gate:** enforce block visibility on REST reads ([#813](https://github.com/Automattic/newspack-workspace/issues/813)) ([3dfb94b](https://github.com/Automattic/newspack-workspace/commit/3dfb94b2e4b31ba91c8f6200be3a4508086b99a1))
+
 ## newspack [6.48.7](https://github.com/Automattic/newspack-workspace/compare/newspack@6.48.6...newspack@6.48.7) (2026-08-19)
 
 

--- a/plugins/newspack-plugin/CHANGELOG.md
+++ b/plugins/newspack-plugin/CHANGELOG.md
@@ -1,3 +1,10 @@
+## newspack [6.48.9](https://github.com/Automattic/newspack-workspace/compare/newspack@6.48.8...newspack@6.48.9) (2026-08-19)
+
+
+### Bug Fixes
+
+* **reader-activation:** escape the row-action URLs in the users list ([#873](https://github.com/Automattic/newspack-workspace/issues/873)) ([816fc2b](https://github.com/Automattic/newspack-workspace/commit/816fc2bdf7bb0e442ddbc19d240d9fe63f41e9bc))
+
 ## newspack [6.48.8](https://github.com/Automattic/newspack-workspace/compare/newspack@6.48.7...newspack@6.48.8) (2026-08-19)
 
 

--- a/plugins/newspack-plugin/includes/class-magic-link.php
+++ b/plugins/newspack-plugin/includes/class-magic-link.php
@@ -1006,7 +1006,9 @@ final class Magic_Link {
 	 * @param string $action  Which admin action get the URL for.
 	 * @param int    $user_id User to get the URL for.
 	 *
-	 * @return string Admin URL to perform an admin action.
+	 * @return string Admin URL to perform an admin action. Built from the current
+	 *                request, so callers must escape it with esc_url() when
+	 *                rendering it into markup.
 	 */
 	private static function get_admin_action_url( $action, $user_id ) {
 		if ( ! \is_admin() ) {
@@ -1039,7 +1041,7 @@ final class Magic_Link {
 		}
 		if ( self::can_magic_link( $user->ID ) && \current_user_can( 'edit_user', $user->ID ) ) {
 			$url                                 = self::get_admin_action_url( 'send', $user->ID );
-			$actions['newspack-magic-link-send'] = '<a href="' . $url . '">' . \esc_html__( 'Send authentication link', 'newspack-plugin' ) . '</a>';
+			$actions['newspack-magic-link-send'] = '<a href="' . \esc_url( $url ) . '">' . \esc_html__( 'Send authentication link', 'newspack-plugin' ) . '</a>';
 		}
 		return $actions;
 	}

--- a/plugins/newspack-plugin/includes/content-gate/class-block-visibility.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-block-visibility.php
@@ -53,16 +53,78 @@ class Block_Visibility {
 			return $block_content;
 		}
 
-		// Bypass access control in admin screens and REST requests (block renderer,
-		// preview, query-loop rendering inside the editor) so blocks are never hidden
-		// from editors during content authoring.
-		if ( is_admin() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+		// Bypass access control in admin screens so blocks are never hidden from
+		// editors during content authoring.
+		//
+		// REST requests are deliberately NOT exempt: a context check is not a permission
+		// check, and access has to be evaluated per requester. Authoring contexts that
+		// arrive over REST (block renderer, preview, query-loop rendering inside the
+		// editor) are covered by the `edit_post` check further down, which needs a post
+		// in scope — where none is set up, it fails closed. Re-adding a blanket REST
+		// exemption here would widen what is readable; the REST cases in
+		// Newspack_Test_Block_Visibility pin the behaviour.
+		if ( is_admin() ) {
 			return $block_content;
 		}
 
-		return self::is_hidden_for_user( $block, get_current_user_id(), get_the_ID() )
-			? ''
-			: $block_content;
+		$hidden = self::is_hidden_for_user( $block, get_current_user_id(), get_the_ID() );
+
+		// This response now depends on who asked for it, and the page cache in front of
+		// it cannot always tell requesters apart. Batcache skips a request only when it
+		// carries an X-WP-Nonce header or a wp*/wordpress* cookie; an application
+		// password sends neither, so a privileged REST render would be stored and then
+		// served to the next anonymous caller. Cancel the store whenever this render
+		// shows a block an anonymous reader would not see -- the withheld render is
+		// still cached normally, which is the common case and the one worth caching.
+		if ( self::render_varies_from_anonymous( $block, get_current_user_id(), get_the_ID() ) ) {
+			self::prevent_page_cache();
+		}
+
+		return $hidden ? '' : $block_content;
+	}
+
+	/**
+	 * Whether this render differs from the one an anonymous reader would get.
+	 *
+	 * Compares the two hide-decisions rather than testing a single direction.
+	 * `visibility` is a two-way toggle, and is_hidden_for_user() inverts on it: with
+	 * `hidden`, a reader who matches the rules has the block withheld while anonymous
+	 * keeps it. That render varies per requester too, so a one-directional check
+	 * ("shows a block anonymous would not see") misses it and lets it be cached.
+	 *
+	 * Split out so the decision is testable without inspecting response headers:
+	 * batcache_cancel() and header() are both unobservable under PHPUnit, so a test
+	 * written against them asserts nothing.
+	 *
+	 * Assumes an anonymous render never varies from another anonymous render. The
+	 * `institution` rule contradicts that -- it sets supports_anonymous and evaluates
+	 * on IP or cookie, so two anonymous readers can legitimately differ and the first
+	 * one cached wins. That is pre-existing on the front-end path and unchanged here;
+	 * it is tracked separately rather than assumed away.
+	 *
+	 * @param array    $block   Parsed block.
+	 * @param int      $user_id Reader the response was rendered for.
+	 * @param int|null $post_id Post in scope, for the edit-capability bypass.
+	 * @return bool
+	 */
+	public static function render_varies_from_anonymous( $block, $user_id, $post_id = null ) {
+		return self::is_hidden_for_user( $block, $user_id, $post_id ) !== self::is_hidden_for_user( $block, 0 );
+	}
+
+	/**
+	 * Keep the current response out of the page cache.
+	 *
+	 * Batcache exposes batcache_cancel() for this; DONOTCACHEPAGE is not honoured by
+	 * the build running on Atomic, so it is not enough on its own. The header covers
+	 * any other cache in the path and is a no-op once output has started.
+	 */
+	private static function prevent_page_cache() {
+		if ( function_exists( 'batcache_cancel' ) ) {
+			batcache_cancel();
+		}
+		if ( ! headers_sent() ) {
+			header( 'Cache-Control: private, no-store, max-age=0', true );
+		}
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -20,10 +20,23 @@ class WooCommerce_Subscriptions {
 	const REACTIVATED_FOR_SWITCH_META = '_newspack_switch_reactivated_subscriptions';
 
 	/**
+	 * Option recording which WooCommerce Subscriptions product-type settings
+	 * Newspack turned on, as a list of the option names written.
+	 *
+	 * Write provenance, not a gate: once the WooCommerce row exists,
+	 * `maybe_enable_legacy_product_types()` never reconsiders it anyway. This
+	 * exists so the write is answerable afterwards — which sites Newspack
+	 * touched, and which of the two rows it created — so that a corrective
+	 * release could reverse only those and leave a publisher's own choice alone.
+	 */
+	const PRODUCT_TYPES_ENABLED_OPTION = 'newspack_subscriptions_enabled_product_types';
+
+	/**
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
 		add_action( 'plugins_loaded', [ __CLASS__, 'woocommerce_subscriptions_integration_init' ] );
+		add_action( 'admin_init', [ __CLASS__, 'maybe_enable_legacy_product_types' ] );
 		add_filter( 'woocommerce_subscriptions_product_limited_for_user', [ __CLASS__, 'maybe_limit_subscription_product_for_user' ], 10, 3 );
 		add_filter( 'woocommerce_subscriptions_product_trial_length', [ __CLASS__, 'limit_free_trials_to_one_per_user' ], 10, 2 );
 		add_filter( 'wcs_get_users_subscriptions', [ __CLASS__, 'filter_subscriptions_for_account_page' ], 10, 1 );
@@ -672,6 +685,111 @@ class WooCommerce_Subscriptions {
 		Card_Expiry_Warning::init();
 	}
 
+	/**
+	 * Enable the `subscription` and `variable-subscription` product types, once.
+	 *
+	 * WooCommerce Subscriptions 9.0 added a "Subscription product creation" section
+	 * whose two checkboxes default to off, which removes those product types from
+	 * the product-type dropdown. Newspack still creates them — the Audience wizard
+	 * writes them directly — so on an unconfigured site a publisher cannot create
+	 * or switch to a product type our own wizard produces.
+	 *
+	 * Runs on `admin_init`, matching how the plugin writes other third-party
+	 * options (`Parsely::migrate_meta_type()`, `WooCommerce_Email_Style_Sync`,
+	 * `Emails_Section`), which keeps it off ordinary front-end pageloads, REST
+	 * requests and cron. It is not an authentication guarantee: `admin-ajax.php`
+	 * fires `admin_init` too, so a `wp_ajax_nopriv_*` action reaches this
+	 * unauthenticated. That is harmless here — the write is one-shot and the same
+	 * either way — but the hook is a narrower surface, not a logged-in one.
+	 *
+	 * Nothing is lost by waiting — a Subscriptions upgrade happens through an
+	 * admin action, so `admin_init` fires in the same session, and the
+	 * product-type dropdown this unblocks is itself only reachable in wp-admin.
+	 * It also makes the opt-out filter usable from a theme's `functions.php`,
+	 * which a `plugins_loaded` call would not.
+	 *
+	 * @return void
+	 */
+	public static function maybe_enable_legacy_product_types() {
+		if ( ! self::is_active() ) {
+			return;
+		}
+		self::enable_legacy_product_types();
+	}
+
+	/**
+	 * Write the product-type settings, for options that have never been written.
+	 *
+	 * Only an option whose row is absent is touched. Anything that has saved the
+	 * setting leaves a `'no'`, including WooCommerce's own settings screen when the
+	 * box is unticked, so an absent row is the only signal that the publisher has no
+	 * preference. That makes this self-limiting: after the first write the row
+	 * exists, so the check never passes again and an unticked box stays unticked.
+	 *
+	 * Known limitation, accepted deliberately: `WC_Admin_Settings::save_fields()`
+	 * writes every field in a section on any save of that tab, not only the fields
+	 * the publisher touched. A site that reached 9.0 and then saved WooCommerce →
+	 * Settings → Subscriptions for an unrelated reason therefore has `'no'` rows
+	 * nobody chose, and this permanently no-ops for it. Widening the test to treat
+	 * `'no'` as fair game would forfeit the one thing that makes writing another
+	 * plugin's setting safe — so those sites are left to the settings screen.
+	 *
+	 * Deliberately not gated on the Subscriptions version. Writing the option before
+	 * a site reaches 9.0 is the point — the new default then never applies.
+	 *
+	 * @return void
+	 */
+	public static function enable_legacy_product_types() {
+		/**
+		 * Filters whether Newspack enables the legacy subscription product types.
+		 *
+		 * Returning false leaves the WooCommerce settings untouched. Because the
+		 * write runs on `admin_init` and happens at most once per option, the
+		 * filter must be added before then — a plugin, mu-plugin or a theme's
+		 * `functions.php` all work; it cannot be used to undo a write already made.
+		 *
+		 * @param bool $enable Whether to enable the legacy subscription product types.
+		 */
+		if ( ! apply_filters( 'newspack_subscriptions_enable_legacy_product_types', true ) ) {
+			return;
+		}
+
+		$options = [
+			'woocommerce_subscriptions_enable_simple_subscription',
+			'woocommerce_subscriptions_enable_variable_subscription',
+		];
+
+		// A sentinel default rather than a `false ===` test: `get_option()` returns
+		// the default only when the row is absent, so this stays correct even for
+		// an option stored as `false` or an empty string.
+		$absent  = new \stdClass();
+		$written = [];
+		foreach ( $options as $option ) {
+			if ( $absent === get_option( $option, $absent ) ) {
+				$written[] = $option;
+			}
+		}
+
+		if ( empty( $written ) ) {
+			return;
+		}
+
+		foreach ( $written as $option ) {
+			update_option( $option, 'yes' );
+		}
+
+		update_option(
+			self::PRODUCT_TYPES_ENABLED_OPTION,
+			array_values( array_unique( array_merge( (array) get_option( self::PRODUCT_TYPES_ENABLED_OPTION, [] ), $written ) ) )
+		);
+
+		Logger::newspack_log(
+			'newspack_subscriptions_product_types_enabled',
+			'Enabled WooCommerce Subscriptions product types that had never been configured.',
+			[ 'options' => $written ],
+			'info'
+		);
+	}
 
 	/**
 	 * Check if WooCommerce Subscriptions is active.

--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
@@ -466,9 +466,15 @@ final class Reader_Activation {
 
 		$value = \get_option( self::OPTIONS_PREFIX . $name, $config[ $name ] );
 
-		// Use default value type for casting bool option value.
+		/*
+		 * Cast to the default value's type. Options come back from the database as
+		 * strings, but out of a warm object cache as the type they were written with,
+		 * so a setting's type would otherwise vary with cache state.
+		 */
 		if ( is_bool( $config[ $name ] ) ) {
 			$value = (bool) $value;
+		} elseif ( is_int( $config[ $name ] ) ) {
+			$value = (int) $value;
 		}
 		return apply_filters( 'newspack_reader_activation_setting', $value, $name );
 	}

--- a/plugins/newspack-plugin/includes/reader-activation/sync/class-contact-sync-admin.php
+++ b/plugins/newspack-plugin/includes/reader-activation/sync/class-contact-sync-admin.php
@@ -54,7 +54,9 @@ class Contact_Sync_Admin {
 	 *
 	 * @param int $user_id User to get the URL for.
 	 *
-	 * @return string Admin URL to perform the admin action.
+	 * @return string Admin URL to perform the admin action. Built from the current
+	 *                request, so callers must escape it with esc_url() when
+	 *                rendering it into markup.
 	 */
 	private static function get_admin_action_url( $user_id ) {
 		if ( ! \is_admin() ) {
@@ -85,7 +87,7 @@ class Contact_Sync_Admin {
 			return $actions;
 		}
 		$url = self::get_admin_action_url( $user->ID );
-		$actions[ self::ADMIN_ACTION ] = '<a href="' . $url . '">' . \esc_html__( 'Resync contact to ESP', 'newspack-plugin' ) . '</a>';
+		$actions[ self::ADMIN_ACTION ] = '<a href="' . \esc_url( $url ) . '">' . \esc_html__( 'Resync contact to ESP', 'newspack-plugin' ) . '</a>';
 		return $actions;
 	}
 

--- a/plugins/newspack-plugin/newspack.php
+++ b/plugins/newspack-plugin/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 6.48.5
+ * Version: 6.48.6
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '6.48.5' );
+define( 'NEWSPACK_PLUGIN_VERSION', '6.48.6' );
 
 // Path to the main Newspack plugin file.
 if ( ! defined( 'NEWSPACK_PLUGIN_FILE' ) ) {

--- a/plugins/newspack-plugin/newspack.php
+++ b/plugins/newspack-plugin/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 6.48.7
+ * Version: 6.48.8
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '6.48.7' );
+define( 'NEWSPACK_PLUGIN_VERSION', '6.48.8' );
 
 // Path to the main Newspack plugin file.
 if ( ! defined( 'NEWSPACK_PLUGIN_FILE' ) ) {

--- a/plugins/newspack-plugin/newspack.php
+++ b/plugins/newspack-plugin/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 6.48.8
+ * Version: 6.48.9
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '6.48.8' );
+define( 'NEWSPACK_PLUGIN_VERSION', '6.48.9' );
 
 // Path to the main Newspack plugin file.
 if ( ! defined( 'NEWSPACK_PLUGIN_FILE' ) ) {

--- a/plugins/newspack-plugin/newspack.php
+++ b/plugins/newspack-plugin/newspack.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack
  * Description: An advanced open-source publishing and revenue-generating platform for news organizations.
- * Version: 6.48.6
+ * Version: 6.48.7
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPL2
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '6.48.6' );
+define( 'NEWSPACK_PLUGIN_VERSION', '6.48.7' );
 
 // Path to the main Newspack plugin file.
 if ( ! defined( 'NEWSPACK_PLUGIN_FILE' ) ) {

--- a/plugins/newspack-plugin/package.json
+++ b/plugins/newspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack",
-	"version": "6.48.8",
+	"version": "6.48.9",
 	"description": "The Newspack plugin. https://newspack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/newspack-plugin/issues"

--- a/plugins/newspack-plugin/package.json
+++ b/plugins/newspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack",
-	"version": "6.48.5",
+	"version": "6.48.6",
 	"description": "The Newspack plugin. https://newspack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/newspack-plugin/issues"

--- a/plugins/newspack-plugin/package.json
+++ b/plugins/newspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack",
-	"version": "6.48.6",
+	"version": "6.48.7",
 	"description": "The Newspack plugin. https://newspack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/newspack-plugin/issues"

--- a/plugins/newspack-plugin/package.json
+++ b/plugins/newspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack",
-	"version": "6.48.7",
+	"version": "6.48.8",
 	"description": "The Newspack plugin. https://newspack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/newspack-plugin/issues"

--- a/plugins/newspack-plugin/src/wizards/audience/views/setup/setup.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/setup/setup.js
@@ -225,7 +225,10 @@ export default withWizardScreen(
 												'Number of newsletters initially visible during signup. Additional newsletters will be hidden behind a "See all" button.',
 												'newspack-plugin'
 											) }
-											value={ config.newsletter_list_initial_size || '' }
+											// RangeControl discards any value that isn't `typeof 'number'` and
+											// falls back to initialPosition, so coerce: options saved to the
+											// database read back as numeric strings once the cache is cold.
+											value={ parseInt( config.newsletter_list_initial_size ) || undefined }
 											onChange={ value => updateConfig( 'newsletter_list_initial_size', parseInt( value ) ) }
 										/>
 									</Grid>

--- a/plugins/newspack-plugin/src/wizards/audience/views/setup/setup.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/setup/setup.test.js
@@ -1,0 +1,79 @@
+/**
+ * Tests for the Audience Management setup screen.
+ */
+
+/**
+ * External dependencies
+ */
+import { act, render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Setup from './setup';
+
+// The screen fetches the ESP on mount; Newspack Newsletters may not be installed,
+// so the component already tolerates a rejection — resolve empty to keep it quiet.
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn( () => Promise.resolve( { settings: {} } ) ),
+} ) );
+
+const baseProps = {
+	config: {
+		enabled: true,
+		use_custom_lists: true,
+		newsletter_lists: [],
+		newsletter_list_initial_size: 3,
+	},
+	prerequisites: {
+		esp: { active: true, plugins: { 'newspack-newsletters': true } },
+	},
+	requiredPlugins: {},
+	espSyncErrors: [],
+	fetchConfig: () => {},
+	updateConfig: () => {},
+	saveConfig: () => {},
+	getSharedProps: () => ( {} ),
+	inFlight: false,
+};
+
+// Awaited so the on-mount ESP fetch settles inside act().
+const renderSetup = async initialSize => {
+	await act( async () => {
+		render( <Setup { ...baseProps } config={ { ...baseProps.config, newsletter_list_initial_size: initialSize } } /> );
+	} );
+};
+
+describe( 'Audience setup: initial list size', () => {
+	beforeEach( () => {
+		global.newspack_aux_data = { is_debug_mode: false };
+		global.newspackAudience = {
+			available_newsletter_lists: [],
+			integrations_settings_enabled: false,
+			can_use_salesforce: false,
+		};
+	} );
+
+	const slider = () => screen.getByRole( 'slider', { name: 'Initial list size' } );
+
+	it( 'shows the configured size when the value is a number', async () => {
+		await renderSetup( 3 );
+		expect( slider() ).toHaveValue( '3' );
+	} );
+
+	// Options read from the database come back as numeric strings (NPPM-3073).
+	// RangeControl discards any value that is not `typeof 'number'` and silently
+	// falls back to its initial position, so the publisher sees 2 whatever is saved.
+	it( 'shows the configured size when the value is a numeric string', async () => {
+		await renderSetup( '3' );
+		expect( slider() ).toHaveValue( '3' );
+	} );
+
+	// With nothing saved yet, the control should fall back to its own
+	// initialPosition rather than to a value hardcoded at the call site.
+	it( 'falls back to the default size when no value is set', async () => {
+		await renderSetup( undefined );
+		expect( slider() ).toHaveValue( '2' );
+	} );
+} );

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-block-visibility.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-block-visibility.php
@@ -421,6 +421,142 @@ class Newspack_Test_Block_Visibility extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A render that shows a gated block is marked as varying from anonymous.
+	 *
+	 * Once the REST exemption is gone the response depends on who asked for it, and
+	 * batcache skips a request only when it carries an X-WP-Nonce header or a
+	 * WordPress auth cookie. An application password sends neither, so a privileged
+	 * render would be stored and served to the next anonymous caller. This pins the
+	 * decision that cancels the store.
+	 */
+	public function test_privileged_render_varies_from_anonymous() {
+		$editor_id = $this->factory->user->create( [ 'role' => 'editor' ] );
+		$post_id   = $this->factory->post->create( [ 'post_author' => $editor_id ] );
+		$rules     = [ 'registration' => [ 'active' => true ] ];
+		$block     = $this->make_block_with_rules( 'core/group', $rules, 'visible' );
+
+		Block_Visibility::reset_cache_for_tests();
+		$this->assertTrue(
+			Block_Visibility::render_varies_from_anonymous( $block, $editor_id, $post_id ),
+			'An editor sees a block an anonymous reader does not, so the render must not be cached.'
+		);
+
+		Block_Visibility::reset_cache_for_tests();
+		$this->assertFalse(
+			Block_Visibility::render_varies_from_anonymous( $block, 0, $post_id ),
+			'A withheld render is identical for everyone and stays cacheable.'
+		);
+
+		Block_Visibility::reset_cache_for_tests();
+		$ungated = $this->make_block_with_rules( 'core/group', [], 'visible' );
+		$this->assertFalse(
+			Block_Visibility::render_varies_from_anonymous( $ungated, $editor_id, $post_id ),
+			'A block with no active rules is the same for everyone, privileged or not.'
+		);
+
+		// The other direction of the visibility toggle. A reader who matches the
+		// rules has a `hidden` block withheld while anonymous keeps it, so the
+		// render varies per requester just as much -- a check written as "shows a
+		// block anonymous would not see" returns false here and caches it.
+		$reader_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		$other_id  = $this->factory->post->create();
+		$inverted  = $this->make_block_with_rules( 'core/group', $rules, 'hidden' );
+
+		Block_Visibility::reset_cache_for_tests();
+		$this->assertTrue(
+			Block_Visibility::is_hidden_for_user( $inverted, $reader_id, $other_id ),
+			'Precondition: a matching reader has the hidden-mode block withheld.'
+		);
+		Block_Visibility::reset_cache_for_tests();
+		$this->assertFalse(
+			Block_Visibility::is_hidden_for_user( $inverted, 0, $other_id ),
+			'Precondition: an anonymous reader still sees it, so the two renders differ.'
+		);
+
+		Block_Visibility::reset_cache_for_tests();
+		$this->assertTrue(
+			Block_Visibility::render_varies_from_anonymous( $inverted, $reader_id, $other_id ),
+			'A hidden-mode block withheld from a matching reader varies from the anonymous render too.'
+		);
+	}
+
+	/**
+	 * A REST request is not exempt from access control.
+	 *
+	 * Access rules are evaluated for REST reads on the same terms as the front end. The
+	 * authoring case is served by the `edit_post` check below rather than by exempting REST
+	 * as a whole, so this pins that the exemption is not reintroduced.
+	 *
+	 * `REST_REQUEST` is defined only for real HTTP REST requests (wp-includes/rest-api.php),
+	 * so the constant is set explicitly here. Dispatching through `rest_do_request()` never
+	 * defines it, and a test written that way would not exercise this path at all.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_rest_request_is_not_exempt_from_access_rules() {
+		if ( ! defined( 'REST_REQUEST' ) ) {
+			define( 'REST_REQUEST', true );
+		}
+		$post_id         = $this->factory->post->create();
+		$GLOBALS['post'] = get_post( $post_id );
+
+		wp_set_current_user( 0 );
+		Block_Visibility::reset_cache_for_tests();
+
+		$rules  = [ 'registration' => [ 'active' => true ] ];
+		$block  = $this->make_block_with_rules( 'core/group', $rules, 'visible' );
+		$result = Block_Visibility::filter_render_block( '<div>restricted</div>', $block );
+
+		$this->assertSame( '', $result, 'A logged-out caller reading over REST is subject to the same access rules as on the front end.' );
+
+		unset( $GLOBALS['post'] );
+	}
+
+	/**
+	 * The real REST route withholds a gated block from anonymous and shows it to an editor.
+	 *
+	 * Dispatching the route rather than calling the filter directly exercises the
+	 * controller's own post setup, which the edit-capability bypass depends on via
+	 * get_the_ID(). It also covers excerpt.rendered, which reaches readers through a
+	 * different path than content.rendered and needs its own assertion.
+	 */
+	public function test_rest_route_gates_content_and_excerpt_per_requester() {
+		do_action( 'rest_api_init' );
+
+		$editor_id = $this->factory->user->create( [ 'role' => 'editor' ] );
+		$gate      = '{"newspackAccessControlMode":"custom","newspackAccessControlRules":{"registration":{"active":true}},"newspackAccessControlVisibility":"visible"}';
+		$content   = '<!-- wp:paragraph --><p>PUBLICMARK</p><!-- /wp:paragraph -->'
+			. '<!-- wp:group ' . $gate . ' --><div class="wp-block-group">'
+			. '<!-- wp:paragraph --><p>RESTRICTEDMARK</p><!-- /wp:paragraph -->'
+			. '</div><!-- /wp:group -->';
+		$post_id = $this->factory->post->create(
+			[
+				'post_status'  => 'publish',
+				'post_author'  => $editor_id,
+				'post_content' => $content,
+				'post_excerpt' => '',
+			]
+		);
+
+		// Logged out: both fields withhold the gated text.
+		wp_set_current_user( 0 );
+		Block_Visibility::reset_cache_for_tests();
+		$anon = rest_do_request( new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id ) )->get_data();
+
+		$this->assertStringNotContainsString( 'RESTRICTEDMARK', $anon['content']['rendered'], 'content.rendered must withhold the gated block from an anonymous caller.' );
+		$this->assertStringNotContainsString( 'RESTRICTEDMARK', $anon['excerpt']['rendered'], 'excerpt.rendered must withhold it too; it reaches readers by a different path.' );
+		$this->assertStringContainsString( 'PUBLICMARK', $anon['content']['rendered'], 'Ungated content is unaffected.' );
+
+		// The post's editor: the authoring case the removed REST exemption existed for.
+		wp_set_current_user( $editor_id );
+		Block_Visibility::reset_cache_for_tests();
+		$editor = rest_do_request( new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id ) )->get_data();
+
+		$this->assertStringContainsString( 'RESTRICTEDMARK', $editor['content']['rendered'], 'Someone who can edit the post still sees its gated blocks while authoring over REST.' );
+	}
+
+	/**
 	 * The hide-decision is callable directly with an explicit user, so the excerpt
 	 * path can ask what an anonymous reader would see without changing the current user.
 	 */

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-product-types.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-product-types.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Tests that Newspack enables the legacy subscription product types once.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\WooCommerce_Subscriptions;
+
+/**
+ * WooCommerce Subscriptions 9.0 defaults its "Subscription product creation"
+ * checkboxes to off, which removes `subscription` and `variable-subscription`
+ * from the product-type dropdown. Newspack's Audience wizard still creates those
+ * types, so we turn them on once — and only when the publisher has never
+ * expressed a preference.
+ *
+ * @group WooCommerce_Subscriptions_Integration
+ */
+class Newspack_Test_WooCommerce_Subscriptions_Product_Types extends WP_UnitTestCase {
+	/**
+	 * The options under test.
+	 *
+	 * @var string[]
+	 */
+	private $options = [
+		'woocommerce_subscriptions_enable_simple_subscription',
+		'woocommerce_subscriptions_enable_variable_subscription',
+	];
+
+	/**
+	 * Start every test with the options genuinely absent, not merely falsy.
+	 */
+	public function set_up() {
+		parent::set_up();
+		foreach ( $this->options as $option ) {
+			delete_option( $option );
+		}
+		delete_option( WooCommerce_Subscriptions::PRODUCT_TYPES_ENABLED_OPTION );
+	}
+
+	/**
+	 * Leave no state behind for other suites.
+	 */
+	public function tear_down() {
+		foreach ( $this->options as $option ) {
+			delete_option( $option );
+		}
+		delete_option( WooCommerce_Subscriptions::PRODUCT_TYPES_ENABLED_OPTION );
+		remove_all_filters( 'newspack_subscriptions_enable_legacy_product_types' );
+		remove_all_actions( 'newspack_log' );
+		parent::tear_down();
+	}
+
+	/**
+	 * The write is wired to `admin_init`, not to `plugins_loaded` — it must not run
+	 * on anonymous front-end requests, REST probes or cron. Asserted here because
+	 * the guarded entry point is the entire reason this ships, and every other test
+	 * calls past it.
+	 */
+	public function test_is_registered_on_admin_init() {
+		$this->assertSame(
+			10,
+			has_action( 'admin_init', [ WooCommerce_Subscriptions::class, 'maybe_enable_legacy_product_types' ] ),
+			'The product-type write should run on admin_init.'
+		);
+		$this->assertFalse(
+			has_action( 'plugins_loaded', [ WooCommerce_Subscriptions::class, 'maybe_enable_legacy_product_types' ] ),
+			'The product-type write should not run on every request.'
+		);
+	}
+
+	/**
+	 * Nothing is written when WooCommerce Subscriptions is not active. The suite has
+	 * no `WC()` function, so `is_active()` is genuinely false here and the guarded
+	 * entry point is exercised for real.
+	 */
+	public function test_inactive_subscriptions_writes_nothing() {
+		$this->assertFalse( WooCommerce_Subscriptions::is_active(), 'Precondition: Subscriptions is inactive in the suite.' );
+
+		WooCommerce_Subscriptions::maybe_enable_legacy_product_types();
+
+		foreach ( $this->options as $option ) {
+			$this->assertFalse( get_option( $option ), $option . ' should not have been written.' );
+		}
+	}
+
+	/**
+	 * A site that has never configured the setting gets both types enabled.
+	 */
+	public function test_absent_options_are_enabled() {
+		WooCommerce_Subscriptions::enable_legacy_product_types();
+
+		foreach ( $this->options as $option ) {
+			$this->assertSame( 'yes', get_option( $option ), $option . ' should have been enabled.' );
+		}
+	}
+
+	/**
+	 * A publisher who turned the type off keeps it off. This is the whole point of
+	 * checking for an absent row rather than a falsy value: WooCommerce's settings
+	 * screen writes 'no' when the box is unticked, and that is a real preference.
+	 */
+	public function test_explicit_no_is_respected() {
+		update_option( 'woocommerce_subscriptions_enable_simple_subscription', 'no' );
+
+		WooCommerce_Subscriptions::enable_legacy_product_types();
+
+		$this->assertSame(
+			'no',
+			get_option( 'woocommerce_subscriptions_enable_simple_subscription' ),
+			'An explicit "no" must not be overwritten.'
+		);
+		$this->assertSame(
+			'yes',
+			get_option( 'woocommerce_subscriptions_enable_variable_subscription' ),
+			'The untouched option should still be enabled.'
+		);
+	}
+
+	/**
+	 * An option already set to 'yes' is left alone, and not rewritten.
+	 */
+	public function test_existing_yes_is_left_alone() {
+		foreach ( $this->options as $option ) {
+			update_option( $option, 'yes' );
+		}
+
+		$writes = 0;
+		$count  = function ( $value ) use ( &$writes ) {
+			++$writes;
+			return $value;
+		};
+		foreach ( $this->options as $option ) {
+			add_filter( 'pre_update_option_' . $option, $count );
+		}
+
+		WooCommerce_Subscriptions::enable_legacy_product_types();
+
+		foreach ( $this->options as $option ) {
+			remove_filter( 'pre_update_option_' . $option, $count );
+			$this->assertSame( 'yes', get_option( $option ) );
+		}
+		$this->assertSame( 0, $writes, 'Nothing should be written when both options already exist.' );
+	}
+
+	/**
+	 * The write is answerable afterwards: the marker option names exactly the rows
+	 * Newspack created, so a corrective release could reverse those and leave a
+	 * publisher's own choice alone.
+	 */
+	public function test_write_is_recorded_and_logged() {
+		update_option( 'woocommerce_subscriptions_enable_simple_subscription', 'no' );
+
+		$logged = [];
+		add_action(
+			'newspack_log',
+			function ( $code, $message, $data ) use ( &$logged ) {
+				$logged[] = [ $code, $data ];
+			},
+			10,
+			3
+		);
+
+		WooCommerce_Subscriptions::enable_legacy_product_types();
+
+		$this->assertSame(
+			[ 'woocommerce_subscriptions_enable_variable_subscription' ],
+			get_option( WooCommerce_Subscriptions::PRODUCT_TYPES_ENABLED_OPTION ),
+			'Only the option Newspack created should be recorded.'
+		);
+		$this->assertCount( 1, $logged, 'The write should be logged once.' );
+		$this->assertSame( 'newspack_subscriptions_product_types_enabled', $logged[0][0] );
+		$this->assertSame(
+			[ 'woocommerce_subscriptions_enable_variable_subscription' ],
+			$logged[0][1]['data']['options'],
+			'The log entry should name the options written.'
+		);
+	}
+
+	/**
+	 * Nothing is recorded or logged when there was nothing to write.
+	 */
+	public function test_nothing_is_recorded_when_no_write_happens() {
+		foreach ( $this->options as $option ) {
+			update_option( $option, 'no' );
+		}
+
+		$logged = 0;
+		add_action(
+			'newspack_log',
+			function () use ( &$logged ) {
+				++$logged;
+			}
+		);
+
+		WooCommerce_Subscriptions::enable_legacy_product_types();
+
+		$this->assertFalse( get_option( WooCommerce_Subscriptions::PRODUCT_TYPES_ENABLED_OPTION ) );
+		$this->assertSame( 0, $logged );
+	}
+
+	/**
+	 * The filter lets a publisher or custom plugin opt out entirely.
+	 */
+	public function test_filter_can_opt_out() {
+		add_filter( 'newspack_subscriptions_enable_legacy_product_types', '__return_false' );
+
+		WooCommerce_Subscriptions::enable_legacy_product_types();
+
+		foreach ( $this->options as $option ) {
+			$this->assertFalse( get_option( $option ), $option . ' should not have been written.' );
+		}
+		$this->assertFalse( get_option( WooCommerce_Subscriptions::PRODUCT_TYPES_ENABLED_OPTION ) );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/reader-activation.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-activation.php
@@ -364,6 +364,55 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Settings with an integer default must read back as integers even once the
+	 * object cache is cold. Options come out of the database as strings, but out of
+	 * a warm cache as the type they were written with — so without an explicit cast
+	 * the type varies with cache state. The Audience wizard's RangeControl discards
+	 * any value that is not `typeof 'number'` and falls back to its initial position,
+	 * which made `newsletter_list_initial_size` appear to reset to 2 (NPPM-3073).
+	 */
+	public function test_integer_setting_round_trip_with_cold_cache() {
+		$original = Reader_Activation::get_setting( 'newsletter_list_initial_size' );
+
+		Reader_Activation::update_setting( 'newsletter_list_initial_size', 4 );
+
+		// Drop the option out of the object cache, so the next read comes from the
+		// database — the state a publisher's site is in on any later page load.
+		wp_cache_flush();
+
+		$this->assertSame(
+			4,
+			Reader_Activation::get_setting( 'newsletter_list_initial_size' ),
+			'Setting `newsletter_list_initial_size` should round-trip as an integer, not a numeric string.'
+		);
+
+		// Restore.
+		Reader_Activation::update_setting( 'newsletter_list_initial_size', $original );
+	}
+
+	/**
+	 * The same guarantee, asserted without depending on cache behaviour: seed the
+	 * string form the database hands back and read it through `get_setting()`. The
+	 * cold-cache test above documents how a site gets into this state; this one pins
+	 * the cast itself, so it still fails against a reintroduced bug under an object
+	 * cache whose flush is deferred or a no-op.
+	 */
+	public function test_integer_setting_cast_from_stored_string() {
+		$original = Reader_Activation::get_setting( 'newsletter_list_initial_size' );
+
+		update_option( Reader_Activation::OPTIONS_PREFIX . 'newsletter_list_initial_size', '4' );
+
+		$this->assertSame(
+			4,
+			Reader_Activation::get_setting( 'newsletter_list_initial_size' ),
+			'A stored numeric string should be cast to an integer on read.'
+		);
+
+		// Restore.
+		Reader_Activation::update_setting( 'newsletter_list_initial_size', $original );
+	}
+
+	/**
 	 * The admin bar is hidden on the front end for readers but kept for admins.
 	 */
 	public function test_hide_admin_bar_for_readers() {

--- a/plugins/newspack-plugin/tests/unit-tests/user-row-actions-escaping.php
+++ b/plugins/newspack-plugin/tests/unit-tests/user-row-actions-escaping.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Tests that the Users-list row actions escape the reflected request URL.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Magic_Link;
+use Newspack\Reader_Activation;
+use Newspack\Reader_Activation\Contact_Sync_Admin;
+use Newspack\Reader_Activation\Integrations;
+
+require_once __DIR__ . '/integrations/class-sample-integration.php';
+
+/**
+ * Verify the magic-link and contact-sync row-action links escape
+ * $_SERVER['REQUEST_URI'] before echoing it into an href.
+ */
+class Newspack_Test_User_Row_Actions_Escaping extends WP_UnitTestCase {
+
+	/**
+	 * Request URIs whose reflected characters break out of an unescaped href.
+	 * One injects a tag; the other breaks out of the attribute with no `<` at all
+	 * (an `onmouseover` handler). `esc_url()` neutralises both, leaving the anchor
+	 * with only its two delimiter quotes.
+	 *
+	 * @return array<string,string> Label => request URI.
+	 */
+	private function breakout_request_uris() {
+		return [
+			'tag injection'      => '/wp-admin/users.php"><svg/onload=NPPM3043>',
+			'attribute breakout' => '/wp-admin/users.php" onmouseover=NPPM3043 x="',
+		];
+	}
+
+	/**
+	 * Admin user id.
+	 *
+	 * @var int
+	 */
+	private $admin_id;
+
+	/**
+	 * The request URI captured before a test overrides it.
+	 *
+	 * @var string|null
+	 */
+	private $original_request_uri;
+
+	/**
+	 * Enable reader activation and act as an admin before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		// Sample_Integration carries mutable statics; an earlier test leaving
+		// $can_sync_error_codes set makes can_sync() fail and the contact-sync
+		// row action absent, so this file would fail on its precondition.
+		\Sample_Integration::reset();
+		$this->original_request_uri = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- snapshot restored verbatim in tear_down().
+		add_filter( 'newspack_reader_activation_enabled', '__return_true' );
+		// The row actions render on wp-admin/users.php; get_admin_action_url()
+		// short-circuits unless is_admin() is true.
+		set_current_screen( 'users' );
+		$this->admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $this->admin_id );
+	}
+
+	/**
+	 * Restore the global state the framework does not.
+	 *
+	 * WP_UnitTestCase restores the hook registry from its backup and rolls
+	 * back the per-test DB transaction, so removing filters or deleting
+	 * options here would be a no-op. What survives both is the superglobal,
+	 * the current screen and the static integrations registry.
+	 */
+	public function tear_down() {
+		if ( null === $this->original_request_uri ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $this->original_request_uri;
+		}
+		set_current_screen( 'front' );
+		$this->reset_integrations();
+		Integrations::register_integrations();
+		parent::tear_down();
+	}
+
+	/**
+	 * Reset the static integrations registry so a test's fake integration does
+	 * not leak into later tests.
+	 */
+	private function reset_integrations() {
+		$reflection = new \ReflectionClass( Integrations::class );
+		$property   = $reflection->getProperty( 'integrations' );
+		$property->setAccessible( true );
+		$property->setValue( null, [] );
+	}
+
+	/**
+	 * The magic-link "Send authentication link" row action must escape the URL.
+	 */
+	public function test_magic_link_row_action_escapes_request_uri() {
+		// can_magic_link() needs only reader activation plus is_user_reader(),
+		// which the np_reader meta satisfies. register_reader() would also pull
+		// welcome email, data events and ESP sync into a test about esc_url().
+		$reader_id = self::factory()->user->create();
+		update_user_meta( $reader_id, Reader_Activation::READER, true );
+		$reader = get_user_by( 'id', $reader_id );
+		$this->assertTrue( Magic_Link::can_magic_link( $reader_id ), 'Precondition: the user qualifies for a magic link.' );
+
+		foreach ( $this->breakout_request_uris() as $label => $uri ) {
+			$_SERVER['REQUEST_URI'] = $uri;
+			$actions                = Magic_Link::user_row_actions( [], $reader );
+			$this->assertArrayHasKey( 'newspack-magic-link-send', $actions, "Precondition ($label): the magic-link row action is present." );
+			$this->assert_href_not_breakable( $actions['newspack-magic-link-send'] );
+		}
+	}
+
+	/**
+	 * The contact-sync "Resync contact to ESP" row action must escape the URL.
+	 */
+	public function test_contact_sync_row_action_escapes_request_uri() {
+		add_filter( 'newspack_reader_activation_is_syncing_allowed', '__return_true' );
+		Integrations::register( new \Sample_Integration( 'nppm3043-syncable', 'NPPM3043 Syncable' ) );
+		update_option( Integrations::OPTION_NAME, [ 'nppm3043-syncable' ] );
+
+		$target = get_user_by( 'id', self::factory()->user->create() );
+
+		foreach ( $this->breakout_request_uris() as $label => $uri ) {
+			$_SERVER['REQUEST_URI'] = $uri;
+			$actions                = Contact_Sync_Admin::user_row_actions( [], $target );
+			$this->assertArrayHasKey( Contact_Sync_Admin::ADMIN_ACTION, $actions, "Precondition ($label): the contact-sync row action is present." );
+			$this->assert_href_not_breakable( $actions[ Contact_Sync_Admin::ADMIN_ACTION ] );
+		}
+	}
+
+	/**
+	 * Assert a row-action anchor cannot be broken out of at the href attribute.
+	 *
+	 * A well-formed `<a href="…">…</a>` carries exactly the two href-delimiter
+	 * quotes. Any reflected value that escapes the attribute introduces a third,
+	 * so the quote count is the escaping invariant — robust against a partial
+	 * filter that perturbs `<svg` but leaves the attribute-closing `"` intact,
+	 * and against breakout vectors that use no `<` (e.g. `" onmouseover=…`).
+	 *
+	 * The quote count alone would pass on an empty href, which is reachable:
+	 * both get_admin_action_url() implementations return '' when is_admin()
+	 * is false, while the row action is registered either way. So assert the
+	 * link is still populated and functional, not merely well-formed.
+	 *
+	 * @param string $anchor The rendered row-action anchor markup.
+	 */
+	private function assert_href_not_breakable( $anchor ) {
+		$this->assertSame( 2, substr_count( $anchor, '"' ), 'The row-action href must not be breakable out of: ' . $anchor );
+
+		preg_match( '/href="([^"]*)"/', $anchor, $matches );
+		$href = isset( $matches[1] ) ? $matches[1] : '';
+		$this->assertNotSame( '', $href, 'An empty href satisfies the quote count without proving anything: ' . $anchor );
+		$this->assertStringContainsString( 'uid=', $href, 'The escaped href must still carry the user id: ' . $anchor );
+		$this->assertStringContainsString( '_wpnonce=', $href, 'The escaped href must still carry the nonce: ' . $anchor );
+		$this->assertStringContainsString( '&#038;', $href, 'esc_url() must encode the query-arg separators: ' . $anchor );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)? — this carries commits that were reviewed and linted on their own PRs; it adds no new code.
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? — no other open PR syncs `release` into `main`.

### Changes proposed in this Pull Request:

The automated `release` → `main` sync has been failing since 2026-08-19T19:45Z, leaving `main` 15 commits behind `release`. This completes the merge by hand.

Unlike the previous manual syncs, nothing conflicted here. The script's merge succeeds and its **push** is rejected:

```
remote: - refusing to allow a Personal Access Token to create or update workflow
        `.github/workflows/release.yml` without `workflow` scope
! [remote rejected]     main -> main (push declined due to repository rule violations)
```

#811 merged into `release` at 19:45:06Z and rewrites `release.yml`, so every sync merge since then updates a workflow file, which the release bot's token cannot push. Five runs have failed this way: [20:08Z](https://github.com/Automattic/newspack-workspace/actions/runs/32296902204), [21:04Z](https://github.com/Automattic/newspack-workspace/actions/runs/32301960224), [22:35Z](https://github.com/Automattic/newspack-workspace/actions/runs/32309522378), [22:41Z](https://github.com/Automattic/newspack-workspace/actions/runs/32310001237) and [23:21Z](https://github.com/Automattic/newspack-workspace/actions/runs/32312931374). `alpha` is unaffected and fully in sync, because the script runs the alpha leg first and dies on the `main` push.

That push sits inside the script's success branch, so `set -e` ends the run before `notify_slack` — this failure never reached Slack, unlike a merge conflict, which has a designed alert. Worth addressing separately from this merge; a ticket will follow.

What lands here: six fixes (#811, #813, #819, #849, #873, #918) with their release and version-sync commits, and four files under `.github/`.

A clean merge can still blend two branches into something matching neither, so two checks before proposing it:

* **#830's trigger removal survived.** It removed `hotfix/**` and `epic/**` from the release triggers on `main`, and `release` predates that. The merged `release.yml` carries only `release` and `alpha`, and `config/release.js` keeps the reduced branches list.
* **#811's wp.org wiring is intact.** `_release-wporg.yml` is byte-identical to `release`'s copy, and `release.yml` passes `released-sha` into it as the `ref` input.

**This needs a merge commit rather than a squash.** `main` has to genuinely contain `release`, or the next post-release sync re-does all of it.

No Copilot review requested: every commit here was reviewed on its own PR, and the only thing this adds is the merge itself.

### How to test the changes in this Pull Request:

1. `git log --oneline origin/main..HEAD` lists 16 commits, ending at `chore(release): merge in release newspack-network@2.22.1`.
2. `sed -n '/^on:/,/^concurrency/p' .github/workflows/release.yml` shows `release` and `alpha` and nothing else.
3. `diff <(git show origin/release:.github/workflows/_release-wporg.yml) <(git show HEAD:.github/workflows/_release-wporg.yml)` prints nothing.
4. CI on this PR runs the full package matrix, since the merge touches plugins. That is the substantive check on the merged tree.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them? — above.
* [x] Have you written new tests for your changes, as applicable? — n/a: this carries the tests written on both branches and adds none.
* [x] Have you successfully run tests with your changes locally? — the three tree-level checks above; the package suites are left to this PR's CI, which exercises the merged tree across every affected package.
