### PR TITLE
refactor(components): adopt InfoButton in StatCard (DSGNEWS-212)

### DIFF
--- a/packages/components/src/info-button/README.md
+++ b/packages/components/src/info-button/README.md
@@ -13,6 +13,9 @@ import { InfoButton } from 'newspack-components';
 The component imports its own stylesheet, so the barrel ships the CSS with it.
 There is nothing separate to import.
 
+It carries no outer margin, so the row it sits in owns the spacing beside it. In
+a flex or grid row that is the row's own `gap`; anywhere else the caller sets it.
+
 ## What belongs in it
 
 **Supplementary context only.** Anything a reader needs in order to use the

--- a/packages/components/src/info-button/README.md
+++ b/packages/components/src/info-button/README.md
@@ -17,11 +17,12 @@ It carries no inline margin, so the row it sits in owns the spacing beside it.
 In a flex or grid row that is the row's own `gap`; anywhere else the caller sets
 it.
 
-Vertically it trims itself to a 20px line, `$font-line-height-small`, which is
-what `@wordpress/base-styles` pairs with both 13px and 15px text. A 24px control
-would otherwise add 4px to that line, so a label with one of these would sit
-lower than a label without. Beside text on a different line height the trim is
-off by the difference, so give the row a 20px line.
+Vertically it is a 24px control, `$button-size-small`, and it makes no assumption
+about the line it lands on. Beside text on a shorter line it grows the row unless
+the row pulls it back, which is the host's call rather than the component's: a row
+that is happy at 24px needs nothing. `StatCard.Label` and `SettingsSection` both
+trim it to the 20px line their text sits on, so a label carrying one stays level
+with a label without.
 
 ## What belongs in it
 

--- a/packages/components/src/info-button/README.md
+++ b/packages/components/src/info-button/README.md
@@ -13,8 +13,15 @@ import { InfoButton } from 'newspack-components';
 The component imports its own stylesheet, so the barrel ships the CSS with it.
 There is nothing separate to import.
 
-It carries no outer margin, so the row it sits in owns the spacing beside it. In
-a flex or grid row that is the row's own `gap`; anywhere else the caller sets it.
+It carries no inline margin, so the row it sits in owns the spacing beside it.
+In a flex or grid row that is the row's own `gap`; anywhere else the caller sets
+it.
+
+Vertically it trims itself to a 20px line, `$font-line-height-small`, which is
+what `@wordpress/base-styles` pairs with both 13px and 15px text. A 24px control
+would otherwise add 4px to that line, so a label with one of these would sit
+lower than a label without. Beside text on a different line height the trim is
+off by the difference, so give the row a 20px line.
 
 ## What belongs in it
 

--- a/packages/components/src/info-button/style.scss
+++ b/packages/components/src/info-button/style.scss
@@ -13,7 +13,6 @@
 	flex: 0 0 auto;
 	height: wp-vars.$button-size-small;
 	justify-content: center;
-	margin-left: var(--wpds-dimension-gap-xs, #{wp-vars.$grid-unit-05});
 	padding: 0;
 	vertical-align: middle;
 	width: wp-vars.$button-size-small;

--- a/packages/components/src/info-button/style.scss
+++ b/packages/components/src/info-button/style.scss
@@ -13,6 +13,7 @@
 	flex: 0 0 auto;
 	height: wp-vars.$button-size-small;
 	justify-content: center;
+	margin-block: calc((#{wp-vars.$font-line-height-small} - #{wp-vars.$button-size-small}) / 2);
 	padding: 0;
 	vertical-align: middle;
 	width: wp-vars.$button-size-small;

--- a/packages/components/src/info-button/style.scss
+++ b/packages/components/src/info-button/style.scss
@@ -13,7 +13,6 @@
 	flex: 0 0 auto;
 	height: wp-vars.$button-size-small;
 	justify-content: center;
-	margin-block: calc((#{wp-vars.$font-line-height-small} - #{wp-vars.$button-size-small}) / 2);
 	padding: 0;
 	vertical-align: middle;
 	width: wp-vars.$button-size-small;

--- a/packages/components/src/settings/SettingsSection.js
+++ b/packages/components/src/settings/SettingsSection.js
@@ -12,7 +12,7 @@ import InfoButton from '../info-button';
 
 const SettingSection = ( { title, description, children } ) => (
 	<Grid columns={ 1 } gutter={ 8 } className="newspack-settings__section">
-		<Stack direction="row" align="center" gap="xs" className="newspack-settings__section__title">
+		<Stack direction="row" align="flex-start" gap="xs" className="newspack-settings__section__title">
 			<span>{ title }</span>
 			{ description && (
 				<InfoButton

--- a/packages/components/src/settings/SettingsSection.js
+++ b/packages/components/src/settings/SettingsSection.js
@@ -2,6 +2,7 @@
  * WordPress dependencies.
  */
 import { __, sprintf } from '@wordpress/i18n';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies.
@@ -11,7 +12,7 @@ import InfoButton from '../info-button';
 
 const SettingSection = ( { title, description, children } ) => (
 	<Grid columns={ 1 } gutter={ 8 } className="newspack-settings__section">
-		<div className="newspack-settings__section__title">
+		<Stack direction="row" align="center" gap="xs" className="newspack-settings__section__title">
 			<span>{ title }</span>
 			{ description && (
 				<InfoButton
@@ -27,7 +28,7 @@ const SettingSection = ( { title, description, children } ) => (
 					}
 				/>
 			) }
-		</div>
+		</Stack>
 		<div className="newspack-settings__section__content">{ children }</div>
 	</Grid>
 );

--- a/packages/components/src/settings/style.scss
+++ b/packages/components/src/settings/style.scss
@@ -30,11 +30,6 @@
 
 		.newspack-settings__section {
 			&__title {
-				align-items: center;
-				display: flex;
-				gap: var(--wpds-dimension-gap-xs, #{wp-vars.$grid-unit-05});
-				margin: 0;
-
 				span {
 					line-height: wp-vars.$button-size-small;
 				}

--- a/packages/components/src/settings/style.scss
+++ b/packages/components/src/settings/style.scss
@@ -32,6 +32,7 @@
 			&__title {
 				align-items: center;
 				display: flex;
+				gap: var(--wpds-dimension-gap-xs, #{wp-vars.$grid-unit-05});
 				margin: 0;
 
 				span {

--- a/packages/components/src/settings/style.scss
+++ b/packages/components/src/settings/style.scss
@@ -31,7 +31,7 @@
 		.newspack-settings__section {
 			&__title {
 				span {
-					line-height: wp-vars.$button-size-small;
+					line-height: wp-vars.$font-line-height-small;
 				}
 			}
 			&__content {

--- a/packages/components/src/settings/style.scss
+++ b/packages/components/src/settings/style.scss
@@ -33,6 +33,10 @@
 				span {
 					line-height: wp-vars.$font-line-height-small;
 				}
+
+				.newspack-info-button {
+					margin-block: calc((#{wp-vars.$font-line-height-small} - #{wp-vars.$button-size-small}) / 2);
+				}
 			}
 			&__content {
 				> div,

--- a/packages/components/src/stat-card/README.md
+++ b/packages/components/src/stat-card/README.md
@@ -240,10 +240,9 @@ out of the document outline and off the heading's accessible name. Supplementary
 context belongs in an `InfoButton`, which already carries the popup, the touch
 behaviour and the accessible name; the slot itself takes anything.
 
-A control in that slot keeps the label row's height without being asked to. The
-card trims the 2px a 24px control otherwise adds to a 20px line, and it does so
-for whatever sits in the slot rather than for one class each call site has to
-remember:
+An `InfoButton` keeps the label row's height without being asked to: it trims
+itself to the 20px line `heading-large()` gives the heading, so a card carrying
+one and a card without still have their figures level.
 
 ```jsx
 <StatCard.Label
@@ -258,9 +257,8 @@ remember:
 </StatCard.Label>
 ```
 
-The trim is that one figure rather than a measurement, so a control taller than
-24px still grows the row. A row of cards keeps its figures level while the slot
-holds a small control, which is what it is for.
+Any other control in that slot has to hold the 20px line itself, or it grows the
+row and drops that card's figure below the rest.
 
 A level outside 2–6 falls back to `3` and warns outside production, rather than
 rendering an element that is not a heading at all.

--- a/packages/components/src/stat-card/README.md
+++ b/packages/components/src/stat-card/README.md
@@ -240,9 +240,10 @@ out of the document outline and off the heading's accessible name. Supplementary
 context belongs in an `InfoButton`, which already carries the popup, the touch
 behaviour and the accessible name; the slot itself takes anything.
 
-An `InfoButton` keeps the label row's height without being asked to: it trims
-itself to the 20px line `heading-large()` gives the heading, so a card carrying
-one and a card without still have their figures level.
+The card pulls an `InfoButton` in that slot back to the 20px line
+`heading-large()` gives the heading, so a card carrying one and a card without
+still have their figures level. The button makes no assumption about its host, so
+the trim lives here rather than on it.
 
 ```jsx
 <StatCard.Label

--- a/packages/components/src/stat-card/README.md
+++ b/packages/components/src/stat-card/README.md
@@ -108,9 +108,10 @@ across that row.
 It also makes the card a containing block for `position: absolute` and
 `position: fixed` descendants, and `Card.Root` clips its overflow. Anything
 positioned that renders inline inside the card, such as a popover on a control
-in `suffix`, is therefore trapped by the card unless it portals out. The
-tooltips and popovers in `@wordpress/components` portal by default, so this
-mostly matters if a consumer registers its own `Popover.Slot` inside a card.
+in `suffix`, is therefore trapped by the card unless it portals out.
+`InfoButton` portals to the shared overlay slot and the tooltips and popovers in
+`@wordpress/components` portal by default, so this mostly matters if a consumer
+registers its own `Popover.Slot` inside a card.
 
 For a hero that is a phrase rather than a number ("0 of 17", "No conversions"),
 pass `variant="text"`. It keeps the slot and drops the display scale, which
@@ -235,17 +236,31 @@ container query.
 | `suffix` | `React.ReactNode` | — | Rendered beside the heading, e.g. an info button. |
 
 `suffix` sits next to the heading rather than inside it, so a control there stays
-out of the document outline and off the heading's accessible name.
+out of the document outline and off the heading's accessible name. Supplementary
+context belongs in an `InfoButton`, which already carries the popup, the touch
+behaviour and the accessible name; the slot itself takes anything.
 
-An icon button in that slot keeps the label row's height without being asked to.
-The card trims the 2px a 24px control otherwise adds to a 20px line, scoped to
-the slot rather than to a class each call site has to remember:
+A control in that slot keeps the label row's height without being asked to. The
+card trims the 2px a 24px control otherwise adds to a 20px line, and it does so
+for whatever sits in the slot rather than for one class each call site has to
+remember:
 
 ```jsx
-<StatCard.Label suffix={ <Button icon={ info } size="small" label={ … } /> }>
+<StatCard.Label
+	suffix={
+		<InfoButton
+			description={ __( 'Averaged across the timeframe.', 'newspack-plugin' ) }
+			triggerLabel={ __( 'More information about Average order value', 'newspack-plugin' ) }
+		/>
+	}
+>
 	{ __( 'Average order value', 'newspack-plugin' ) }
 </StatCard.Label>
 ```
+
+The trim is that one figure rather than a measurement, so a control taller than
+24px still grows the row. A row of cards keeps its figures level while the slot
+holds a small control, which is what it is for.
 
 A level outside 2–6 falls back to `3` and warns outside production, rather than
 rendering an element that is not a heading at all.

--- a/packages/components/src/stat-card/style.scss
+++ b/packages/components/src/stat-card/style.scss
@@ -25,8 +25,8 @@ $stat-card-min-height: wp-vars.$grid-unit * 21;
 		flex: 1;
 	}
 
-	&__label .components-button.is-small {
-		margin: calc((#{wp-vars.$font-line-height-small} - #{wp-vars.$button-size-small}) / 2) 0;
+	&__label > :not(#{&}__label-text) {
+		margin-block: calc((#{wp-vars.$font-line-height-small} - #{wp-vars.$button-size-small}) / 2);
 	}
 
 	&__label-text {

--- a/packages/components/src/stat-card/style.scss
+++ b/packages/components/src/stat-card/style.scss
@@ -25,6 +25,10 @@ $stat-card-min-height: wp-vars.$grid-unit * 21;
 		flex: 1;
 	}
 
+	&__label .newspack-info-button {
+		margin-block: calc((#{wp-vars.$font-line-height-small} - #{wp-vars.$button-size-small}) / 2);
+	}
+
 	&__label-text {
 		@include wp-mixins.heading-large();
 		color: wp-colors.$gray-900;

--- a/packages/components/src/stat-card/style.scss
+++ b/packages/components/src/stat-card/style.scss
@@ -25,10 +25,6 @@ $stat-card-min-height: wp-vars.$grid-unit * 21;
 		flex: 1;
 	}
 
-	&__label > :not(#{&}__label-text) {
-		margin-block: calc((#{wp-vars.$font-line-height-small} - #{wp-vars.$button-size-small}) / 2);
-	}
-
 	&__label-text {
 		@include wp-mixins.heading-large();
 		color: wp-colors.$gray-900;

--- a/plugins/newspack-plugin/src/wizards/componentsDemo/index.js
+++ b/plugins/newspack-plugin/src/wizards/componentsDemo/index.js
@@ -21,7 +21,7 @@ import {
 } from '@wordpress/components';
 import { Component, Fragment, render, createInterpolateElement, createRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Icon, info, plus, postList, settings } from '@wordpress/icons';
+import { Icon, plus, postList, settings } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -43,6 +43,7 @@ import {
 	Grid,
 	Handoff,
 	ImageUpload,
+	InfoButton,
 	Modal,
 	Notice,
 	Page,
@@ -411,7 +412,10 @@ class ComponentsDemo extends Component {
 								<StatCard.Root>
 									<StatCard.Label
 										suffix={
-											<Button icon={ info } size="small" label={ __( 'Averaged across the timeframe.', 'newspack-plugin' ) } />
+											<InfoButton
+												description={ __( 'Averaged across the timeframe.', 'newspack-plugin' ) }
+												triggerLabel={ __( 'More information about Average order value', 'newspack-plugin' ) }
+											/>
 										}
 									>
 										{ __( 'Average order value', 'newspack-plugin' ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`StatCard`'s label slot was documented and demoed with a raw `<Button icon={ info } size="small" />` rather than the house `InfoButton`, which moved onto `Popover` in #887. Two spacing rules no longer matched it.

The label row trimmed a 24px control back to its 20px line, but keyed that on `.components-button.is-small`. `InfoButton` renders a `Popover.Trigger` classed `.newspack-info-button`, so the row grew 4px with nothing to flag it. Each row now trims the button it holds, back to the 20px line `@wordpress/base-styles` pairs with both 13px and 15px text. The button assumes nothing about a line height it cannot know, and a row happy at 24px asks for nothing.

It also set its own `margin-left`, which stacked on the row's gap for 12px instead of 8px. That is gone, so the row owns the spacing beside it.

`SettingsSection`'s title row is a `Stack` now, replacing hand-rolled flex, and its text takes `$font-line-height-small` rather than a control height. Rows drop 24px to 20px, and a wrapped title keeps the button on its first line instead of floating it 12px down.

Both adopters put an info affordance in that slot, so each picks up the house component once.

Part of DSGNEWS-212.

![StatCard row on the components demo, with an InfoButton in the label slot and its popover open](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/21/07dhfxub-statcard-info-button-label-slot.png)

### How to test the changes in this Pull Request:

1. Build `newspack-plugin` and open Newspack → Components Demo.
2. Scroll to the StatCard section. "Average order value" carries an info button.
3. Hover that button. A popover reads "Averaged across the timeframe." and renders above the card.
4. Compare the four label rows. The button adds no height to the row it sits in.
5. Open Audience → Campaigns → Segments and edit a segment. Section titles sit 4px from each info button.
6. Find a title with no description, such as User Account. Its row matches the ones that have a button.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? Tests n/a: this is CSS, README and demo markup, and Jest loads no stylesheets.
* [x] Have you successfully run tests with your changes locally?

A control other than `InfoButton` in either slot has to hold the 20px line itself, or it grows the row. Both READMEs record that.
