### PR TITLE
fix(reader-activation): clear stuck auth-form loading spinner

### DIFF
--- a/plugins/newspack-plugin/src/newspack-ui/js/modals.js
+++ b/plugins/newspack-plugin/src/newspack-ui/js/modals.js
@@ -78,7 +78,11 @@ domReady( function () {
 		} );
 
 		// Form-submit modals: show a spinner on the submit button while the form
-		// navigates away. No need to remove the class — page reloads. Covers both
+		// navigates away. For forms that reload the page this is the whole story —
+		// the class is gone after the reload. Forms that intercept submit and stay
+		// on the page (e.g. the reader auth form) must clear the class themselves;
+		// the auth form does this in reader-activation-auth/auth-form.js, where it
+		// also adds the class for its inline (non-modal) instances. Covers both
 		// shapes: form IS the modal content, or form lives inside a content section.
 		const modalForm = modal.querySelector( 'form.newspack-ui__modal__content, .newspack-ui__modal__content form' );
 		if ( modalForm ) {

--- a/plugins/newspack-plugin/src/reader-activation-auth/auth-form.js
+++ b/plugins/newspack-plugin/src/reader-activation-auth/auth-form.js
@@ -269,8 +269,9 @@ window.newspackRAS.push( function ( readerActivation ) {
 								form.style.opacity = 1;
 								submitButtons.forEach( submitButton => {
 									submitButton.disabled = false;
-									// Keep the loading class in lockstep with the disabled attribute, as at
-									// the other re-enable sites; harmless if it was never added on this path.
+									// startLoginFlow() added the spinner for this send/resend request; this
+									// branch doesn't route through setFormAction() on error, so clear it here
+									// in lockstep with the disabled attribute.
 									submitButton.classList.remove( 'newspack-ui__button--loading' );
 								} );
 							} );
@@ -284,10 +285,11 @@ window.newspackRAS.push( function ( readerActivation ) {
 				container.removeAttribute( 'data-form-status' );
 				submitButtons.forEach( button => {
 					button.disabled = true;
-					// This flow owns the submit button's loading state end to end. The modal-submit
-					// handler in newspack-ui/js/modals.js also adds this class, but only for forms
-					// inside a modal; adding it here covers the inline auth form (e.g. /my-account) too,
-					// and pairs with the removal at every re-enable site below.
+					// Add the loading spinner here so both the modal and the inline auth form (e.g.
+					// /my-account) show it — newspack-ui/js/modals.js also adds it, but only for forms
+					// inside a modal. Removal is centralized in setFormAction() (on every step change)
+					// and endLoginFlow() (on errors), with the few AJAX branches that bypass those
+					// clearing it directly.
 					button.classList.add( 'newspack-ui__button--loading' );
 				} );
 				form.setMessageContent();
@@ -302,11 +304,13 @@ window.newspackRAS.push( function ( readerActivation ) {
 					form.style.opacity = 1;
 				}
 				if ( status !== 200 ) {
-					// Any non-success outcome must re-enable the submit button and clear its loading
-					// spinner so the reader can retry — including the null-message network/parse
-					// failures from the fetch .catch() paths, which would otherwise leave the button
-					// stuck spinning. Show an inline error only when we actually have a message.
+					// Any non-success outcome must restore the form so the reader can retry: undim it,
+					// clear the loading spinner, and re-enable the button. This is the only reset for the
+					// null-message network/parse failures from the fetch .catch() paths — they have no
+					// other opacity/spinner restore and would otherwise leave the form dimmed with a stuck
+					// spinner. Show an inline error only when we actually have a message.
 					form.isVerifying = false;
+					form.style.opacity = 1;
 					if ( message ) {
 						form.setMessageContent( message, true );
 						messageContentElement.querySelectorAll( '[data-set-action]' ).forEach( setActionListener );
@@ -393,9 +397,9 @@ window.newspackRAS.push( function ( readerActivation ) {
 						// back to it in OTP state on Send code.
 						submitButtons.forEach( button => {
 							button.disabled = false;
-							// Clear the loading class in lockstep with the disabled attribute. It's added
-							// by the modal-submit handler in newspack-ui/js/modals.js (which assumes a page
-							// navigation); this flow is AJAX, so the button would otherwise stay spinning.
+							// startLoginFlow() added the spinner; this branch opens the verification modal
+							// instead of routing through setFormAction(), so clear it here in lockstep
+							// with the disabled attribute.
 							button.classList.remove( 'newspack-ui__button--loading' );
 						} );
 						form.style.opacity = 1;
@@ -603,9 +607,9 @@ window.newspackRAS.push( function ( readerActivation ) {
 							onCancel: () => {
 								submitButtons.forEach( button => {
 									button.disabled = false;
-									// Clear the loading class (added on submit by newspack-ui/js/modals.js)
-									// in lockstep with the disabled attribute so the button doesn't stay
-									// spinning once we switch to the OTP/password state.
+									// startLoginFlow() added the spinner; cancelling keeps us on the signin step
+									// without routing through setFormAction(), so clear it here in lockstep
+									// with the disabled attribute.
 									button.classList.remove( 'newspack-ui__button--loading' );
 								} );
 								form.style.opacity = 1;

--- a/plugins/newspack-plugin/src/reader-activation-auth/auth-form.js
+++ b/plugins/newspack-plugin/src/reader-activation-auth/auth-form.js
@@ -101,6 +101,13 @@ window.newspackRAS.push( function ( readerActivation ) {
 				if ( ! FORM_ALLOWED_ACTIONS.includes( action ) ) {
 					action = 'signin';
 				}
+				// Moving to any form step ends the previous step's in-flight request, so clear the
+				// submit button's loading spinner here. This is the single owner for the transition
+				// case (signin -> pwd/otp, -> success, back button): startLoginFlow() adds the class,
+				// every step change removes it. Same-state errors clear it in endLoginFlow() instead.
+				submitButtons.forEach( button => {
+					button.classList.remove( 'newspack-ui__button--loading' );
+				} );
 				// Signin and success steps should clear any modal errors or messages.
 				if ( 'signin' === action || 'success' === action ) {
 					form.setMessageContent();
@@ -277,6 +284,11 @@ window.newspackRAS.push( function ( readerActivation ) {
 				container.removeAttribute( 'data-form-status' );
 				submitButtons.forEach( button => {
 					button.disabled = true;
+					// This flow owns the submit button's loading state end to end. The modal-submit
+					// handler in newspack-ui/js/modals.js also adds this class, but only for forms
+					// inside a modal; adding it here covers the inline auth form (e.g. /my-account) too,
+					// and pairs with the removal at every re-enable site below.
+					button.classList.add( 'newspack-ui__button--loading' );
 				} );
 				form.setMessageContent();
 				form.style.opacity = 0.5;
@@ -289,22 +301,20 @@ window.newspackRAS.push( function ( readerActivation ) {
 				if ( container.config?.closeOnSuccess ) {
 					form.style.opacity = 1;
 				}
-				if ( message ) {
-					const messageNode = document.createElement( 'p' );
-					messageNode.innerHTML = message;
-
-					if ( status !== 200 ) {
-						form.isVerifying = false;
+				if ( status !== 200 ) {
+					// Any non-success outcome must re-enable the submit button and clear its loading
+					// spinner so the reader can retry — including the null-message network/parse
+					// failures from the fetch .catch() paths, which would otherwise leave the button
+					// stuck spinning. Show an inline error only when we actually have a message.
+					form.isVerifying = false;
+					if ( message ) {
 						form.setMessageContent( message, true );
 						messageContentElement.querySelectorAll( '[data-set-action]' ).forEach( setActionListener );
-						submitButtons.forEach( button => {
-							button.disabled = false;
-							// Clear the loading class in lockstep with the disabled attribute. It's added
-							// by the modal-submit handler in newspack-ui/js/modals.js (which assumes a page
-							// navigation); this flow is AJAX, so the button would otherwise stay spinning.
-							button.classList.remove( 'newspack-ui__button--loading' );
-						} );
 					}
+					submitButtons.forEach( button => {
+						button.disabled = false;
+						button.classList.remove( 'newspack-ui__button--loading' );
+					} );
 				}
 				if ( status === 200 ) {
 					if ( data?.email ) {
@@ -555,6 +565,8 @@ window.newspackRAS.push( function ( readerActivation ) {
 											if ( data.action === 'otp' || data.action === 'pwd' ) {
 												form.style.opacity = 1;
 											}
+											// The spinner is already cleared by setFormAction() above; just
+											// re-enable the button for the new step.
 											submitButtons.forEach( button => {
 												button.disabled = false;
 											} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Follow-up to #625. That PR fixed most of the reader auth form's stuck loading spinner, but the most common path was missed: when a returning reader submits their email and the form advances to the password (`pwd`) or one-time-code (`otp`) step, the submit button keeps spinning indefinitely. One "Continue" button is shared across the `signin`, `pwd`, and `otp` steps (`data-action="signin pwd otp"`), so the spinner class added on submit stays on it through the step change and never clears.

The underlying reason the fix was incomplete: the loading class was *added* in one file (`newspack-ui/js/modals.js`, and only for forms inside a modal) but *removed* at several hand-picked sites in `auth-form.js` — and the `data.action` transition branch wasn't one of them. That same split is why the inline auth form (e.g. `/my-account`) showed no loading feedback at all: `modals.js` never touches non-modal forms.

This makes `auth-form.js` the single owner of the submit button's loading state, so no future step can leave it stuck:

- `startLoginFlow()` **adds** the class (now covering the inline auth form too).
- `setFormAction()` **removes** it on every step change — the catch-all for `signin → pwd`/`otp`, `→ success`, and the back button.
- `endLoginFlow()`'s error branch was restructured to clear it on **all** non-200 outcomes, including the null-message network/parse failures from the `fetch` `.catch()` paths that previously left the button stuck.

`modals.js` still adds the class for navigating (page-reload) modal forms; only its stale comment changed.

Addresses NPPM-3025.

<details>
<summary>Manual verification (env with Reader Activation enabled)</summary>

Instrumented the submit button with a `MutationObserver` and drove each flow with a seeded reader. In every case the spinner appears in-flight and clears the moment the next step renders; the button is never left stuck.

| Surface | Password reader (`→ pwd`) | Passwordless reader (`→ otp`) |
| --- | --- | --- |
| Sign-in modal | ✅ `loading:true@signin → loading:false@pwd` | ✅ `loading:true@signin → loading:false@otp` |
| Inline `/my-account` | ✅ (spinner is new here) | ✅ (spinner is new here) |

The modal `otp` **error** path (a non-200 response) also cleared the spinner via the restructured error branch. ESLint clean.

</details>

### How to test the changes in this Pull Request:

Requires Reader Activation enabled, plus a reader account **with** a password and a **passwordless** reader account.

1. On a page with the sign-in modal, click **Sign In**, enter the password reader's email, and click **Continue**.
2. Confirm the button shows a brief spinner and then the password step appears with a clean "Continue" button — **not** stuck spinning.
3. Repeat with the passwordless reader; the form advances to the one-time-code step. Again confirm the button isn't stuck.
4. Repeat steps 1–3 on the inline `/my-account` login form while logged out. It now shows a spinner during submit and clears it on the step change (previously it showed none).
5. Trigger an error — a wrong password, or submit with the network offline — and confirm the button re-enables and the spinner clears so the reader can retry.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? <!-- Loading state is DOM-only in a script bound at RAS-ready; verified manually across all four surfaces plus error paths, matching how #625 verified this behavior. -->
* [x] Have you successfully run tests with your changes locally? <!-- ESLint clean; full manual browser verification. -->
