### PR TITLE
fix(newspack-plugin): restore membership paywall content

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/content-gifting/class-content-gifting.php
+++ b/plugins/newspack-plugin/includes/content-gate/content-gifting/class-content-gifting.php
@@ -635,8 +635,7 @@ class Content_Gifting {
 		}
 
 		$restriction_instance = \wc_memberships()->get_restrictions_instance()->get_posts_restrictions_instance();
-		\remove_action( 'wp', spl_object_hash( $restriction_instance ) . 'handle_restriction_modes', 9 );
-		\remove_action( 'wp', spl_object_hash( $restriction_instance ) . 'handle_restriction_modes' ); // For compatibility with Woo Memberships < 1.27.2.
+		Memberships::remove_posts_restriction_handler( $restriction_instance );
 		\add_filter( 'wc_memberships_restrictable_comment_types', '__return_empty_array' );
 		\add_filter( 'newspack_can_render_overlay_gate', '__return_false' );
 	}

--- a/plugins/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php
+++ b/plugins/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php
@@ -504,9 +504,19 @@ class Memberships {
 
 		// Remove the default restriction handler from 'SkyVerge\WooCommerce\Memberships\Restrictions\Posts::restrict_post'.
 		$restriction_instance = \wc_memberships()->get_restrictions_instance()->get_posts_restrictions_instance();
-		\remove_action( 'wp', spl_object_hash( $restriction_instance ) . 'handle_restriction_modes', 9 );
-		\remove_action( 'wp', spl_object_hash( $restriction_instance ) . 'handle_restriction_modes' ); // For compatibility with Woo Memberships < 1.27.2.
+		self::remove_posts_restriction_handler( $restriction_instance );
 		\add_filter( 'wc_memberships_restrictable_comment_types', '__return_empty_array' );
+	}
+
+	/**
+	 * Remove WooCommerce Memberships' default posts restriction handler.
+	 *
+	 * @param object $restriction_instance WooCommerce Memberships posts restriction instance.
+	 */
+	public static function remove_posts_restriction_handler( $restriction_instance ) {
+		$callback = [ $restriction_instance, 'handle_restriction_modes' ];
+		\remove_action( 'wp', $callback, 9 );
+		\remove_action( 'wp', $callback ); // For compatibility with Woo Memberships < 1.27.2.
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/wc-memberships/content-restrictions.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/wc-memberships/content-restrictions.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Tests for WooCommerce Memberships content restrictions.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Memberships;
+
+/**
+ * Test WooCommerce Memberships content restriction handling.
+ *
+ * @group wc-memberships
+ */
+class Test_Memberships_Content_Restrictions extends WP_UnitTestCase {
+
+	/**
+	 * Ensure the restriction handler is removed using its callable.
+	 *
+	 * WordPress 7.1 replaced spl_object_hash() with spl_object_id() when building
+	 * hook callback IDs. Passing the callable keeps removal compatible with both.
+	 *
+	 * @dataProvider restriction_handler_priorities
+	 *
+	 * @param int $priority Hook priority.
+	 */
+	public function test_removes_posts_restriction_handler( $priority ) {
+		$restriction_instance = new class() {
+			/**
+			 * Mock restriction handler.
+			 */
+			public function handle_restriction_modes() {}
+		};
+		$callback             = [ $restriction_instance, 'handle_restriction_modes' ];
+
+		add_action( 'wp', $callback, $priority );
+		$this->assertSame( $priority, has_action( 'wp', $callback ) );
+
+		Memberships::remove_posts_restriction_handler( $restriction_instance );
+
+		$this->assertFalse( has_action( 'wp', $callback ) );
+	}
+
+	/**
+	 * WooCommerce Memberships restriction handler priorities.
+	 *
+	 * @return array[]
+	 */
+	public function restriction_handler_priorities() {
+		return [
+			'current versions' => [ 9 ],
+			'before 1.27.2'    => [ 10 ],
+		];
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

WordPress 7.1 changed object-method hook identifiers from `spl_object_hash()` to `spl_object_id()`. Newspack constructed the previous identifier directly, so WooCommerce Memberships continued truncating metered and gifted articles after Newspack intended to unrestrict them.

This change removes the restriction handler using its callable, allowing WordPress to build the version-appropriate identifier. It also centralizes the shared behavior and adds coverage for current and pre-1.27.2 WooCommerce Memberships priorities.

### How to test the changes in this Pull Request:

1. Run `n test-php --group wc-memberships`; confirm the content-restriction tests pass on WordPress 7.1.
2. Open a metered restricted article logged out; confirm an allowed view displays the complete article without a gate.
3. Exhaust the meter and refresh; confirm the gate remains alongside the configured article excerpt.
4. Open a gifted restricted article; confirm the complete article displays without the Memberships restriction.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

PHPCS and direct WordPress 7.1 hook validation passed; PHPUnit was unavailable because Docker was not running.
