### PR TITLE
fix(newsletters): cut redundant Mailchimp audience cache refreshes

### DIFF
--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -64,6 +64,20 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	const SURFACE_ERRORS_AFTER = 20 * HOUR_IN_SECONDS;
 
 	/**
+	 * Prefix of the option that holds the refresh lock for a given list
+	 *
+	 * @var string
+	 */
+	const LOCK_KEY_PREFIX = 'newspack_nl_mailchimp_refresh_lock_';
+
+	/**
+	 * Time in seconds a refresh lock is honored before we consider it stale and allow a new refresh
+	 *
+	 * @var int
+	 */
+	const LOCK_MAX_TIME = 120;
+
+	/**
 	 * Memoized data to be served across the same request
 	 *
 	 * @var array
@@ -431,6 +445,11 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 			return;
 		}
 
+		if ( ! self::lock_refresh( $list_id ) ) {
+			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Refresh already in progress for list ' . $list_id );
+			return;
+		}
+
 		if ( ! function_exists( 'wp_create_nonce' ) ) {
 			require_once ABSPATH . WPINC . '/pluggable.php';
 		}
@@ -476,6 +495,8 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 			self::refresh_cached_data( $list_id );
 		} catch ( Exception $e ) {
 			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Error refreshing cache: ' . $e->getMessage() );
+		} finally {
+			self::unlock_refresh( $list_id );
 		}
 		die;
 	}
@@ -543,6 +564,63 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Dispatching request to refresh cache for list ' . $list['id'] );
 			self::dispatch_refresh( $list['id'] );
 		}
+	}
+
+	/**
+	 * Gets the refresh lock option name for a given list
+	 *
+	 * @param string $list_id The List ID.
+	 * @return string The lock option name
+	 */
+	private static function get_lock_key( $list_id ) {
+		return self::LOCK_KEY_PREFIX . $list_id;
+	}
+
+	/**
+	 * Acquires the refresh lock for a given list, so we don't dispatch concurrent refreshes for the same list
+	 *
+	 * @param string $list_id The List ID.
+	 * @return boolean Whether the lock was acquired.
+	 */
+	private static function lock_refresh( $list_id ) {
+		if ( self::is_refresh_locked( $list_id ) ) {
+			return false;
+		}
+
+		update_option( self::get_lock_key( $list_id ), time(), false ); // auto-load false.
+		return true;
+	}
+
+	/**
+	 * Releases the refresh lock for a given list
+	 *
+	 * @param string $list_id The List ID.
+	 * @return void
+	 */
+	private static function unlock_refresh( $list_id ) {
+		delete_option( self::get_lock_key( $list_id ) );
+		Newspack_Newsletters_Logger::log( 'Mailchimp cache: Refresh lock released for list ' . $list_id );
+	}
+
+	/**
+	 * Checks whether a refresh is already in progress for a given list
+	 *
+	 * A lock older than self::LOCK_MAX_TIME is considered stale and is discarded.
+	 *
+	 * @param string $list_id The List ID.
+	 * @return boolean
+	 */
+	private static function is_refresh_locked( $list_id ) {
+		$lock = get_option( self::get_lock_key( $list_id ) );
+		if ( ! $lock ) {
+			return false;
+		}
+		if ( time() - $lock > self::LOCK_MAX_TIME ) {
+			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Refresh lock expired. Unlocking.' );
+			delete_option( self::get_lock_key( $list_id ) );
+			return false;
+		}
+		return true;
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -505,6 +505,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 
 			// Update the cache.
 			self::update_cache( $list_id, $list_data );
+			Newspack_Newsletters_Subscription::clear_lists_cache();
 
 			return $list_data;
 		} catch ( Exception $e ) {

--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -8,6 +8,7 @@
 defined( 'ABSPATH' ) || exit;
 
 use Newspack_Newsletters_Mailchimp_Api as Mailchimp;
+use Newspack\Newsletters\Subscription_Lists;
 
 /**
  * Mailchimp cached class data
@@ -76,6 +77,13 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @var int
 	 */
 	const LOCK_MAX_TIME = 120;
+
+	/**
+	 * How often the cron refreshes an audience that is not offered for subscription
+	 *
+	 * @var int
+	 */
+	const INACTIVE_REFRESH_INTERVAL = DAY_IN_SECONDS;
 
 	/**
 	 * Memoized data to be served across the same request
@@ -259,6 +267,24 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	private static function is_cache_expired( $list_id = 'lists' ) {
 		$cache_date = get_option( self::get_cache_date_key( $list_id ) );
 		return $cache_date && ( time() - $cache_date ) > 20 * MINUTE_IN_SECONDS;
+	}
+
+	/**
+	 * Checks whether the cached data for a given list is older than a given age
+	 *
+	 * Unlike self::is_cache_expired(), a list that was never cached counts as older
+	 * than any age, so the cron can warm it for the first time.
+	 *
+	 * @param string $list_id The List ID.
+	 * @param int    $max_age The age, in seconds.
+	 * @return boolean
+	 */
+	private static function is_cache_older_than( $list_id, $max_age ) {
+		$cache_date = get_option( self::get_cache_date_key( $list_id ) );
+		if ( ! $cache_date ) {
+			return true;
+		}
+		return ( time() - $cache_date ) > $max_age;
 	}
 
 	/**
@@ -560,10 +586,57 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 			return;
 		}
 
+		$active_audience_ids = self::get_active_audience_ids();
+
 		foreach ( $lists as $list ) {
-			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Dispatching request to refresh cache for list ' . $list['id'] );
-			self::dispatch_refresh( $list['id'] );
+			$list_id = (string) $list['id'];
+
+			// Audiences the site does not offer for subscription are refreshed once a day.
+			if (
+				! in_array( $list_id, $active_audience_ids, true )
+				&& ! self::is_cache_older_than( $list_id, self::INACTIVE_REFRESH_INTERVAL )
+			) {
+				Newspack_Newsletters_Logger::log( 'Mailchimp cache: Skipping refresh for inactive list ' . $list_id );
+				continue;
+			}
+
+			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Dispatching request to refresh cache for list ' . $list_id );
+			self::dispatch_refresh( $list_id );
 		}
+	}
+
+	/**
+	 * Gets the IDs of the audiences the site offers for subscription
+	 *
+	 * An audience counts as active when it is offered for subscription itself, or
+	 * when any of its groups or tags is.
+	 *
+	 * @return string[] The audience IDs.
+	 */
+	private static function get_active_audience_ids() {
+		if ( ! class_exists( 'Newspack\Newsletters\Subscription_Lists' ) ) {
+			return [];
+		}
+
+		$audience_ids = [];
+		foreach ( Subscription_Lists::get_configured_for_provider( 'mailchimp' ) as $list ) {
+			if ( ! $list->is_active() ) {
+				continue;
+			}
+			$audience_id = $list->mailchimp_get_audience_id();
+			if ( $audience_id ) {
+				$audience_ids[] = (string) $audience_id;
+			}
+		}
+
+		/**
+		 * Filters the audiences the cron keeps warm.
+		 *
+		 * @param string[] $audience_ids IDs of the audiences offered for subscription.
+		 */
+		$audience_ids = apply_filters( 'newspack_newsletters_mailchimp_active_audiences', array_values( array_unique( $audience_ids ) ) );
+
+		return array_map( 'strval', $audience_ids );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Refreshing the cached data for one Mailchimp audience costs about five API calls. Two things made a site do that work far more often than it needs to.

The cron dispatched a refresh for **every audience in the account** every ten minutes, whether or not the site offers it for subscription. Accounts carrying dozens of unused audiences paid for all of them. The cron now keeps an audience on that cadence only while the site offers it: the audience itself is enabled in Newsletters > Settings, or any of its groups or tags is. The rest refresh once a day. Any audience still refreshes on demand when someone opens it, so the daily interval governs background warming only.

Separately, when an audience's cache expired, every request that read it dispatched its own refresh. On large audiences a refresh takes a while, so one expired audience became dozens of overlapping refreshes. A **per-audience lock** now lets the first request through and skips the rest while that refresh is in flight. The lock is released once the refresh finishes, whether or not it succeeded. A 120-second timeout discards a lock left behind by a request that died early.

A third commit clears the subscription lists cache after an audience refresh, so refreshed data reaches the settings screen.

### How to test the changes in this Pull Request:

1. Connect a site to a Mailchimp account with several audiences.
2. Set `NEWSPACK_LOG_LEVEL` to `1` in `wp-config.php`. Refresh activity goes to the error log.
3. In Newsletters > Settings, enable one audience and leave the others off.
4. Run `wp cron event run newspack_nl_mailchimp_refresh_cache`. Only the enabled audience is dispatched.
5. Confirm the log reads "Skipping refresh for inactive list" for each audience left off.
6. Disable that audience, then enable a single tag or group inside it.
7. Run the cron again. The parent audience is dispatched, because one of its tags is enabled.
8. Age an unused audience: `wp option update newspack_nl_mailchimp_cache_date_<audience_id> 1`.
9. Run the cron again. That audience refreshes, a day having passed since its last one.
10. Expire an enabled audience: `wp option update newspack_nl_mailchimp_cache_date_<audience_id> 1`.
11. Load a Newsletters screen in several tabs at once. The log shows one dispatch, then "Refresh already in progress".
12. Wait for the refresh to finish. The log shows "Refresh lock released" and the cache date updates.
13. Set an invalid Mailchimp API key, expire that audience again, and load the screen.
14. Confirm the log shows the error followed by "Refresh lock released", and that a later request dispatches a new refresh.
15. Restore the key. Simulate an abandoned lock: `wp option update newspack_nl_mailchimp_refresh_lock_<audience_id> 1`.
16. Expire that audience and load the screen. The log reads "Refresh lock expired. Unlocking." and a new refresh dispatches.
17. Confirm audiences, groups, tags, and segments still list correctly in Newsletters > Settings.
18. Confirm the same lists appear in the newsletter editor sidebar.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? No new tests yet: see the note below.
* [x] Have you successfully run tests with your changes locally? 798 pass in `newspack-newsletters`.

Two things worth a reviewer's attention:

- The daily interval reads the cache date, which is written on a successful refresh. An unused audience whose refresh keeps failing is therefore retried every ten minutes rather than daily. Tracking attempts separately from successes would close that, at the cost of another option write per audience; the refresh lock already caps it at one in-flight request.
- The lock is taken before the non-blocking loopback request that carries out the refresh. Where loopback requests are blocked, an audience waits out the 120-second timeout before another refresh can be dispatched.

New filter: `newspack_newsletters_mailchimp_active_audiences` overrides which audiences the cron keeps warm.

Tests for the cron scoping are still to come: `get_active_audience_ids()` is coverable with real `newspack_nl_list` posts, and the daily interval with a cache-date fixture.
