### PR TITLE
ci(needs-changelog): stop changelog reminders on hotfixes

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/labeler@v5
 
   comment_pr:
-    if: github.event.pull_request.merged == true && (github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'alpha' || github.event.pull_request.base.ref == 'release') && github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && github.event.pull_request.user.login != 'dependabot[bot]'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   labeler:
-    if: github.event.pull_request.merged == true && (github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'alpha' || github.event.pull_request.base.ref == 'release') && github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && github.event.pull_request.user.login != 'dependabot[bot]'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Stops the `needs-changelog` job from posting reminder comments on hotfix-type PRs (those based against `release` or `alpha`) after merge. Hotfix release notes are now automated, so the reminder is unnecessary.

### How to test the changes in this Pull Request:

After this merges, confirm that a reminder comment like [this](https://github.com/Automattic/newspack-workspace/pull/830#issuecomment-5320882457) is NOT posted to this PR, and the "needs-changelog" label is NOT appended.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
