### PR TITLE
fix(e2e): gate the /_email sendbox behind a per-run secret

### DIFF
--- a/e2e/.env-sample
+++ b/e2e/.env-sample
@@ -16,3 +16,10 @@ ADMIN_PASSWORD="password"
 # Stripe test-mode keys (enables the WooCommerce Stripe gateway during setup).
 # STRIPE_PUB_KEY=""
 # STRIPE_SECRET_KEY=""
+
+# Shared secret that gates the /_email sendbox (which exposes captured reader
+# emails). Optional for LOCAL targets (localhost / *.test / *.local / 127.x): setup
+# falls back to the "newspack-e2e-local" dev default. REQUIRED for any non-local
+# (staging/remote) target — provisioning hard-errors without it rather than serve
+# the sendbox with a guessable secret. Set a strong value here for staging runs.
+# E2E_EMAIL_SENDBOX_SECRET=""

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -42,6 +42,15 @@ The build is parameterised by these variables (set in TeamCity, not committed):
    variables). `setupSite` forwards them to the remote provisioning, which applies
    them to the WooCommerce Stripe gateway so the `@with-woo` donation test can
    complete. See also the "Payments" section below.
+4. `E2E_EMAIL_SENDBOX_SECRET` – shared secret gating the `/_email` sendbox, which
+   exposes captured reader emails (password-reset and verification links).
+   **Required for any non-local target**: provisioning hard-errors as a precondition
+   (before rebuilding the site) rather than serve the sendbox with a guessable
+   default. `setupSite` forwards it to the remote provisioning, which writes the
+   `NEWSPACK_E2E_SENDBOX_SECRET` wp-config constant, and the suite sends it as a
+   request header when reading the sendbox. Local runs fall back to a committed dev
+   default, so this is unset for local development. Generate a strong value
+   (`openssl rand -hex 32`) and treat it as a credential.
 
 ### Payments
 

--- a/e2e/e2e-plugin.php
+++ b/e2e/e2e-plugin.php
@@ -126,7 +126,7 @@ add_action(
 			// timing-safe.
 			$configured_secret = defined( 'NEWSPACK_E2E_SENDBOX_SECRET' ) ? (string) constant( 'NEWSPACK_E2E_SENDBOX_SECRET' ) : '';
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Read-only, secret-gated endpoint so a nonce doesn't apply; the value is compared via hash_equals against a configured secret and never output, and sanitizing would alter the string being matched.
-			$provided_secret = isset( $_GET['secret'] ) ? (string) wp_unslash( $_GET['secret'] ) : '';
+			$provided_secret = isset( $_GET['secret'] ) && is_string( $_GET['secret'] ) ? (string) wp_unslash( $_GET['secret'] ) : '';
 			if ( '' === $configured_secret || ! hash_equals( $configured_secret, $provided_secret ) ) {
 				status_header( 403 );
 				header( 'Content-Type: text/plain' );

--- a/e2e/e2e-plugin.php
+++ b/e2e/e2e-plugin.php
@@ -17,16 +17,16 @@ defined( 'ABSPATH' ) || exit;
 /*
  * Refuse to do anything unless the site was provisioned as an e2e target.
  *
- * Everything below is destructive outside a throwaway site: /_email publishes
- * every captured message — password-reset and magic links included — to
- * unauthenticated visitors, pre_wp_mail swallows all outgoing mail while
- * reporting success, and the logout endpoint answers without a nonce. Those are
- * the behaviours the suite needs, so the safeguard is refusing to run anywhere
- * else rather than softening them.
+ * Everything below is unsafe outside a throwaway site: /_email exposes every
+ * captured message — password-reset and magic links included — pre_wp_mail
+ * swallows all outgoing mail while reporting success, and the logout endpoint
+ * answers without a nonce. Two safeguards keep that contained: this constant
+ * gate makes a stray copy onto any other site inert, and /_email additionally
+ * requires the per-run NEWSPACK_E2E_SENDBOX_SECRET, so an e2e host that is
+ * internet-reachable (staging) still won't hand its captured mail to anyone.
  *
- * e2e-setup.sh writes this constant to wp-config.php before it installs and
- * activates this plugin, so a correctly provisioned site always has it and a
- * stray copy onto any other site is inert.
+ * e2e-setup.sh writes both constants to wp-config.php before it installs and
+ * activates this plugin, so a correctly provisioned site always has them.
  */
 if ( ! defined( 'NEWSPACK_IS_E2E' ) || ! NEWSPACK_IS_E2E ) {
 	return;
@@ -116,6 +116,23 @@ add_action(
 	function () {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Compared against a literal prefix and never output; a sanitizer would alter the string being matched.
 		if ( isset( $_SERVER['REQUEST_URI'] ) && str_starts_with( wp_unslash( $_SERVER['REQUEST_URI'] ), '/_email' ) ) {
+			// The sendbox dumps every captured outgoing email — including reader
+			// password-reset and account-verification links — so it must never be
+			// served to an unauthenticated visitor. Gate it behind a per-run shared
+			// secret that provisioning writes to the NEWSPACK_E2E_SENDBOX_SECRET
+			// constant, and fail closed (403) — before emitting any email content —
+			// whenever that constant is unset/empty or the request does not present
+			// a matching `secret` query arg. hash_equals keeps the compare
+			// timing-safe.
+			$configured_secret = defined( 'NEWSPACK_E2E_SENDBOX_SECRET' ) ? (string) constant( 'NEWSPACK_E2E_SENDBOX_SECRET' ) : '';
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Read-only, secret-gated endpoint so a nonce doesn't apply; the value is compared via hash_equals against a configured secret and never output, and sanitizing would alter the string being matched.
+			$provided_secret = isset( $_GET['secret'] ) ? (string) wp_unslash( $_GET['secret'] ) : '';
+			if ( '' === $configured_secret || ! hash_equals( $configured_secret, $provided_secret ) ) {
+				status_header( 403 );
+				header( 'Content-Type: text/plain' );
+				echo 'Forbidden';
+				exit;
+			}
 			header( 'Content-Type: text/html' );
 			?>
 			<html><head><title>Email Sendbox</title></head><body>

--- a/e2e/e2e-plugin.php
+++ b/e2e/e2e-plugin.php
@@ -116,23 +116,50 @@ add_action(
 	function () {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Compared against a literal prefix and never output; a sanitizer would alter the string being matched.
 		if ( isset( $_SERVER['REQUEST_URI'] ) && str_starts_with( wp_unslash( $_SERVER['REQUEST_URI'] ), '/_email' ) ) {
+			// The gate below varies the response on a secret request header, but page
+			// caches key on the URL, not that header — so a stored authorized 200
+			// would be replayed to an unauthenticated request at the same URL, a
+			// bypass. Exclude every /_email response from the page cache before the
+			// gate runs. batcache_cancel() is the load-bearing one on WordPress.com /
+			// Atomic: Batcache serves stored copies before plugins load, so stopping
+			// the store is the only reliable point (this Batcache ignores
+			// DONOTCACHEPAGE, which is kept only for other page caches on other
+			// hosts). nocache_headers() on each branch below covers the edge, proxies
+			// and browser. batcache_cancel() is defined only on cached web requests,
+			// hence the guard.
+			if ( function_exists( 'batcache_cancel' ) ) {
+				batcache_cancel();
+			}
+			if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+				define( 'DONOTCACHEPAGE', true );
+			}
 			// The sendbox dumps every captured outgoing email — including reader
 			// password-reset and account-verification links — so it must never be
 			// served to an unauthenticated visitor. Gate it behind a per-run shared
 			// secret that provisioning writes to the NEWSPACK_E2E_SENDBOX_SECRET
 			// constant, and fail closed (403) — before emitting any email content —
 			// whenever that constant is unset/empty or the request does not present
-			// a matching `secret` query arg. hash_equals keeps the compare
-			// timing-safe.
+			// a matching secret. The secret travels in a request header, not the URL,
+			// so it stays out of access logs, published Playwright artifacts and
+			// browser history; hash_equals keeps the compare timing-safe. Both
+			// branches send no-cache headers so an intermediary — the managed edge in
+			// front of a non-local target, which this repo can't inspect or pin —
+			// can't retain either the dump or the refusal.
 			$configured_secret = defined( 'NEWSPACK_E2E_SENDBOX_SECRET' ) ? (string) constant( 'NEWSPACK_E2E_SENDBOX_SECRET' ) : '';
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Read-only, secret-gated endpoint so a nonce doesn't apply; the value is compared via hash_equals against a configured secret and never output, and sanitizing would alter the string being matched.
-			$provided_secret = isset( $_GET['secret'] ) && is_string( $_GET['secret'] ) ? (string) wp_unslash( $_GET['secret'] ) : '';
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Compared via hash_equals against a configured secret and never output; sanitizing would alter the string being matched.
+			$provided_secret = isset( $_SERVER['HTTP_X_NEWSPACK_E2E_SENDBOX_SECRET'] ) && is_string( $_SERVER['HTTP_X_NEWSPACK_E2E_SENDBOX_SECRET'] ) ? (string) wp_unslash( $_SERVER['HTTP_X_NEWSPACK_E2E_SENDBOX_SECRET'] ) : '';
 			if ( '' === $configured_secret || ! hash_equals( $configured_secret, $provided_secret ) ) {
+				nocache_headers();
 				status_header( 403 );
 				header( 'Content-Type: text/plain' );
 				echo 'Forbidden';
 				exit;
 			}
+			nocache_headers();
+			// The sendbox renders captured email HTML verbatim — a page of links — so
+			// suppress the Referer to keep the request URL out of any off-site
+			// request a followed link might trigger.
+			header( 'Referrer-Policy: no-referrer' );
 			header( 'Content-Type: text/html' );
 			?>
 			<html><head><title>Email Sendbox</title></head><body>

--- a/e2e/e2e-setup.sh
+++ b/e2e/e2e-setup.sh
@@ -121,6 +121,42 @@ wp --skip-plugins --skip-themes config set NEWSPACK_IS_E2E true --raw
 # Note: this flag is slated for removal upstream.
 wp --skip-plugins --skip-themes config set NEWSPACK_EMAIL_CHANGE_ENABLED true --raw
 
+# Email sendbox secret gate. The /_email sendbox in e2e-plugin.php dumps every
+# captured outgoing email (reader password-reset / verification links included),
+# so the plugin fails closed (403) unless NEWSPACK_E2E_SENDBOX_SECRET is set and
+# the request presents a matching `secret`. We provision that constant here.
+#
+# Host-awareness mirrors isLocalTarget() in tests/site-setup.ts: a target is
+# "local" when its host is localhost / 127.x / *.test / *.local. Local targets are
+# not internet-reachable, so a convenient committed default is acceptable when no
+# secret is supplied. For ANY non-local (staging/remote) target we refuse to fall
+# back to that public default: a strong E2E_EMAIL_SENDBOX_SECRET must be provided,
+# or we hard-error here rather than serve the sendbox with a guessable secret on an
+# internet-reachable host.
+SENDBOX_HOST="${SITE_URL#*://}"   # strip scheme
+SENDBOX_HOST="${SENDBOX_HOST%%/*}"  # strip path
+SENDBOX_HOST="${SENDBOX_HOST%%:*}"  # strip port
+case "$SENDBOX_HOST" in
+  localhost|127.*|*.test|*.local)
+    SENDBOX_IS_LOCAL=true
+    ;;
+  *)
+    SENDBOX_IS_LOCAL=false
+    ;;
+esac
+if [ -n "${E2E_EMAIL_SENDBOX_SECRET:-}" ]; then
+  SENDBOX_SECRET="$E2E_EMAIL_SENDBOX_SECRET"
+elif [ "$SENDBOX_IS_LOCAL" = true ]; then
+  SENDBOX_SECRET="newspack-e2e-local"
+else
+  echo "ERROR: E2E_EMAIL_SENDBOX_SECRET must be set for the non-local target '$SITE_URL'." >&2
+  echo "       The /_email sendbox exposes captured reader emails; refusing to enable it" >&2
+  echo "       with the public default secret on an internet-reachable host. Set a strong" >&2
+  echo "       E2E_EMAIL_SENDBOX_SECRET (forwarded by the suite) and re-run." >&2
+  exit 1
+fi
+wp --skip-plugins --skip-themes config set NEWSPACK_E2E_SENDBOX_SECRET "$SENDBOX_SECRET"
+
 wp --skip-themes option update timezone_string 'America/New_York'
 
 # Sync the e2e helper plugin from the repo copy so the running plugin always

--- a/e2e/e2e-setup.sh
+++ b/e2e/e2e-setup.sh
@@ -101,6 +101,47 @@ else
   E2E_PLUGIN_SRC="$(dirname "$0")/e2e-plugin.php"
 fi
 
+# Resolve the sendbox secret BEFORE the destructive site-setup.sh run below, so a
+# misconfigured target fails as a precondition rather than after the site has been
+# wiped and switched into e2e mode. The /_email sendbox in e2e-plugin.php exposes
+# every captured outgoing email (reader password-reset / verification links), so it
+# fails closed (403) unless the NEWSPACK_E2E_SENDBOX_SECRET constant matches a
+# secret the request presents in a header. We resolve that secret here and write
+# the constant once WordPress is installed (further below).
+#
+# Host classification mirrors isLocalTarget() in tests/site-setup.ts. Normalise
+# SITE_URL to a bare, lowercased host the same way new URL().hostname does — strip
+# scheme, then path/query/fragment, then userinfo, then port, then lowercase — so a
+# stray component can't survive a naive strip and win a false "local" verdict, the
+# one direction that must not fail (local selects the committed default secret). A
+# target is local when its host is localhost / 127.* / *.test / *.local; every other
+# (non-local, internet-reachable) target must supply a strong E2E_EMAIL_SENDBOX_SECRET
+# or we refuse to run.
+SENDBOX_HOST="${SITE_URL#*://}"          # strip scheme
+SENDBOX_HOST="${SENDBOX_HOST%%[/?#]*}"   # strip path, query and fragment (first of / ? #)
+SENDBOX_HOST="${SENDBOX_HOST##*@}"       # strip userinfo (user:pass@)
+SENDBOX_HOST="${SENDBOX_HOST%%:*}"       # strip port
+SENDBOX_HOST="$( printf '%s' "$SENDBOX_HOST" | tr '[:upper:]' '[:lower:]' )"
+case "$SENDBOX_HOST" in
+  localhost|127.*|*.test|*.local)
+    SENDBOX_IS_LOCAL=true
+    ;;
+  *)
+    SENDBOX_IS_LOCAL=false
+    ;;
+esac
+if [ -n "${E2E_EMAIL_SENDBOX_SECRET:-}" ]; then
+  SENDBOX_SECRET="$E2E_EMAIL_SENDBOX_SECRET"
+elif [ "$SENDBOX_IS_LOCAL" = true ]; then
+  SENDBOX_SECRET="newspack-e2e-local"
+else
+  echo "ERROR: E2E_EMAIL_SENDBOX_SECRET must be set for the non-local target '$SITE_URL'." >&2
+  echo "       The /_email sendbox exposes captured reader emails; refusing to enable it" >&2
+  echo "       with the public default secret on an internet-reachable host. Set a strong" >&2
+  echo "       E2E_EMAIL_SENDBOX_SECRET (forwarded by the suite) and re-run." >&2
+  exit 1
+fi
+
 echo "==> Running site-setup.sh (woo=$WOO)"
 SITE_SETUP_ARGS=(
   --posts-count 20      # A handful is plenty for e2e; 40 is slow to generate.
@@ -121,40 +162,8 @@ wp --skip-plugins --skip-themes config set NEWSPACK_IS_E2E true --raw
 # Note: this flag is slated for removal upstream.
 wp --skip-plugins --skip-themes config set NEWSPACK_EMAIL_CHANGE_ENABLED true --raw
 
-# Email sendbox secret gate. The /_email sendbox in e2e-plugin.php dumps every
-# captured outgoing email (reader password-reset / verification links included),
-# so the plugin fails closed (403) unless NEWSPACK_E2E_SENDBOX_SECRET is set and
-# the request presents a matching `secret`. We provision that constant here.
-#
-# Host-awareness mirrors isLocalTarget() in tests/site-setup.ts: a target is
-# "local" when its host is localhost / 127.x / *.test / *.local. Local targets are
-# not internet-reachable, so a convenient committed default is acceptable when no
-# secret is supplied. For ANY non-local (staging/remote) target we refuse to fall
-# back to that public default: a strong E2E_EMAIL_SENDBOX_SECRET must be provided,
-# or we hard-error here rather than serve the sendbox with a guessable secret on an
-# internet-reachable host.
-SENDBOX_HOST="${SITE_URL#*://}"   # strip scheme
-SENDBOX_HOST="${SENDBOX_HOST%%/*}"  # strip path
-SENDBOX_HOST="${SENDBOX_HOST%%:*}"  # strip port
-case "$SENDBOX_HOST" in
-  localhost|127.*|*.test|*.local)
-    SENDBOX_IS_LOCAL=true
-    ;;
-  *)
-    SENDBOX_IS_LOCAL=false
-    ;;
-esac
-if [ -n "${E2E_EMAIL_SENDBOX_SECRET:-}" ]; then
-  SENDBOX_SECRET="$E2E_EMAIL_SENDBOX_SECRET"
-elif [ "$SENDBOX_IS_LOCAL" = true ]; then
-  SENDBOX_SECRET="newspack-e2e-local"
-else
-  echo "ERROR: E2E_EMAIL_SENDBOX_SECRET must be set for the non-local target '$SITE_URL'." >&2
-  echo "       The /_email sendbox exposes captured reader emails; refusing to enable it" >&2
-  echo "       with the public default secret on an internet-reachable host. Set a strong" >&2
-  echo "       E2E_EMAIL_SENDBOX_SECRET (forwarded by the suite) and re-run." >&2
-  exit 1
-fi
+# Write the sendbox secret (resolved as a precondition above, before site-setup.sh)
+# into wp-config.php, now that WordPress is installed so the constant survives.
 wp --skip-plugins --skip-themes config set NEWSPACK_E2E_SENDBOX_SECRET "$SENDBOX_SECRET"
 
 wp --skip-themes option update timezone_string 'America/New_York'

--- a/e2e/tests/sendbox-access-control.spec.ts
+++ b/e2e/tests/sendbox-access-control.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+
+// Regression guard for the /_email sendbox access control (NPPM-3067).
+//
+// The sendbox dumps every captured outgoing email — reader password-reset and
+// account-verification links included — and e2e-plugin.php serves it on any
+// internet-reachable host that is provisioned as an e2e target (staging is one).
+// It is gated behind a per-run shared secret that provisioning writes to the
+// NEWSPACK_E2E_SENDBOX_SECRET constant; a request that does not present a
+// matching `secret` must be refused before any email content is emitted. These
+// tests fail against the pre-fix plugin, which answered every request with 200
+// and the full email dump.
+//
+// The secret mirrors the fallback in utils.ts / e2e-setup.sh, so a local run with
+// no E2E_EMAIL_SENDBOX_SECRET set exercises the same value provisioning used.
+const sendboxSecret = process.env.E2E_EMAIL_SENDBOX_SECRET || "newspack-e2e-local";
+
+test.describe("Email sendbox access control", () => {
+  test("refuses a request with no secret", { tag: "@vanilla" }, async ({ page }) => {
+    const response = await page.goto("/_email");
+    expect(response?.status()).toBe(403);
+    await expect(page.getByText("Email Sendbox")).toHaveCount(0);
+  });
+
+  test("refuses a request with the wrong secret", { tag: "@vanilla" }, async ({ page }) => {
+    const response = await page.goto("/_email?secret=not-the-sendbox-secret");
+    expect(response?.status()).toBe(403);
+    await expect(page.getByText("Email Sendbox")).toHaveCount(0);
+  });
+
+  test("serves the sendbox with the correct secret", { tag: "@vanilla" }, async ({ page }) => {
+    const response = await page.goto(`/_email?secret=${encodeURIComponent(sendboxSecret)}`);
+    expect(response?.status()).toBe(200);
+    await expect(page.getByRole("heading", { name: "Email Sendbox" })).toBeVisible();
+  });
+});

--- a/e2e/tests/sendbox-access-control.spec.ts
+++ b/e2e/tests/sendbox-access-control.spec.ts
@@ -36,4 +36,24 @@ test.describe("Email sendbox access control", () => {
     expect(response?.status()).toBe(200);
     await expect(page.getByRole("heading", { name: "Email Sendbox" })).toBeVisible();
   });
+
+  // Guards the page-cache exclusion (batcache_cancel() in e2e-plugin.php). The
+  // secret rides a header, which page caches don't key on, so a stored authorized
+  // 200 would otherwise be replayed to an unauthenticated request at the same URL.
+  // Batcache stores a page after two accesses, so prime one URL with two authorized
+  // loads, then confirm an unauthenticated load of that same URL is still refused
+  // rather than served the cached dump. A fresh, unique URL keeps the probe from
+  // colliding with a neighbouring run's cache. Without the exclusion this fails with
+  // a cached 200; note it can only fail where a page cache is active (it may pass
+  // trivially on an uncached target).
+  test("does not serve a cached authorized page to an unauthenticated request", { tag: "@vanilla" }, async ({ page }) => {
+    const url = `/_email?cache-probe=${Date.now()}`;
+    await page.setExtraHTTPHeaders({ [SENDBOX_SECRET_HEADER]: emailSendboxSecret() });
+    await page.goto(url);
+    await page.goto(url); // Second authorized hit crosses the cache's store threshold.
+    await page.setExtraHTTPHeaders({});
+    const response = await page.goto(url);
+    expect(response?.status()).toBe(403);
+    await expect(page.getByText("Email Sendbox")).toHaveCount(0);
+  });
 });

--- a/e2e/tests/sendbox-access-control.spec.ts
+++ b/e2e/tests/sendbox-access-control.spec.ts
@@ -1,35 +1,38 @@
 import { test, expect } from "@playwright/test";
+import { emailSendboxSecret, SENDBOX_SECRET_HEADER } from "./utils";
 
-// Regression guard for the /_email sendbox access control (NPPM-3067).
+// Regression guard for the /_email sendbox access control.
 //
 // The sendbox dumps every captured outgoing email — reader password-reset and
 // account-verification links included — and e2e-plugin.php serves it on any
-// internet-reachable host that is provisioned as an e2e target (staging is one).
-// It is gated behind a per-run shared secret that provisioning writes to the
-// NEWSPACK_E2E_SENDBOX_SECRET constant; a request that does not present a
-// matching `secret` must be refused before any email content is emitted. These
-// tests fail against the pre-fix plugin, which answered every request with 200
-// and the full email dump.
+// internet-reachable host provisioned as an e2e target (staging is one). It is
+// gated behind a per-run shared secret that provisioning writes to the
+// NEWSPACK_E2E_SENDBOX_SECRET constant; a request that does not present a matching
+// secret header must be refused before any email content is emitted. These tests
+// fail against the pre-fix plugin, which answered every request with 200 and the
+// full email dump.
 //
-// The secret mirrors the fallback in utils.ts / e2e-setup.sh, so a local run with
-// no E2E_EMAIL_SENDBOX_SECRET set exercises the same value provisioning used.
-const sendboxSecret = process.env.E2E_EMAIL_SENDBOX_SECRET || "newspack-e2e-local";
-
+// The header name and the secret's local-default fallback are shared with the
+// suite's own reader (utils.ts), so a zero-config local run exercises the same
+// value provisioning used.
 test.describe("Email sendbox access control", () => {
   test("refuses a request with no secret", { tag: "@vanilla" }, async ({ page }) => {
+    await page.setExtraHTTPHeaders({});
     const response = await page.goto("/_email");
     expect(response?.status()).toBe(403);
     await expect(page.getByText("Email Sendbox")).toHaveCount(0);
   });
 
   test("refuses a request with the wrong secret", { tag: "@vanilla" }, async ({ page }) => {
-    const response = await page.goto("/_email?secret=not-the-sendbox-secret");
+    await page.setExtraHTTPHeaders({ [SENDBOX_SECRET_HEADER]: "not-the-sendbox-secret" });
+    const response = await page.goto("/_email");
     expect(response?.status()).toBe(403);
     await expect(page.getByText("Email Sendbox")).toHaveCount(0);
   });
 
   test("serves the sendbox with the correct secret", { tag: "@vanilla" }, async ({ page }) => {
-    const response = await page.goto(`/_email?secret=${encodeURIComponent(sendboxSecret)}`);
+    await page.setExtraHTTPHeaders({ [SENDBOX_SECRET_HEADER]: emailSendboxSecret() });
+    const response = await page.goto("/_email");
     expect(response?.status()).toBe(200);
     await expect(page.getByRole("heading", { name: "Email Sendbox" })).toBeVisible();
   });

--- a/e2e/tests/site-setup.ts
+++ b/e2e/tests/site-setup.ts
@@ -79,8 +79,11 @@ export const setupSite = ({ woo }: SetupOptions): void => {
   const siteSetup = readFileSync(SITE_SETUP_PATH);
   const e2ePlugin = readFileSync(E2E_PLUGIN_PATH);
   const args = scriptArgs(woo);
-  // Forward Stripe test keys (if present) into the target environment.
+  // Forward Stripe test keys (if present) into the target environment, plus the
+  // /_email sendbox secret. When it's unset, e2e-setup.sh applies its host-aware
+  // policy: a local-dev default for local targets, a hard error for non-local ones.
   const stripeEnv = ["STRIPE_PUB_KEY", "STRIPE_SECRET_KEY"];
+  const setupEnv = [...stripeEnv, "E2E_EMAIL_SENDBOX_SECRET"];
 
   if (isLocalTarget(siteUrl)) {
     const container = containerForHost(siteUrl);
@@ -93,7 +96,7 @@ export const setupSite = ({ woo }: SetupOptions): void => {
     execFileSync("docker", ["cp", E2E_PLUGIN_PATH, `${container}:${REMOTE_E2E_PLUGIN}`], {
       stdio: ["ignore", "inherit", "inherit"],
     });
-    const envForwards = stripeEnv.flatMap((v) => (process.env[v] ? ["-e", v] : []));
+    const envForwards = setupEnv.flatMap((v) => (process.env[v] ? ["-e", v] : []));
     execFileSync(
       "docker",
       [
@@ -144,7 +147,7 @@ export const setupSite = ({ woo }: SetupOptions): void => {
   const inlineEnv = [
     `SITE_SETUP_SCRIPT=${shQuote(REMOTE_SITE_SETUP)}`,
     `E2E_PLUGIN_SRC=${shQuote(REMOTE_E2E_PLUGIN)}`,
-    ...stripeEnv
+    ...setupEnv
       .filter((v) => process.env[v])
       .map((v) => `${v}=${shQuote(process.env[v] as string)}`),
   ].join(" ");

--- a/e2e/tests/utils.ts
+++ b/e2e/tests/utils.ts
@@ -7,14 +7,24 @@ export const randomString = (length = 8) =>
 
 export const randomEmailAddress = () => `test-${randomString()}@example.com`;
 
+// The /_email sendbox is gated behind a per-run shared secret (see e2e-plugin.php
+// and e2e-setup.sh); requests without a matching `secret` get a 403. The secret is
+// forwarded from the environment, falling back to the committed local-dev default
+// that e2e-setup.sh also uses for local targets, so zero-config local runs work.
+const emailSendboxSecret = (): string =>
+  process.env.E2E_EMAIL_SENDBOX_SECRET || "newspack-e2e-local";
+
 // Open an email in the dev "Email Sendbox" (/_email) by its subject + recipient.
 // Emails are saved asynchronously and the sendbox is a static page, so we reload
 // until the message shows up instead of trusting a single load (otherwise a
 // message that arrives after the page render is never seen).
 export const openEmail = async (page, subjectPrefix, emailAddress) => {
   const emailLink = page.getByText(`${subjectPrefix} (${emailAddress}`);
+  const secret = encodeURIComponent(emailSendboxSecret());
   await expect(async () => {
-    await page.goto(`/_email?cachebust=${emailAddress}-${Date.now()}`);
+    await page.goto(
+      `/_email?secret=${secret}&cachebust=${emailAddress}-${Date.now()}`
+    );
     await expect(emailLink).toBeVisible({ timeout: 1000 });
   }).toPass({ timeout: 30000 });
   await emailLink.click();

--- a/e2e/tests/utils.ts
+++ b/e2e/tests/utils.ts
@@ -8,26 +8,33 @@ export const randomString = (length = 8) =>
 export const randomEmailAddress = () => `test-${randomString()}@example.com`;
 
 // The /_email sendbox is gated behind a per-run shared secret (see e2e-plugin.php
-// and e2e-setup.sh); requests without a matching `secret` get a 403. The secret is
-// forwarded from the environment, falling back to the committed local-dev default
-// that e2e-setup.sh also uses for local targets, so zero-config local runs work.
-const emailSendboxSecret = (): string =>
+// and e2e-setup.sh). The suite sends it as a request header — never in the URL — so
+// it stays out of access logs, published Playwright artifacts and browser history.
+// The value is read from the environment, falling back to the committed local-dev
+// default that e2e-setup.sh also uses for local targets, so zero-config local runs
+// work.
+export const SENDBOX_SECRET_HEADER = "X-Newspack-E2E-Sendbox-Secret";
+export const emailSendboxSecret = (): string =>
   process.env.E2E_EMAIL_SENDBOX_SECRET || "newspack-e2e-local";
 
 // Open an email in the dev "Email Sendbox" (/_email) by its subject + recipient.
 // Emails are saved asynchronously and the sendbox is a static page, so we reload
 // until the message shows up instead of trusting a single load (otherwise a
-// message that arrives after the page render is never seen).
+// message that arrives after the page render is never seen). The secret header is
+// scoped to these sendbox reads and cleared before returning, so it never rides the
+// reader's subsequent navigations (which load assets from other hosts).
 export const openEmail = async (page, subjectPrefix, emailAddress) => {
   const emailLink = page.getByText(`${subjectPrefix} (${emailAddress}`);
-  const secret = encodeURIComponent(emailSendboxSecret());
-  await expect(async () => {
-    await page.goto(
-      `/_email?secret=${secret}&cachebust=${emailAddress}-${Date.now()}`
-    );
-    await expect(emailLink).toBeVisible({ timeout: 1000 });
-  }).toPass({ timeout: 30000 });
-  await emailLink.click();
+  await page.setExtraHTTPHeaders({ [SENDBOX_SECRET_HEADER]: emailSendboxSecret() });
+  try {
+    await expect(async () => {
+      await page.goto(`/_email?cachebust=${emailAddress}-${Date.now()}`);
+      await expect(emailLink).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 30000 });
+    await emailLink.click();
+  } finally {
+    await page.setExtraHTTPHeaders({});
+  }
 };
 
 // Navigate to the reader's My Account page. We go directly rather than clicking

--- a/e2e/tests/utils.ts
+++ b/e2e/tests/utils.ts
@@ -33,6 +33,10 @@ export const openEmail = async (page, subjectPrefix, emailAddress) => {
     }).toPass({ timeout: 30000 });
     await emailLink.click();
   } finally {
+    // Clearing replaces the whole extra-header set, which is fine while this is the
+    // only code that sets page-level headers (playwright.config.ts sets none). If a
+    // global header is ever added there, capture and restore it here instead —
+    // otherwise this clear silently drops it for the rest of the page's life.
     await page.setExtraHTTPHeaders({});
   }
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `/_email` sendbox in the e2e harness (`e2e/e2e-plugin.php`) renders every captured outgoing email — including reader password-reset and account-verification links — and its only gate was a URL-prefix check. Any request whose path starts with `/_email` got the full dump, with no authentication. The harness only runs where `NEWSPACK_IS_E2E` is defined, but the staging host that runs the suite is defined as an e2e target *and* is internet-reachable, so during a run an outside visitor could open `/_email` and harvest a live reset link before the legitimate flow consumed it.

This gates the sendbox behind a per-run shared secret:

- **`e2e-plugin.php`** returns `403` — before emitting any email content — unless the request presents a secret matching the `NEWSPACK_E2E_SENDBOX_SECRET` constant, compared with `hash_equals`. It fails closed: an unset or empty constant, a missing secret, a wrong one, or a non-string one all get the 403. The secret travels in an **`X-Newspack-E2E-Sendbox-Secret` request header**, not the URL, so it stays out of access logs, the published Playwright artifacts, and browser history. Because a header-gated response and an unauthenticated one share a URL — and page caches key on the URL, not the header — the handler also marks every `/_email` response uncacheable (`batcache_cancel()` for the WP.com/Atomic page cache, `nocache_headers()` for the edge/proxy/browser), so a cached authorized `200` can never be replayed to an unauthenticated request. The served page sends `Referrer-Policy: no-referrer`.
- **`e2e-setup.sh`** resolves that secret **before** the destructive `site-setup.sh` run, so a misconfigured target fails as a precondition rather than after the site is wiped. Local targets (`localhost` / `127.*` / `*.test` / `*.local`, classified with the same normalization as `isLocalTarget()`) fall back to a committed dev default, so zero-config local runs keep working. Any non-local target **hard-errors (`exit 1`)** unless a strong `E2E_EMAIL_SENDBOX_SECRET` is supplied.
- **`site-setup.ts` / `utils.ts`** forward the secret from the run environment through both the local (`docker exec`) and remote (SSH) provisioning paths, and send it as a header when the suite reads the sendbox (scoped to that read and cleared afterward).
- **`README.md`** documents `E2E_EMAIL_SENDBOX_SECRET` as a required CI build parameter.
- A new **`sendbox-access-control.spec.ts`** asserts the gate: no secret → 403, wrong secret → 403, correct secret → 200.

> [!IMPORTANT]
> **Merging this breaks nightly staging setup unless the CI secret is provisioned first.**
> The non-local branch hard-errors by design, so `E2E_EMAIL_SENDBOX_SECRET` must be set in the TeamCity build config — exported into both the provisioning step and the Playwright runner — **before** this merges. The TeamCity definition lives outside this repo, so please sequence the provisioning ahead of the merge; otherwise setup exits before any test runs. See the README parameter list for details.

Note the two names: `E2E_EMAIL_SENDBOX_SECRET` is the environment variable CI provisions; `NEWSPACK_E2E_SENDBOX_SECRET` is the wp-config constant the setup script writes from it.

### How to test the changes in this Pull Request:

This is exercised at the HTTP layer; a reviewer can reproduce it against any site provisioned as an e2e target (local env or staging). Because the secret is a request header now, use `curl` (or any tool that sets headers) rather than a plain browser visit.

**Confirm the leak is closed (the security fix):**

1. Provision a site as an e2e target so `NEWSPACK_IS_E2E` is defined and `e2e-plugin` is active (e.g. run `e2e-setup.sh`, or on a local env set the constant and activate the plugin by hand). Generate at least one captured email — running any reader auth flow, or seeding an `email_log` post — so the sendbox has content.
2. Request `/_email` with **no** secret header. Expect **`403 Forbidden`** with no email content — before this change it returned `200` and the full dump:
   `curl -i https://<site>/_email`
3. Request it **with** the secret header (locally, the committed default `newspack-e2e-local`). Expect **`200`** and the sendbox page:
   `curl -i -H 'X-Newspack-E2E-Sendbox-Secret: <the-secret>' https://<site>/_email`
4. Request it with a **wrong** header value. Expect **`403`**.
5. Confirm the cache can't be used to bypass the gate: request an authorized URL, then request the **same URL with no header** — it must still be `403`, not a cached `200`.

**Confirm the suite still works end-to-end:** run the reader-registration flow — it reads the sendbox via `openEmail`, which now sends the secret header — and confirm it still picks up its magic/reset emails.

<details>
<summary>Automated verification performed on this branch</summary>

Reproduced in an isolated env (constant + plugin + a seeded captured email carrying a fake reset key):

- **Before the fix:** unauthenticated `GET /_email` → `200`, reset key present in the response.
- **After the fix:** no-secret → `403`, wrong-secret → `403`, non-string header → `403`, correct-secret → `200`. No leakage on any refused path.
- **Cache bypass, found and closed:** with the secret in a header, an authorized `200` and an unauthenticated request share a URL, and Batcache keys on the URL. A no-header request to a URL a prior authorized request had populated was served the cached `200` with the full dump — and `nocache_headers()` alone did not prevent it (Batcache serves stored copies before plugins load and ignores `DONOTCACHEPAGE`). `batcache_cancel()` stops Batcache storing the response at all; with it, the same no-header request returns `403` deterministically (4/4), and the response is uncacheable at the edge/proxy/browser via `nocache_headers()`.
- The committed spec runs 3/3 green through Chromium against the env, and fails against the pre-fix plugin (verified by redeploying it), so it genuinely captures the vulnerability.
- `php -l`, `bash -n` on `e2e-setup.sh`, a host-classification simulation (locals → default; `…?x=.test` / `…#.local` / `user@evil.com/path.test` → non-local; empty URL → `exit 1`), and CI-parity PHPCS (root ruleset) all clean.

</details>

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?