### PR TITLE
fix(analytics): provision only GA4 dimensions the site can populate

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
@@ -30,6 +30,46 @@ final class GA4_Custom_Dimensions {
 	const RECHECK_GROUP      = 'newspack';
 
 	/**
+	 * Parameters only a site running access control can populate. Every one of
+	 * them originates with a rendered gate: `src/content-gate/gate.js` enqueues
+	 * only when {@see Content_Gate::get_frontend_script_conditions()} passes – a
+	 * singular, restricted post carrying a published gate – and the handful of
+	 * other dispatchers that carry `gate_post_id` (the auth form, the reader
+	 * registration block, the modal checkout) receive it from that same gate.
+	 * With no access control there is no gate, so no event carries them.
+	 *
+	 * `access_source` is deliberately NOT in this group. It is emitted server
+	 * side by {@see GoogleSiteKit::add_ga_custom_parameters()} under
+	 * `Content_Gate::is_gating_active()`, which is stricter than what makes a
+	 * gate render – see `get_dimensions()`.
+	 */
+	const ACCESS_CONTROL_DIMENSIONS = [
+		'gate_post_id',
+		'gate_has_donation_block',
+		'gate_has_registration_block',
+		'gate_has_checkout_button',
+		'gate_has_registration_link',
+		'gate_has_signin_link',
+	];
+
+	/**
+	 * Parameters only a site running reader revenue can populate. `is_subscriber`
+	 * and `is_donor` are sourced from Reader Data, which fills them from
+	 * WooCommerce subscriptions and donation orders; the checkout and donation
+	 * parameters are emitted by the modal checkout and the Donate block, both of
+	 * which need the WooCommerce suite to render at all.
+	 */
+	const READER_REVENUE_DIMENSIONS = [
+		'is_subscriber',
+		'is_donor',
+		'product_id',
+		'product_type',
+		'recurrence',
+		'donation_frequency',
+		'donation_amount',
+	];
+
+	/**
 	 * Register hooks.
 	 */
 	public static function init() {
@@ -194,14 +234,69 @@ final class GA4_Custom_Dimensions {
 	}
 
 	/**
+	 * Whether this site runs access control, and so can render a gate and
+	 * populate the gate parameters. Covers both routes a gate can come from, the
+	 * way `Content_Gate::get_gate_post_id()` does: WooCommerce Memberships when
+	 * it is active, the first-party feature otherwise.
+	 *
+	 * @return bool
+	 */
+	public static function is_access_control_enabled(): bool {
+		$is_enabled = Content_Gate::is_newspack_feature_enabled() || Memberships::is_active();
+
+		/**
+		 * Filters whether GA4 custom dimensions specific to access control are
+		 * provisioned. Lets a site opt in or out when the automatic detection
+		 * reads its setup wrongly.
+		 *
+		 * @param bool $is_enabled Whether the site runs access control.
+		 */
+		return (bool) apply_filters( 'newspack_ga4_dimensions_access_control_enabled', $is_enabled );
+	}
+
+	/**
+	 * Whether this site runs reader revenue, and so can populate the commerce
+	 * parameters.
+	 *
+	 * Deliberately not `Donations::is_platform_wc()`: the platform option
+	 * defaults to `wc` and is therefore true on sites that never touched reader
+	 * revenue. Equally deliberately not `Reader_Activation::is_woocommerce_active()`,
+	 * which additionally requires WooCommerce Subscriptions – the modal checkout
+	 * sends `product_id`, `product_type` and `recurrence` on one-time purchases
+	 * too, so keying on Subscriptions would silently cost those sites their
+	 * checkout reporting. WooCommerce itself is the floor every emitter in
+	 * {@see self::READER_REVENUE_DIMENSIONS} actually stands on.
+	 *
+	 * @return bool
+	 */
+	public static function is_reader_revenue_enabled(): bool {
+		$is_enabled = class_exists( 'WooCommerce' );
+
+		/**
+		 * Filters whether GA4 custom dimensions specific to reader revenue are
+		 * provisioned. Lets a site opt in or out when the automatic detection
+		 * reads its setup wrongly.
+		 *
+		 * @param bool $is_enabled Whether the site runs reader revenue.
+		 */
+		return (bool) apply_filters( 'newspack_ga4_dimensions_reader_revenue_enabled', $is_enabled );
+	}
+
+	/**
 	 * Priority-ordered list of custom dimensions Newspack provisions.
 	 * Each entry: parameter name => display name.
 	 *
-	 * `access_source` is appended conditionally rather than listed inline: it
-	 * only fires on sites running Access Control, and GA4 caps event-scoped
-	 * custom dimensions at 50 – a publisher has already hit that ceiling, so a
-	 * dimension that never fires must not spend a slot. Appending (rather than
-	 * inserting) keeps the existing entries' priority order intact.
+	 * GA4 caps event-scoped custom dimensions at 50 per property and never
+	 * back-fills them, so a dimension that no event on this site can carry is
+	 * pure waste – and publishers have hit that ceiling. Parameters belonging to
+	 * a feature the site does not run are therefore dropped rather than listed
+	 * unconditionally. Turning the feature on later grows this list, which
+	 * `maybe_schedule_provisioning_for_new_dimensions()` detects and provisions
+	 * on the next admin request rather than at the monthly recheck.
+	 *
+	 * Dropping is by key from the ordered list, so the priority order of what
+	 * remains is unchanged; `access_source` stays appended, keeping its position
+	 * at the end.
 	 *
 	 * @return array<string,string>
 	 */
@@ -236,7 +331,10 @@ final class GA4_Custom_Dimensions {
 			'product_id'                  => 'Product ID',
 			'product_type'                => 'Product Type',
 			'recurrence'                  => 'Recurrence',
-			'price'                       => 'Price',
+			// `price` is deliberately absent: no event carries it. The modal
+			// checkout's GA4 payload whitelist (analytics/ga4/utils/index.js)
+			// admits `amount`, and analytics/ga4/opened.js folds `price` into it
+			// before sending, so provisioning `price` only spent a slot.
 			'donation_frequency'          => 'Donation Frequency',
 			'donation_amount'             => 'Donation Amount',
 			'registration_method'         => 'Registration Method',
@@ -246,7 +344,25 @@ final class GA4_Custom_Dimensions {
 			'segment_id'                  => 'Matched Segment',
 		];
 
-		if ( Content_Gate::is_newspack_feature_enabled() ) {
+		// Each predicate is read once. Both are filterable, and a filter that is
+		// not a pure function would otherwise be able to return a list that
+		// contradicts itself – which then gets fingerprinted and persisted.
+		$has_access_control = self::is_access_control_enabled();
+		$has_reader_revenue = self::is_reader_revenue_enabled();
+
+		if ( ! $has_access_control ) {
+			$dimensions = array_diff_key( $dimensions, array_flip( self::ACCESS_CONTROL_DIMENSIONS ) );
+		}
+
+		if ( ! $has_reader_revenue ) {
+			$dimensions = array_diff_key( $dimensions, array_flip( self::READER_REVENUE_DIMENSIONS ) );
+		}
+
+		// Not $has_access_control: a gate renders on WooCommerce Memberships alone,
+		// but GoogleSiteKit only sends access_source under is_gating_active(), which
+		// also requires the first-party feature and Reader Activation. Provisioning
+		// it any wider hands the site a dimension nothing populates.
+		if ( Content_Gate::is_gating_active() ) {
 			$dimensions['access_source'] = 'Access Source';
 		}
 
@@ -258,10 +374,18 @@ final class GA4_Custom_Dimensions {
 	 * provisioning run so a later addition to the list can be told apart from a
 	 * property that is already fully provisioned.
 	 *
+	 * Accepts an already-resolved list so a caller that acts on one snapshot can
+	 * fingerprint that same snapshot. `get_dimensions()` runs publisher filters,
+	 * so re-deriving it here could fingerprint a list the caller never used.
+	 *
+	 * @param array<string,string>|null $dimensions Resolved dimension list, or null to resolve now.
 	 * @return string
 	 */
-	public static function schema_fingerprint() {
-		return md5( (string) wp_json_encode( array_keys( self::get_dimensions() ) ) );
+	public static function schema_fingerprint( $dimensions = null ) {
+		if ( null === $dimensions ) {
+			$dimensions = self::get_dimensions();
+		}
+		return md5( (string) wp_json_encode( array_keys( $dimensions ) ) );
 	}
 
 	/**
@@ -467,9 +591,14 @@ final class GA4_Custom_Dimensions {
 			return new \WP_Error( 'newspack_ga4_dimensions', 'No GA4 property ID configured.' );
 		}
 
+		// One snapshot for the whole run: the create loop, the fingerprint and the
+		// recorded list must all describe the same list, or the summary claims a
+		// schema that was never provisioned and every later run sees it as stale.
+		$dimensions = self::get_dimensions();
+
 		$used_source = null;
 		$result      = self::with_admin_client(
-			function ( $client, $source ) use ( $property_id, &$used_source ) {
+			function ( $client, $source ) use ( $property_id, $dimensions, &$used_source ) {
 				$used_source = $source;
 				try {
 					$existing = $client->list_custom_dimensions( $property_id );
@@ -490,7 +619,7 @@ final class GA4_Custom_Dimensions {
 				$errors              = [];
 				$has_transient_error = false;
 
-				foreach ( self::get_dimensions() as $parameter_name => $display_name ) {
+				foreach ( $dimensions as $parameter_name => $display_name ) {
 					if ( isset( $existing_params[ $parameter_name ] ) ) {
 						$skipped_exists[] = $parameter_name;
 						continue;
@@ -536,12 +665,12 @@ final class GA4_Custom_Dimensions {
 			// repairs the Google connection. Permanent failures (the dimension
 			// cap, validation) record the fingerprint anyway – no retry can fix
 			// them; the monthly recheck is the self-heal path.
-			'schema'         => $has_transient_error ? null : self::schema_fingerprint(),
+			'schema'         => $has_transient_error ? null : self::schema_fingerprint( $dimensions ),
 			'auth_source'    => $used_source,
 			'timestamp'      => time(),
 			// The list this run knew about, so a later addition to
 			// get_dimensions() is detectable and can provision immediately.
-			'dimensions'     => array_keys( self::get_dimensions() ),
+			'dimensions'     => array_keys( $dimensions ),
 			'created'        => $created,
 			'skipped_exists' => $skipped_exists,
 			'errors'         => $errors,

--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
@@ -46,15 +46,33 @@ final class GA4_Custom_Dimensions {
 	];
 
 	/**
-	 * Parameters that only WooCommerce can produce, via Reader Data, the modal
-	 * checkout, or the Donate block.
+	 * Parameters that only WooCommerce can produce: the modal checkout's product
+	 * fields, and the subscription flag Reader Data writes from WooCommerce
+	 * Subscriptions.
+	 *
+	 * Donation parameters are not in this group. See `DONATION_DIMENSIONS`.
 	 */
-	const READER_REVENUE_DIMENSIONS = [
+	const WOOCOMMERCE_DIMENSIONS = [
 		'is_subscriber',
-		'is_donor',
 		'product_id',
 		'product_type',
 		'recurrence',
+	];
+
+	/**
+	 * Donation parameters, which WooCommerce does not have to itself. The Donate
+	 * block renders on every reader-revenue platform - NRH redirects its
+	 * submission to NRH's own checkout - and the gate's form handler reads
+	 * `donation_frequency` and `donation_amount` straight off the submitted form,
+	 * client-side. `is_donor` rides along on every pageview from Reader Data,
+	 * which non-WooCommerce platforms write from the donor landing page (see
+	 * `Reader_Data::get_read_only_keys()`).
+	 *
+	 * So a site donating through NRH or an external platform emits all three
+	 * without WooCommerce, and needs the dimensions to query them.
+	 */
+	const DONATION_DIMENSIONS = [
+		'is_donor',
 		'donation_frequency',
 		'donation_amount',
 	];
@@ -243,25 +261,53 @@ final class GA4_Custom_Dimensions {
 	}
 
 	/**
-	 * Whether this site runs reader revenue.
+	 * Whether this site runs WooCommerce, which is what produces the checkout and
+	 * subscription parameters.
 	 *
-	 * Two near-misses to avoid. `Donations::is_platform_wc()` defaults to true on
-	 * sites that never touched reader revenue. `Reader_Activation::is_woocommerce_active()`
-	 * also demands WooCommerce Subscriptions, which would cost one-time-purchase
-	 * sites their checkout reporting.
+	 * One near-miss to avoid: `Reader_Activation::is_woocommerce_active()` also
+	 * demands WooCommerce Subscriptions, which would cost one-time-purchase sites
+	 * their checkout reporting.
 	 *
 	 * @return bool
 	 */
-	public static function is_reader_revenue_enabled(): bool {
+	public static function is_woocommerce_enabled(): bool {
 		$is_enabled = class_exists( 'WooCommerce' );
 
 		/**
-		 * Filters reader-revenue dimension provisioning, for a site the detection
+		 * Filters WooCommerce dimension provisioning, for a site the detection
 		 * above reads wrongly.
 		 *
-		 * @param bool $is_enabled Whether the site runs reader revenue.
+		 * @param bool $is_enabled Whether the site runs WooCommerce.
 		 */
-		return (bool) apply_filters( 'newspack_ga4_dimensions_reader_revenue_enabled', $is_enabled );
+		return (bool) apply_filters( 'newspack_ga4_dimensions_woocommerce_enabled', $is_enabled );
+	}
+
+	/**
+	 * Whether this site takes donations, on any platform.
+	 *
+	 * Either WooCommerce is installed, or the publisher picked a platform that
+	 * isn't it. `Donations::is_platform_wc()` cannot carry this alone because it
+	 * defaults to true on sites that never touched reader revenue - but read
+	 * negatively, as it is here, a non-`wc` slug is only ever a deliberate choice
+	 * of NRH or an external platform.
+	 *
+	 * Deliberately reads WooCommerce directly rather than through
+	 * `is_woocommerce_enabled()`: the two groups are provisioned independently,
+	 * so each predicate takes exactly one filter and neither override leaks into
+	 * the other.
+	 *
+	 * @return bool
+	 */
+	public static function is_donations_enabled(): bool {
+		$is_enabled = class_exists( 'WooCommerce' ) || ! Donations::is_platform_wc();
+
+		/**
+		 * Filters donation dimension provisioning, for a site the detection above
+		 * reads wrongly.
+		 *
+		 * @param bool $is_enabled Whether the site takes donations.
+		 */
+		return (bool) apply_filters( 'newspack_ga4_dimensions_donations_enabled', $is_enabled );
 	}
 
 	/**
@@ -320,17 +366,22 @@ final class GA4_Custom_Dimensions {
 			'segment_id'                  => 'Matched Segment',
 		];
 
-		// Read once each: both are filterable, and an impure filter could
+		// Read once each: all three are filterable, and an impure filter could
 		// otherwise yield a self-contradictory list that then gets persisted.
 		$has_access_control = self::is_access_control_enabled();
-		$has_reader_revenue = self::is_reader_revenue_enabled();
+		$has_woocommerce    = self::is_woocommerce_enabled();
+		$has_donations      = self::is_donations_enabled();
 
 		if ( ! $has_access_control ) {
 			$dimensions = array_diff_key( $dimensions, array_flip( self::ACCESS_CONTROL_DIMENSIONS ) );
 		}
 
-		if ( ! $has_reader_revenue ) {
-			$dimensions = array_diff_key( $dimensions, array_flip( self::READER_REVENUE_DIMENSIONS ) );
+		if ( ! $has_woocommerce ) {
+			$dimensions = array_diff_key( $dimensions, array_flip( self::WOOCOMMERCE_DIMENSIONS ) );
+		}
+
+		if ( ! $has_donations ) {
+			$dimensions = array_diff_key( $dimensions, array_flip( self::DONATION_DIMENSIONS ) );
 		}
 
 		// Not $has_access_control: Memberships alone renders a gate, but

--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
@@ -30,11 +30,8 @@ final class GA4_Custom_Dimensions {
 	const RECHECK_GROUP      = 'newspack';
 
 	/**
-	 * Parameters that only a rendered gate produces. No access control, no gate,
-	 * so nothing ever carries them.
-	 *
-	 * `access_source` is not in this group; it has a stricter condition of its
-	 * own. See `get_dimensions()`.
+	 * Parameters only a rendered gate produces. `access_source` is not among
+	 * them; it has a stricter condition of its own, see `get_dimensions()`.
 	 */
 	const ACCESS_CONTROL_DIMENSIONS = [
 		'gate_post_id',
@@ -46,11 +43,9 @@ final class GA4_Custom_Dimensions {
 	];
 
 	/**
-	 * Parameters that only WooCommerce can produce: the modal checkout's product
-	 * fields, and the subscription flag Reader Data writes from WooCommerce
-	 * Subscriptions.
-	 *
-	 * Donation parameters are not in this group. See `DONATION_DIMENSIONS`.
+	 * Parameters only WooCommerce produces: the modal checkout's product fields,
+	 * and the subscription flag Reader Data writes from WooCommerce
+	 * Subscriptions. Donations are separate, see `DONATION_DIMENSIONS`.
 	 */
 	const WOOCOMMERCE_DIMENSIONS = [
 		'is_subscriber',
@@ -60,16 +55,11 @@ final class GA4_Custom_Dimensions {
 	];
 
 	/**
-	 * Donation parameters, which WooCommerce does not have to itself. The Donate
-	 * block renders on every reader-revenue platform - NRH redirects its
-	 * submission to NRH's own checkout - and the gate's form handler reads
-	 * `donation_frequency` and `donation_amount` straight off the submitted form,
-	 * client-side. `is_donor` rides along on every pageview from Reader Data,
-	 * which non-WooCommerce platforms write from the donor landing page (see
+	 * Donation parameters, which WooCommerce does not have to itself. A site on
+	 * NRH or an external platform emits all three without it: `gate.js` reads
+	 * `donation_frequency` and `donation_amount` off the submitted Donate block
+	 * form, and non-WooCommerce platforms write `is_donor` client-side (see
 	 * `Reader_Data::get_read_only_keys()`).
-	 *
-	 * So a site donating through NRH or an external platform emits all three
-	 * without WooCommerce, and needs the dimensions to query them.
 	 */
 	const DONATION_DIMENSIONS = [
 		'is_donor',
@@ -261,12 +251,12 @@ final class GA4_Custom_Dimensions {
 	}
 
 	/**
-	 * Whether this site runs WooCommerce, which is what produces the checkout and
+	 * Whether this site runs WooCommerce, which produces the checkout and
 	 * subscription parameters.
 	 *
-	 * One near-miss to avoid: `Reader_Activation::is_woocommerce_active()` also
-	 * demands WooCommerce Subscriptions, which would cost one-time-purchase sites
-	 * their checkout reporting.
+	 * Not `Reader_Activation::is_woocommerce_active()`: that also demands
+	 * WooCommerce Subscriptions, and would cost one-time-purchase sites their
+	 * checkout reporting.
 	 *
 	 * @return bool
 	 */
@@ -283,18 +273,13 @@ final class GA4_Custom_Dimensions {
 	}
 
 	/**
-	 * Whether this site takes donations, on any platform.
+	 * Whether this site takes donations, on any platform: WooCommerce is
+	 * installed, or the publisher picked a platform that isn't it.
 	 *
-	 * Either WooCommerce is installed, or the publisher picked a platform that
-	 * isn't it. `Donations::is_platform_wc()` cannot carry this alone because it
-	 * defaults to true on sites that never touched reader revenue - but read
-	 * negatively, as it is here, a non-`wc` slug is only ever a deliberate choice
-	 * of NRH or an external platform.
-	 *
-	 * Deliberately reads WooCommerce directly rather than through
-	 * `is_woocommerce_enabled()`: the two groups are provisioned independently,
-	 * so each predicate takes exactly one filter and neither override leaks into
-	 * the other.
+	 * The platform slug defaults to `wc`, so it only reads reliably negated - a
+	 * non-`wc` slug is always a deliberate choice of NRH or an external platform.
+	 * Reads WooCommerce directly rather than through `is_woocommerce_enabled()`,
+	 * so each group takes exactly one filter.
 	 *
 	 * @return bool
 	 */
@@ -316,11 +301,9 @@ final class GA4_Custom_Dimensions {
 	 *
 	 * GA4 caps event-scoped dimensions at 50 per property and never back-fills,
 	 * and publishers have hit that ceiling, so parameters belonging to a feature
-	 * the site does not run are dropped. Enabling that feature later grows this
-	 * list, which `maybe_schedule_provisioning_for_new_dimensions()` picks up on
-	 * the next admin request.
-	 *
-	 * Dropping is by key, so the priority order of what remains is unchanged.
+	 * the site does not run are dropped - by key, leaving the order intact.
+	 * Enabling the feature later grows the list, which
+	 * `maybe_schedule_provisioning_for_new_dimensions()` picks up.
 	 *
 	 * @return array<string,string>
 	 */
@@ -366,8 +349,8 @@ final class GA4_Custom_Dimensions {
 			'segment_id'                  => 'Matched Segment',
 		];
 
-		// Read once each: all three are filterable, and an impure filter could
-		// otherwise yield a self-contradictory list that then gets persisted.
+		// Read once each: an impure filter could otherwise yield a
+		// self-contradictory list that then gets persisted.
 		$has_access_control = self::is_access_control_enabled();
 		$has_woocommerce    = self::is_woocommerce_enabled();
 		$has_donations      = self::is_donations_enabled();
@@ -398,9 +381,8 @@ final class GA4_Custom_Dimensions {
 	 * provisioning run so a later addition to the list can be told apart from a
 	 * property that is already fully provisioned.
 	 *
-	 * Takes an already-resolved list so a caller can fingerprint the same
-	 * snapshot it acted on; `get_dimensions()` runs filters, so re-deriving it
-	 * here could fingerprint a list the caller never used.
+	 * Takes an already-resolved list, so a caller fingerprints the snapshot it
+	 * acted on rather than a fresh one the filters could answer differently.
 	 *
 	 * @param array<string,string>|null $dimensions Resolved dimension list, or null to resolve now.
 	 * @return string

--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
@@ -30,18 +30,11 @@ final class GA4_Custom_Dimensions {
 	const RECHECK_GROUP      = 'newspack';
 
 	/**
-	 * Parameters only a site running access control can populate. Every one of
-	 * them originates with a rendered gate: `src/content-gate/gate.js` enqueues
-	 * only when {@see Content_Gate::get_frontend_script_conditions()} passes – a
-	 * singular, restricted post carrying a published gate – and the handful of
-	 * other dispatchers that carry `gate_post_id` (the auth form, the reader
-	 * registration block, the modal checkout) receive it from that same gate.
-	 * With no access control there is no gate, so no event carries them.
+	 * Parameters that only a rendered gate produces. No access control, no gate,
+	 * so nothing ever carries them.
 	 *
-	 * `access_source` is deliberately NOT in this group. It is emitted server
-	 * side by {@see GoogleSiteKit::add_ga_custom_parameters()} under
-	 * `Content_Gate::is_gating_active()`, which is stricter than what makes a
-	 * gate render – see `get_dimensions()`.
+	 * `access_source` is not in this group; it has a stricter condition of its
+	 * own. See `get_dimensions()`.
 	 */
 	const ACCESS_CONTROL_DIMENSIONS = [
 		'gate_post_id',
@@ -53,11 +46,8 @@ final class GA4_Custom_Dimensions {
 	];
 
 	/**
-	 * Parameters only a site running reader revenue can populate. `is_subscriber`
-	 * and `is_donor` are sourced from Reader Data, which fills them from
-	 * WooCommerce subscriptions and donation orders; the checkout and donation
-	 * parameters are emitted by the modal checkout and the Donate block, both of
-	 * which need the WooCommerce suite to render at all.
+	 * Parameters that only WooCommerce can produce, via Reader Data, the modal
+	 * checkout, or the Donate block.
 	 */
 	const READER_REVENUE_DIMENSIONS = [
 		'is_subscriber',
@@ -234,10 +224,9 @@ final class GA4_Custom_Dimensions {
 	}
 
 	/**
-	 * Whether this site runs access control, and so can render a gate and
-	 * populate the gate parameters. Covers both routes a gate can come from, the
-	 * way `Content_Gate::get_gate_post_id()` does: WooCommerce Memberships when
-	 * it is active, the first-party feature otherwise.
+	 * Whether this site can render a gate. Covers both routes, the way
+	 * `Content_Gate::get_gate_post_id()` does: Memberships when active, the
+	 * first-party feature otherwise.
 	 *
 	 * @return bool
 	 */
@@ -245,9 +234,8 @@ final class GA4_Custom_Dimensions {
 		$is_enabled = Content_Gate::is_newspack_feature_enabled() || Memberships::is_active();
 
 		/**
-		 * Filters whether GA4 custom dimensions specific to access control are
-		 * provisioned. Lets a site opt in or out when the automatic detection
-		 * reads its setup wrongly.
+		 * Filters access-control dimension provisioning, for a site the detection
+		 * above reads wrongly.
 		 *
 		 * @param bool $is_enabled Whether the site runs access control.
 		 */
@@ -255,17 +243,12 @@ final class GA4_Custom_Dimensions {
 	}
 
 	/**
-	 * Whether this site runs reader revenue, and so can populate the commerce
-	 * parameters.
+	 * Whether this site runs reader revenue.
 	 *
-	 * Deliberately not `Donations::is_platform_wc()`: the platform option
-	 * defaults to `wc` and is therefore true on sites that never touched reader
-	 * revenue. Equally deliberately not `Reader_Activation::is_woocommerce_active()`,
-	 * which additionally requires WooCommerce Subscriptions – the modal checkout
-	 * sends `product_id`, `product_type` and `recurrence` on one-time purchases
-	 * too, so keying on Subscriptions would silently cost those sites their
-	 * checkout reporting. WooCommerce itself is the floor every emitter in
-	 * {@see self::READER_REVENUE_DIMENSIONS} actually stands on.
+	 * Two near-misses to avoid. `Donations::is_platform_wc()` defaults to true on
+	 * sites that never touched reader revenue. `Reader_Activation::is_woocommerce_active()`
+	 * also demands WooCommerce Subscriptions, which would cost one-time-purchase
+	 * sites their checkout reporting.
 	 *
 	 * @return bool
 	 */
@@ -273,9 +256,8 @@ final class GA4_Custom_Dimensions {
 		$is_enabled = class_exists( 'WooCommerce' );
 
 		/**
-		 * Filters whether GA4 custom dimensions specific to reader revenue are
-		 * provisioned. Lets a site opt in or out when the automatic detection
-		 * reads its setup wrongly.
+		 * Filters reader-revenue dimension provisioning, for a site the detection
+		 * above reads wrongly.
 		 *
 		 * @param bool $is_enabled Whether the site runs reader revenue.
 		 */
@@ -286,17 +268,13 @@ final class GA4_Custom_Dimensions {
 	 * Priority-ordered list of custom dimensions Newspack provisions.
 	 * Each entry: parameter name => display name.
 	 *
-	 * GA4 caps event-scoped custom dimensions at 50 per property and never
-	 * back-fills them, so a dimension that no event on this site can carry is
-	 * pure waste – and publishers have hit that ceiling. Parameters belonging to
-	 * a feature the site does not run are therefore dropped rather than listed
-	 * unconditionally. Turning the feature on later grows this list, which
-	 * `maybe_schedule_provisioning_for_new_dimensions()` detects and provisions
-	 * on the next admin request rather than at the monthly recheck.
+	 * GA4 caps event-scoped dimensions at 50 per property and never back-fills,
+	 * and publishers have hit that ceiling, so parameters belonging to a feature
+	 * the site does not run are dropped. Enabling that feature later grows this
+	 * list, which `maybe_schedule_provisioning_for_new_dimensions()` picks up on
+	 * the next admin request.
 	 *
-	 * Dropping is by key from the ordered list, so the priority order of what
-	 * remains is unchanged; `access_source` stays appended, keeping its position
-	 * at the end.
+	 * Dropping is by key, so the priority order of what remains is unchanged.
 	 *
 	 * @return array<string,string>
 	 */
@@ -331,10 +309,8 @@ final class GA4_Custom_Dimensions {
 			'product_id'                  => 'Product ID',
 			'product_type'                => 'Product Type',
 			'recurrence'                  => 'Recurrence',
-			// `price` is deliberately absent: no event carries it. The modal
-			// checkout's GA4 payload whitelist (analytics/ga4/utils/index.js)
-			// admits `amount`, and analytics/ga4/opened.js folds `price` into it
-			// before sending, so provisioning `price` only spent a slot.
+			// `price` is absent on purpose: the modal checkout sends `amount`
+			// instead, folding `price` into it, so no event ever carried it.
 			'donation_frequency'          => 'Donation Frequency',
 			'donation_amount'             => 'Donation Amount',
 			'registration_method'         => 'Registration Method',
@@ -344,9 +320,8 @@ final class GA4_Custom_Dimensions {
 			'segment_id'                  => 'Matched Segment',
 		];
 
-		// Each predicate is read once. Both are filterable, and a filter that is
-		// not a pure function would otherwise be able to return a list that
-		// contradicts itself – which then gets fingerprinted and persisted.
+		// Read once each: both are filterable, and an impure filter could
+		// otherwise yield a self-contradictory list that then gets persisted.
 		$has_access_control = self::is_access_control_enabled();
 		$has_reader_revenue = self::is_reader_revenue_enabled();
 
@@ -358,10 +333,8 @@ final class GA4_Custom_Dimensions {
 			$dimensions = array_diff_key( $dimensions, array_flip( self::READER_REVENUE_DIMENSIONS ) );
 		}
 
-		// Not $has_access_control: a gate renders on WooCommerce Memberships alone,
-		// but GoogleSiteKit only sends access_source under is_gating_active(), which
-		// also requires the first-party feature and Reader Activation. Provisioning
-		// it any wider hands the site a dimension nothing populates.
+		// Not $has_access_control: Memberships alone renders a gate, but
+		// GoogleSiteKit sends access_source only under is_gating_active().
 		if ( Content_Gate::is_gating_active() ) {
 			$dimensions['access_source'] = 'Access Source';
 		}
@@ -374,9 +347,9 @@ final class GA4_Custom_Dimensions {
 	 * provisioning run so a later addition to the list can be told apart from a
 	 * property that is already fully provisioned.
 	 *
-	 * Accepts an already-resolved list so a caller that acts on one snapshot can
-	 * fingerprint that same snapshot. `get_dimensions()` runs publisher filters,
-	 * so re-deriving it here could fingerprint a list the caller never used.
+	 * Takes an already-resolved list so a caller can fingerprint the same
+	 * snapshot it acted on; `get_dimensions()` runs filters, so re-deriving it
+	 * here could fingerprint a list the caller never used.
 	 *
 	 * @param array<string,string>|null $dimensions Resolved dimension list, or null to resolve now.
 	 * @return string
@@ -591,9 +564,8 @@ final class GA4_Custom_Dimensions {
 			return new \WP_Error( 'newspack_ga4_dimensions', 'No GA4 property ID configured.' );
 		}
 
-		// One snapshot for the whole run: the create loop, the fingerprint and the
-		// recorded list must all describe the same list, or the summary claims a
-		// schema that was never provisioned and every later run sees it as stale.
+		// One snapshot for the whole run, or the summary records a schema that
+		// was never provisioned and every later run reads it as out of date.
 		$dimensions = self::get_dimensions();
 
 		$used_source = null;

--- a/plugins/newspack-plugin/tests/unit-tests/ga4-custom-dimensions.php
+++ b/plugins/newspack-plugin/tests/unit-tests/ga4-custom-dimensions.php
@@ -5,6 +5,7 @@
  * @package Newspack\Tests
  */
 
+use Newspack\Donations;
 use Newspack\GA4_Custom_Dimensions;
 use Newspack\Google_OAuth_GA4_Client;
 
@@ -24,12 +25,18 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	/**
 	 * Mirrors the production group, so a change to it must be made here too.
 	 */
-	const READER_REVENUE_DIMENSIONS = [
+	const WOOCOMMERCE_DIMENSIONS = [
 		'is_subscriber',
-		'is_donor',
 		'product_id',
 		'product_type',
 		'recurrence',
+	];
+
+	/**
+	 * Mirrors the production group, so a change to it must be made here too.
+	 */
+	const DONATION_DIMENSIONS = [
+		'is_donor',
 		'donation_frequency',
 		'donation_amount',
 	];
@@ -284,23 +291,79 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	/**
 	 * A site that sells nothing must not spend slots on commerce parameters.
 	 */
-	public function test_reader_revenue_dimensions_are_omitted_without_reader_revenue() {
-		add_filter( 'newspack_ga4_dimensions_reader_revenue_enabled', '__return_false' );
+	public function test_woocommerce_dimensions_are_omitted_without_woocommerce() {
+		add_filter( 'newspack_ga4_dimensions_woocommerce_enabled', '__return_false' );
 		$dimensions = GA4_Custom_Dimensions::get_dimensions();
-		foreach ( self::READER_REVENUE_DIMENSIONS as $parameter_name ) {
-			$this->assertArrayNotHasKey( $parameter_name, $dimensions, "'$parameter_name' must not be provisioned without reader revenue." );
+		foreach ( self::WOOCOMMERCE_DIMENSIONS as $parameter_name ) {
+			$this->assertArrayNotHasKey( $parameter_name, $dimensions, "'$parameter_name' must not be provisioned without WooCommerce." );
 		}
 	}
 
 	/**
 	 * The same dimensions are provisioned once the site does sell something.
 	 */
-	public function test_reader_revenue_dimensions_are_provisioned_with_reader_revenue() {
-		add_filter( 'newspack_ga4_dimensions_reader_revenue_enabled', '__return_true' );
+	public function test_woocommerce_dimensions_are_provisioned_with_woocommerce() {
+		add_filter( 'newspack_ga4_dimensions_woocommerce_enabled', '__return_true' );
 		$dimensions = GA4_Custom_Dimensions::get_dimensions();
-		foreach ( self::READER_REVENUE_DIMENSIONS as $parameter_name ) {
-			$this->assertArrayHasKey( $parameter_name, $dimensions, "'$parameter_name' must be provisioned on a reader-revenue site." );
+		foreach ( self::WOOCOMMERCE_DIMENSIONS as $parameter_name ) {
+			$this->assertArrayHasKey( $parameter_name, $dimensions, "'$parameter_name' must be provisioned on a WooCommerce site." );
 		}
+	}
+
+	/**
+	 * A site that takes no donations must not spend slots on donation parameters.
+	 */
+	public function test_donation_dimensions_are_omitted_without_donations() {
+		add_filter( 'newspack_ga4_dimensions_donations_enabled', '__return_false' );
+		$dimensions = GA4_Custom_Dimensions::get_dimensions();
+		foreach ( self::DONATION_DIMENSIONS as $parameter_name ) {
+			$this->assertArrayNotHasKey( $parameter_name, $dimensions, "'$parameter_name' must not be provisioned without donations." );
+		}
+	}
+
+	/**
+	 * The same dimensions are provisioned once the site does take donations.
+	 */
+	public function test_donation_dimensions_are_provisioned_with_donations() {
+		add_filter( 'newspack_ga4_dimensions_donations_enabled', '__return_true' );
+		$dimensions = GA4_Custom_Dimensions::get_dimensions();
+		foreach ( self::DONATION_DIMENSIONS as $parameter_name ) {
+			$this->assertArrayHasKey( $parameter_name, $dimensions, "'$parameter_name' must be provisioned on a donation site." );
+		}
+	}
+
+	/**
+	 * The donation parameters are not WooCommerce's to gate. A publisher on NRH
+	 * or an external platform emits them from the Donate block and Reader Data
+	 * with no WooCommerce installed, and GA4 never back-fills what it had no
+	 * dimension for.
+	 *
+	 * No filters here: this is the automatic detection, on the environment's real
+	 * (WooCommerce-free) state.
+	 */
+	public function test_donation_dimensions_survive_on_a_non_woocommerce_platform() {
+		$this->assertFalse( class_exists( 'WooCommerce' ), 'This test is only meaningful with WooCommerce absent.' );
+
+		update_option( Donations::NEWSPACK_READER_REVENUE_PLATFORM, 'nrh' );
+		$dimensions = GA4_Custom_Dimensions::get_dimensions();
+
+		foreach ( self::DONATION_DIMENSIONS as $parameter_name ) {
+			$this->assertArrayHasKey( $parameter_name, $dimensions, "'$parameter_name' must be provisioned for a non-WooCommerce donation platform." );
+		}
+		foreach ( self::WOOCOMMERCE_DIMENSIONS as $parameter_name ) {
+			$this->assertArrayNotHasKey( $parameter_name, $dimensions, "'$parameter_name' has no emitter without WooCommerce and must not be provisioned." );
+		}
+	}
+
+	/**
+	 * The platform option defaults to `wc`, so a site that never chose a platform
+	 * and never installed WooCommerce is not a donation site.
+	 */
+	public function test_donation_dimensions_are_omitted_on_the_default_platform_without_woocommerce() {
+		$this->assertFalse( class_exists( 'WooCommerce' ), 'This test is only meaningful with WooCommerce absent.' );
+
+		delete_option( Donations::NEWSPACK_READER_REVENUE_PLATFORM );
+		$this->assertFalse( GA4_Custom_Dimensions::is_donations_enabled(), 'The default platform slug alone is not a donation site.' );
 	}
 
 	/**
@@ -320,7 +383,8 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	 */
 	public function test_gated_groups_match_the_production_constants() {
 		$this->assertSame( self::ACCESS_CONTROL_DIMENSIONS, GA4_Custom_Dimensions::ACCESS_CONTROL_DIMENSIONS, 'The access-control group changed; update the test list deliberately.' );
-		$this->assertSame( self::READER_REVENUE_DIMENSIONS, GA4_Custom_Dimensions::READER_REVENUE_DIMENSIONS, 'The reader-revenue group changed; update the test list deliberately.' );
+		$this->assertSame( self::WOOCOMMERCE_DIMENSIONS, GA4_Custom_Dimensions::WOOCOMMERCE_DIMENSIONS, 'The WooCommerce group changed; update the test list deliberately.' );
+		$this->assertSame( self::DONATION_DIMENSIONS, GA4_Custom_Dimensions::DONATION_DIMENSIONS, 'The donation group changed; update the test list deliberately.' );
 	}
 
 	/**
@@ -355,7 +419,46 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	 */
 	public function test_predicates_are_false_on_a_site_running_neither_feature() {
 		$this->assertFalse( GA4_Custom_Dimensions::is_access_control_enabled(), 'No gating constant and no Memberships means no access control.' );
-		$this->assertFalse( GA4_Custom_Dimensions::is_reader_revenue_enabled(), 'No WooCommerce means no reader revenue.' );
+		$this->assertFalse( GA4_Custom_Dimensions::is_woocommerce_enabled(), 'No WooCommerce means no checkout parameters.' );
+		$this->assertFalse( GA4_Custom_Dimensions::is_donations_enabled(), 'No WooCommerce and the default platform means no donation parameters.' );
+	}
+
+	/**
+	 * The automatic WooCommerce detection, not the filter that overrides it: a
+	 * detector stuck at false would otherwise leave the suite green while every
+	 * WooCommerce site lost its checkout dimensions.
+	 *
+	 * Isolated because the alias cannot be undone once declared.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_woocommerce_predicate_follows_the_woocommerce_class() {
+		$this->assertFalse( GA4_Custom_Dimensions::is_woocommerce_enabled(), 'Process isolation failed: WooCommerce leaked in, so this was never tested.' );
+
+		class_alias( self::class, 'WooCommerce' );
+
+		$this->assertTrue( GA4_Custom_Dimensions::is_woocommerce_enabled(), 'A loaded WooCommerce switches the checkout dimensions on, with no filter.' );
+		$this->assertTrue( GA4_Custom_Dimensions::is_donations_enabled(), 'A loaded WooCommerce is also a donation platform.' );
+		$this->assertArrayHasKey( 'product_id', GA4_Custom_Dimensions::get_dimensions(), 'The checkout dimensions follow the automatic detection.' );
+	}
+
+	/**
+	 * The automatic access-control detection, via the gates constant, rather than
+	 * the filter that overrides it.
+	 *
+	 * Isolated because NEWSPACK_CONTENT_GATES cannot be unset once defined.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_access_control_predicate_follows_the_gates_constant() {
+		$this->assertFalse( GA4_Custom_Dimensions::is_access_control_enabled(), 'Process isolation failed: gating leaked in, so this was never tested.' );
+
+		define( 'NEWSPACK_CONTENT_GATES', true );
+
+		$this->assertTrue( GA4_Custom_Dimensions::is_access_control_enabled(), 'The gates constant switches the gate dimensions on, with no filter.' );
+		$this->assertArrayHasKey( 'gate_post_id', GA4_Custom_Dimensions::get_dimensions(), 'The gate dimensions follow the automatic detection.' );
 	}
 
 	/**
@@ -373,7 +476,8 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	 * `price` has no emitter on any site: the modal checkout sends `amount`.
 	 */
 	public function test_unemitted_price_dimension_is_never_provisioned() {
-		add_filter( 'newspack_ga4_dimensions_reader_revenue_enabled', '__return_true' );
+		add_filter( 'newspack_ga4_dimensions_woocommerce_enabled', '__return_true' );
+		add_filter( 'newspack_ga4_dimensions_donations_enabled', '__return_true' );
 		add_filter( 'newspack_ga4_dimensions_access_control_enabled', '__return_true' );
 		$this->assertArrayNotHasKey( 'price', GA4_Custom_Dimensions::get_dimensions(), "'price' has no emitter and must not be provisioned." );
 	}
@@ -382,7 +486,8 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	 * Gating must not touch parameters any site can populate.
 	 */
 	public function test_feature_independent_dimensions_survive_both_features_off() {
-		add_filter( 'newspack_ga4_dimensions_reader_revenue_enabled', '__return_false' );
+		add_filter( 'newspack_ga4_dimensions_woocommerce_enabled', '__return_false' );
+		add_filter( 'newspack_ga4_dimensions_donations_enabled', '__return_false' );
 		add_filter( 'newspack_ga4_dimensions_access_control_enabled', '__return_false' );
 		$dimensions = GA4_Custom_Dimensions::get_dimensions();
 		$expected   = [
@@ -417,7 +522,8 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 		$this->connect_property( 'PROP-FEATURE' );
 
 		// Provisioned while the site ran neither feature.
-		add_filter( 'newspack_ga4_dimensions_reader_revenue_enabled', '__return_false' );
+		add_filter( 'newspack_ga4_dimensions_woocommerce_enabled', '__return_false' );
+		add_filter( 'newspack_ga4_dimensions_donations_enabled', '__return_false' );
 		add_filter( 'newspack_ga4_dimensions_access_control_enabled', '__return_false' );
 		update_option(
 			GA4_Custom_Dimensions::PROVISIONED_OPTION,
@@ -433,12 +539,12 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 		GA4_Custom_Dimensions::maybe_schedule_recheck();
 		$this->assertFalse( wp_next_scheduled( GA4_Custom_Dimensions::PROVISION_ACTION ), 'A site whose features are unchanged is not rescheduled.' );
 
-		// The publisher switches reader revenue on.
-		remove_filter( 'newspack_ga4_dimensions_reader_revenue_enabled', '__return_false' );
-		add_filter( 'newspack_ga4_dimensions_reader_revenue_enabled', '__return_true' );
+		// The publisher switches WooCommerce on.
+		remove_filter( 'newspack_ga4_dimensions_woocommerce_enabled', '__return_false' );
+		add_filter( 'newspack_ga4_dimensions_woocommerce_enabled', '__return_true' );
 		delete_transient( GA4_Custom_Dimensions::SCHEMA_TRANSIENT );
 		GA4_Custom_Dimensions::maybe_schedule_recheck();
-		$this->assertNotFalse( wp_next_scheduled( GA4_Custom_Dimensions::PROVISION_ACTION ), 'Enabling reader revenue schedules provisioning for its dimensions.' );
+		$this->assertNotFalse( wp_next_scheduled( GA4_Custom_Dimensions::PROVISION_ACTION ), 'Enabling WooCommerce schedules provisioning for its dimensions.' );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/ga4-custom-dimensions.php
+++ b/plugins/newspack-plugin/tests/unit-tests/ga4-custom-dimensions.php
@@ -22,7 +22,7 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	const SK_SETTINGS_OPTION = 'googlesitekit_analytics-4_settings';
 
 	/**
-	 * Dimensions only a reader-revenue site can populate.
+	 * Mirrors the production group, so a change to it must be made here too.
 	 */
 	const READER_REVENUE_DIMENSIONS = [
 		'is_subscriber',
@@ -35,7 +35,7 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	];
 
 	/**
-	 * Dimensions only an access-control site can populate.
+	 * Mirrors the production group, so a change to it must be made here too.
 	 */
 	const ACCESS_CONTROL_DIMENSIONS = [
 		'gate_post_id',
@@ -282,9 +282,7 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Dimensions that only a reader-revenue site can populate must not spend a
-	 * slot on a site that sells nothing. GA4 caps event-scoped custom dimensions
-	 * at 50 and never back-fills, so a dimension no event carries is pure waste.
+	 * A site that sells nothing must not spend slots on commerce parameters.
 	 */
 	public function test_reader_revenue_dimensions_are_omitted_without_reader_revenue() {
 		add_filter( 'newspack_ga4_dimensions_reader_revenue_enabled', '__return_false' );
@@ -306,9 +304,7 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The gate dimensions are emitted only by `gate.js`, which enqueues solely on
-	 * a restricted post carrying a published gate. A site running no access
-	 * control cannot populate them at all.
+	 * The gate parameters need a rendered gate, which needs access control.
 	 */
 	public function test_gate_dimensions_are_omitted_without_access_control() {
 		add_filter( 'newspack_ga4_dimensions_access_control_enabled', '__return_false' );
@@ -319,10 +315,8 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The gated groups the tests assert on must stay in step with the ones the
-	 * code actually drops, so adding a parameter to a group is a deliberate act
-	 * rather than a silent loss of coverage. The lists are spelled out above
-	 * rather than derived, so this is the one place they are compared.
+	 * The lists above are spelled out rather than derived, so that a test can
+	 * fail rather than silently follow the code. This is where they are compared.
 	 */
 	public function test_gated_groups_match_the_production_constants() {
 		$this->assertSame( self::ACCESS_CONTROL_DIMENSIONS, GA4_Custom_Dimensions::ACCESS_CONTROL_DIMENSIONS, 'The access-control group changed; update the test list deliberately.' );
@@ -330,15 +324,11 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * `access_source` is emitted by GoogleSiteKit under
-	 * `Content_Gate::is_gating_active()`, which is narrower than what makes the
-	 * gate parameters fire -- WooCommerce Memberships alone is enough for a gate,
-	 * but not for `access_source`. Provisioning it with the rest of the gate group
-	 * would hand a Memberships-only site a dimension nothing can populate, which
-	 * is the waste this whole class exists to avoid.
+	 * Memberships alone is enough for a gate, but not for `access_source`, so it
+	 * must not ride along with the gate group.
 	 *
-	 * Runs isolated because NEWSPACK_CONTENT_GATES is a constant a dozen sibling
-	 * suites define, and once defined it cannot be unset.
+	 * Isolated because NEWSPACK_CONTENT_GATES is a constant a dozen sibling suites
+	 * define, and once defined it cannot be unset.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -357,9 +347,8 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The predicates themselves -- not just the filter plumbing -- must read a
-	 * bare site correctly. This environment loads neither WooCommerce nor
-	 * WooCommerce Memberships and defines no gating constant.
+	 * The predicates themselves, not just the filter plumbing. This environment
+	 * loads no WooCommerce, no Memberships, and defines no gating constant.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -370,8 +359,7 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * And are provisioned once the site does run access control. `access_source`
-	 * is checked separately -- it follows its own, stricter emitter.
+	 * And are provisioned once it does. `access_source` is checked separately.
 	 */
 	public function test_gate_dimensions_are_provisioned_with_access_control() {
 		add_filter( 'newspack_ga4_dimensions_access_control_enabled', '__return_true' );
@@ -382,9 +370,7 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * `price` has no emitter on any site: the modal-checkout GA4 whitelist
-	 * (`analytics/ga4/utils/index.js`) admits `amount`, and `ga4/opened.js` folds
-	 * `price` into it before send. Provisioning it burns a slot on every property.
+	 * `price` has no emitter on any site: the modal checkout sends `amount`.
 	 */
 	public function test_unemitted_price_dimension_is_never_provisioned() {
 		add_filter( 'newspack_ga4_dimensions_reader_revenue_enabled', '__return_true' );
@@ -393,8 +379,7 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Feature gating must not touch dimensions that any site can populate --
-	 * campaigns, segments, newsletters and the always-on page context.
+	 * Gating must not touch parameters any site can populate.
 	 */
 	public function test_feature_independent_dimensions_survive_both_features_off() {
 		add_filter( 'newspack_ga4_dimensions_reader_revenue_enabled', '__return_false' );
@@ -425,9 +410,8 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Turning a feature on after provisioning must provision its dimensions
-	 * without waiting for the monthly recheck: GA4 dimensions are not
-	 * retroactive, so events sent before one exists are never queryable.
+	 * Enabling a feature must provision its parameters without waiting for the
+	 * monthly recheck; GA4 never back-fills.
 	 */
 	public function test_enabling_a_feature_schedules_provisioning_for_its_dimensions() {
 		$this->connect_property( 'PROP-FEATURE' );
@@ -444,8 +428,7 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 				'created'     => [],
 			]
 		);
-		// Connecting the property queues its own first-time run; this test is
-		// about the recheck path, so start from a clean queue.
+		// Connecting the property queues its own run; this is about the recheck.
 		wp_clear_scheduled_hook( GA4_Custom_Dimensions::PROVISION_ACTION );
 		GA4_Custom_Dimensions::maybe_schedule_recheck();
 		$this->assertFalse( wp_next_scheduled( GA4_Custom_Dimensions::PROVISION_ACTION ), 'A site whose features are unchanged is not rescheduled.' );

--- a/plugins/newspack-plugin/tests/unit-tests/ga4-custom-dimensions.php
+++ b/plugins/newspack-plugin/tests/unit-tests/ga4-custom-dimensions.php
@@ -333,13 +333,9 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The donation parameters are not WooCommerce's to gate. A publisher on NRH
-	 * or an external platform emits them from the Donate block and Reader Data
-	 * with no WooCommerce installed, and GA4 never back-fills what it had no
-	 * dimension for.
-	 *
-	 * No filters here: this is the automatic detection, on the environment's real
-	 * (WooCommerce-free) state.
+	 * The donation parameters are not WooCommerce's to gate: a publisher on NRH
+	 * emits them from the Donate block and Reader Data with none installed. No
+	 * filters here, so this runs the automatic detection.
 	 */
 	public function test_donation_dimensions_survive_on_a_non_woocommerce_platform() {
 		$this->assertFalse( class_exists( 'WooCommerce' ), 'This test is only meaningful with WooCommerce absent.' );
@@ -356,8 +352,8 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The platform option defaults to `wc`, so a site that never chose a platform
-	 * and never installed WooCommerce is not a donation site.
+	 * The platform option defaults to `wc`, so never choosing one and never
+	 * installing WooCommerce is not a donation site.
 	 */
 	public function test_donation_dimensions_are_omitted_on_the_default_platform_without_woocommerce() {
 		$this->assertFalse( class_exists( 'WooCommerce' ), 'This test is only meaningful with WooCommerce absent.' );
@@ -378,8 +374,8 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The lists above are spelled out rather than derived, so that a test can
-	 * fail rather than silently follow the code. This is where they are compared.
+	 * The lists above are spelled out rather than derived, so a change to the
+	 * code fails a test instead of silently following it. Compared here.
 	 */
 	public function test_gated_groups_match_the_production_constants() {
 		$this->assertSame( self::ACCESS_CONTROL_DIMENSIONS, GA4_Custom_Dimensions::ACCESS_CONTROL_DIMENSIONS, 'The access-control group changed; update the test list deliberately.' );
@@ -388,11 +384,9 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Memberships alone is enough for a gate, but not for `access_source`, so it
-	 * must not ride along with the gate group.
-	 *
-	 * Isolated because NEWSPACK_CONTENT_GATES is a constant a dozen sibling suites
-	 * define, and once defined it cannot be unset.
+	 * Memberships alone is enough for a gate but not for `access_source`, so it
+	 * must not ride along with the gate group. Isolated because sibling suites
+	 * define NEWSPACK_CONTENT_GATES, which cannot then be unset.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -411,8 +405,8 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The predicates themselves, not just the filter plumbing. This environment
-	 * loads no WooCommerce, no Memberships, and defines no gating constant.
+	 * The predicates themselves, not the filter plumbing. This environment loads
+	 * no WooCommerce, no Memberships, and defines no gating constant.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -424,11 +418,9 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The automatic WooCommerce detection, not the filter that overrides it: a
-	 * detector stuck at false would otherwise leave the suite green while every
-	 * WooCommerce site lost its checkout dimensions.
-	 *
-	 * Isolated because the alias cannot be undone once declared.
+	 * The automatic detection, not the filter over it: a detector stuck at false
+	 * would leave the suite green while every WooCommerce site lost its checkout
+	 * dimensions. Isolated because an alias cannot be undone.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -444,10 +436,8 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The automatic access-control detection, via the gates constant, rather than
-	 * the filter that overrides it.
-	 *
-	 * Isolated because NEWSPACK_CONTENT_GATES cannot be unset once defined.
+	 * The same for access control, via the gates constant. Isolated because
+	 * NEWSPACK_CONTENT_GATES cannot be unset once defined.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled

--- a/plugins/newspack-plugin/tests/unit-tests/ga4-custom-dimensions.php
+++ b/plugins/newspack-plugin/tests/unit-tests/ga4-custom-dimensions.php
@@ -22,6 +22,31 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	const SK_SETTINGS_OPTION = 'googlesitekit_analytics-4_settings';
 
 	/**
+	 * Dimensions only a reader-revenue site can populate.
+	 */
+	const READER_REVENUE_DIMENSIONS = [
+		'is_subscriber',
+		'is_donor',
+		'product_id',
+		'product_type',
+		'recurrence',
+		'donation_frequency',
+		'donation_amount',
+	];
+
+	/**
+	 * Dimensions only an access-control site can populate.
+	 */
+	const ACCESS_CONTROL_DIMENSIONS = [
+		'gate_post_id',
+		'gate_has_donation_block',
+		'gate_has_registration_block',
+		'gate_has_checkout_button',
+		'gate_has_registration_link',
+		'gate_has_signin_link',
+	];
+
+	/**
 	 * Recorded HTTP requests, each `[ 'url' => string, 'method' => string, 'body' => string|null ]`.
 	 *
 	 * @var array
@@ -257,6 +282,183 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Dimensions that only a reader-revenue site can populate must not spend a
+	 * slot on a site that sells nothing. GA4 caps event-scoped custom dimensions
+	 * at 50 and never back-fills, so a dimension no event carries is pure waste.
+	 */
+	public function test_reader_revenue_dimensions_are_omitted_without_reader_revenue() {
+		add_filter( 'newspack_ga4_dimensions_reader_revenue_enabled', '__return_false' );
+		$dimensions = GA4_Custom_Dimensions::get_dimensions();
+		foreach ( self::READER_REVENUE_DIMENSIONS as $parameter_name ) {
+			$this->assertArrayNotHasKey( $parameter_name, $dimensions, "'$parameter_name' must not be provisioned without reader revenue." );
+		}
+	}
+
+	/**
+	 * The same dimensions are provisioned once the site does sell something.
+	 */
+	public function test_reader_revenue_dimensions_are_provisioned_with_reader_revenue() {
+		add_filter( 'newspack_ga4_dimensions_reader_revenue_enabled', '__return_true' );
+		$dimensions = GA4_Custom_Dimensions::get_dimensions();
+		foreach ( self::READER_REVENUE_DIMENSIONS as $parameter_name ) {
+			$this->assertArrayHasKey( $parameter_name, $dimensions, "'$parameter_name' must be provisioned on a reader-revenue site." );
+		}
+	}
+
+	/**
+	 * The gate dimensions are emitted only by `gate.js`, which enqueues solely on
+	 * a restricted post carrying a published gate. A site running no access
+	 * control cannot populate them at all.
+	 */
+	public function test_gate_dimensions_are_omitted_without_access_control() {
+		add_filter( 'newspack_ga4_dimensions_access_control_enabled', '__return_false' );
+		$dimensions = GA4_Custom_Dimensions::get_dimensions();
+		foreach ( self::ACCESS_CONTROL_DIMENSIONS as $parameter_name ) {
+			$this->assertArrayNotHasKey( $parameter_name, $dimensions, "'$parameter_name' must not be provisioned without access control." );
+		}
+	}
+
+	/**
+	 * The gated groups the tests assert on must stay in step with the ones the
+	 * code actually drops, so adding a parameter to a group is a deliberate act
+	 * rather than a silent loss of coverage. The lists are spelled out above
+	 * rather than derived, so this is the one place they are compared.
+	 */
+	public function test_gated_groups_match_the_production_constants() {
+		$this->assertSame( self::ACCESS_CONTROL_DIMENSIONS, GA4_Custom_Dimensions::ACCESS_CONTROL_DIMENSIONS, 'The access-control group changed; update the test list deliberately.' );
+		$this->assertSame( self::READER_REVENUE_DIMENSIONS, GA4_Custom_Dimensions::READER_REVENUE_DIMENSIONS, 'The reader-revenue group changed; update the test list deliberately.' );
+	}
+
+	/**
+	 * `access_source` is emitted by GoogleSiteKit under
+	 * `Content_Gate::is_gating_active()`, which is narrower than what makes the
+	 * gate parameters fire -- WooCommerce Memberships alone is enough for a gate,
+	 * but not for `access_source`. Provisioning it with the rest of the gate group
+	 * would hand a Memberships-only site a dimension nothing can populate, which
+	 * is the waste this whole class exists to avoid.
+	 *
+	 * Runs isolated because NEWSPACK_CONTENT_GATES is a constant a dozen sibling
+	 * suites define, and once defined it cannot be unset.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_access_source_is_not_provisioned_for_the_gate_group_alone() {
+		$this->assertFalse(
+			Newspack\Content_Gate::is_gating_active(),
+			'Process isolation failed: gating leaked in, so this was never tested.'
+		);
+
+		add_filter( 'newspack_ga4_dimensions_access_control_enabled', '__return_true' );
+		$dimensions = GA4_Custom_Dimensions::get_dimensions();
+
+		$this->assertArrayHasKey( 'gate_post_id', $dimensions, 'The gate parameters still follow the access-control predicate.' );
+		$this->assertArrayNotHasKey( 'access_source', $dimensions, "'access_source' must follow its own emitter, not the gate group." );
+	}
+
+	/**
+	 * The predicates themselves -- not just the filter plumbing -- must read a
+	 * bare site correctly. This environment loads neither WooCommerce nor
+	 * WooCommerce Memberships and defines no gating constant.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_predicates_are_false_on_a_site_running_neither_feature() {
+		$this->assertFalse( GA4_Custom_Dimensions::is_access_control_enabled(), 'No gating constant and no Memberships means no access control.' );
+		$this->assertFalse( GA4_Custom_Dimensions::is_reader_revenue_enabled(), 'No WooCommerce means no reader revenue.' );
+	}
+
+	/**
+	 * And are provisioned once the site does run access control. `access_source`
+	 * is checked separately -- it follows its own, stricter emitter.
+	 */
+	public function test_gate_dimensions_are_provisioned_with_access_control() {
+		add_filter( 'newspack_ga4_dimensions_access_control_enabled', '__return_true' );
+		$dimensions = GA4_Custom_Dimensions::get_dimensions();
+		foreach ( self::ACCESS_CONTROL_DIMENSIONS as $parameter_name ) {
+			$this->assertArrayHasKey( $parameter_name, $dimensions, "'$parameter_name' must be provisioned on an access-control site." );
+		}
+	}
+
+	/**
+	 * `price` has no emitter on any site: the modal-checkout GA4 whitelist
+	 * (`analytics/ga4/utils/index.js`) admits `amount`, and `ga4/opened.js` folds
+	 * `price` into it before send. Provisioning it burns a slot on every property.
+	 */
+	public function test_unemitted_price_dimension_is_never_provisioned() {
+		add_filter( 'newspack_ga4_dimensions_reader_revenue_enabled', '__return_true' );
+		add_filter( 'newspack_ga4_dimensions_access_control_enabled', '__return_true' );
+		$this->assertArrayNotHasKey( 'price', GA4_Custom_Dimensions::get_dimensions(), "'price' has no emitter and must not be provisioned." );
+	}
+
+	/**
+	 * Feature gating must not touch dimensions that any site can populate --
+	 * campaigns, segments, newsletters and the always-on page context.
+	 */
+	public function test_feature_independent_dimensions_survive_both_features_off() {
+		add_filter( 'newspack_ga4_dimensions_reader_revenue_enabled', '__return_false' );
+		add_filter( 'newspack_ga4_dimensions_access_control_enabled', '__return_false' );
+		$dimensions = GA4_Custom_Dimensions::get_dimensions();
+		$expected   = [
+			'is_reader',
+			'action_type',
+			'action',
+			'logged_in',
+			'is_newsletter_subscriber',
+			'newspack_popup_id',
+			'contextual_prompt_post_id',
+			'contextual_prompt_placement',
+			'button_text',
+			'prompt_placement',
+			'prompt_frequency',
+			'prompt_title',
+			'registration_method',
+			'lists',
+			'categories',
+			'author',
+			'segment_id',
+		];
+		foreach ( $expected as $parameter_name ) {
+			$this->assertArrayHasKey( $parameter_name, $dimensions, "'$parameter_name' is feature-independent and must always be provisioned." );
+		}
+	}
+
+	/**
+	 * Turning a feature on after provisioning must provision its dimensions
+	 * without waiting for the monthly recheck: GA4 dimensions are not
+	 * retroactive, so events sent before one exists are never queryable.
+	 */
+	public function test_enabling_a_feature_schedules_provisioning_for_its_dimensions() {
+		$this->connect_property( 'PROP-FEATURE' );
+
+		// Provisioned while the site ran neither feature.
+		add_filter( 'newspack_ga4_dimensions_reader_revenue_enabled', '__return_false' );
+		add_filter( 'newspack_ga4_dimensions_access_control_enabled', '__return_false' );
+		update_option(
+			GA4_Custom_Dimensions::PROVISIONED_OPTION,
+			[
+				'property_id' => 'PROP-FEATURE',
+				'dimensions'  => array_keys( GA4_Custom_Dimensions::get_dimensions() ),
+				'schema'      => GA4_Custom_Dimensions::schema_fingerprint(),
+				'created'     => [],
+			]
+		);
+		// Connecting the property queues its own first-time run; this test is
+		// about the recheck path, so start from a clean queue.
+		wp_clear_scheduled_hook( GA4_Custom_Dimensions::PROVISION_ACTION );
+		GA4_Custom_Dimensions::maybe_schedule_recheck();
+		$this->assertFalse( wp_next_scheduled( GA4_Custom_Dimensions::PROVISION_ACTION ), 'A site whose features are unchanged is not rescheduled.' );
+
+		// The publisher switches reader revenue on.
+		remove_filter( 'newspack_ga4_dimensions_reader_revenue_enabled', '__return_false' );
+		add_filter( 'newspack_ga4_dimensions_reader_revenue_enabled', '__return_true' );
+		delete_transient( GA4_Custom_Dimensions::SCHEMA_TRANSIENT );
+		GA4_Custom_Dimensions::maybe_schedule_recheck();
+		$this->assertNotFalse( wp_next_scheduled( GA4_Custom_Dimensions::PROVISION_ACTION ), 'Enabling reader revenue schedules provisioning for its dimensions.' );
+	}
+
+	/**
 	 * Connecting / changing the GA4 property schedules background provisioning,
 	 * and the scheduler de-duplicates redundant requests.
 	 */
@@ -464,16 +666,16 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 	public function test_provision_does_not_merge_across_a_property_switch() {
 		$this->connect_property( 'PROP-NEW' );
 		$this->configure_newspack_oauth( true );
-		// 'gate_post_id' already exists on the new property, so this run skips it.
-		$this->mock_admin_api( 'PROP-NEW', [ 'gate_post_id' ] );
-		// The previous run targeted a different property and created 'gate_post_id' there.
+		// 'categories' already exists on the new property, so this run skips it.
+		$this->mock_admin_api( 'PROP-NEW', [ 'categories' ] );
+		// The previous run targeted a different property and created 'categories' there.
 		update_option(
 			GA4_Custom_Dimensions::PROVISIONED_OPTION,
 			[
 				'property_id'    => 'PROP-OLD',
 				'auth_source'    => 'newspack',
 				'timestamp'      => time(),
-				'created'        => [ 'gate_post_id', 'is_reader' ],
+				'created'        => [ 'categories', 'is_reader' ],
 				'skipped_exists' => [],
 				'errors'         => [],
 			]
@@ -482,8 +684,8 @@ class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
 		$summary = GA4_Custom_Dimensions::provision();
 		$expected_created = count( GA4_Custom_Dimensions::get_dimensions() ) - 1;
 		$this->assertSame( 'PROP-NEW', $summary['property_id'] );
-		$this->assertContains( 'gate_post_id', $summary['skipped_exists'], "'gate_post_id' already exists on the new property." );
-		$this->assertNotContains( 'gate_post_id', $summary['created'], "The previous property's created list is not carried over." );
+		$this->assertContains( 'categories', $summary['skipped_exists'], "'categories' already exists on the new property." );
+		$this->assertNotContains( 'categories', $summary['created'], "The previous property's created list is not carried over." );
 		$this->assertCount( $expected_created, $summary['created'] );
 		$this->assertSame( $summary, get_option( GA4_Custom_Dimensions::PROVISIONED_OPTION ), 'The summary is persisted.' );
 	}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/google-site-kit-dimensions.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/google-site-kit-dimensions.php
@@ -16,12 +16,8 @@ use Newspack\GA4_Custom_Dimensions;
 class Newspack_Test_GoogleSiteKit_Dimensions extends WP_UnitTestCase {
 
 	/**
-	 * The always-on dimensions are unaffected by the feature flag.
-	 *
-	 * `is_reader` and `logged_in` are feature-independent: both ride gtag's
-	 * `config` call on every event, whatever the site runs. Reader-revenue and
-	 * access-control parameters are deliberately not stand-ins here -- they have
-	 * their own conditional coverage in the ga4-custom-dimensions suite.
+	 * The always-on dimensions are unaffected by the feature flag. `is_reader` and
+	 * `logged_in` ride gtag's `config` call on every event, whatever the site runs.
 	 */
 	public function test_core_dimensions_are_always_provisioned() {
 		$dimensions = GA4_Custom_Dimensions::get_dimensions();

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/google-site-kit-dimensions.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/google-site-kit-dimensions.php
@@ -17,10 +17,15 @@ class Newspack_Test_GoogleSiteKit_Dimensions extends WP_UnitTestCase {
 
 	/**
 	 * The always-on dimensions are unaffected by the feature flag.
+	 *
+	 * `is_reader` and `logged_in` are feature-independent: both ride gtag's
+	 * `config` call on every event, whatever the site runs. Reader-revenue and
+	 * access-control parameters are deliberately not stand-ins here -- they have
+	 * their own conditional coverage in the ga4-custom-dimensions suite.
 	 */
 	public function test_core_dimensions_are_always_provisioned() {
 		$dimensions = GA4_Custom_Dimensions::get_dimensions();
-		$this->assertArrayHasKey( 'is_subscriber', $dimensions );
+		$this->assertArrayHasKey( 'is_reader', $dimensions );
 		$this->assertArrayHasKey( 'logged_in', $dimensions );
 	}
 
@@ -68,6 +73,6 @@ class Newspack_Test_GoogleSiteKit_Dimensions extends WP_UnitTestCase {
 		$dimensions = GA4_Custom_Dimensions::get_dimensions();
 
 		$this->assertArrayNotHasKey( 'access_source', $dimensions );
-		$this->assertArrayHasKey( 'is_subscriber', $dimensions, 'The always-on dimensions stay put.' );
+		$this->assertArrayHasKey( 'is_reader', $dimensions, 'The always-on dimensions stay put.' );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

GA4 caps event-scoped custom dimensions at 50 per property. Newspack provisioned 31 on every connected property regardless of what the site runs, and a publisher has now hit that ceiling.

Dimensions register only where something can populate them. The four checkout parameters need WooCommerce. The three donation parameters need a donation platform, and WooCommerce is only one of those: a site on NRH or an external platform emits `is_donor`, `donation_frequency` and `donation_amount` from Reader Data and the Donate block with no WooCommerce installed. The six gate parameters need access control, meaning the gates constant or WooCommerce Memberships. `access_source` follows its own emitter, which also requires reader activation. `price` is dropped everywhere: no event carries it, because the modal checkout sends `amount` instead.

A site running neither feature goes from 31 dimensions to 17. Sites running both keep everything except `price`.

Enabling a feature later provisions its dimensions on the next admin request. Nothing is deleted, so dimensions already on a property stay until a publisher archives them.

Three filters override the detection per site: `newspack_ga4_dimensions_woocommerce_enabled`, `newspack_ga4_dimensions_donations_enabled` and `newspack_ga4_dimensions_access_control_enabled`.

Closes NPPM-3002.

### How to test the changes in this Pull Request:

1. Run `n test-php` from `plugins/newspack-plugin`. All tests pass.
2. Set up a site with WooCommerce and WooCommerce Memberships active, reader activation on, and `NEWSPACK_CONTENT_GATES` defined.
3. Print `Newspack\GA4_Custom_Dimensions::get_dimensions()`. The list holds 31 entries, and `price` is absent.
4. Deactivate the WooCommerce plugins, then print the list again. It holds 24 entries. The four checkout parameters and the three donation parameters are gone.
5. Set the reader revenue platform to NRH with `wp option update newspack_reader_revenue_platform nrh`, then print the list again. It holds 27 entries. `is_donor`, `donation_frequency` and `donation_amount` are back, and `is_subscriber`, `product_id`, `product_type` and `recurrence` stay out.
6. Set the platform back to `wc`, comment out `NEWSPACK_CONTENT_GATES`, then print the list again. It holds 17 entries. `gate_post_id` and the five `gate_has_*` parameters are gone.
7. Reactivate WooCommerce and WooCommerce Memberships, leaving `NEWSPACK_CONTENT_GATES` commented out. The list holds 30 entries. The gate parameters return and `access_source` stays out.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? Sixteen added, covering both states of each predicate and the automatic detection behind each one.
* [x] Have you successfully run tests with your changes locally? Full newspack-plugin suite passes: 3322 tests, 9 pre-existing environmental skips.

<details>
<summary>Notes for reviewers and agents</summary>

Three predicate choices are deliberate and easy to get backwards.

`is_woocommerce_enabled()` uses `class_exists( 'WooCommerce' )` rather than `Reader_Activation::is_woocommerce_active()`. The latter wraps `Donations::is_woocommerce_suite_active()`, which also requires `WC_Subscriptions_Product`. Keying on it would silently cost checkout reporting to sites selling one-time products, and GA4 never backfills.

`is_donations_enabled()` reads `class_exists( 'WooCommerce' ) || ! Donations::is_platform_wc()`. The platform slug defaults to `wc`, so it cannot carry the predicate alone. Read negatively, as it is here, a non-`wc` slug is only ever a deliberate choice of NRH or an external platform. It also reads WooCommerce directly rather than calling `is_woocommerce_enabled()`, so each group takes exactly one filter and neither override leaks into the other.

`access_source` is gated on `Content_Gate::is_gating_active()`, not on the access-control predicate that governs the gate group. A gate renders on WooCommerce Memberships alone, but `GoogleSiteKit::add_ga_custom_parameters()` only sends `access_source` when the gates constant and reader activation are both on. Grouping the two would provision a dimension nothing populates.

</details>
