### PR TITLE
fix(scheduled-posts): rescue scheduled posts in non-public CPTs

### DIFF
--- a/plugins/newspack-plugin/includes/scheduled-post-checker/scheduled-post-checker.php
+++ b/plugins/newspack-plugin/includes/scheduled-post-checker/scheduled-post-checker.php
@@ -30,6 +30,37 @@ function nspc_deactivate() {
 }
 
 /**
+ * The post types the checker rescues.
+ *
+ * WordPress's `post_type => 'any'` shorthand matches only types whose
+ * `exclude_from_search` is false — which it derives from `public` when the
+ * argument is omitted. Editor-authored types registered `public => false`
+ * (Campaign prompts, Sponsors) are therefore invisible to `'any'`, so a
+ * scheduled one that misses its cron slot would otherwise sit in `future`
+ * indefinitely. Start from the search-visible set and add those known editorial
+ * types; the filter lets any plugin register its own schedulable type.
+ *
+ * @return string[] Post type slugs.
+ */
+function nspc_get_post_types() {
+	$post_types = get_post_types( [ 'exclude_from_search' => false ] );
+
+	foreach ( [ 'newspack_popups_cpt', 'newspack_spnsrs_cpt' ] as $editorial_cpt ) {
+		if ( post_type_exists( $editorial_cpt ) ) {
+			$post_types[ $editorial_cpt ] = $editorial_cpt;
+		}
+	}
+
+	/**
+	 * Filters the post types the scheduled-post checker rescues. Add a slug here
+	 * to have a non-public, editor-scheduled CPT rescued when it misses its slot.
+	 *
+	 * @param string[] $post_types Post type slugs.
+	 */
+	return apply_filters( 'newspack_scheduled_post_checker_post_types', array_values( $post_types ) );
+}
+
+/**
  * Check to see if any posts have missed schedule, and try sending them live again if so.
  */
 function nspc_run_check() {
@@ -37,10 +68,11 @@ function nspc_run_check() {
 
 	$posts_with_missed_schedule = get_posts(
 		[
-			'post_status' => 'future',
-			'post_type'   => 'any',
-			'fields'      => 'ids',
-			'date_query'  => [
+			'post_status'    => 'future',
+			'post_type'      => nspc_get_post_types(),
+			'fields'         => 'ids',
+			'posts_per_page' => -1,
+			'date_query'     => [
 				[
 					'before'    => $time,
 					'inclusive' => false,

--- a/plugins/newspack-plugin/includes/scheduled-post-checker/scheduled-post-checker.php
+++ b/plugins/newspack-plugin/includes/scheduled-post-checker/scheduled-post-checker.php
@@ -71,7 +71,8 @@ function nspc_run_check() {
 			'post_status'    => 'future',
 			'post_type'      => nspc_get_post_types(),
 			'fields'         => 'ids',
-			'posts_per_page' => -1,
+			// Rescue a backlog in one run rather than the get_posts() default of 5.
+			'posts_per_page' => 100,
 			'date_query'     => [
 				[
 					'before'    => $time,

--- a/plugins/newspack-plugin/tests/unit-tests/scheduled-post-checker.php
+++ b/plugins/newspack-plugin/tests/unit-tests/scheduled-post-checker.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Tests the scheduled-post-checker safety net's post-type coverage.
+ *
+ * @package Newspack
+ */
+
+/**
+ * Test the scheduled-post checker.
+ */
+class Scheduled_Post_Checker_Test extends WP_UnitTestCase {
+
+	/**
+	 * CPT slugs registered during a test, unregistered on tear down.
+	 *
+	 * @var string[]
+	 */
+	private $registered_cpts = [];
+
+	/**
+	 * Unregister any CPTs a test registered so they don't leak into the next one.
+	 */
+	public function tear_down() {
+		foreach ( $this->registered_cpts as $cpt ) {
+			if ( post_type_exists( $cpt ) ) {
+				unregister_post_type( $cpt );
+			}
+		}
+		$this->registered_cpts = [];
+		parent::tear_down();
+	}
+
+	/**
+	 * Register a non-public CPT for the duration of a test.
+	 *
+	 * @param string $slug CPT slug (max 20 chars, per register_post_type()).
+	 * @param array  $args Registration args, merged over a non-public default.
+	 */
+	private function register_test_cpt( $slug, $args = [] ) {
+		register_post_type(
+			$slug,
+			array_merge(
+				[
+					'public'   => false,
+					'supports' => [ 'title' ],
+				],
+				$args
+			)
+		);
+		$this->registered_cpts[] = $slug;
+	}
+
+	/**
+	 * Create a post in the exact state a missed cron slot leaves: `future` status
+	 * with a publish time already in the past.
+	 *
+	 * Written straight to the DB because both wp_insert_post() and wp_update_post()
+	 * coerce a `future` post with a past date to `publish`, so the stuck state
+	 * can't be produced through the normal API.
+	 *
+	 * @param string $post_type Post type.
+	 * @return int Post ID.
+	 */
+	private function create_overdue_future_post( $post_type ) {
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'   => $post_type,
+				'post_status' => 'draft',
+			]
+		);
+
+		global $wpdb;
+		$past = gmdate( 'Y-m-d H:i:s', time() - HOUR_IN_SECONDS );
+		$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->posts,
+			[
+				'post_status'   => 'future',
+				'post_date'     => $past,
+				'post_date_gmt' => $past,
+			],
+			[ 'ID' => $post_id ]
+		);
+		clean_post_cache( $post_id );
+
+		$this->assertSame( 'future', get_post_status( $post_id ), 'Precondition: scheduled (future) with a past slot.' );
+		return $post_id;
+	}
+
+	/**
+	 * The rescued-type list covers the known non-public editorial CPTs and the
+	 * search-visible types, and is filterable.
+	 */
+	public function test_post_type_list_covers_hidden_editorial_cpts() {
+		// Simulate the popups and sponsors plugins being active.
+		$this->register_test_cpt( 'newspack_popups_cpt' );
+		$this->register_test_cpt( 'newspack_spnsrs_cpt' );
+
+		$post_types = \Newspack\Scheduled_Post_Checker\nspc_get_post_types();
+
+		$this->assertContains( 'newspack_popups_cpt', $post_types, 'Campaign prompts are covered.' );
+		$this->assertContains( 'newspack_spnsrs_cpt', $post_types, 'Sponsors are covered.' );
+		$this->assertContains( 'post', $post_types, 'Search-visible types are still covered.' );
+
+		// An unrelated non-public CPT is not swept in by default.
+		$this->register_test_cpt( 'nspc_unrelated' );
+		$this->assertNotContains( 'nspc_unrelated', \Newspack\Scheduled_Post_Checker\nspc_get_post_types(), 'Unlisted hidden types are not rescued by default.' );
+
+		// ...but the filter lets a plugin opt one in.
+		$filter = function ( $types ) {
+			$types[] = 'nspc_unrelated';
+			return $types;
+		};
+		add_filter( 'newspack_scheduled_post_checker_post_types', $filter );
+		$this->assertContains( 'nspc_unrelated', \Newspack\Scheduled_Post_Checker\nspc_get_post_types(), 'The filter can register a schedulable type.' );
+		remove_filter( 'newspack_scheduled_post_checker_post_types', $filter );
+	}
+
+	/**
+	 * A scheduled post in a non-public CPT that missed its slot is republished.
+	 * The bug was that `post_type => 'any'` never saw it.
+	 */
+	public function test_rescues_missed_schedule_in_hidden_cpt() {
+		$this->register_test_cpt( 'nspc_hidden' );
+		add_filter(
+			'newspack_scheduled_post_checker_post_types',
+			function ( $types ) {
+				$types[] = 'nspc_hidden';
+				return $types;
+			}
+		);
+
+		$hidden_id = $this->create_overdue_future_post( 'nspc_hidden' );
+		$public_id = $this->create_overdue_future_post( 'post' );
+
+		// The old `post_type => 'any'` query never sees the hidden post — the bug.
+		$seen_by_any = get_posts(
+			[
+				'post_status' => 'future',
+				'post_type'   => 'any',
+				'fields'      => 'ids',
+			]
+		);
+		$this->assertNotContains( $hidden_id, $seen_by_any, 'A non-public CPT is invisible to post_type => any.' );
+
+		\Newspack\Scheduled_Post_Checker\nspc_run_check();
+
+		$this->assertSame( 'publish', get_post_status( $hidden_id ), 'The missed pop-up/sponsor-style post is rescued.' );
+		$this->assertSame( 'publish', get_post_status( $public_id ), 'Search-visible posts are still rescued.' );
+	}
+
+	/**
+	 * A non-public CPT nobody opted in stays scheduled — the fix is scoped, not a
+	 * blanket "publish every future post regardless of type".
+	 */
+	public function test_does_not_rescue_unlisted_hidden_cpt() {
+		$this->register_test_cpt( 'nspc_untracked' );
+		$post_id = $this->create_overdue_future_post( 'nspc_untracked' );
+
+		\Newspack\Scheduled_Post_Checker\nspc_run_check();
+
+		$this->assertSame( 'future', get_post_status( $post_id ), 'An unlisted hidden type is left alone.' );
+	}
+
+	/**
+	 * More than five missed posts are all rescued in a single run — the default
+	 * get_posts() limit of 5 used to strand the rest.
+	 */
+	public function test_rescues_more_than_five_missed_posts() {
+		$ids = [];
+		for ( $i = 0; $i < 6; $i++ ) {
+			$ids[] = $this->create_overdue_future_post( 'post' );
+		}
+
+		\Newspack\Scheduled_Post_Checker\nspc_run_check();
+
+		foreach ( $ids as $id ) {
+			$this->assertSame( 'publish', get_post_status( $id ), 'Every missed post is rescued, not just the first five.' );
+		}
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/scheduled-post-checker.php
+++ b/plugins/newspack-plugin/tests/unit-tests/scheduled-post-checker.php
@@ -18,7 +18,16 @@ class Scheduled_Post_Checker_Test extends WP_UnitTestCase {
 	private $registered_cpts = [];
 
 	/**
-	 * Unregister any CPTs a test registered so they don't leak into the next one.
+	 * Filters added during a test, as [ hook, callback ] pairs, removed on tear
+	 * down. Keeping the callback is what makes an anonymous one removable.
+	 *
+	 * @var array[]
+	 */
+	private $added_filters = [];
+
+	/**
+	 * Undo anything a test registered so it can't leak into the next one — test
+	 * order isn't guaranteed.
 	 */
 	public function tear_down() {
 		foreach ( $this->registered_cpts as $cpt ) {
@@ -26,8 +35,24 @@ class Scheduled_Post_Checker_Test extends WP_UnitTestCase {
 				unregister_post_type( $cpt );
 			}
 		}
+		foreach ( $this->added_filters as [ $hook, $callback ] ) {
+			remove_filter( $hook, $callback );
+		}
 		$this->registered_cpts = [];
+		$this->added_filters   = [];
 		parent::tear_down();
+	}
+
+	/**
+	 * Add a filter that tear_down() will remove — even an anonymous callback,
+	 * which remove_filter() otherwise can't target once its reference is lost.
+	 *
+	 * @param string   $hook     Filter hook.
+	 * @param callable $callback Callback.
+	 */
+	private function add_cleanup_filter( $hook, $callback ) {
+		add_filter( $hook, $callback );
+		$this->added_filters[] = [ $hook, $callback ];
 	}
 
 	/**
@@ -106,13 +131,14 @@ class Scheduled_Post_Checker_Test extends WP_UnitTestCase {
 		$this->assertNotContains( 'nspc_unrelated', \Newspack\Scheduled_Post_Checker\nspc_get_post_types(), 'Unlisted hidden types are not rescued by default.' );
 
 		// ...but the filter lets a plugin opt one in.
-		$filter = function ( $types ) {
-			$types[] = 'nspc_unrelated';
-			return $types;
-		};
-		add_filter( 'newspack_scheduled_post_checker_post_types', $filter );
+		$this->add_cleanup_filter(
+			'newspack_scheduled_post_checker_post_types',
+			function ( $types ) {
+				$types[] = 'nspc_unrelated';
+				return $types;
+			}
+		);
 		$this->assertContains( 'nspc_unrelated', \Newspack\Scheduled_Post_Checker\nspc_get_post_types(), 'The filter can register a schedulable type.' );
-		remove_filter( 'newspack_scheduled_post_checker_post_types', $filter );
 	}
 
 	/**
@@ -121,7 +147,7 @@ class Scheduled_Post_Checker_Test extends WP_UnitTestCase {
 	 */
 	public function test_rescues_missed_schedule_in_hidden_cpt() {
 		$this->register_test_cpt( 'nspc_hidden' );
-		add_filter(
+		$this->add_cleanup_filter(
 			'newspack_scheduled_post_checker_post_types',
 			function ( $types ) {
 				$types[] = 'nspc_hidden';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The scheduled-post checker is the safety net that republishes posts whose scheduled slot passed without their cron event firing. It queried `post_type => 'any'`, which WordPress limits to search-visible types (those where `exclude_from_search` is false — a value WP derives from `public` when it isn't set explicitly). Editorial CPTs registered `public => false` — Campaign prompts (`newspack_popups_cpt`) and Sponsors (`newspack_spnsrs_cpt`) — are therefore invisible to that query, so a scheduled one that misses its slot is never rescued and sits in `future` indefinitely. Newsletters (`public => true`) were covered; prompts and sponsors were not.

This PR:

- Replaces `post_type => 'any'` with a filterable list built by `nspc_get_post_types()`: it starts from the search-visible types and adds the known non-public editorial CPTs, so prompts and sponsors are rescued alongside posts and newsletters. A new `newspack_scheduled_post_checker_post_types` filter lets any plugin register its own schedulable type without editing this file. The fix stays scoped — a non-public type nobody opts in is left alone, so this is not a blanket "publish every `future` post".
- Raises the per-run batch from the implicit `get_posts()` limit of 5 to 100, so a backlog of missed posts drains far faster (and re-runs every 5 minutes).

Part of NPPM-2669.

### How to test the changes in this Pull Request:

1. Run the new unit tests — from `plugins/newspack-plugin`: `n test-php --filter Scheduled_Post_Checker_Test`. All four pass. They cover: the rescued-type list includes prompts + sponsors and stays filterable; a missed scheduled post in a non-public CPT is republished (and is confirmed invisible to `post_type => 'any'`); an un-opted-in non-public type is left alone; and more than five missed posts are all rescued in one run.
2. Live check (optional): on a site with Campaign prompts active, a prompt left stuck in `future` after its publish time has passed now transitions to `publish` when the `newspack_scheduled_post_checker` cron runs. Before this change it stayed `future`.

Note: reproducing the stuck state by hand is awkward because `wp_insert_post()`/`wp_update_post()` coerce a `future` post with a past date straight to `publish`; the unit tests write the exact stuck state directly, which is the reliable path.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?