### PR TITLE
fix(memberships): restore membership paywall content (#931)

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/content-gifting/class-content-gifting.php
+++ b/plugins/newspack-plugin/includes/content-gate/content-gifting/class-content-gifting.php
@@ -629,8 +629,7 @@ class Content_Gifting {
 		}
 
 		$restriction_instance = \wc_memberships()->get_restrictions_instance()->get_posts_restrictions_instance();
-		\remove_action( 'wp', spl_object_hash( $restriction_instance ) . 'handle_restriction_modes', 9 );
-		\remove_action( 'wp', spl_object_hash( $restriction_instance ) . 'handle_restriction_modes' ); // For compatibility with Woo Memberships < 1.27.2.
+		Memberships::remove_posts_restriction_handler( $restriction_instance );
 		\add_filter( 'wc_memberships_restrictable_comment_types', '__return_empty_array' );
 		\add_filter( 'newspack_can_render_overlay_gate', '__return_false' );
 	}

--- a/plugins/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php
+++ b/plugins/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php
@@ -504,9 +504,19 @@ class Memberships {
 
 		// Remove the default restriction handler from 'SkyVerge\WooCommerce\Memberships\Restrictions\Posts::restrict_post'.
 		$restriction_instance = \wc_memberships()->get_restrictions_instance()->get_posts_restrictions_instance();
-		\remove_action( 'wp', spl_object_hash( $restriction_instance ) . 'handle_restriction_modes', 9 );
-		\remove_action( 'wp', spl_object_hash( $restriction_instance ) . 'handle_restriction_modes' ); // For compatibility with Woo Memberships < 1.27.2.
+		self::remove_posts_restriction_handler( $restriction_instance );
 		\add_filter( 'wc_memberships_restrictable_comment_types', '__return_empty_array' );
+	}
+
+	/**
+	 * Remove WooCommerce Memberships' default posts restriction handler.
+	 *
+	 * @param object $restriction_instance WooCommerce Memberships posts restriction instance.
+	 */
+	public static function remove_posts_restriction_handler( $restriction_instance ) {
+		$callback = [ $restriction_instance, 'handle_restriction_modes' ];
+		\remove_action( 'wp', $callback, 9 );
+		\remove_action( 'wp', $callback ); // For compatibility with Woo Memberships < 1.27.2.
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/wc-memberships/content-restrictions.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/wc-memberships/content-restrictions.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Tests for WooCommerce Memberships content restrictions.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Memberships;
+
+/**
+ * Test WooCommerce Memberships content restriction handling.
+ *
+ * @group wc-memberships
+ */
+class Test_Memberships_Content_Restrictions extends WP_UnitTestCase {
+
+	/**
+	 * Ensure the restriction handler is removed using its callable.
+	 *
+	 * WordPress 7.1 replaced spl_object_hash() with spl_object_id() when building
+	 * hook callback IDs. Passing the callable keeps removal compatible with both.
+	 *
+	 * @dataProvider restriction_handler_priorities
+	 *
+	 * @param int $priority Hook priority.
+	 */
+	public function test_removes_posts_restriction_handler( $priority ) {
+		$restriction_instance = new class() {
+			/**
+			 * Mock restriction handler.
+			 */
+			public function handle_restriction_modes() {}
+		};
+		$callback             = [ $restriction_instance, 'handle_restriction_modes' ];
+
+		add_action( 'wp', $callback, $priority );
+		$this->assertSame( $priority, has_action( 'wp', $callback ) );
+
+		Memberships::remove_posts_restriction_handler( $restriction_instance );
+
+		$this->assertFalse( has_action( 'wp', $callback ) );
+	}
+
+	/**
+	 * WooCommerce Memberships restriction handler priorities.
+	 *
+	 * @return array[]
+	 */
+	public function restriction_handler_priorities() {
+		return [
+			'current versions' => [ 9 ],
+			'before 1.27.2'    => [ 10 ],
+		];
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and the VIP Go coding standards?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Cherry-picks #931 onto `release`.

On WordPress 7.1, metered and gifted readers get a truncated article instead of the full one. Core changed how it builds object-method hook identifiers, so the identifier Newspack constructed by hand no longer matched, and the call that unhooks WooCommerce Memberships' restriction handler stopped removing anything. Memberships then truncated content Newspack had already decided to unrestrict.

The handler is now removed by passing its callable, so WordPress builds the identifier itself on every supported version.

Publishers on WordPress 7.1 are serving partial articles to readers entitled to the whole thing, which is why this goes to `release` ahead of the next promotion.

### How to test the changes in this Pull Request:

1. On a WordPress 7.1 site with WooCommerce Memberships active, restrict a post and set restriction mode to "Hide content only".
2. Configure a content gate with metering enabled and anonymous free views above zero.
3. Open the post logged out. The full article renders, with no visible gate.
4. Set anonymous free views to zero and reload. The article is truncated and the gate shows.
5. Open a gifted article via its gift link. The full article renders.
6. Repeat step 3 on WordPress 7.0.x and confirm behaviour is unchanged there.
7. Run `n test-php --group wc-memberships`. Both tests pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Clean cherry-pick (`-x`) of 5ab0ccf — no conflicts, content identical to the commit on `main`.
