### PR TITLE
fix(cli): record per-post exemptions from the Memberships force-public flag (NPPD-2199)

### DIFF
--- a/plugins/newspack-plugin/includes/cli/class-initializer.php
+++ b/plugins/newspack-plugin/includes/cli/class-initializer.php
@@ -93,6 +93,12 @@ class Initializer {
 		WP_CLI::add_command( 'newspack export-subscriptions', [ 'Newspack\CLI\Export', 'export_subscriptions' ] );
 		WP_CLI::add_command( 'newspack export-users', [ 'Newspack\CLI\Export', 'export_users' ] );
 
+		// Registered whether or not WooCommerce Memberships is active, unlike the
+		// migrate-* commands below: it reads `_wc_memberships_force_public`, ordinary
+		// postmeta that outlives the plugin, and already-flipped sites are the ones
+		// needing it.
+		WP_CLI::add_command( 'newspack migrate-post-exemptions', [ 'Newspack\CLI\Membership_Gates_Migration', 'migrate_post_exemptions' ] );
+
 		// Only register the Teams for Memberships diagnostics command on sites where the
 		// SkyVerge plugin is active. No reason to surface it in `wp help` otherwise.
 		if ( class_exists( 'WC_Memberships_For_Teams_Loader' ) ) {

--- a/plugins/newspack-plugin/includes/cli/class-membership-gates-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-membership-gates-migration.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * WP-CLI command to migrate WooCommerce Membership plans and their content gate
- * layouts to Newspack Access Control content gates.
+ * WP-CLI commands to migrate WooCommerce Memberships content restriction to
+ * Newspack Access Control: `migrate-membership-gates` for the plans and their
+ * content gate layouts, `migrate-post-exemptions` for the per-post "public"
+ * overrides those plans never carried.
  *
  * Ported from the standalone `migrate-memberships` drop-in so the tooling ships
  * with the plugin. The class file is included on every request (like the other
  * CLI classes), but only the command registration is gated on WP_CLI, so the
- * runtime cost outside CLI is a class definition. The command reads each
- * published Membership plan's content
- * restriction rules plus the `np_memberships_gate` layout posts and writes the
- * equivalent Access Control gate(s), content rules, and gate layouts through the
- * Content_Gate / Content_Rules data layer.
+ * runtime cost outside CLI is a class definition. `migrate-membership-gates` writes
+ * through the Content_Gate / Content_Rules data layer; `migrate-post-exemptions` is
+ * postmeta plumbing and touches neither.
  *
  * @package Newspack
  */
@@ -22,7 +22,7 @@ use WP_CLI;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Membership plan → Access Control content gate migration CLI command.
+ * WooCommerce Memberships → Access Control content restriction migration CLI commands.
  */
 class Membership_Gates_Migration {
 
@@ -1000,5 +1000,292 @@ class Membership_Gates_Migration {
 		// Fallback only if JSON encoding fails; the fingerprint is an internal
 		// grouping key, never unserialized.
 		return $fingerprint ? $fingerprint : serialize( $normalised ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+	}
+
+	/**
+	 * Record Access Control exemptions for the posts WooCommerce Memberships forced public.
+	 *
+	 * Memberships' "This content is public" checkbox writes
+	 * `_wc_memberships_force_public = 'yes'` and short-circuits every restriction rule.
+	 * Access Control's equivalent is the "Disable access control restrictions for this
+	 * post" toggle. Nothing bridges the two, so without this step those posts are gated
+	 * the moment Memberships is deactivated.
+	 *
+	 * A post already carrying a falsy exemption row is overwritten, not skipped, and its
+	 * ID listed.
+	 *
+	 * Migrates only the post types the exemption toggle is offered on; rows on any other
+	 * type are counted and reported so the totals reconcile.
+	 *
+	 * Idempotent, but additive: an exemption recorded by an earlier run is never removed.
+	 * A post whose Memberships flag has since been unchecked is reported so it can be
+	 * reviewed — it would otherwise stay public after cutover. Publishers keep using the
+	 * checkbox up to cutover, so the run that counts is the one immediately before
+	 * Memberships is deactivated.
+	 *
+	 * Dry-run by default; pass --live to write.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--live]
+	 * : Apply the changes. Without this flag the command runs as a dry-run and writes nothing.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp newspack migrate-post-exemptions
+	 *     wp newspack migrate-post-exemptions --live
+	 *
+	 * @param array $args       Positional args (unused).
+	 * @param array $assoc_args Named args.
+	 *
+	 * @return void
+	 */
+	public function migrate_post_exemptions( $args, $assoc_args ) {
+		$dry_run = ! (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'live', false );
+
+		if ( ! class_exists( 'Newspack\Content_Restriction_Control' ) ) {
+			WP_CLI::error( 'Newspack\Content_Restriction_Control class not found. Is newspack-plugin active? Aborting.' );
+		}
+
+		if ( $dry_run ) {
+			WP_CLI::line( '' );
+			WP_CLI::line( '*** DRY RUN MODE — no data will be modified. Pass --live to write. ***' );
+			WP_CLI::line( '' );
+		}
+
+		if ( ! \Newspack\Content_Gate::is_newspack_feature_enabled() ) {
+			WP_CLI::warning( 'Content gates are disabled on this site (NEWSPACK_CONTENT_GATES). The exemptions will be recorded, but nothing reads them until the feature is enabled.' );
+		}
+
+		$flagged = self::get_force_public_posts();
+		if ( null === $flagged ) {
+			WP_CLI::error( 'Could not read the force-public flags. Aborting rather than reporting an empty set to an operator about to deactivate Memberships.' );
+		}
+
+		$post_types   = array_column( (array) \Newspack\Content_Restriction_Control::get_available_post_types(), 'value' );
+		$in_scope     = [];
+		$out_of_scope = [];
+		foreach ( $flagged as $post ) {
+			if ( in_array( $post['post_type'], $post_types, true ) ) {
+				$in_scope[] = $post;
+			} else {
+				$out_of_scope[ $post['post_type'] ] = ( $out_of_scope[ $post['post_type'] ] ?? 0 ) + 1;
+			}
+		}
+
+		if ( empty( $in_scope ) ) {
+			WP_CLI::line( 'No posts carry the WooCommerce Memberships force-public flag on a post type the exemption applies to.' );
+			self::report_out_of_scope_force_public( $out_of_scope );
+			self::report_revoked_force_public();
+			return;
+		}
+
+		$missing   = [];
+		$falsy     = [];
+		$failed    = [];
+		$breakdown = [];
+		// Classify and write a chunk at a time, so the meta cache neither grows with the
+		// site nor is thrown away between reading a post and writing it.
+		foreach ( array_chunk( $in_scope, 200 ) as $chunk ) {
+			\update_meta_cache( 'post', array_column( $chunk, 'ID' ) );
+			foreach ( $chunk as $post ) {
+				$post_id = (int) $post['ID'];
+				$state   = self::classify_exemption_state( $post_id );
+
+				$key                 = $post['post_type'] . '|' . $post['post_status'];
+				$breakdown[ $key ] ??= [
+					'post_type'   => $post['post_type'],
+					'post_status' => $post['post_status'],
+					'missing'     => 0,
+					'falsy'       => 0,
+					'already'     => 0,
+				];
+				++$breakdown[ $key ][ $state ];
+
+				if ( 'already' === $state ) {
+					continue;
+				}
+				if ( ! $dry_run && ! \update_post_meta( $post_id, \Newspack\Content_Restriction_Control::IS_EXEMPT_META_KEY, true ) ) {
+					$failed[] = $post_id;
+					continue;
+				}
+				if ( 'missing' === $state ) {
+					$missing[] = $post_id;
+				} else {
+					$falsy[] = $post_id;
+				}
+			}
+			\WP_CLI\Utils\wp_clear_object_cache();
+		}
+
+		WP_CLI::line( '' );
+		WP_CLI::line( $dry_run ? '=== DRY RUN SUMMARY ===' : '=== MIGRATION SUMMARY ===' );
+		WP_CLI::line( '' );
+
+		\WP_CLI\Utils\format_items(
+			'table',
+			array_map(
+				fn( $row ) => [
+					'Post Type'      => $row['post_type'],
+					'Status'         => $row['post_status'],
+					'No Row'         => $row['missing'],
+					'Falsy Row'      => $row['falsy'],
+					'Already Exempt' => $row['already'],
+				],
+				array_values( $breakdown )
+			),
+			[ 'Post Type', 'Status', 'No Row', 'Falsy Row', 'Already Exempt' ]
+		);
+
+		WP_CLI::line( '' );
+
+		if ( ! empty( $falsy ) ) {
+			WP_CLI::warning(
+				sprintf(
+					'%d post(s) carried a falsy exemption row and %s: %s',
+					count( $falsy ),
+					$dry_run ? 'would be overwritten' : 'were overwritten',
+					implode( ', ', $falsy )
+				)
+			);
+		}
+
+		if ( ! empty( $failed ) ) {
+			WP_CLI::warning( sprintf( '%d exemption(s) could not be written, and are still counted in the table above: %s', count( $failed ), implode( ', ', $failed ) ) );
+		}
+
+		self::report_out_of_scope_force_public( $out_of_scope );
+		self::report_revoked_force_public();
+
+		WP_CLI::success(
+			sprintf(
+				'Done. %d exemption(s) %s (%d with no row, %d overwriting a falsy row). %d post(s) were already exempt.',
+				count( $missing ) + count( $falsy ),
+				$dry_run ? 'would be recorded' : 'recorded',
+				count( $missing ),
+				count( $falsy ),
+				count( $in_scope ) - count( $missing ) - count( $falsy ) - count( $failed )
+			)
+		);
+
+		if ( ! $dry_run ) {
+			WP_CLI::line( 'Keep the `_wc_memberships_force_public` meta until this has run for the last time — it is what this command reads.' );
+		}
+	}
+
+	/**
+	 * Every post carrying the Memberships force-public flag, whatever its post type.
+	 *
+	 * The `meta_value = 'yes'` filter is not optional: the checkbox writes a `no` row for
+	 * every post it was ever rendered on, outnumbering the real ones by an order of
+	 * magnitude.
+	 *
+	 * @return array[]|null Rows of ID / post_type / post_status ordered by ID, or null
+	 *                      if the query failed.
+	 */
+	private static function get_force_public_posts(): ?array {
+		global $wpdb;
+
+		$rows = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"SELECT DISTINCT p.ID, p.post_type, p.post_status
+				FROM {$wpdb->posts} p
+				INNER JOIN {$wpdb->postmeta} pm ON pm.post_id = p.ID
+				WHERE pm.meta_key = %s AND pm.meta_value = 'yes'
+				ORDER BY p.ID",
+				\Newspack\Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY
+			),
+			ARRAY_A
+		);
+
+		// get_results() reports a failed query as an empty set, which here would read as
+		// "no post was ever forced public" to an operator about to deactivate Memberships.
+		return $wpdb->last_error ? null : (array) $rows;
+	}
+
+	/**
+	 * Report posts that are exempt while their Memberships flag says otherwise.
+	 *
+	 * An earlier live run records an exemption; the publisher then unchecks the box. This
+	 * command never revisits that post — it selects on `meta_value = 'yes'` — so the
+	 * exemption outlives the flag and the post stays public after cutover. The same shape
+	 * is also a legitimate editor-set exemption on a post Memberships never forced public,
+	 * so these are named for review, never removed.
+	 *
+	 * @return void
+	 */
+	private static function report_revoked_force_public(): void {
+		global $wpdb;
+
+		$post_ids = $wpdb->get_col( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"SELECT DISTINCT p.ID
+				FROM {$wpdb->posts} p
+				INNER JOIN {$wpdb->postmeta} fp ON fp.post_id = p.ID AND fp.meta_key = %s AND fp.meta_value = 'no'
+				INNER JOIN {$wpdb->postmeta} ex ON ex.post_id = p.ID AND ex.meta_key = %s AND ex.meta_value NOT IN ( '', '0' )
+				ORDER BY p.ID",
+				\Newspack\Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY,
+				\Newspack\Content_Restriction_Control::IS_EXEMPT_META_KEY
+			)
+		);
+
+		if ( empty( $post_ids ) ) {
+			return;
+		}
+
+		WP_CLI::warning(
+			sprintf(
+				'%d post(s) are exempt while the Memberships flag says they are not, so they stay public after cutover. Review and clear any the publisher no longer wants free: %s',
+				count( $post_ids ),
+				implode( ', ', $post_ids )
+			)
+		);
+	}
+
+	/**
+	 * Report the force-public rows on post types the exemption does not apply to.
+	 *
+	 * @param array<string,int> $out_of_scope Post type => row count.
+	 *
+	 * @return void
+	 */
+	private static function report_out_of_scope_force_public( array $out_of_scope ): void {
+		if ( empty( $out_of_scope ) ) {
+			return;
+		}
+		arsort( $out_of_scope );
+		$parts = [];
+		foreach ( $out_of_scope as $post_type => $count ) {
+			$parts[] = sprintf( '%s (%d)', $post_type, $count );
+		}
+		WP_CLI::line(
+			sprintf(
+				'Ignored %d force-public row(s) on post types the exemption does not apply to: %s.',
+				array_sum( $out_of_scope ),
+				implode( ', ', $parts )
+			)
+		);
+	}
+
+	/**
+	 * Where a post stands with respect to the Access Control exemption.
+	 *
+	 * Reads through metadata_exists() rather than get_post_meta(). The exemption meta is
+	 * registered with a default, so get_post_meta() cannot tell "no row" from "row set
+	 * falsy" — and a build carrying a `default_post_metadata` fallback for the Memberships
+	 * flag answers true for exactly the posts this command selects, which would leave it
+	 * with nothing to write. metadata_exists() reads the row itself, past both.
+	 *
+	 * @param int $post_id Post ID.
+	 *
+	 * @return string 'missing' (no row), 'falsy' (a row set falsy), or 'already' (a real
+	 *                exemption, left alone).
+	 */
+	private static function classify_exemption_state( int $post_id ): string {
+		$meta_key = \Newspack\Content_Restriction_Control::IS_EXEMPT_META_KEY;
+		if ( ! \metadata_exists( 'post', $post_id, $meta_key ) ) {
+			return 'missing';
+		}
+		return \get_post_meta( $post_id, $meta_key, true ) ? 'already' : 'falsy';
 	}
 }

--- a/plugins/newspack-plugin/includes/cli/class-membership-gates-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-membership-gates-migration.php
@@ -1014,8 +1014,9 @@ class Membership_Gates_Migration {
 	 * A post already carrying a falsy exemption row is overwritten, not skipped, and its
 	 * ID listed.
 	 *
-	 * Migrates only the post types the exemption toggle is offered on; rows on any other
-	 * type are counted and reported so the totals reconcile.
+	 * Migrates only the post types the exemption toggle is offered on. Posts on any other
+	 * type are counted and warned about rather than written: they can still be gated by a
+	 * taxonomy access rule, so they need a human decision this command cannot make.
 	 *
 	 * Idempotent, but additive: an exemption recorded by an earlier run is never removed.
 	 * A post whose Memberships flag has since been unchecked is reported so it can be
@@ -1044,7 +1045,7 @@ class Membership_Gates_Migration {
 		$dry_run = ! (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'live', false );
 
 		if ( ! class_exists( 'Newspack\Content_Restriction_Control' ) ) {
-			WP_CLI::error( 'Newspack\Content_Restriction_Control class not found. Is newspack-plugin active? Aborting.' );
+			WP_CLI::error( 'Newspack\Content_Restriction_Control class not found, so the exemption meta key and its post types cannot be resolved. Aborting.' );
 		}
 
 		if ( $dry_run ) {
@@ -1139,19 +1140,32 @@ class Membership_Gates_Migration {
 
 		WP_CLI::line( '' );
 
+		// The command never removes an exemption, so this list is the only record of what a
+		// live run touched. Printing it is what makes an over-broad run undoable without
+		// re-deriving the set from the database afterwards.
+		if ( ! empty( $missing ) || ! empty( $falsy ) ) {
+			WP_CLI::line(
+				sprintf(
+					'Exemption %s for: %s',
+					$dry_run ? 'would be recorded' : 'recorded',
+					self::format_post_id_list( array_merge( $missing, $falsy ) )
+				)
+			);
+		}
+
 		if ( ! empty( $falsy ) ) {
 			WP_CLI::warning(
 				sprintf(
 					'%d post(s) carried a falsy exemption row and %s: %s',
 					count( $falsy ),
 					$dry_run ? 'would be overwritten' : 'were overwritten',
-					implode( ', ', $falsy )
+					self::format_post_id_list( $falsy )
 				)
 			);
 		}
 
 		if ( ! empty( $failed ) ) {
-			WP_CLI::warning( sprintf( '%d exemption(s) could not be written, and are still counted in the table above: %s', count( $failed ), implode( ', ', $failed ) ) );
+			WP_CLI::warning( sprintf( '%d exemption(s) could not be written, and are still counted in the table above: %s', count( $failed ), self::format_post_id_list( $failed ) ) );
 		}
 
 		self::report_out_of_scope_force_public( $out_of_scope );
@@ -1170,6 +1184,13 @@ class Membership_Gates_Migration {
 
 		if ( ! $dry_run ) {
 			WP_CLI::line( 'Keep the `_wc_memberships_force_public` meta until this has run for the last time — it is what this command reads.' );
+		}
+
+		// A warning line is invisible to whatever chained this command with the Memberships
+		// deactivation that follows it, and an unwritten exemption cannot be recovered once
+		// the flag it came from is gone. Exit non-zero so the cutover stops here.
+		if ( ! empty( $failed ) ) {
+			WP_CLI::halt( 1 );
 		}
 	}
 
@@ -1229,6 +1250,14 @@ class Membership_Gates_Migration {
 			)
 		);
 
+		// Same hazard as the census query: get_col() reports a failure as an empty set, and
+		// an empty review list is what an operator about to deactivate Memberships reads as
+		// "nothing stays wrongly public".
+		if ( $wpdb->last_error ) {
+			WP_CLI::warning( 'Could not check for exemptions whose Memberships flag was since revoked. Nothing was reviewed — treat this as "unknown", not "none".' );
+			return;
+		}
+
 		if ( empty( $post_ids ) ) {
 			return;
 		}
@@ -1237,15 +1266,25 @@ class Membership_Gates_Migration {
 			sprintf(
 				'%d post(s) are exempt while the Memberships flag says they are not, so they stay public after cutover. Review and clear any the publisher no longer wants free: %s',
 				count( $post_ids ),
-				implode( ', ', $post_ids )
+				self::format_post_id_list( $post_ids )
 			)
 		);
 	}
 
 	/**
-	 * Report the force-public rows on post types the exemption does not apply to.
+	 * Report the force-public posts on post types the exemption toggle is not offered on.
 	 *
-	 * @param array<string,int> $out_of_scope Post type => row count.
+	 * A warning rather than a plain line, because "the exemption does not apply" is not the
+	 * same as "these posts cannot be gated". Nothing in the restriction check is scoped by
+	 * post type: the exemption is honoured on any post ID, and a category or tag access rule
+	 * matches a post through its terms. So a public post type the exemption toggle is not
+	 * offered on — it is absent from `get_available_post_types()` — can still be gated at
+	 * cutover, and these posts are exactly the ones the publisher marked free.
+	 *
+	 * Counts posts, not meta rows: the census query selects DISTINCT post IDs, so duplicate
+	 * force-public rows on one post collapse to a single entry.
+	 *
+	 * @param array<string,int> $out_of_scope Post type => post count.
 	 *
 	 * @return void
 	 */
@@ -1258,12 +1297,35 @@ class Membership_Gates_Migration {
 		foreach ( $out_of_scope as $post_type => $count ) {
 			$parts[] = sprintf( '%s (%d)', $post_type, $count );
 		}
-		WP_CLI::line(
+		WP_CLI::warning(
 			sprintf(
-				'Ignored %d force-public row(s) on post types the exemption does not apply to: %s.',
+				'Skipped %d force-public post(s) on post types the exemption toggle is not offered on: %s. A category or tag access rule can still gate them, and no exemption was recorded — check these by hand before deactivating Memberships.',
 				array_sum( $out_of_scope ),
 				implode( ', ', $parts )
 			)
+		);
+	}
+
+	/**
+	 * Render a list of post IDs for a single CLI line, capped.
+	 *
+	 * These lists are what an operator acts on before deactivating Memberships. Imploding
+	 * every ID scrolls the rest of the summary out of the terminal buffer once the list runs
+	 * to thousands, so the tail is summarised instead.
+	 *
+	 * @param int[] $post_ids Post IDs.
+	 * @param int   $limit    How many IDs to name before summarising the rest.
+	 *
+	 * @return string
+	 */
+	private static function format_post_id_list( array $post_ids, int $limit = 100 ): string {
+		if ( count( $post_ids ) <= $limit ) {
+			return implode( ', ', $post_ids );
+		}
+		return sprintf(
+			'%s (and %d more)',
+			implode( ', ', array_slice( $post_ids, 0, $limit ) ),
+			count( $post_ids ) - $limit
 		);
 	}
 
@@ -1272,9 +1334,10 @@ class Membership_Gates_Migration {
 	 *
 	 * Reads through metadata_exists() rather than get_post_meta(). The exemption meta is
 	 * registered with a default, so get_post_meta() cannot tell "no row" from "row set
-	 * falsy" — and a build carrying a `default_post_metadata` fallback for the Memberships
-	 * flag answers true for exactly the posts this command selects, which would leave it
-	 * with nothing to write. metadata_exists() reads the row itself, past both.
+	 * falsy" — and on a build carrying the `default_post_metadata` fallback for the exemption
+	 * key (which answers from the Memberships flag), it answers true for exactly the posts
+	 * this command selects, which would leave it with nothing to write. metadata_exists()
+	 * reads the row itself, past both.
 	 *
 	 * @param int $post_id Post ID.
 	 *

--- a/plugins/newspack-plugin/includes/content-gate/class-content-restriction-control.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-restriction-control.php
@@ -55,6 +55,13 @@ class Content_Restriction_Control {
 	const IS_EXEMPT_META_KEY = 'newspack_content_restriction_is_exempt';
 
 	/**
+	 * Post meta key WooCommerce Memberships uses to force a post public.
+	 *
+	 * @var string
+	 */
+	const WC_FORCE_PUBLIC_META_KEY = '_wc_memberships_force_public';
+
+	/**
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {

--- a/plugins/newspack-plugin/tests/mocks/wp-cli-mock.php
+++ b/plugins/newspack-plugin/tests/mocks/wp-cli-mock.php
@@ -1,45 +1,10 @@
-<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FileComment.Missing, Squiz.Commenting.VariableComment.Missing
+<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Squiz.Commenting.FileComment.Missing
 
 /**
- * Minimal WP_CLI stub for tests exercising CLI code paths under PHPUnit.
- *
- * The real WP_CLI is not loaded in the test environment; only the logging
- * surface the batch sync/pull drivers touch is stubbed. Messages are recorded
- * so tests can assert CLI output — call reset() in set_up (or at the start of
- * the test) before asserting on $logs / $successes / $halt_code. error() throws
- * so tests can assert pre-flight failures; halt() records the exit code instead
- * of exiting, so callers must return immediately after calling it.
+ * Compatibility shim: the WP_CLI stub this file used to define moved into the
+ * shared `wp-cli-mocks.php` recording mock (a superset of this file's surface —
+ * $logs / $successes / $warnings / $tables / $halt_code / halt() are all preserved).
+ * Only one WP_CLI class can exist per PHPUnit process, so both require paths
+ * must resolve to the same definition; requires of this file keep working.
  */
-if ( ! class_exists( 'WP_CLI' ) ) {
-	class WP_CLI {
-		public static $logs      = [];
-		public static $successes = [];
-		public static $warnings  = [];
-		public static $halt_code = null;
-
-		public static function reset() {
-			self::$logs      = [];
-			self::$successes = [];
-			self::$warnings  = [];
-			self::$halt_code = null;
-		}
-		public static function halt( $code = 0 ) {
-			self::$halt_code = $code;
-		}
-		public static function log( $message ) {
-			self::$logs[] = $message;
-		}
-		public static function warning( $message ) {
-			self::$warnings[] = $message;
-		}
-		public static function line( $message = '' ) {
-			self::$logs[] = $message;
-		}
-		public static function success( $message ) {
-			self::$successes[] = $message;
-		}
-		public static function error( $message ) {
-			throw new \Exception( esc_html( $message ) );
-		}
-	}
-}
+require_once __DIR__ . '/wp-cli-mocks.php';

--- a/plugins/newspack-plugin/tests/mocks/wp-cli-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wp-cli-mocks.php
@@ -1,0 +1,177 @@
+<?php // phpcs:ignoreFile
+/**
+ * Minimal WP-CLI mocks so CLI command methods can be exercised in unit tests,
+ * where the real WP-CLI runtime is not loaded. Shared by every test that drives
+ * a `Newspack\CLI\*` command method directly.
+ *
+ * The WP_CLI class records every emitted message on two surfaces so different
+ * suites can assert in the style that fits them:
+ *
+ * - WP_CLI::$output   — flat rendered strings ('Warning: ...', 'Success: ...'),
+ *                       convenient for whole-transcript substring assertions.
+ * - WP_CLI::$messages — raw `[ level, message ]` pairs ('line', 'log',
+ *                       'warning', 'success', and 'table' for format_items),
+ *                       convenient for level-filtered assertions.
+ *
+ * WP_CLI::error() throws WP_CLI_Mock_Exception (an \Exception subclass) so
+ * tests can assert an abort — real WP-CLI exits the process. Only the surface
+ * used by the Newspack CLI classes is implemented.
+ *
+ * @package Newspack\Tests
+ */
+
+namespace {
+	if ( ! class_exists( 'WP_CLI_Mock_Exception' ) ) {
+		/**
+		 * Thrown by the WP_CLI::error() mock in place of a process exit.
+		 */
+		class WP_CLI_Mock_Exception extends \Exception {}
+	}
+
+	if ( ! class_exists( 'WP_CLI' ) ) {
+		/**
+		 * Recording mock of the WP_CLI logger surface.
+		 */
+		class WP_CLI {
+			/**
+			 * Every line emitted through the mock as a rendered string, in order.
+			 *
+			 * @var string[]
+			 */
+			public static $output = [];
+
+			/**
+			 * Every message emitted through the mock as a `[ level, message ]`
+			 * pair, in order.
+			 *
+			 * @var array[]
+			 */
+			public static $messages = [];
+
+			/**
+			 * Level-keyed surfaces mirroring the sibling `wp-cli-mock.php` stub, so
+			 * suites written against either mock run under this one — only one WP_CLI
+			 * class can exist per process, so this file is the superset both requires
+			 * resolve to.
+			 *
+			 * @var string[]
+			 */
+			public static $logs      = [];
+			public static $successes = [];
+			public static $warnings  = [];
+
+			/**
+			 * Structured rows recorded by the format_items() stub, one entry per
+			 * call: [ 'format' => ..., 'items' => ..., 'fields' => ... ].
+			 *
+			 * @var array[]
+			 */
+			public static $tables = [];
+
+			/**
+			 * Exit code recorded by halt(), null when halt() was never called.
+			 *
+			 * @var int|null
+			 */
+			public static $halt_code = null;
+
+			/**
+			 * Clear recorded output. Call from a test's set_up().
+			 */
+			public static function reset() {
+				self::$output    = [];
+				self::$messages  = [];
+				self::$logs      = [];
+				self::$successes = [];
+				self::$warnings  = [];
+				self::$tables    = [];
+				self::$halt_code = null;
+			}
+
+			/**
+			 * Real WP_CLI::halt() exits the process; the mock records the code so
+			 * callers must return immediately after calling it.
+			 *
+			 * @param int $code Exit code.
+			 */
+			public static function halt( $code = 0 ) {
+				self::$halt_code = $code;
+			}
+
+			public static function line( $message = '' ) {
+				self::$output[]   = (string) $message;
+				self::$messages[] = [ 'line', (string) $message ];
+				self::$logs[]     = (string) $message;
+			}
+
+			public static function log( $message ) {
+				self::$output[]   = (string) $message;
+				self::$messages[] = [ 'log', (string) $message ];
+				self::$logs[]     = (string) $message;
+			}
+
+			public static function warning( $message ) {
+				self::$output[]   = 'Warning: ' . $message;
+				self::$messages[] = [ 'warning', (string) $message ];
+				self::$warnings[] = (string) $message;
+			}
+
+			public static function success( $message ) {
+				self::$output[]    = 'Success: ' . $message;
+				self::$messages[]  = [ 'success', (string) $message ];
+				self::$successes[] = (string) $message;
+			}
+
+			/**
+			 * Real WP_CLI::confirm() prompts on STDIN and exits on anything but 'y';
+			 * the mock records the question and returns, standing in for a "yes".
+			 *
+			 * @param string     $question   The yes/no question.
+			 * @param array|null $assoc_args Named args (unused).
+			 */
+			public static function confirm( $question, $assoc_args = null ) {
+				self::$output[]   = 'Confirm: ' . $question;
+				self::$messages[] = [ 'confirm', (string) $question ];
+			}
+
+			/**
+			 * Real WP_CLI::error() prints and exits; the mock throws instead so the
+			 * abort is observable and the test process survives.
+			 *
+			 * @param string $message Error message.
+			 * @throws WP_CLI_Mock_Exception Always.
+			 */
+			public static function error( $message ) {
+				throw new \WP_CLI_Mock_Exception( (string) $message );
+			}
+		}
+	}
+}
+
+namespace WP_CLI\Utils {
+	if ( ! function_exists( 'WP_CLI\Utils\get_flag_value' ) ) {
+		// isset(), not array_key_exists() — matching real WP-CLI's implementation.
+		function get_flag_value( $assoc_args, $flag, $default = null ) {
+			return isset( $assoc_args[ $flag ] ) ? $assoc_args[ $flag ] : $default;
+		}
+	}
+
+	if ( ! function_exists( 'WP_CLI\Utils\format_items' ) ) {
+		function format_items( $format, $items, $fields ) {
+			$items               = is_array( $items ) ? $items : iterator_to_array( $items );
+			\WP_CLI::$output[]   = sprintf( '(%s: %d row(s))', $format, count( $items ) );
+			\WP_CLI::$messages[] = [ 'table', wp_json_encode( array_values( $items ) ) ];
+			\WP_CLI::$tables[]   = [
+				'format' => $format,
+				'items'  => $items,
+				'fields' => $fields,
+			];
+		}
+	}
+
+	if ( ! function_exists( 'WP_CLI\Utils\wp_clear_object_cache' ) ) {
+		function wp_clear_object_cache() {
+			// No-op: the real helper trims caches to bound long-running CLI memory.
+		}
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/cli/class-test-post-exemptions-migration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/cli/class-test-post-exemptions-migration.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Tests for the migrate-post-exemptions CLI (NPPD-2199).
+ *
+ * Pins what makes the command more than a two-line loop; each case below names its own.
+ * The load-bearing one is the missing/falsy split: `get_post_meta()` cannot see it, and it
+ * is what makes a row an editor set falsy distinguishable from no row at all.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\CLI\Membership_Gates_Migration;
+use Newspack\Content_Restriction_Control;
+
+require_once dirname( __DIR__, 2 ) . '/mocks/wp-cli-mocks.php';
+require_once dirname( __DIR__, 3 ) . '/includes/cli/class-membership-gates-migration.php';
+
+/**
+ * Test the migrate-post-exemptions command.
+ *
+ * @group content-gate
+ */
+class Test_Post_Exemptions_Migration extends WP_UnitTestCase {
+
+	/**
+	 * Enable content gates and register the exemption meta, so the tests run against the
+	 * registered shape — the default is what stops get_post_meta() telling "no row" from
+	 * "row set falsy".
+	 */
+	public function set_up() {
+		parent::set_up();
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+		Content_Restriction_Control::register_meta();
+	}
+
+	/**
+	 * Unregister the exemption meta so its registered default does not leak into other suites.
+	 */
+	public function tear_down() {
+		foreach ( array_column( (array) Content_Restriction_Control::get_available_post_types(), 'value' ) as $subtype ) {
+			unregister_meta_key( 'post', Content_Restriction_Control::IS_EXEMPT_META_KEY, $subtype );
+		}
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a post carrying Memberships' force-public flag.
+	 *
+	 * @param array $args Post args passed to the factory.
+	 *
+	 * @return int Post ID.
+	 */
+	private function create_force_public_post( array $args = [] ): int {
+		$post_id = self::factory()->post->create( $args );
+		update_post_meta( $post_id, Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY, 'yes' );
+		return $post_id;
+	}
+
+	/**
+	 * Run the command and return its whole transcript.
+	 *
+	 * @param array $assoc_args Named args, e.g. [ 'live' => true ].
+	 *
+	 * @return string
+	 */
+	private function run_migration( array $assoc_args = [] ): string {
+		WP_CLI::reset();
+		( new Membership_Gates_Migration() )->migrate_post_exemptions( [], $assoc_args );
+		return implode( "\n", WP_CLI::$output );
+	}
+
+	/**
+	 * Whether a real exemption row exists.
+	 *
+	 * @param int $post_id Post ID.
+	 *
+	 * @return bool
+	 */
+	private function has_recorded_exemption( int $post_id ): bool {
+		global $wpdb;
+		// Straight to the row rather than through metadata_exists(), which is the primitive
+		// the command classifies with — an oracle sharing it could not see it fooled.
+		return (bool) $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"SELECT meta_value FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = %s",
+				$post_id,
+				Content_Restriction_Control::IS_EXEMPT_META_KEY
+			)
+		);
+	}
+
+	/**
+	 * A force-public post with no exemption row of its own gets one, and a second run has
+	 * nothing left to do.
+	 */
+	public function test_records_an_exemption_where_only_the_memberships_flag_exists() {
+		$post_id = $this->create_force_public_post();
+
+		$this->run_migration( [ 'live' => true ] );
+		$this->assertTrue( $this->has_recorded_exemption( $post_id ) );
+
+		$output = $this->run_migration( [ 'live' => true ] );
+		$this->assertStringContainsString( '0 exemption(s) recorded', $output );
+		$this->assertStringContainsString( '1 post(s) were already exempt', $output );
+	}
+
+	/**
+	 * The row `get_post_meta()` cannot distinguish from no row at all. It is overwritten,
+	 * not skipped, and its ID reported.
+	 */
+	public function test_overwrites_a_falsy_exemption_row() {
+		$post_id = $this->create_force_public_post();
+		update_post_meta( $post_id, Content_Restriction_Control::IS_EXEMPT_META_KEY, '' );
+
+		$output = $this->run_migration( [ 'live' => true ] );
+
+		$this->assertTrue( $this->has_recorded_exemption( $post_id ) );
+		$this->assertStringContainsString( '1 post(s) carried a falsy exemption row', $output );
+		$this->assertStringContainsString( (string) $post_id, $output );
+	}
+
+	/**
+	 * The `no` rows the checkbox writes in bulk are not exemptions.
+	 */
+	public function test_ignores_force_public_no_rows() {
+		$declined_id = self::factory()->post->create();
+		update_post_meta( $declined_id, Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY, 'no' );
+
+		$output = $this->run_migration( [ 'live' => true ] );
+
+		$this->assertFalse( metadata_exists( 'post', $declined_id, Content_Restriction_Control::IS_EXEMPT_META_KEY ) );
+		$this->assertStringContainsString( 'No posts carry the WooCommerce Memberships force-public flag', $output );
+	}
+
+	/**
+	 * A row on a post type the exemption is not registered for is inert, so it is counted
+	 * rather than migrated — that is what lets a census of the raw meta key reconcile.
+	 */
+	public function test_ignores_post_types_the_exemption_is_not_registered_for() {
+		$gateable_id = $this->create_force_public_post();
+		$inert_id    = $this->create_force_public_post( [ 'post_type' => 'attachment' ] );
+
+		$output = $this->run_migration( [ 'live' => true ] );
+
+		$this->assertTrue( $this->has_recorded_exemption( $gateable_id ) );
+		$this->assertFalse( metadata_exists( 'post', $inert_id, Content_Restriction_Control::IS_EXEMPT_META_KEY ) );
+		$this->assertStringContainsString( 'Ignored 1 force-public row(s) on post types the exemption does not apply to: attachment (1)', $output );
+	}
+
+	/**
+	 * An exemption recorded by an earlier run outlives the flag it came from, because the
+	 * command only ever selects `yes` rows. Such a post stays public after cutover, so it
+	 * is named for review rather than left silent — or cleared, which would also take out
+	 * an exemption an editor set deliberately.
+	 */
+	public function test_reports_an_exemption_whose_memberships_flag_was_revoked() {
+		$post_id = $this->create_force_public_post();
+		$this->run_migration( [ 'live' => true ] );
+		update_post_meta( $post_id, Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY, 'no' );
+
+		$output = $this->run_migration( [ 'live' => true ] );
+
+		$this->assertTrue( $this->has_recorded_exemption( $post_id ), 'The exemption is reported, never cleared.' );
+		$this->assertStringContainsString( '1 post(s) are exempt while the Memberships flag says they are not', $output );
+		$this->assertStringContainsString( (string) $post_id, $output );
+	}
+
+	/**
+	 * Dry-run is the default: it reports the split it would write, and writes neither the
+	 * missing row nor the overwrite.
+	 */
+	public function test_dry_run_reports_the_split_and_writes_nothing() {
+		$missing_row_id = $this->create_force_public_post();
+		$falsy_row_id   = $this->create_force_public_post();
+		update_post_meta( $falsy_row_id, Content_Restriction_Control::IS_EXEMPT_META_KEY, '' );
+
+		$output = $this->run_migration();
+
+		$this->assertFalse( metadata_exists( 'post', $missing_row_id, Content_Restriction_Control::IS_EXEMPT_META_KEY ) );
+		$this->assertFalse( $this->has_recorded_exemption( $falsy_row_id ) );
+		$this->assertStringContainsString(
+			'2 exemption(s) would be recorded (1 with no row, 1 overwriting a falsy row)',
+			$output
+		);
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/cli/class-test-post-exemptions-migration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/cli/class-test-post-exemptions-migration.php
@@ -98,8 +98,11 @@ class Test_Post_Exemptions_Migration extends WP_UnitTestCase {
 	public function test_records_an_exemption_where_only_the_memberships_flag_exists() {
 		$post_id = $this->create_force_public_post();
 
-		$this->run_migration( [ 'live' => true ] );
+		$first_run = $this->run_migration( [ 'live' => true ] );
 		$this->assertTrue( $this->has_recorded_exemption( $post_id ) );
+		// The command never removes an exemption, so this list is the only record of what to
+		// undo if a run turns out to have been too broad.
+		$this->assertStringContainsString( 'Exemption recorded for: ' . $post_id, $first_run );
 
 		$output = $this->run_migration( [ 'live' => true ] );
 		$this->assertStringContainsString( '0 exemption(s) recorded', $output );
@@ -135,8 +138,13 @@ class Test_Post_Exemptions_Migration extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A row on a post type the exemption is not registered for is inert, so it is counted
-	 * rather than migrated — that is what lets a census of the raw meta key reconcile.
+	 * A post type the exemption toggle is not offered on is skipped rather than migrated.
+	 * It is warned about, not merely counted: nothing in the restriction check is scoped by
+	 * post type, so a taxonomy access rule can still gate those posts.
+	 *
+	 * Also pins the per-type breakdown table, which is the artifact an operator reconciles
+	 * against before deactivating Memberships — the summary line alone cannot show that the
+	 * skipped type is absent from it.
 	 */
 	public function test_ignores_post_types_the_exemption_is_not_registered_for() {
 		$gateable_id = $this->create_force_public_post();
@@ -146,7 +154,22 @@ class Test_Post_Exemptions_Migration extends WP_UnitTestCase {
 
 		$this->assertTrue( $this->has_recorded_exemption( $gateable_id ) );
 		$this->assertFalse( metadata_exists( 'post', $inert_id, Content_Restriction_Control::IS_EXEMPT_META_KEY ) );
-		$this->assertStringContainsString( 'Ignored 1 force-public row(s) on post types the exemption does not apply to: attachment (1)', $output );
+		$this->assertStringContainsString( 'Skipped 1 force-public post(s) on post types the exemption toggle is not offered on: attachment (1)', $output );
+		$this->assertStringContainsString( 'check these by hand before deactivating Memberships', $output );
+
+		$this->assertSame(
+			[
+				[
+					'Post Type'      => 'post',
+					'Status'         => 'publish',
+					'No Row'         => 1,
+					'Falsy Row'      => 0,
+					'Already Exempt' => 0,
+				],
+			],
+			array_values( WP_CLI::$tables[0]['items'] ),
+			'The breakdown table reports the migrated post type only.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds `wp newspack migrate-post-exemptions`, which writes a real `newspack_content_restriction_is_exempt` row for every post carrying `_wc_memberships_force_public = 'yes'`. Nothing did this before — `migrate-membership-gates` works plan-to-gate and has no per-post loop — so posts a publisher marked always-public are gated the moment Memberships is deactivated. One migrated site lost 725 of 730.

**Targeting `release`, not `main`.** #855 makes Access Control *infer* the exemption where no row exists, but it is on `main` and `alpha` and in no tagged build, so on stable those posts are gated right now with nothing to save them. Landing the command here is what makes the repair possible on the sites that already flipped, and it stays correct once #855 ships: the inference is consulted only where no row exists, so a post already carrying a falsy row is invisible to it. Those rows are overwritten, not skipped, and every ID prints.

`Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY` and `tests/mocks/wp-cli-mocks.php` are added here byte-for-byte from `main`, which already has both, so the release-to-main sync merges them cleanly instead of conflicting.

Closes NPPD-2199.

### How to test the changes in this Pull Request:

1. Set `NEWSPACK_CONTENT_GATES` to true in `wp-config.php`.
2. Enable Reader Activation.
3. Create a published post. Set its `_wc_memberships_force_public` meta to `yes`.
4. Create a second published post. Set the same meta to `yes`.
5. Set the second post's `newspack_content_restriction_is_exempt` meta to an empty string.
6. Create a published content gate. Restrict all Posts to registered readers.
7. Open both posts in a logged-out browser. Confirm both show the gate.
8. Run `wp newspack migrate-post-exemptions`.
9. Confirm the summary reports one "No Row" and one "Falsy Row".
10. Confirm neither post's exemption meta changed.
11. Run `wp newspack migrate-post-exemptions --live`.
12. Confirm both posts now hold `newspack_content_restriction_is_exempt` = `1`.
13. Open both posts in a logged-out browser. Confirm neither shows the gate.
14. Run `wp newspack migrate-post-exemptions --live` again.
15. Confirm it reports 0 recorded and 2 already exempt.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Full `newspack-plugin` PHPUnit suite and PHPCS pass on this base. The six new tests were mutation-checked: reading the exemption through `get_post_meta()`, skipping falsy rows, dropping the `meta_value = 'yes'` filter, widening the post-type scope, writing during a dry-run, and dropping the revoked-flag report each turn at least one of them red.

* Recording an exemption is additive, so one that an earlier live run wrote survives the publisher later unchecking the box — the command only ever selects `yes` rows. Those posts would stay public after cutover, so they are named for review at the end of every run. They are not cleared: the same shape is also an exemption an editor set deliberately.
* No parallel `main` PR: the standing `sync/release-to-main-*` merge carries it, as it did for #873, #833 and #821. Verified this version also passes `main`'s full suite (3313 tests), so the sync needs no fix-ups.
* Follow-up worth its own issue: once #855 is in a site's build, the inference means a falsy row on a force-public post is more likely a deliberate revocation than editor noise. A `--skip-falsy` flag would let an operator take the safe half on an already-flipped site. Deliberately not in this PR — before #855 ships there is nothing ambiguous to protect.


