### PR TITLE
fix(content-gate): hide sticky ads while a banner shows

### DIFF
--- a/plugins/newspack-plugin/src/content-gate/content-banner.scss
+++ b/plugins/newspack-plugin/src/content-gate/content-banner.scss
@@ -70,12 +70,15 @@ body.newspack-has-countdown-banner {
 // third-party plugins are out of that filter's reach, so hide them here for as
 // long as the banner is on screen.
 //
-// The countdown banner is printed hidden and revealed by content-banner.js once
-// the reader's view count resolves, hence the `:has()` test for the visible
-// state: keying off the body class alone would pull the ad on pages where the
-// banner never appears. The gifting CTA has no such hidden state. Browsers
-// without `:has()` support drop the rule and keep the overlap they have today.
-body.newspack-is-gifted-post,
+// Both halves test for the banner element rather than the body class alone,
+// because either class can be on the page without a banner under it. The
+// countdown banner is printed hidden and revealed by content-banner.js once the
+// reader's view count resolves; `newspack-is-gifted-post` is set for any gifted
+// post, while `Content_Gifting_CTA::print_cta()` also requires the post to be
+// restricted, so a reader who already has access gets the class and no banner.
+// Browsers without `:has()` support drop the rule and keep the overlap they
+// have today.
+body.newspack-is-gifted-post:has(.newspack-content-gifting__cta),
 body.newspack-has-countdown-banner:has(.newspack-countdown-banner__cta:not(.newspack-countdown-banner__cta--hidden)) {
 	// `.bsa-ad-type-sneaker` is Broadstreet's slide-in/sticky footer unit. Both
 	// containers carry an inline `display` set by the ad provider's own script,
@@ -100,6 +103,11 @@ body.newspack-has-countdown-banner:has(.newspack-countdown-banner__cta:not(.news
 
 		&--hidden {
 			opacity: 0;
+			// The banner keeps its full-width fixed footprint while invisible, so
+			// without this it swallows clicks aimed at whatever sits under it —
+			// including the sticky footer ad this file deliberately leaves visible
+			// in that state.
+			pointer-events: none;
 		}
 
 		&__content {

--- a/plugins/newspack-plugin/src/content-gate/content-banner.scss
+++ b/plugins/newspack-plugin/src/content-gate/content-banner.scss
@@ -63,6 +63,29 @@ body.newspack-has-countdown-banner {
 	}
 }
 
+// A banner is pinned to the bottom of the viewport, where sticky footer ads also
+// live, so the two land on top of each other: the banner wins on z-index and the
+// ad is left partly covered (NPPM-3027). Newspack's own sticky placement is
+// switched off server-side while a banner shows, but ad units injected by
+// third-party plugins are out of that filter's reach, so hide them here for as
+// long as the banner is on screen.
+//
+// The countdown banner is printed hidden and revealed by content-banner.js once
+// the reader's view count resolves, hence the `:has()` test for the visible
+// state: keying off the body class alone would pull the ad on pages where the
+// banner never appears. The gifting CTA has no such hidden state. Browsers
+// without `:has()` support drop the rule and keep the overlap they have today.
+body.newspack-is-gifted-post,
+body.newspack-has-countdown-banner:has(.newspack-countdown-banner__cta:not(.newspack-countdown-banner__cta--hidden)) {
+	// `.bsa-ad-type-sneaker` is Broadstreet's slide-in/sticky footer unit. Both
+	// containers carry an inline `display` set by the ad provider's own script,
+	// so `!important` is what actually wins here.
+	.bsa-ad-type-sneaker,
+	.newspack_global_ad.sticky {
+		display: none !important;
+	}
+}
+
 .newspack-content-gifting,
 .newspack-countdown-banner {
 	&__cta {

--- a/plugins/newspack-plugin/src/content-gate/content-banner.scss
+++ b/plugins/newspack-plugin/src/content-gate/content-banner.scss
@@ -80,10 +80,13 @@ body.newspack-has-countdown-banner {
 // have today.
 body.newspack-is-gifted-post:has(.newspack-content-gifting__cta),
 body.newspack-has-countdown-banner:has(.newspack-countdown-banner__cta:not(.newspack-countdown-banner__cta--hidden)) {
-	// `.bsa-ad-type-sneaker` is Broadstreet's slide-in/sticky footer unit. Both
-	// containers carry an inline `display` set by the ad provider's own script,
-	// so `!important` is what actually wins here.
-	.bsa-ad-type-sneaker,
+	// Broadstreet's slide-in ("sneaker") unit. Its street.js moves the rendered
+	// bar out of the `.bsa-ad-type-sneaker` container it was authored in and
+	// reparents it to `body`, under a random id, so the only stable hook is the
+	// `.bs-sneaker-container` it wraps. Both this and our own sticky container
+	// carry an inline `display` set by the ad provider's own script, so
+	// `!important` is what actually wins here.
+	div:has(> .bs-sneaker-container),
 	.newspack_global_ad.sticky {
 		display: none !important;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the WordPress coding standards and VIP Go coding standards?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The metering countdown banner and a sticky footer ad both pin themselves to the bottom of the viewport, so they overlap: the banner wins on z-index and leaves the ad half-covered.

Newspack's own sticky placement is already switched off server-side while a banner shows, but ad units injected by third-party plugins are beyond that filter's reach. The reported case is a Broadstreet slide-in ("sneaker") unit. Broadstreet's `street.js` moves the rendered bar out of the container it was authored in and reparents it to `body` under a random id, so the rule keys off the `.bs-sneaker-container` that bar wraps.

This hides bottom-fixed ad rails for as long as a countdown or content-gifting banner is on screen. Each half tests for the banner element rather than the body class, because either class can be on the page with no banner under it.

Before:
<img width="1400" height="813" alt="live2-before" src="https://github.com/user-attachments/assets/3c4b91b0-4d47-48c5-b466-bc02021bd749" />

After:
<img width="1400" height="813" alt="live2-after" src="https://github.com/user-attachments/assets/3c2d0e75-a544-44a5-a4f7-6d4dca846f72" />

Closes NPPM-3027.

### How to test the changes in this Pull Request:

1. Set up a metered content gate so a restricted post shows the countdown banner.
2. Add a bottom-fixed ad stand-in in the footer: `<div id="x"><div class="bs-sneaker-container">ad</div></div>`, with `#x` styled `position: fixed; bottom: 0; z-index: 10000`.
3. Load the post signed out, on desktop, with one metered view recorded. The banner shows and the stand-in is hidden.
4. Turn the countdown banner off and reload. The stand-in renders as before.
5. Open a gifted post as a reader without access, so the gifting CTA shows. The stand-in is hidden there too.
6. Open a gifted post as a reader who already has access. No CTA renders, and the stand-in stays visible.

Note, I couldn't get broadstreet to work locally so had to inject a matching stub to confirm locally. Alternatively, you can test by adding a new stylesheet via dev tools with the css from this PR:

```
body.newspack-is-gifted-post:has(.newspack-content-gifting__cta),
body.newspack-has-countdown-banner:has(.newspack-countdown-banner__cta:not(.newspack-countdown-banner__cta--hidden)) {
  div:has(> .bs-sneaker-container),
	.newspack_global_ad.sticky {
		display: none !important;
	}
}
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? — n/a: CSS only.
* [x] Have you successfully run tests with your changes locally? — verified in an isolated env, and against a live publisher page serving the real Broadstreet unit: with the banner on screen, the compiled stylesheet takes the bar from 122px tall to `display: none`.

Worth knowing while reviewing: our own GAM sticky placement cannot produce this overlap on desktop at all. It is suppressed twice over, by `Metering_Countdown::filter_ads_placement_data()` and by the sticky size mapping in `class-gam-scripts.php`, which maps viewports at or above 600px to no sizes. Third-party units are the practical case.

The hidden countdown banner also gains `pointer-events: none`. It keeps its full-width fixed footprint while invisible, so it was swallowing clicks aimed at whatever sits under it, including the ad this rule deliberately leaves visible in that state.
