### PR TITLE
fix(my-account): expire and single-use the email change links

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
@@ -15,15 +15,17 @@ defined( 'ABSPATH' ) || exit;
  * This class handles functional customizations. UI customizations are handled in My_Account_UI classes.
  */
 class WooCommerce_My_Account {
-	const RESET_PASSWORD_URL_PARAM     = 'reset-password';
-	const DELETE_ACCOUNT_URL_PARAM     = 'delete-account';
-	const DELETE_ACCOUNT_FORM          = 'delete-account-form';
-	const SEND_MAGIC_LINK_PARAM        = 'magic-link';
-	const AFTER_ACCOUNT_DELETION_PARAM = 'account-deleted';
-	const CANCEL_EMAIL_CHANGE_PARAM    = 'cancel-email-change';
-	const VERIFY_EMAIL_CHANGE_PARAM    = 'verify-email-change';
-	const PENDING_EMAIL_CHANGE_META    = 'newspack_pending_email_change';
-	const ALLOWED_PARAMS               = [
+	const RESET_PASSWORD_URL_PARAM         = 'reset-password';
+	const DELETE_ACCOUNT_URL_PARAM         = 'delete-account';
+	const DELETE_ACCOUNT_FORM              = 'delete-account-form';
+	const SEND_MAGIC_LINK_PARAM            = 'magic-link';
+	const AFTER_ACCOUNT_DELETION_PARAM     = 'account-deleted';
+	const CANCEL_EMAIL_CHANGE_PARAM        = 'cancel-email-change';
+	const VERIFY_EMAIL_CHANGE_PARAM        = 'verify-email-change';
+	const PENDING_EMAIL_CHANGE_META        = 'newspack_pending_email_change';
+	const PENDING_EMAIL_CHANGE_TOKENS_META = 'newspack_pending_email_change_tokens';
+	const EMAIL_CHANGE_TOKEN_EXPIRY        = DAY_IN_SECONDS;
+	const ALLOWED_PARAMS                   = [
 		self::RESET_PASSWORD_URL_PARAM,
 		self::DELETE_ACCOUNT_URL_PARAM,
 		self::SEND_MAGIC_LINK_PARAM,
@@ -1087,20 +1089,110 @@ class WooCommerce_My_Account {
 	}
 
 	/**
-	 * Get email change verification url.
+	 * Get an email change url carrying a single-use token.
 	 *
 	 * @param string $param The email change param.
-	 * @param string $value The email change param value.
+	 * @param string $token The token to embed in the url.
 	 *
 	 * @return string
 	 */
-	public static function get_email_change_url( $param, $value ) {
+	public static function get_email_change_url( $param, $token ) {
 		return \add_query_arg(
 			[
-				$param => \wp_hash( $value ),
+				$param => $token,
 			],
 			\wc_get_endpoint_url( 'edit-account', '', \wc_get_page_permalink( 'myaccount' ) )
 		);
+	}
+
+	/**
+	 * Issue a fresh set of single-use tokens for a pending email change.
+	 *
+	 * The verification and cancellation links are delivered to different
+	 * mailboxes, so each gets its own token. Both are stored on the user and
+	 * expire together.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return array Token set with 'verify', 'cancel' and 'expires' keys.
+	 */
+	private static function create_email_change_tokens( $user_id ) {
+		$tokens = [
+			'verify'  => \wp_generate_password( 32, false ),
+			'cancel'  => \wp_generate_password( 32, false ),
+			'expires' => time() + self::EMAIL_CHANGE_TOKEN_EXPIRY,
+		];
+		\update_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_TOKENS_META, $tokens );
+		return $tokens;
+	}
+
+	/**
+	 * Get a user's unexpired email change tokens.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return array Token set, or an empty array if there is none or it has expired.
+	 */
+	private static function get_email_change_tokens( $user_id ) {
+		$tokens = \get_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_TOKENS_META, true );
+		if (
+			! is_array( $tokens )
+			|| empty( $tokens['verify'] )
+			|| empty( $tokens['cancel'] )
+			|| empty( $tokens['expires'] )
+			|| time() > (int) $tokens['expires']
+		) {
+			return [];
+		}
+		return $tokens;
+	}
+
+	/**
+	 * Get the address a user's email change is waiting on.
+	 *
+	 * A request whose links have expired is cleared here, so the account form
+	 * unlocks instead of holding a change the reader can no longer complete or
+	 * cancel.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return string Pending email address, or an empty string if there is none.
+	 */
+	public static function get_pending_email_change( $user_id ) {
+		$new_email = \get_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META, true );
+		if ( ! $new_email ) {
+			return '';
+		}
+		if ( ! self::get_email_change_tokens( $user_id ) ) {
+			self::clear_pending_email_change( $user_id );
+			return '';
+		}
+		return $new_email;
+	}
+
+	/**
+	 * Get the cancellation url for a user's pending email change.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return string Cancellation url, or an empty string if there is no pending change.
+	 */
+	public static function get_cancel_email_change_url( $user_id ) {
+		$tokens = self::get_email_change_tokens( $user_id );
+		if ( empty( $tokens['cancel'] ) ) {
+			return '';
+		}
+		return self::get_email_change_url( self::CANCEL_EMAIL_CHANGE_PARAM, $tokens['cancel'] );
+	}
+
+	/**
+	 * Clear all pending email change state for a user.
+	 *
+	 * @param int $user_id User ID.
+	 */
+	private static function clear_pending_email_change( $user_id ) {
+		\delete_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META );
+		\delete_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_TOKENS_META );
 	}
 
 	/**
@@ -1131,7 +1223,8 @@ class WooCommerce_My_Account {
 			if ( ! $update ) {
 				\wc_add_notice( __( 'Something went wrong. Please try again.', 'newspack-plugin' ), 'error' );
 			} else {
-				$sent = [];
+				$tokens = self::create_email_change_tokens( $user_id );
+				$sent   = [];
 				if (
 					Emails::send_email(
 						Reader_Activation_Emails::EMAIL_TYPES['CHANGE_EMAIL_CANCEL'],
@@ -1143,7 +1236,7 @@ class WooCommerce_My_Account {
 							],
 							[
 								'template' => '*EMAIL_CANCELLATION_URL*',
-								'value'    => self::get_email_change_url( self::CANCEL_EMAIL_CHANGE_PARAM, $old_email ),
+								'value'    => self::get_email_change_url( self::CANCEL_EMAIL_CHANGE_PARAM, $tokens['cancel'] ),
 							],
 						]
 					)
@@ -1157,11 +1250,11 @@ class WooCommerce_My_Account {
 						[
 							[
 								'template' => '*EMAIL_VERIFICATION_URL*',
-								'value'    => self::get_email_change_url( self::VERIFY_EMAIL_CHANGE_PARAM, $old_email ),
+								'value'    => self::get_email_change_url( self::VERIFY_EMAIL_CHANGE_PARAM, $tokens['verify'] ),
 							],
 							[
 								'template' => '*EMAIL_CANCELLATION_URL*',
-								'value'    => self::get_email_change_url( self::CANCEL_EMAIL_CHANGE_PARAM, $old_email ),
+								'value'    => self::get_email_change_url( self::CANCEL_EMAIL_CHANGE_PARAM, $tokens['cancel'] ),
 							],
 						]
 					)
@@ -1219,10 +1312,12 @@ class WooCommerce_My_Account {
 		$message   = __( 'Your email address has been successfully updated.', 'newspack-plugin' );
 		$is_error  = false;
 		$user_id   = \get_current_user_id();
-		$new_email = \get_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META, true );
+		$new_email = self::get_pending_email_change( $user_id );
 		$old_email = \wp_get_current_user()->user_email;
-		if ( $new_email && \wp_hash( $old_email ) === $secret ) {
-			\delete_user_meta( \get_current_user_id(), self::PENDING_EMAIL_CHANGE_META );
+		$tokens    = self::get_email_change_tokens( $user_id );
+		if ( $new_email && ! empty( $tokens['verify'] ) && hash_equals( $tokens['verify'], (string) $secret ) ) {
+			// Single use: the request is spent whether or not the update succeeds.
+			self::clear_pending_email_change( $user_id );
 			$update = \wp_update_user(
 				[
 					'ID'         => $user_id,
@@ -1235,7 +1330,6 @@ class WooCommerce_My_Account {
 				$customer->save();
 				self::maybe_sync_email_change_with_stripe( $user_id, $new_email );
 				self::sync_email_change_with_esp( $user_id, $new_email, $old_email );
-				\delete_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META );
 			} else {
 				$message  = __( 'Something went wrong.', 'newspack-plugin' );
 				$is_error = true;
@@ -1271,11 +1365,12 @@ class WooCommerce_My_Account {
 		if ( ! $secret ) {
 			return;
 		}
-		$current_email = \wp_get_current_user()->user_email;
-		$message       = __( 'Your email address change request has been cancelled.', 'newspack-plugin' );
-		$is_error      = false;
-		if ( \wp_hash( $current_email ) === $secret ) {
-			\delete_user_meta( \get_current_user_id(), self::PENDING_EMAIL_CHANGE_META );
+		$user_id  = \get_current_user_id();
+		$message  = __( 'Your email address change request has been cancelled.', 'newspack-plugin' );
+		$is_error = false;
+		$tokens   = self::get_email_change_tokens( $user_id );
+		if ( ! empty( $tokens['cancel'] ) && hash_equals( $tokens['cancel'], (string) $secret ) ) {
+			self::clear_pending_email_change( $user_id );
 		} else {
 			$message  = __( 'This email change request has been cancelled or expired.', 'newspack-plugin' );
 			$is_error = true;

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
@@ -1109,20 +1109,25 @@ class WooCommerce_My_Account {
 	 * Issue a fresh set of single-use tokens for a pending email change.
 	 *
 	 * The verification and cancellation links are delivered to different
-	 * mailboxes, so each gets its own token. Both are stored on the user and
-	 * expire together.
+	 * mailboxes, so each gets its own token. The requested address is stored
+	 * with them in a single record, so a token can only ever settle the address
+	 * it was issued for, and both tokens expire together.
 	 *
-	 * @param int $user_id User ID.
+	 * @param int    $user_id   User ID.
+	 * @param string $new_email The address the request is for.
 	 *
-	 * @return array Token set with 'verify', 'cancel' and 'expires' keys.
+	 * @return array Token set with 'email', 'verify', 'cancel' and 'expires' keys, or an empty array if it could not be stored.
 	 */
-	private static function create_email_change_tokens( $user_id ) {
+	private static function create_email_change_tokens( $user_id, $new_email ) {
 		$tokens = [
+			'email'   => $new_email,
 			'verify'  => \wp_generate_password( 32, false ),
 			'cancel'  => \wp_generate_password( 32, false ),
 			'expires' => time() + self::EMAIL_CHANGE_TOKEN_EXPIRY,
 		];
-		\update_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_TOKENS_META, $tokens );
+		if ( ! \update_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_TOKENS_META, $tokens ) ) {
+			return [];
+		}
 		return $tokens;
 	}
 
@@ -1137,6 +1142,7 @@ class WooCommerce_My_Account {
 		$tokens = \get_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_TOKENS_META, true );
 		if (
 			! is_array( $tokens )
+			|| empty( $tokens['email'] )
 			|| empty( $tokens['verify'] )
 			|| empty( $tokens['cancel'] )
 			|| empty( $tokens['expires'] )
@@ -1159,15 +1165,14 @@ class WooCommerce_My_Account {
 	 * @return string Pending email address, or an empty string if there is none.
 	 */
 	public static function get_pending_email_change( $user_id ) {
-		$new_email = \get_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META, true );
-		if ( ! $new_email ) {
-			return '';
+		$tokens = self::get_email_change_tokens( $user_id );
+		if ( $tokens ) {
+			return $tokens['email'];
 		}
-		if ( ! self::get_email_change_tokens( $user_id ) ) {
+		if ( \get_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META, true ) ) {
 			self::clear_pending_email_change( $user_id );
-			return '';
 		}
-		return $new_email;
+		return '';
 	}
 
 	/**
@@ -1196,6 +1201,91 @@ class WooCommerce_My_Account {
 	}
 
 	/**
+	 * Claim a pending email change, so that only one caller can settle it.
+	 *
+	 * Two clicks on the same link can both pass the token comparison before
+	 * either clears the request. The delete is what decides: the database
+	 * removes the record once, and only the caller whose statement removed it
+	 * goes on to apply the change.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return bool Whether this caller claimed the request.
+	 */
+	private static function claim_pending_email_change( $user_id ) {
+		global $wpdb;
+		$claimed = $wpdb->delete( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			$wpdb->usermeta,
+			[
+				'user_id'  => $user_id,
+				'meta_key' => self::PENDING_EMAIL_CHANGE_TOKENS_META,
+			]
+		);
+		\wp_cache_delete( $user_id, 'user_meta' );
+		\delete_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META );
+		return (bool) $claimed;
+	}
+
+	/**
+	 * Settle a pending email change, applying the requested address.
+	 *
+	 * @param int    $user_id User ID.
+	 * @param string $secret  Token from the verification link.
+	 *
+	 * @return true|\WP_Error True once the address is updated.
+	 */
+	public static function verify_email_change( $user_id, $secret ) {
+		$tokens = self::get_email_change_tokens( $user_id );
+		if ( empty( $tokens['verify'] ) || ! hash_equals( $tokens['verify'], (string) $secret ) ) {
+			return new \WP_Error( 'newspack_email_change_unavailable', __( 'This email change request has been cancelled or expired.', 'newspack-plugin' ) );
+		}
+		$user = \get_userdata( $user_id );
+		if ( ! $user ) {
+			return new \WP_Error( 'newspack_email_change_unavailable', __( 'This email change request has been cancelled or expired.', 'newspack-plugin' ) );
+		}
+		// Single use: the request is spent whether or not the update succeeds.
+		if ( ! self::claim_pending_email_change( $user_id ) ) {
+			return new \WP_Error( 'newspack_email_change_unavailable', __( 'This email change request has been cancelled or expired.', 'newspack-plugin' ) );
+		}
+		$new_email = $tokens['email'];
+		$old_email = $user->user_email;
+		$update    = \wp_update_user(
+			[
+				'ID'         => $user_id,
+				'user_email' => $new_email,
+			]
+		);
+		if ( \is_wp_error( $update ) || ! $update ) {
+			return new \WP_Error( 'newspack_email_change_failed', __( 'Something went wrong.', 'newspack-plugin' ) );
+		}
+		$customer = new \WC_Customer( $user_id );
+		$customer->set_billing_email( $new_email );
+		$customer->save();
+		self::maybe_sync_email_change_with_stripe( $user_id, $new_email );
+		self::sync_email_change_with_esp( $user_id, $new_email, $old_email );
+		return true;
+	}
+
+	/**
+	 * Drop a pending email change, leaving the account address as it is.
+	 *
+	 * @param int    $user_id User ID.
+	 * @param string $secret  Token from the cancellation link.
+	 *
+	 * @return true|\WP_Error True once the request is dropped.
+	 */
+	public static function cancel_email_change( $user_id, $secret ) {
+		$tokens = self::get_email_change_tokens( $user_id );
+		if ( empty( $tokens['cancel'] ) || ! hash_equals( $tokens['cancel'], (string) $secret ) ) {
+			return new \WP_Error( 'newspack_email_change_unavailable', __( 'This email change request has been cancelled or expired.', 'newspack-plugin' ) );
+		}
+		if ( ! self::claim_pending_email_change( $user_id ) ) {
+			return new \WP_Error( 'newspack_email_change_unavailable', __( 'This email change request has been cancelled or expired.', 'newspack-plugin' ) );
+		}
+		return true;
+	}
+
+	/**
 	 * Handle email change request.
 	 *
 	 * @param int $user_id User ID.
@@ -1219,12 +1309,15 @@ class WooCommerce_My_Account {
 		} elseif ( \email_exists( $new_email ) ) {
 			\wc_add_notice( __( 'This email address is already in use.', 'newspack-plugin' ), 'error' );
 		} else {
-			$update = \update_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META, $new_email );
-			if ( ! $update ) {
+			// The token record carries the requested address, so it is written
+			// first and is what every later step reads. The plain meta below
+			// mirrors it for anything still reading that key directly.
+			$tokens = self::create_email_change_tokens( $user_id, $new_email );
+			if ( ! $tokens ) {
 				\wc_add_notice( __( 'Something went wrong. Please try again.', 'newspack-plugin' ), 'error' );
 			} else {
-				$tokens = self::create_email_change_tokens( $user_id );
-				$sent   = [];
+				\update_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META, $new_email );
+				$sent = [];
 				if (
 					Emails::send_email(
 						Reader_Activation_Emails::EMAIL_TYPES['CHANGE_EMAIL_CANCEL'],
@@ -1309,35 +1402,9 @@ class WooCommerce_My_Account {
 		if ( ! $secret ) {
 			return;
 		}
-		$message   = __( 'Your email address has been successfully updated.', 'newspack-plugin' );
-		$is_error  = false;
-		$user_id   = \get_current_user_id();
-		$new_email = self::get_pending_email_change( $user_id );
-		$old_email = \wp_get_current_user()->user_email;
-		$tokens    = self::get_email_change_tokens( $user_id );
-		if ( $new_email && ! empty( $tokens['verify'] ) && hash_equals( $tokens['verify'], (string) $secret ) ) {
-			// Single use: the request is spent whether or not the update succeeds.
-			self::clear_pending_email_change( $user_id );
-			$update = \wp_update_user(
-				[
-					'ID'         => $user_id,
-					'user_email' => $new_email,
-				]
-			);
-			if ( $update ) {
-				$customer = new \WC_Customer( $user_id );
-				$customer->set_billing_email( $new_email );
-				$customer->save();
-				self::maybe_sync_email_change_with_stripe( $user_id, $new_email );
-				self::sync_email_change_with_esp( $user_id, $new_email, $old_email );
-			} else {
-				$message  = __( 'Something went wrong.', 'newspack-plugin' );
-				$is_error = true;
-			}
-		} else {
-			$message  = __( 'This email change request has been cancelled or expired.', 'newspack-plugin' );
-			$is_error = true;
-		}
+		$result   = self::verify_email_change( \get_current_user_id(), $secret );
+		$is_error = \is_wp_error( $result );
+		$message  = $is_error ? $result->get_error_message() : __( 'Your email address has been successfully updated.', 'newspack-plugin' );
 		\wp_safe_redirect(
 			\add_query_arg(
 				[
@@ -1365,16 +1432,9 @@ class WooCommerce_My_Account {
 		if ( ! $secret ) {
 			return;
 		}
-		$user_id  = \get_current_user_id();
-		$message  = __( 'Your email address change request has been cancelled.', 'newspack-plugin' );
-		$is_error = false;
-		$tokens   = self::get_email_change_tokens( $user_id );
-		if ( ! empty( $tokens['cancel'] ) && hash_equals( $tokens['cancel'], (string) $secret ) ) {
-			self::clear_pending_email_change( $user_id );
-		} else {
-			$message  = __( 'This email change request has been cancelled or expired.', 'newspack-plugin' );
-			$is_error = true;
-		}
+		$result   = self::cancel_email_change( \get_current_user_id(), $secret );
+		$is_error = \is_wp_error( $result );
+		$message  = $is_error ? $result->get_error_message() : __( 'Your email address change request has been cancelled.', 'newspack-plugin' );
 		\wp_safe_redirect(
 			\add_query_arg(
 				[

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
@@ -1109,17 +1109,24 @@ class WooCommerce_My_Account {
 	 * Issue a fresh set of single-use tokens for a pending email change.
 	 *
 	 * The verification and cancellation links are delivered to different
-	 * mailboxes, so each gets its own token. The requested address is stored
-	 * with them in a single record, so a token can only ever settle the address
-	 * it was issued for, and both tokens expire together.
+	 * mailboxes, so each gets its own token. Both addresses are stored with
+	 * them in a single record: the one the request is for, so a token can only
+	 * ever settle the address it was issued for, and the one it was issued
+	 * from, so the links stop working if the account address moves by any other
+	 * route in the meantime. Both tokens expire together.
 	 *
 	 * @param int    $user_id   User ID.
 	 * @param string $new_email The address the request is for.
 	 *
-	 * @return array Token set with 'email', 'verify', 'cancel' and 'expires' keys, or an empty array if it could not be stored.
+	 * @return array Token set with 'from', 'email', 'verify', 'cancel' and 'expires' keys, or an empty array if it could not be stored.
 	 */
 	private static function create_email_change_tokens( $user_id, $new_email ) {
+		$user = \get_userdata( $user_id );
+		if ( ! $user ) {
+			return [];
+		}
 		$tokens = [
+			'from'    => $user->user_email,
 			'email'   => $new_email,
 			'verify'  => \wp_generate_password( 32, false ),
 			'cancel'  => \wp_generate_password( 32, false ),
@@ -1132,16 +1139,23 @@ class WooCommerce_My_Account {
 	}
 
 	/**
-	 * Get a user's unexpired email change tokens.
+	 * Get a user's usable email change tokens.
+	 *
+	 * A request is only usable while the account still holds the address it was
+	 * issued from. If that address moves by any other route — an admin
+	 * correcting it, or any programmatic update — the request no longer
+	 * describes the account it was made against, and settling it would revert
+	 * the newer address and push that revert on to Stripe and the ESP.
 	 *
 	 * @param int $user_id User ID.
 	 *
-	 * @return array Token set, or an empty array if there is none or it has expired.
+	 * @return array Token set, or an empty array if there is none, it has expired, or the account address has moved.
 	 */
 	private static function get_email_change_tokens( $user_id ) {
 		$tokens = \get_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_TOKENS_META, true );
 		if (
 			! is_array( $tokens )
+			|| empty( $tokens['from'] )
 			|| empty( $tokens['email'] )
 			|| empty( $tokens['verify'] )
 			|| empty( $tokens['cancel'] )
@@ -1150,15 +1164,25 @@ class WooCommerce_My_Account {
 		) {
 			return [];
 		}
+		$user = \get_userdata( $user_id );
+		if ( ! $user || $tokens['from'] !== $user->user_email ) {
+			return [];
+		}
 		return $tokens;
 	}
 
 	/**
 	 * Get the address a user's email change is waiting on.
 	 *
-	 * A request whose links have expired is cleared here, so the account form
-	 * unlocks instead of holding a change the reader can no longer complete or
-	 * cancel.
+	 * A request that can no longer be settled — expired links, or an account
+	 * address that has moved since — is cleared here, so the account form
+	 * unlocks instead of holding a change the reader can neither complete nor
+	 * cancel. Either key left behind is swept, since by this point the request
+	 * is unusable whichever half of it survived.
+	 *
+	 * Note that this is an accessor that writes: reading the pending address
+	 * settles an unusable request as a side effect. Both call sites render the
+	 * account form for the current reader, which is what that behaviour is for.
 	 *
 	 * @param int $user_id User ID.
 	 *
@@ -1169,7 +1193,10 @@ class WooCommerce_My_Account {
 		if ( $tokens ) {
 			return $tokens['email'];
 		}
-		if ( \get_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META, true ) ) {
+		if (
+			\get_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META, true )
+			|| \get_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_TOKENS_META, true )
+		) {
 			self::clear_pending_email_change( $user_id );
 		}
 		return '';
@@ -1191,6 +1218,26 @@ class WooCommerce_My_Account {
 	}
 
 	/**
+	 * Get the verification url for a user's pending email change.
+	 *
+	 * Deliberately private, and deliberately not the mirror image of the
+	 * accessor above: this hands out the token that completes the change, so it
+	 * exists to keep the two links assembled the same way and under test, not
+	 * as something other code should be able to call.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return string Verification url, or an empty string if there is no pending change.
+	 */
+	private static function get_verify_email_change_url( $user_id ) {
+		$tokens = self::get_email_change_tokens( $user_id );
+		if ( empty( $tokens['verify'] ) ) {
+			return '';
+		}
+		return self::get_email_change_url( self::VERIFY_EMAIL_CHANGE_PARAM, $tokens['verify'] );
+	}
+
+	/**
 	 * Clear all pending email change state for a user.
 	 *
 	 * @param int $user_id User ID.
@@ -1208,6 +1255,12 @@ class WooCommerce_My_Account {
 	 * removes the record once, and only the caller whose statement removed it
 	 * goes on to apply the change.
 	 *
+	 * The claim is all or nothing. `$wpdb::delete()` returns `false` on a SQL
+	 * error as well as `0` when another caller got there first, so the mirror
+	 * is only cleared once the token record is actually gone. Clearing it
+	 * regardless would leave a request the caller has been told is over still
+	 * live in every other respect — form locked, both links working.
+	 *
 	 * @param int $user_id User ID.
 	 *
 	 * @return bool Whether this caller claimed the request.
@@ -1222,8 +1275,11 @@ class WooCommerce_My_Account {
 			]
 		);
 		\wp_cache_delete( $user_id, 'user_meta' );
+		if ( ! $claimed ) {
+			return false;
+		}
 		\delete_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META );
-		return (bool) $claimed;
+		return true;
 	}
 
 	/**
@@ -1256,7 +1312,13 @@ class WooCommerce_My_Account {
 			]
 		);
 		if ( \is_wp_error( $update ) || ! $update ) {
-			return new \WP_Error( 'newspack_email_change_failed', __( 'Something went wrong.', 'newspack-plugin' ) );
+			// The request is already spent, so the reader has to ask again. Core
+			// rechecks the address on update, so the common failure here is that
+			// something claimed it inside the 24 hours — worth saying, since
+			// "something went wrong" reads as a site fault and invites a reload
+			// of a link that will never work again.
+			$reason = \is_wp_error( $update ) ? $update->get_error_message() : '';
+			return new \WP_Error( 'newspack_email_change_failed', $reason ? $reason : __( 'Something went wrong.', 'newspack-plugin' ) );
 		}
 		$customer = new \WC_Customer( $user_id );
 		$customer->set_billing_email( $new_email );
@@ -1329,7 +1391,7 @@ class WooCommerce_My_Account {
 							],
 							[
 								'template' => '*EMAIL_CANCELLATION_URL*',
-								'value'    => self::get_email_change_url( self::CANCEL_EMAIL_CHANGE_PARAM, $tokens['cancel'] ),
+								'value'    => self::get_cancel_email_change_url( $user_id ),
 							],
 						]
 					)
@@ -1343,11 +1405,11 @@ class WooCommerce_My_Account {
 						[
 							[
 								'template' => '*EMAIL_VERIFICATION_URL*',
-								'value'    => self::get_email_change_url( self::VERIFY_EMAIL_CHANGE_PARAM, $tokens['verify'] ),
+								'value'    => self::get_verify_email_change_url( $user_id ),
 							],
 							[
 								'template' => '*EMAIL_CANCELLATION_URL*',
-								'value'    => self::get_email_change_url( self::CANCEL_EMAIL_CHANGE_PARAM, $tokens['cancel'] ),
+								'value'    => self::get_cancel_email_change_url( $user_id ),
 							],
 						]
 					)

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v0/edit-account.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v0/edit-account.php
@@ -32,8 +32,9 @@ if ( isset( $_GET['is_error'] ) ) { // phpcs:ignore WordPress.Security.NonceVeri
 $without_password        = true === Reader_Activation::is_reader_without_password( $user );
 $is_reader               = true === Reader_Activation::is_user_reader( $user );
 $is_email_change_enabled = true === WooCommerce_My_Account::is_email_change_enabled();
-$is_pending_email_change = $user->get( WooCommerce_My_Account::PENDING_EMAIL_CHANGE_META ) ? true : false;
-$display_email           = $is_pending_email_change ? $user->get( WooCommerce_My_Account::PENDING_EMAIL_CHANGE_META ) : $user->user_email;
+$pending_email_change    = WooCommerce_My_Account::get_pending_email_change( $user->ID );
+$is_pending_email_change = '' !== $pending_email_change;
+$display_email           = $is_pending_email_change ? $pending_email_change : $user->user_email;
 ?>
 
 <?php
@@ -113,7 +114,7 @@ endif;
 	<p class="woocommerce-buttons-card">
 		<?php \wp_nonce_field( 'save_account_details', 'save-account-details-nonce' ); ?>
 		<?php if ( $is_email_change_enabled && $is_pending_email_change ) : ?>
-			<a href="<?php echo esc_url( WooCommerce_My_Account::get_email_change_url( WooCommerce_My_Account::CANCEL_EMAIL_CHANGE_PARAM, $user->user_email ) ); ?>" class="woocommerce-Button button"><?php \esc_html_e( 'Cancel email change', 'newspack-plugin' ); ?></a>
+			<a href="<?php echo esc_url( WooCommerce_My_Account::get_cancel_email_change_url( $user->ID ) ); ?>" class="woocommerce-Button button"><?php \esc_html_e( 'Cancel email change', 'newspack-plugin' ); ?></a>
 		<?php endif; ?>
 		<button type="submit" class="woocommerce-Button button secondary" name="save_account_details" value="<?php \esc_attr_e( 'Save changes', 'newspack-plugin' ); ?>"><?php \esc_html_e( 'Save changes', 'newspack-plugin' ); ?></button>
 		<input type="hidden" name="action" value="save_account_details" />

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php
@@ -25,8 +25,9 @@ $newspack_delete_account_arg = WooCommerce_My_Account::DELETE_ACCOUNT_URL_PARAM;
 $without_password        = true === Reader_Activation::is_reader_without_password( $user );
 $is_reader               = true === Reader_Activation::is_user_reader( $user );
 $is_email_change_enabled = true === WooCommerce_My_Account::is_email_change_enabled();
-$is_pending_email_change = $user->get( WooCommerce_My_Account::PENDING_EMAIL_CHANGE_META ) ? true : false;
-$display_email           = $is_pending_email_change ? $user->get( WooCommerce_My_Account::PENDING_EMAIL_CHANGE_META ) : $user->user_email;
+$pending_email_change    = WooCommerce_My_Account::get_pending_email_change( $user->ID );
+$is_pending_email_change = '' !== $pending_email_change;
+$display_email           = $is_pending_email_change ? $pending_email_change : $user->user_email;
 ?>
 
 <section id="account-profile">
@@ -160,7 +161,7 @@ $display_email           = $is_pending_email_change ? $user->get( WooCommerce_My
 		<p class="woocommerce-buttons-card">
 			<?php \wp_nonce_field( 'save_account_details', 'save-account-details-nonce' ); ?>
 			<?php if ( $is_email_change_enabled && $is_pending_email_change ) : ?>
-				<a href="<?php echo esc_url( WooCommerce_My_Account::get_email_change_url( WooCommerce_My_Account::CANCEL_EMAIL_CHANGE_PARAM, $user->user_email ) ); ?>" class="woocommerce-Button button"><?php \esc_html_e( 'Cancel email change', 'newspack-plugin' ); ?></a>
+				<a href="<?php echo esc_url( WooCommerce_My_Account::get_cancel_email_change_url( $user->ID ) ); ?>" class="woocommerce-Button button"><?php \esc_html_e( 'Cancel email change', 'newspack-plugin' ); ?></a>
 			<?php endif; ?>
 			<input type="hidden" name="action" value="save_account_details" />
 			<button type="submit" class="woocommerce-Button button primary newspack-ui__button--wide-on-mobile newspack-ui--block-on-interaction" name="save_account_details" value="<?php \esc_attr_e( 'Save changes', 'newspack-plugin' ); ?>"><?php \esc_html_e( 'Update profile', 'newspack-plugin' ); ?></button>

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -989,12 +989,21 @@ function wc_create_order( $data ) {
 function wc_get_checkout_url() {
 	return 'https://example.com/checkout';
 }
-function wc_get_page_permalink( $page ) {
-	return 'https://example.com/' . $page;
+// Guarded, unlike the rest of this file: these two names are also declared by
+// tests/unit-tests/my-account.php and the group-subscription my-account tests.
+// Nothing is broken today only because include order happens to reach this file
+// first; a new file declaring either name at file scope and sorting earlier
+// would fatal the suite on redeclare.
+if ( ! function_exists( 'wc_get_page_permalink' ) ) {
+	function wc_get_page_permalink( $page ) {
+		return 'https://example.com/' . $page;
+	}
 }
-function wc_get_endpoint_url( $endpoint, $value = '', $permalink = '' ) {
-	$permalink = $permalink ? $permalink : 'https://example.com/';
-	return \trailingslashit( $permalink ) . $endpoint . ( $value ? '/' . $value : '' );
+if ( ! function_exists( 'wc_get_endpoint_url' ) ) {
+	function wc_get_endpoint_url( $endpoint, $value = '', $permalink = '' ) {
+		$permalink = $permalink ? $permalink : 'https://example.com/';
+		return \trailingslashit( $permalink ) . $endpoint . ( $value ? '/' . $value : '' );
+	}
 }
 function wcs_is_subscription( $order ) {
 	global $subscriptions_database;

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -989,6 +989,13 @@ function wc_create_order( $data ) {
 function wc_get_checkout_url() {
 	return 'https://example.com/checkout';
 }
+function wc_get_page_permalink( $page ) {
+	return 'https://example.com/' . $page;
+}
+function wc_get_endpoint_url( $endpoint, $value = '', $permalink = '' ) {
+	$permalink = $permalink ? $permalink : 'https://example.com/';
+	return \trailingslashit( $permalink ) . $endpoint . ( $value ? '/' . $value : '' );
+}
 function wcs_is_subscription( $order ) {
 	global $subscriptions_database;
 	// Mirror real WooCommerce Subscriptions: only an actual WC_Subscription object

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-my-account-email-change.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-my-account-email-change.php
@@ -61,6 +61,49 @@ class Newspack_Test_WooCommerce_My_Account_Email_Change extends WP_UnitTestCase 
 	}
 
 	/**
+	 * Push the stored links past their expiry.
+	 *
+	 * @param array $tokens The token set to expire.
+	 *
+	 * @return array The expired token set, as stored.
+	 */
+	private function expire_tokens( $tokens ) {
+		$tokens['expires'] = time() - HOUR_IN_SECONDS;
+		\update_user_meta( $this->user_id, WooCommerce_My_Account::PENDING_EMAIL_CHANGE_TOKENS_META, $tokens );
+		return $tokens;
+	}
+
+	/**
+	 * The verification link for the test reader's pending request.
+	 *
+	 * Private on purpose in the class under test — it hands out the token that
+	 * completes a change — so the test reaches it the same way it reaches the
+	 * other private members here.
+	 *
+	 * @return string
+	 */
+	private function verify_url() {
+		$method = new ReflectionMethod( WooCommerce_My_Account::class, 'get_verify_email_change_url' );
+		$method->setAccessible( true );
+		return $method->invoke( null, $this->user_id );
+	}
+
+	/**
+	 * Move the account address, as an admin correction or any other route would.
+	 *
+	 * @param string $email The address to move the account to.
+	 */
+	private function move_account_email( $email ) {
+		\wp_update_user(
+			[
+				'ID'         => $this->user_id,
+				'user_email' => $email,
+			]
+		);
+		\clean_user_cache( $this->user_id );
+	}
+
+	/**
 	 * The address currently on the account.
 	 *
 	 * @return string
@@ -86,6 +129,8 @@ class Newspack_Test_WooCommerce_My_Account_Email_Change extends WP_UnitTestCase 
 		$this->assertNotEmpty( $tokens['verify'], 'A verification token should be issued.' );
 		$this->assertNotEmpty( $tokens['cancel'], 'A cancellation token should be issued.' );
 		$this->assertNotEquals( $tokens['verify'], $tokens['cancel'], 'The two links should never carry the same token.' );
+		$this->assertSame( 32, strlen( $tokens['verify'] ), 'Tokens should be 32 characters long.' );
+		$this->assertSame( 32, strlen( $tokens['cancel'] ), 'Tokens should be 32 characters long.' );
 	}
 
 	/**
@@ -96,7 +141,6 @@ class Newspack_Test_WooCommerce_My_Account_Email_Change extends WP_UnitTestCase 
 		$second = $this->issue_tokens();
 		$this->assertNotEquals( $first['verify'], $second['verify'], 'A new request should issue a new verification token.' );
 		$this->assertNotEquals( $first['cancel'], $second['cancel'], 'A new request should issue a new cancellation token.' );
-		$this->assertSame( 32, strlen( $second['verify'] ), 'Tokens should be 32 characters long.' );
 	}
 
 	/**
@@ -142,13 +186,22 @@ class Newspack_Test_WooCommerce_My_Account_Email_Change extends WP_UnitTestCase 
 	 * Once the links expire the request is dropped, so the account form unlocks.
 	 */
 	public function test_expired_request_is_dropped() {
-		$tokens            = $this->start_email_change();
-		$tokens['expires'] = time() - HOUR_IN_SECONDS;
-		\update_user_meta( $this->user_id, WooCommerce_My_Account::PENDING_EMAIL_CHANGE_TOKENS_META, $tokens );
+		$this->expire_tokens( $this->start_email_change() );
 
 		$this->assertSame( '', WooCommerce_My_Account::get_pending_email_change( $this->user_id ), 'An expired request should not hold the account form.' );
-		$this->assertSame( '', \get_user_meta( $this->user_id, WooCommerce_My_Account::PENDING_EMAIL_CHANGE_META, true ), 'The pending address should be cleared.' );
-		$this->assertSame( '', \get_user_meta( $this->user_id, WooCommerce_My_Account::PENDING_EMAIL_CHANGE_TOKENS_META, true ), 'The spent tokens should be cleared.' );
+		$this->assertNoPendingRequest();
+	}
+
+	/**
+	 * A token record with no mirror alongside it is swept once it is unusable,
+	 * rather than sitting on the account forever. The sweep follows what the
+	 * function has just concluded, not whichever key happens to be present.
+	 */
+	public function test_an_orphaned_token_record_is_swept() {
+		$this->expire_tokens( $this->issue_tokens() );
+
+		$this->assertSame( '', WooCommerce_My_Account::get_pending_email_change( $this->user_id ) );
+		$this->assertNoPendingRequest();
 	}
 
 	/**
@@ -166,9 +219,7 @@ class Newspack_Test_WooCommerce_My_Account_Email_Change extends WP_UnitTestCase 
 	 * An expired request offers no cancellation link.
 	 */
 	public function test_expired_request_offers_no_cancellation_link() {
-		$tokens            = $this->start_email_change();
-		$tokens['expires'] = time() - HOUR_IN_SECONDS;
-		\update_user_meta( $this->user_id, WooCommerce_My_Account::PENDING_EMAIL_CHANGE_TOKENS_META, $tokens );
+		$this->expire_tokens( $this->start_email_change() );
 
 		$this->assertSame( '', WooCommerce_My_Account::get_cancel_email_change_url( $this->user_id ) );
 	}
@@ -219,9 +270,7 @@ class Newspack_Test_WooCommerce_My_Account_Email_Change extends WP_UnitTestCase 
 	 * A token that has expired no longer completes the change.
 	 */
 	public function test_expired_token_cannot_verify() {
-		$tokens            = $this->start_email_change();
-		$tokens['expires'] = time() - HOUR_IN_SECONDS;
-		\update_user_meta( $this->user_id, WooCommerce_My_Account::PENDING_EMAIL_CHANGE_TOKENS_META, $tokens );
+		$tokens = $this->expire_tokens( $this->start_email_change() );
 
 		$this->assertWPError( WooCommerce_My_Account::verify_email_change( $this->user_id, $tokens['verify'] ) );
 		$this->assertSame( 'reader@example.com', $this->account_email() );
@@ -270,6 +319,117 @@ class Newspack_Test_WooCommerce_My_Account_Email_Change extends WP_UnitTestCase 
 
 		$this->assertTrue( WooCommerce_My_Account::verify_email_change( $this->user_id, $first['verify'] ) );
 		$this->assertSame( 'first@example.com', $this->account_email() );
+	}
+
+	/**
+	 * The verification link carries the token that completes the change, and
+	 * never the one that cancels it. This is the line the vulnerability was on,
+	 * so it is asserted rather than assumed.
+	 */
+	public function test_verification_link_carries_only_the_verification_token() {
+		$tokens = $this->start_email_change();
+		$url    = $this->verify_url();
+		$this->assertStringContainsString( WooCommerce_My_Account::VERIFY_EMAIL_CHANGE_PARAM . '=' . $tokens['verify'], $url, 'The verification link should carry the verification token.' );
+		$this->assertStringNotContainsString( $tokens['cancel'], $url, 'The verification link should never carry the cancellation token.' );
+	}
+
+	/**
+	 * With nothing pending there is no verification link to hand out either.
+	 */
+	public function test_no_verification_link_without_a_pending_change() {
+		$this->assertSame( '', $this->verify_url() );
+	}
+
+	/**
+	 * A pending link must not survive the account address moving by another
+	 * route. Settling it would revert the newer address and push that revert on
+	 * to Stripe and the ESP, with the reader told the change succeeded.
+	 */
+	public function test_pending_request_does_not_survive_an_outside_address_change() {
+		$tokens = $this->start_email_change( 'typo@exmaple.com' );
+		$this->move_account_email( 'corrected@example.com' );
+
+		$this->assertWPError( WooCommerce_My_Account::verify_email_change( $this->user_id, $tokens['verify'] ), 'A link issued against the old address should no longer complete.' );
+		$this->assertSame( 'corrected@example.com', $this->account_email(), 'The correction should stand.' );
+	}
+
+	/**
+	 * The cancellation link goes the same way, and the account form unlocks so
+	 * the reader can ask again from the address the account now holds.
+	 */
+	public function test_an_outside_address_change_releases_the_account_form() {
+		$tokens = $this->start_email_change( 'typo@exmaple.com' );
+		$this->move_account_email( 'corrected@example.com' );
+
+		$this->assertWPError( WooCommerce_My_Account::cancel_email_change( $this->user_id, $tokens['cancel'] ) );
+		$this->assertSame( '', WooCommerce_My_Account::get_cancel_email_change_url( $this->user_id ), 'A stale request should offer no cancellation link.' );
+		$this->assertSame( '', WooCommerce_My_Account::get_pending_email_change( $this->user_id ), 'A stale request should not hold the account form.' );
+		$this->assertNoPendingRequest();
+	}
+
+	/**
+	 * The claim is what decides who settles the request, so it works once.
+	 */
+	public function test_only_one_caller_claims_the_request() {
+		$this->start_email_change();
+		$method = new ReflectionMethod( WooCommerce_My_Account::class, 'claim_pending_email_change' );
+		$method->setAccessible( true );
+
+		$this->assertTrue( $method->invoke( null, $this->user_id ), 'The first caller should claim the request.' );
+		$this->assertFalse( $method->invoke( null, $this->user_id ), 'A second caller should find the request already claimed.' );
+		$this->assertNoPendingRequest();
+	}
+
+	/**
+	 * A claim that fails outright leaves the request whole. Clearing half of it
+	 * would tell the reader it is over while the form stays locked and both
+	 * links still work — stopping them from the one thing that would help.
+	 */
+	public function test_a_failed_claim_leaves_the_request_intact() {
+		global $wpdb;
+		$tokens = $this->start_email_change();
+		$method = new ReflectionMethod( WooCommerce_My_Account::class, 'claim_pending_email_change' );
+		$method->setAccessible( true );
+
+		// Stand in for a SQL error on the claim: the statement fails, so the
+		// token record survives and nothing else about the request may move.
+		$break = function ( $query ) {
+			if ( 0 === stripos( (string) $query, 'DELETE' ) && false !== stripos( (string) $query, WooCommerce_My_Account::PENDING_EMAIL_CHANGE_TOKENS_META ) ) {
+				return 'DELETE FROM newspack_no_such_table WHERE 1 = 0';
+			}
+			return $query;
+		};
+		$suppressed = $wpdb->suppress_errors( true );
+		\add_filter( 'query', $break );
+		$claimed = $method->invoke( null, $this->user_id );
+		\remove_filter( 'query', $break );
+		$wpdb->suppress_errors( $suppressed );
+
+		$this->assertFalse( $claimed, 'A failed delete should not count as a claim.' );
+		$this->assertSame( 'new@example.com', WooCommerce_My_Account::get_pending_email_change( $this->user_id ), 'The request should still be pending.' );
+		$this->assertStringContainsString( $tokens['cancel'], WooCommerce_My_Account::get_cancel_email_change_url( $this->user_id ), 'The reader should still be able to cancel.' );
+		$this->assertSame( 'new@example.com', \get_user_meta( $this->user_id, WooCommerce_My_Account::PENDING_EMAIL_CHANGE_META, true ), 'The mirror should not be cleared on a failed claim.' );
+	}
+
+	/**
+	 * When the address is taken inside the 24 hours, say so. The request is
+	 * already spent by then, so "something went wrong" would send the reader
+	 * back to a link that can never work again.
+	 */
+	public function test_a_failed_update_reports_why() {
+		$tokens = $this->start_email_change( 'taken@example.com' );
+		self::factory()->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_email' => 'taken@example.com',
+			]
+		);
+
+		$result = WooCommerce_My_Account::verify_email_change( $this->user_id, $tokens['verify'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'newspack_email_change_failed', $result->get_error_code() );
+		$this->assertNotSame( 'Something went wrong.', $result->get_error_message(), 'The reader should be told what actually stopped the change.' );
+		$this->assertSame( 'reader@example.com', $this->account_email(), 'The account address should be untouched.' );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-my-account-email-change.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-my-account-email-change.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Tests for the My Account email change request lifecycle.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\WooCommerce_My_Account;
+
+require_once __DIR__ . '/../../mocks/wc-mocks.php';
+
+/**
+ * Test the tokens backing the email change verification and cancellation links.
+ */
+class Newspack_Test_WooCommerce_My_Account_Email_Change extends WP_UnitTestCase {
+
+	/**
+	 * A reader with an account.
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * Set up a reader for each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->user_id = self::factory()->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_email' => 'reader@example.com',
+			]
+		);
+	}
+
+	/**
+	 * Issue a token set for the test reader.
+	 *
+	 * @return array The stored token set.
+	 */
+	private function issue_tokens() {
+		$method = new ReflectionMethod( WooCommerce_My_Account::class, 'create_email_change_tokens' );
+		$method->setAccessible( true );
+		return $method->invoke( null, $this->user_id );
+	}
+
+	/**
+	 * Record a pending change to the given address, with fresh links.
+	 *
+	 * @param string $new_email The address the change is waiting on.
+	 *
+	 * @return array The stored token set.
+	 */
+	private function start_email_change( $new_email = 'new@example.com' ) {
+		\update_user_meta( $this->user_id, WooCommerce_My_Account::PENDING_EMAIL_CHANGE_META, $new_email );
+		return $this->issue_tokens();
+	}
+
+	/**
+	 * Each link gets its own token, since the two are delivered to different mailboxes.
+	 */
+	public function test_verification_and_cancellation_tokens_are_distinct() {
+		$tokens = $this->issue_tokens();
+		$this->assertNotEmpty( $tokens['verify'], 'A verification token should be issued.' );
+		$this->assertNotEmpty( $tokens['cancel'], 'A cancellation token should be issued.' );
+		$this->assertNotEquals( $tokens['verify'], $tokens['cancel'], 'The two links should never carry the same token.' );
+	}
+
+	/**
+	 * Tokens are unguessable and specific to the request that issued them.
+	 */
+	public function test_tokens_are_unique_per_request() {
+		$first  = $this->issue_tokens();
+		$second = $this->issue_tokens();
+		$this->assertNotEquals( $first['verify'], $second['verify'], 'A new request should issue a new verification token.' );
+		$this->assertNotEquals( $first['cancel'], $second['cancel'], 'A new request should issue a new cancellation token.' );
+		$this->assertSame( 32, strlen( $second['verify'] ), 'Tokens should be 32 characters long.' );
+	}
+
+	/**
+	 * Re-requesting a change retires the tokens from the previous request.
+	 */
+	public function test_a_new_request_retires_the_previous_tokens() {
+		$first = $this->start_email_change( 'first@example.com' );
+		$this->start_email_change( 'second@example.com' );
+		$this->assertStringNotContainsString(
+			$first['cancel'],
+			WooCommerce_My_Account::get_cancel_email_change_url( $this->user_id ),
+			'The superseded cancellation link should no longer be offered.'
+		);
+	}
+
+	/**
+	 * The cancellation link must not leak the token that completes the change.
+	 */
+	public function test_cancellation_link_carries_only_the_cancellation_token() {
+		$tokens = $this->start_email_change();
+		$url    = WooCommerce_My_Account::get_cancel_email_change_url( $this->user_id );
+		$this->assertStringContainsString( $tokens['cancel'], $url, 'The cancellation link should carry the cancellation token.' );
+		$this->assertStringNotContainsString( $tokens['verify'], $url, 'The cancellation link should never carry the verification token.' );
+	}
+
+	/**
+	 * With nothing pending there is no address to show and no link to offer.
+	 */
+	public function test_no_pending_change() {
+		$this->assertSame( '', WooCommerce_My_Account::get_pending_email_change( $this->user_id ) );
+		$this->assertSame( '', WooCommerce_My_Account::get_cancel_email_change_url( $this->user_id ) );
+	}
+
+	/**
+	 * A pending change with live links is reported as pending.
+	 */
+	public function test_pending_change_is_reported() {
+		$this->start_email_change( 'new@example.com' );
+		$this->assertSame( 'new@example.com', WooCommerce_My_Account::get_pending_email_change( $this->user_id ) );
+	}
+
+	/**
+	 * Once the links expire the request is dropped, so the account form unlocks.
+	 */
+	public function test_expired_request_is_dropped() {
+		$tokens            = $this->start_email_change();
+		$tokens['expires'] = time() - HOUR_IN_SECONDS;
+		\update_user_meta( $this->user_id, WooCommerce_My_Account::PENDING_EMAIL_CHANGE_TOKENS_META, $tokens );
+
+		$this->assertSame( '', WooCommerce_My_Account::get_pending_email_change( $this->user_id ), 'An expired request should not hold the account form.' );
+		$this->assertSame( '', \get_user_meta( $this->user_id, WooCommerce_My_Account::PENDING_EMAIL_CHANGE_META, true ), 'The pending address should be cleared.' );
+		$this->assertSame( '', \get_user_meta( $this->user_id, WooCommerce_My_Account::PENDING_EMAIL_CHANGE_TOKENS_META, true ), 'The spent tokens should be cleared.' );
+	}
+
+	/**
+	 * A request with no usable links — one predating this flow, say — is dropped
+	 * rather than left holding the account form with nothing the reader can click.
+	 */
+	public function test_request_without_usable_links_is_dropped() {
+		\update_user_meta( $this->user_id, WooCommerce_My_Account::PENDING_EMAIL_CHANGE_META, 'new@example.com' );
+
+		$this->assertSame( '', WooCommerce_My_Account::get_pending_email_change( $this->user_id ) );
+		$this->assertSame( '', \get_user_meta( $this->user_id, WooCommerce_My_Account::PENDING_EMAIL_CHANGE_META, true ), 'The unusable request should be cleared.' );
+	}
+
+	/**
+	 * An expired request offers no cancellation link.
+	 */
+	public function test_expired_request_offers_no_cancellation_link() {
+		$tokens            = $this->start_email_change();
+		$tokens['expires'] = time() - HOUR_IN_SECONDS;
+		\update_user_meta( $this->user_id, WooCommerce_My_Account::PENDING_EMAIL_CHANGE_TOKENS_META, $tokens );
+
+		$this->assertSame( '', WooCommerce_My_Account::get_cancel_email_change_url( $this->user_id ) );
+	}
+
+	/**
+	 * The token is carried through to the link as-is, so what lands in the
+	 * mailbox is what the handler compares against.
+	 */
+	public function test_link_carries_the_token_verbatim() {
+		$url = WooCommerce_My_Account::get_email_change_url( WooCommerce_My_Account::VERIFY_EMAIL_CHANGE_PARAM, 'abc123' );
+		$this->assertStringContainsString( WooCommerce_My_Account::VERIFY_EMAIL_CHANGE_PARAM . '=abc123', $url );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-my-account-email-change.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-my-account-email-change.php
@@ -37,12 +37,14 @@ class Newspack_Test_WooCommerce_My_Account_Email_Change extends WP_UnitTestCase 
 	/**
 	 * Issue a token set for the test reader.
 	 *
+	 * @param string $new_email The address the request is for.
+	 *
 	 * @return array The stored token set.
 	 */
-	private function issue_tokens() {
+	private function issue_tokens( $new_email = 'new@example.com' ) {
 		$method = new ReflectionMethod( WooCommerce_My_Account::class, 'create_email_change_tokens' );
 		$method->setAccessible( true );
-		return $method->invoke( null, $this->user_id );
+		return $method->invoke( null, $this->user_id, $new_email );
 	}
 
 	/**
@@ -53,8 +55,27 @@ class Newspack_Test_WooCommerce_My_Account_Email_Change extends WP_UnitTestCase 
 	 * @return array The stored token set.
 	 */
 	private function start_email_change( $new_email = 'new@example.com' ) {
+		$tokens = $this->issue_tokens( $new_email );
 		\update_user_meta( $this->user_id, WooCommerce_My_Account::PENDING_EMAIL_CHANGE_META, $new_email );
-		return $this->issue_tokens();
+		return $tokens;
+	}
+
+	/**
+	 * The address currently on the account.
+	 *
+	 * @return string
+	 */
+	private function account_email() {
+		\clean_user_cache( $this->user_id );
+		return \get_userdata( $this->user_id )->user_email;
+	}
+
+	/**
+	 * Assert that no pending request remains on the account.
+	 */
+	private function assertNoPendingRequest() {
+		$this->assertSame( '', \get_user_meta( $this->user_id, WooCommerce_My_Account::PENDING_EMAIL_CHANGE_META, true ), 'The pending address should be cleared.' );
+		$this->assertSame( '', \get_user_meta( $this->user_id, WooCommerce_My_Account::PENDING_EMAIL_CHANGE_TOKENS_META, true ), 'The tokens should be cleared.' );
 	}
 
 	/**
@@ -159,5 +180,109 @@ class Newspack_Test_WooCommerce_My_Account_Email_Change extends WP_UnitTestCase 
 	public function test_link_carries_the_token_verbatim() {
 		$url = WooCommerce_My_Account::get_email_change_url( WooCommerce_My_Account::VERIFY_EMAIL_CHANGE_PARAM, 'abc123' );
 		$this->assertStringContainsString( WooCommerce_My_Account::VERIFY_EMAIL_CHANGE_PARAM . '=abc123', $url );
+	}
+
+	/**
+	 * The verification token applies the requested address and settles the request.
+	 */
+	public function test_verifying_applies_the_requested_address() {
+		$tokens = $this->start_email_change( 'confirmed@example.com' );
+
+		$this->assertTrue( WooCommerce_My_Account::verify_email_change( $this->user_id, $tokens['verify'] ) );
+		$this->assertSame( 'confirmed@example.com', $this->account_email() );
+		$this->assertNoPendingRequest();
+	}
+
+	/**
+	 * The cancellation token does not complete the change.
+	 */
+	public function test_cancellation_token_cannot_verify() {
+		$tokens = $this->start_email_change( 'confirmed@example.com' );
+
+		$result = WooCommerce_My_Account::verify_email_change( $this->user_id, $tokens['cancel'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'reader@example.com', $this->account_email(), 'The account address should be untouched.' );
+		$this->assertSame( 'confirmed@example.com', WooCommerce_My_Account::get_pending_email_change( $this->user_id ), 'A rejected attempt should leave the request standing.' );
+	}
+
+	/**
+	 * The verification token does not cancel the change.
+	 */
+	public function test_verification_token_cannot_cancel() {
+		$tokens = $this->start_email_change();
+
+		$this->assertWPError( WooCommerce_My_Account::cancel_email_change( $this->user_id, $tokens['verify'] ) );
+		$this->assertSame( 'new@example.com', WooCommerce_My_Account::get_pending_email_change( $this->user_id ) );
+	}
+
+	/**
+	 * A token that has expired no longer completes the change.
+	 */
+	public function test_expired_token_cannot_verify() {
+		$tokens            = $this->start_email_change();
+		$tokens['expires'] = time() - HOUR_IN_SECONDS;
+		\update_user_meta( $this->user_id, WooCommerce_My_Account::PENDING_EMAIL_CHANGE_TOKENS_META, $tokens );
+
+		$this->assertWPError( WooCommerce_My_Account::verify_email_change( $this->user_id, $tokens['verify'] ) );
+		$this->assertSame( 'reader@example.com', $this->account_email() );
+	}
+
+	/**
+	 * A verification token works once.
+	 */
+	public function test_verification_token_cannot_be_replayed() {
+		$tokens = $this->start_email_change( 'confirmed@example.com' );
+		WooCommerce_My_Account::verify_email_change( $this->user_id, $tokens['verify'] );
+
+		$this->assertWPError( WooCommerce_My_Account::verify_email_change( $this->user_id, $tokens['verify'] ) );
+		$this->assertSame( 'confirmed@example.com', $this->account_email(), 'The replay should not change the address again.' );
+	}
+
+	/**
+	 * A cancellation token works once.
+	 */
+	public function test_cancellation_token_cannot_be_replayed() {
+		$tokens = $this->start_email_change();
+		$this->assertTrue( WooCommerce_My_Account::cancel_email_change( $this->user_id, $tokens['cancel'] ) );
+
+		$this->assertWPError( WooCommerce_My_Account::cancel_email_change( $this->user_id, $tokens['cancel'] ) );
+	}
+
+	/**
+	 * Cancelling settles the request and leaves the account address alone.
+	 */
+	public function test_cancelling_leaves_the_account_address() {
+		$tokens = $this->start_email_change();
+
+		$this->assertTrue( WooCommerce_My_Account::cancel_email_change( $this->user_id, $tokens['cancel'] ) );
+		$this->assertSame( 'reader@example.com', $this->account_email() );
+		$this->assertNoPendingRequest();
+	}
+
+	/**
+	 * A token settles the address it was issued for, not whichever address was
+	 * recorded last. Two overlapping requests can otherwise leave one request's
+	 * token paired with the other's address.
+	 */
+	public function test_token_settles_the_address_it_was_issued_for() {
+		$first = $this->issue_tokens( 'first@example.com' );
+		\update_user_meta( $this->user_id, WooCommerce_My_Account::PENDING_EMAIL_CHANGE_META, 'second@example.com' );
+
+		$this->assertTrue( WooCommerce_My_Account::verify_email_change( $this->user_id, $first['verify'] ) );
+		$this->assertSame( 'first@example.com', $this->account_email() );
+	}
+
+	/**
+	 * A request that cannot be stored is reported rather than half-started.
+	 */
+	public function test_unstorable_request_is_reported() {
+		$fail = function () {
+			return false;
+		};
+		\add_filter( 'update_user_metadata', $fail, 10, 1 );
+		$tokens = $this->issue_tokens();
+		\remove_filter( 'update_user_metadata', $fail, 10 );
+
+		$this->assertSame( [], $tokens, 'A request that could not be stored should not hand back usable tokens.' );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Changing the account email in My Account sends two links: one to confirm the change, one to cancel it. Each link now carries a token issued for that request, stored on the user and compared with `hash_equals`. The links expire after 24 hours and stop working once the request is settled.

Because the links can now expire, a request can outlive them. The account form drops an expired request instead of holding it, so the email field becomes editable again and the reader can start over. That path also covers a request carried over from before this change.

Both account templates are covered, `v0` and `v1`.

Closes NPPM-3061.

### How to test the changes in this Pull Request:

1. With Reader Activation on, sign in as a reader and open **My Account → Account details**.
2. Enter a different email address and save. Two emails arrive.
3. Compare the links in the two emails. They carry different tokens.
4. Swap one link's token into the other link's query argument and load it. The page reports the request as cancelled or expired.
5. Confirm the account email is unchanged.
6. Open the cancellation link. The request is dropped and the email field is editable again.
7. Request the change again, then open the confirmation link. The account email updates.
8. Reload that same confirmation link. It reports the request as cancelled or expired.
9. Request the change again, then set `expires` in the `newspack_pending_email_change_tokens` user meta to a past timestamp.
10. Reload the account page. The email field is editable and shows the current address.
11. Set only `newspack_pending_email_change` on a reader, with no token meta, then reload the account page. The field is editable.
12. Add `define( 'NEWSPACK_MY_ACCOUNT_VERSION', '0.0.0' );` to `wp-config.php` and repeat steps 2 to 8.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally? Full `newspack-plugin` suite passes; `phpcs` clean.

Both handlers still require a signed-in reader, unchanged from before, so a link opened without a session does nothing. Worth a separate look; deliberately out of scope here.
