### PR TITLE
feat(components): use an icon and label for DataViews Status columns (DSGNEWS-222)

### DIFF
--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -43,6 +43,7 @@ export { default as SectionHeader } from './section-header';
 export { default as SelectControl } from './select-control';
 export { default as Settings } from './settings';
 export { default as StatCard, STAT_CARD_NULL_GLYPH } from './stat-card';
+export { default as StatusIndicator } from './status-indicator';
 export { default as StepsList } from './steps-list';
 export { default as StepsListItem } from './steps-list-item';
 export { default as StyleCard } from './style-card';

--- a/packages/components/src/status-indicator/README.md
+++ b/packages/components/src/status-indicator/README.md
@@ -69,3 +69,8 @@ to the visible footprint with a negative margin, which is what makes the 8px gap
 measure 8px between the glyph and the label rather than 12px. An icon that fills
 its viewBox would be cropped by 4px a side; the statuses all come from
 `@wordpress/icons`, which does not.
+
+The margin is derived rather than written as `-4px`, so it follows the two
+values it depends on: `calc((#{wp-vars.$grid-unit-20} - #{wp-vars.$icon-size}) / 2)`,
+the glyph's footprint minus the box it sits in, halved for one side. Sass folds
+it to a literal at build time, so nothing is paid for at runtime.

--- a/packages/components/src/status-indicator/README.md
+++ b/packages/components/src/status-indicator/README.md
@@ -1,0 +1,71 @@
+# StatusIndicator
+
+A status glyph followed by its label, for the Status column of a DataView.
+
+A badge is an attention marker. In a column where every row carries one it marks
+nothing and adds a block of colour to each row, so the quiet treatment is the
+default there and a badge is kept for the rare row that genuinely stands out,
+such as a group with a seat request waiting on payment.
+
+## Importing
+
+```jsx
+// The barrel.
+import { StatusIndicator } from 'newspack-components';
+
+// The component on its own.
+import StatusIndicator from '../../packages/components/src/status-indicator';
+```
+
+## Usage
+
+```jsx
+import { published } from '@wordpress/icons';
+
+<StatusIndicator icon={ published }>{ __( 'Active', 'newspack-plugin' ) }</StatusIndicator>;
+```
+
+In a field definition:
+
+```jsx
+{
+	id: 'status',
+	label: __( 'Status', 'newspack-plugin' ),
+	getValue: ( { item } ) => item.status,
+	render: ( { item } ) => <StatusIndicator icon={ STATUS_ICONS[ item.status ] }>{ item.status_label }</StatusIndicator>,
+	elements: statusElements,
+	filterBy: { operators: [ 'is' ] },
+}
+```
+
+## Props
+
+| Prop | Type | Required | Description |
+| --- | --- | --- | --- |
+| `icon` | `Icon`'s `icon` prop | yes | The status glyph, from `@wordpress/icons`. |
+| `children` | `ReactNode` | no | The status label. |
+
+Anything else is spread onto the wrapper, a `Stack` from `@wordpress/ui`, which
+takes the props of a `div`.
+
+## Choosing an icon
+
+**No two statuses in one column may share a glyph.** A DataViews Status column
+offers its statuses as separate filters, so two that look identical make two
+different states indistinguishable in the one place the difference matters. This
+is the constraint the badge intents carried before, and it survives the move
+unchanged.
+
+The glyph does the separating on its own: the component inherits its colour from
+the surrounding text and tints nothing, so no status leans on colour to carry
+its meaning. That also means a state that needs to shout cannot, which is the
+trade the quiet treatment makes.
+
+## The icon's footprint
+
+`@wordpress/icons` draws a 16px glyph inside a 24px viewBox, so a 24px icon
+carries 4px of transparent padding on every side. The component trims that back
+to the visible footprint with a negative margin, which is what makes the 8px gap
+measure 8px between the glyph and the label rather than 12px. An icon that fills
+its viewBox would be cropped by 4px a side; the statuses all come from
+`@wordpress/icons`, which does not.

--- a/packages/components/src/status-indicator/README.md
+++ b/packages/components/src/status-indicator/README.md
@@ -43,7 +43,7 @@ In a field definition:
 | Prop | Type | Required | Description |
 | --- | --- | --- | --- |
 | `icon` | `Icon`'s `icon` prop | yes | The status glyph, from `@wordpress/icons`. |
-| `children` | `ReactNode` | no | The status label. |
+| `children` | `ReactNode` | yes | The status label. `@wordpress/primitives` forces `aria-hidden` on the glyph, so this is the whole accessible name. |
 
 Anything else is spread onto the wrapper, a `Stack` from `@wordpress/ui`, which
 takes the props of a `div`.
@@ -74,3 +74,8 @@ The margin is derived rather than written as `-4px`, so it follows the two
 values it depends on: `calc((#{wp-vars.$grid-unit-20} - #{wp-vars.$icon-size}) / 2)`,
 the glyph's footprint minus the box it sits in, halved for one side. Sass folds
 it to a literal at build time, so nothing is paid for at runtime.
+
+The box it sits in is the `size={ 24 }` the component passes to `Icon`, which is
+`$icon-size`. The two are written in different files, so anything that changes
+the rendered size has to change the token the margin reads, or the trim stops
+matching the padding it is there to remove.

--- a/packages/components/src/status-indicator/index.test.js
+++ b/packages/components/src/status-indicator/index.test.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { drafts, published } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import StatusIndicator from '.';
+
+describe( 'StatusIndicator', () => {
+	it( 'renders the glyph alongside the label', () => {
+		const { container } = render( <StatusIndicator icon={ published }>Active</StatusIndicator> );
+		expect( screen.getByText( 'Active' ) ).toBeInTheDocument();
+		expect( container.querySelector( 'svg.newspack-status-indicator__icon' ) ).toBeInTheDocument();
+	} );
+
+	// The trim is what makes the 8px gap measure 8px, so it is styled through a
+	// class rather than left to the consumer.
+	it( 'carries the class the icon trim is scoped to', () => {
+		const { container } = render( <StatusIndicator icon={ published }>Active</StatusIndicator> );
+		expect( container.querySelector( '.newspack-status-indicator' ) ).toBeInTheDocument();
+		expect( container.querySelector( '.newspack-status-indicator__icon' ) ).toBeInTheDocument();
+	} );
+
+	// A Status column offers its statuses as separate filters, so two of them
+	// rendering the same glyph would make two different states read alike.
+	it( 'draws a different glyph per status', () => {
+		const { container: active } = render( <StatusIndicator icon={ published }>Active</StatusIndicator> );
+		const { container: inactive } = render( <StatusIndicator icon={ drafts }>Inactive</StatusIndicator> );
+		expect( active.querySelector( 'svg' ).innerHTML ).not.toBe( inactive.querySelector( 'svg' ).innerHTML );
+	} );
+
+	it( 'keeps the consumer class and passes the rest through', () => {
+		const { container } = render(
+			<StatusIndicator className="custom" data-testid="status" icon={ published }>
+				Active
+			</StatusIndicator>
+		);
+		const root = container.querySelector( '.newspack-status-indicator' );
+		expect( root ).toHaveClass( 'custom' );
+		expect( root ).toHaveAttribute( 'data-testid', 'status' );
+	} );
+} );

--- a/packages/components/src/status-indicator/index.test.js
+++ b/packages/components/src/status-indicator/index.test.js
@@ -28,9 +28,10 @@ describe( 'StatusIndicator', () => {
 		expect( container.querySelector( '.newspack-status-indicator__icon' ) ).toBeInTheDocument();
 	} );
 
-	// A Status column offers its statuses as separate filters, so two of them
-	// rendering the same glyph would make two different states read alike.
-	it( 'draws a different glyph per status', () => {
+	// The rule that no two statuses in one column share a glyph is pinned in the
+	// status-map suites, where a collision could actually appear. All this checks
+	// is that the prop reaches the SVG, so a map holding distinct glyphs draws them.
+	it( 'draws the glyph it is given rather than a fixed one', () => {
 		const { container: active } = render( <StatusIndicator icon={ published }>Active</StatusIndicator> );
 		const { container: inactive } = render( <StatusIndicator icon={ drafts }>Inactive</StatusIndicator> );
 		expect( active.querySelector( 'svg' ).innerHTML ).not.toBe( inactive.querySelector( 'svg' ).innerHTML );

--- a/packages/components/src/status-indicator/index.tsx
+++ b/packages/components/src/status-indicator/index.tsx
@@ -1,0 +1,32 @@
+/**
+ * StatusIndicator
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { Icon } from '@wordpress/components';
+import { forwardRef } from '@wordpress/element';
+import { Stack } from '@wordpress/ui';
+
+/**
+ * External dependencies.
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies.
+ */
+import type { StatusIndicatorProps } from './types';
+import './style.scss';
+
+const StatusIndicator = forwardRef< HTMLDivElement, StatusIndicatorProps >( function StatusIndicator( { icon, className, children, ...props }, ref ) {
+	return (
+		<Stack ref={ ref } direction="row" align="center" gap="sm" className={ classnames( 'newspack-status-indicator', className ) } { ...props }>
+			<Icon className="newspack-status-indicator__icon" icon={ icon } size={ 24 } />
+			<span>{ children }</span>
+		</Stack>
+	);
+} );
+
+export default StatusIndicator;

--- a/packages/components/src/status-indicator/style.scss
+++ b/packages/components/src/status-indicator/style.scss
@@ -1,7 +1,9 @@
+@use "~@wordpress/base-styles/variables" as wp-vars;
+
 .newspack-status-indicator {
 	&__icon {
 		fill: currentcolor;
 		flex-shrink: 0;
-		margin: -4px;
+		margin: calc((#{wp-vars.$grid-unit-20} - #{wp-vars.$icon-size}) / 2);
 	}
 }

--- a/packages/components/src/status-indicator/style.scss
+++ b/packages/components/src/status-indicator/style.scss
@@ -1,0 +1,7 @@
+.newspack-status-indicator {
+	&__icon {
+		fill: currentcolor;
+		flex-shrink: 0;
+		margin: -4px;
+	}
+}

--- a/packages/components/src/status-indicator/types.ts
+++ b/packages/components/src/status-indicator/types.ts
@@ -10,11 +10,13 @@ import type { ComponentProps, ReactNode } from 'react';
 
 // @wordpress/components does not export the Icon prop type, so the union is
 // derived from the component to track the library instead of a copy kept here.
-type StatusIcon = ComponentProps< typeof Icon >[ 'icon' ];
+// `icon` is optional there, and indexing an optional property widens the union
+// with `undefined`, so NonNullable is what keeps the glyph required here.
+type StatusIcon = NonNullable< ComponentProps< typeof Icon >[ 'icon' ] >;
 
 export interface StatusIndicatorProps extends Omit< ComponentProps< 'div' >, 'children' > {
 	/** The status glyph, from `@wordpress/icons`. */
 	icon: StatusIcon;
-	/** The status label. */
-	children?: ReactNode;
+	/** The status label. @wordpress/primitives forces `aria-hidden` on the glyph, so this is the whole accessible name. */
+	children: ReactNode;
 }

--- a/packages/components/src/status-indicator/types.ts
+++ b/packages/components/src/status-indicator/types.ts
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies.
+ */
+import { Icon } from '@wordpress/components';
+
+/**
+ * External dependencies.
+ */
+import type { ComponentProps, ReactNode } from 'react';
+
+// @wordpress/components does not export the Icon prop type, so the union is
+// derived from the component to track the library instead of a copy kept here.
+type StatusIcon = ComponentProps< typeof Icon >[ 'icon' ];
+
+export interface StatusIndicatorProps extends Omit< ComponentProps< 'div' >, 'children' > {
+	/** The status glyph, from `@wordpress/icons`. */
+	icon: StatusIcon;
+	/** The status label. */
+	children?: ReactNode;
+}

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.js
@@ -5,10 +5,12 @@
  * `newspack_newsletters_ad_status` so the column matches the filter.
  */
 
-import { Icon, Tooltip } from '@wordpress/components';
+import { Tooltip } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { drafts, notAllowed, published, scheduled, trash } from '@wordpress/icons';
 import { dateI18n, getSettings as getDateSettings, gmdateI18n } from '@wordpress/date';
+
+import { StatusIndicator } from 'newspack-components';
 
 import { getAdminUrl } from '../../admin-globals';
 import { formatPostDate } from '../../utils/format-date';
@@ -110,12 +112,7 @@ const renderStatus = ( { item } ) => {
 		label = statusKindLabel( kind );
 	}
 
-	return (
-		<span className="newspack-newsletters-list__status">
-			<Icon className="newspack-newsletters-list__status-icon" icon={ icon } size={ 24 } />
-			<span>{ label }</span>
-		</span>
-	);
+	return <StatusIndicator icon={ icon }>{ label }</StatusIndicator>;
 };
 
 const renderTerms =

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.test.js
@@ -125,10 +125,12 @@ describe( 'Ads list date columns', () => {
 describe( 'Ads list status column dates', () => {
 	afterEach( () => configureSite( 0 ) );
 
+	// `newspack-components` is stubbed for these tests, so read the label off the
+	// StatusIndicator's props rather than rendering it.
 	const statusLabel = ( status, postStatus = 'publish' ) =>
 		fieldById( 'status' ).render( {
 			item: { id: 1, meta: {}, status: postStatus, newspack_newsletters_ad_status: status },
-		} ).props.children[ 1 ].props.children;
+		} ).props.children;
 
 	it( 'drops the clock time when the site date format carries one', () => {
 		configureSite( -4, 'F j, Y, g:i a' );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/fields.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/fields.js
@@ -10,6 +10,8 @@ import { __, sprintf } from '@wordpress/i18n';
 import { commentAuthorAvatar, drafts, envelope, globe, published, scheduled, trash } from '@wordpress/icons';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 
+import { StatusIndicator } from 'newspack-components';
+
 import { getAdminUrl } from '../../admin-globals';
 import { isManualProvider } from '../../../utils/service-provider';
 import { formatPostDate } from '../../utils/format-date';
@@ -79,12 +81,7 @@ const renderStatus = ( { item } ) => {
 		label = statusKindLabel( kind );
 	}
 
-	return (
-		<span className="newspack-newsletters-list__status">
-			<Icon className="newspack-newsletters-list__status-icon" icon={ icon } size={ 24 } />
-			<span>{ label }</span>
-		</span>
-	);
+	return <StatusIndicator icon={ icon }>{ label }</StatusIndicator>;
 };
 
 const renderSendDate = ( { item } ) => {
@@ -138,16 +135,15 @@ const renderPublicPage = ( { item } ) => {
 	// cmd/middle-click; mirrors the `view-public-page` action's gate.
 	const publicUrl = isPublic && 'publish' === item?.status && item?.link ? item.link : null;
 	return (
-		<span className="newspack-newsletters-list__visibility">
-			<Icon className="newspack-newsletters-list__visibility-icon" icon={ icon } size={ 24 } />
+		<StatusIndicator icon={ icon }>
 			{ publicUrl ? (
 				<ExternalLink href={ publicUrl } onClickCapture={ event => event.stopPropagation() }>
 					{ label }
 				</ExternalLink>
 			) : (
-				<span>{ label }</span>
+				label
 			) }
-		</span>
+		</StatusIndicator>
 	);
 };
 

--- a/plugins/newspack-newsletters/src/admin-shell/style.scss
+++ b/plugins/newspack-newsletters/src/admin-shell/style.scss
@@ -233,17 +233,13 @@ body.newspack-newsletters-admin-screen .dataviews-filters__visibility-toggle[ari
 }
 
 .newspack-newsletters-list {
-	&__author,
-	&__status,
-	&__visibility {
+	&__author {
 		align-items: center;
 		display: inline-flex;
 		gap: wp-vars.$grid-unit-10;
 	}
 
-	&__author-icon,
-	&__status-icon,
-	&__visibility-icon {
+	&__author-icon {
 		@include inline-icon;
 	}
 
@@ -423,9 +419,7 @@ body.newspack-newsletters-admin-screen .dataviews-filters__visibility-toggle[ari
 
 // Trim the WP icon's 4px viewBox padding to its visible 16px footprint.
 .dataviews-view-table {
-	.newspack-newsletters-list__author-icon,
-	.newspack-newsletters-list__status-icon,
-	.newspack-newsletters-list__visibility-icon {
+	.newspack-newsletters-list__author-icon {
 		margin: -4px;
 	}
 

--- a/plugins/newspack-plugin/src/wizards/audience/status-icons.test.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/status-icons.test.ts
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { drafts } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { postStatusIcon } from './status-icons';
+
+/**
+ * Pricing rules, Plans and Emails offer these statuses as separate filters, so two
+ * of them sharing a glyph leaves the reader unable to tell apart the results of two
+ * different filters. Pinned through the helper rather than the map behind it, since
+ * that is the whole of what the three screens call.
+ */
+describe( 'postStatusIcon', () => {
+	const STATUSES = [ 'publish', 'future', 'draft', 'pending', 'private', 'trash' ];
+
+	it( 'draws every post status the columns surface', () => {
+		STATUSES.forEach( status => expect( postStatusIcon( status ) ).toBeTruthy() );
+	} );
+
+	it( 'gives no two statuses the same glyph', () => {
+		const icons = STATUSES.map( postStatusIcon );
+		expect( new Set( icons ).size ).toBe( icons.length );
+	} );
+
+	it( 'separates a live rule from a scheduled one and a binned one', () => {
+		expect( postStatusIcon( 'publish' ) ).not.toBe( postStatusIcon( 'future' ) );
+		expect( postStatusIcon( 'publish' ) ).not.toBe( postStatusIcon( 'trash' ) );
+	} );
+
+	// Pricing rules reads its statuses from a plugin outside this repo and builds its
+	// filter elements from the rows themselves, so an unrecognised status can reach the
+	// column. It draws the draft glyph, which is how an unrecognised status is treated
+	// everywhere else, and is the one place the distinctness rule is knowingly relaxed.
+	it( 'falls back to the draft glyph for a status it does not know', () => {
+		expect( postStatusIcon( 'wc-on-hold' ) ).toBe( drafts );
+		expect( postStatusIcon( '' ) ).toBe( drafts );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/audience/status-icons.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/status-icons.ts
@@ -1,0 +1,25 @@
+/**
+ * Glyphs for the WordPress post statuses the Audience lists surface in a Status column.
+ *
+ * A Status column offers its statuses as separate filters, so no two may share a
+ * glyph. Anything outside the set falls back to the draft glyph, which is what
+ * an unrecognised status is treated as everywhere else.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { drafts, lock, pending, published, scheduled, trash } from '@wordpress/icons';
+
+const POST_STATUS_ICONS = {
+	publish: published,
+	future: scheduled,
+	draft: drafts,
+	pending,
+	private: lock,
+	trash,
+} as const;
+
+export const postStatusIcon = ( status: string ) => POST_STATUS_ICONS[ status as keyof typeof POST_STATUS_ICONS ] ?? drafts;
+
+export default POST_STATUS_ICONS;

--- a/plugins/newspack-plugin/src/wizards/audience/status-icons.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/status-icons.ts
@@ -21,5 +21,3 @@ const POST_STATUS_ICONS = {
 } as const;
 
 export const postStatusIcon = ( status: string ) => POST_STATUS_ICONS[ status as keyof typeof POST_STATUS_ICONS ] ?? drafts;
-
-export default POST_STATUS_ICONS;

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/constants.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/constants.js
@@ -18,7 +18,7 @@ export const API_BASE = '/newspack/v1/wizard/newspack-audience-integrations/sett
 // share `failed`'s treatment. The column offers them as separate filters and they
 // have to read apart. The design system files terminal, non-actionable states
 // like this under `none`.
-/** @type {Record< string, { label: string, icon: unknown, intent: import('../../../../../packages/components/src/types').BadgeIntent } >} */
+/** @type {Record< string, { label: string, icon: import('../../../../../packages/components/src/status-indicator/types').StatusIndicatorProps[ 'icon' ], intent: import('../../../../../packages/components/src/types').BadgeIntent } >} */
 export const STATUS_MAP = {
 	complete: { label: __( 'Complete', 'newspack-plugin' ), icon: published, intent: 'stable' },
 	failed: { label: __( 'Failed', 'newspack-plugin' ), icon: error, intent: 'high' },

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/constants.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/constants.js
@@ -8,19 +8,23 @@
  */
 import { __ } from '@wordpress/i18n';
 import { dateI18n, getSettings } from '@wordpress/date';
+import { error, notAllowed, pending, published, update } from '@wordpress/icons';
 
 export const API_BASE = '/newspack/v1/wizard/newspack-audience-integrations/settings';
 
-/** @type {Record< string, { label: string, intent: import('../../../../../packages/components/src/types').BadgeIntent } >} */
+// `icon` renders the log's Status column; `intent` badges the single status in
+// the detail modal, where one marker is what a badge is for. Both carry the same
+// constraint: a cancelled job is a deliberate stop, not a failure, so it must not
+// share `failed`'s treatment. The column offers them as separate filters and they
+// have to read apart. The design system files terminal, non-actionable states
+// like this under `none`.
+/** @type {Record< string, { label: string, icon: unknown, intent: import('../../../../../packages/components/src/types').BadgeIntent } >} */
 export const STATUS_MAP = {
-	complete: { label: __( 'Complete', 'newspack-plugin' ), intent: 'stable' },
-	failed: { label: __( 'Failed', 'newspack-plugin' ), intent: 'high' },
-	pending: { label: __( 'Pending', 'newspack-plugin' ), intent: 'low' },
-	'in-progress': { label: __( 'In progress', 'newspack-plugin' ), intent: 'informational' },
-	// A cancelled job is a deliberate stop, not a failure, so it must not share `failed`'s
-	// intent: the column offers them as separate filters and they have to read apart. The
-	// design system files terminal, non-actionable states like this under `none`.
-	canceled: { label: __( 'Canceled', 'newspack-plugin' ), intent: 'none' },
+	complete: { label: __( 'Complete', 'newspack-plugin' ), icon: published, intent: 'stable' },
+	failed: { label: __( 'Failed', 'newspack-plugin' ), icon: error, intent: 'high' },
+	pending: { label: __( 'Pending', 'newspack-plugin' ), icon: pending, intent: 'low' },
+	'in-progress': { label: __( 'In progress', 'newspack-plugin' ), icon: update, intent: 'informational' },
+	canceled: { label: __( 'Canceled', 'newspack-plugin' ), icon: notAllowed, intent: 'none' },
 };
 
 export function formatTimestamp( gmt ) {

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/constants.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/constants.test.js
@@ -5,13 +5,23 @@ import { STATUS_MAP } from './constants';
 
 /**
  * The activity log's Status column offers these as separate filters, so two statuses
- * sharing an intent makes the column unreadable at a glance: the reader can filter to
- * Canceled and Failed separately but cannot tell them apart in the results.
+ * sharing a glyph makes the column unreadable at a glance: the reader can filter to
+ * Canceled and Failed separately but cannot tell them apart in the results. The same
+ * holds for the intents, which still badge a single status in the detail modal.
  */
 describe( 'STATUS_MAP', () => {
 	it( 'labels every status the log can report', () => {
 		expect( Object.keys( STATUS_MAP ).sort() ).toEqual( [ 'canceled', 'complete', 'failed', 'in-progress', 'pending' ] );
 		Object.values( STATUS_MAP ).forEach( ( { label } ) => expect( label ).toBeTruthy() );
+	} );
+
+	it( 'draws every status with a glyph', () => {
+		Object.values( STATUS_MAP ).forEach( ( { icon } ) => expect( icon ).toBeTruthy() );
+	} );
+
+	it( 'gives no two statuses the same glyph', () => {
+		const icons = Object.values( STATUS_MAP ).map( ( { icon } ) => icon );
+		expect( new Set( icons ).size ).toBe( icons.length );
 	} );
 
 	it( 'gives no two statuses the same intent', () => {
@@ -22,6 +32,7 @@ describe( 'STATUS_MAP', () => {
 	it( 'separates a cancelled job from a failed one', () => {
 		// Cancelling is a deliberate stop with nothing to act on; failure is the one
 		// state in this column that asks the reader to do something.
+		expect( STATUS_MAP.failed.icon ).not.toBe( STATUS_MAP.canceled.icon );
 		expect( STATUS_MAP.failed.intent ).toBe( 'high' );
 		expect( STATUS_MAP.canceled.intent ).toBe( 'none' );
 	} );

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/logs-view.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/logs-view.js
@@ -8,12 +8,12 @@ import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { Spinner } from '@wordpress/components';
 import { DataViews as WPDataViews } from '@wordpress/dataviews';
-import { Badge } from '@wordpress/ui';
+import { notAllowed } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-import { DataViews } from '../../../../../packages/components/src';
+import { DataViews, StatusIndicator } from '../../../../../packages/components/src';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 import { API_BASE, STATUS_MAP, formatTimestamp } from './constants';
 import { LogDetailsModal } from './log-details-modal';
@@ -133,8 +133,8 @@ export const LogsView = ( { integrations, match } ) => {
 				id: 'status',
 				label: __( 'Status', 'newspack-plugin' ),
 				render: ( { item } ) => {
-					const mapped = STATUS_MAP[ item.status ] || { label: item.status, intent: 'none' };
-					return <Badge intent={ mapped.intent }>{ mapped.label }</Badge>;
+					const mapped = STATUS_MAP[ item.status ] || { label: item.status, icon: notAllowed };
+					return <StatusIndicator icon={ mapped.icon }>{ mapped.label }</StatusIndicator>;
 				},
 				enableSorting: true,
 				elements: [

--- a/plugins/newspack-plugin/src/wizards/audience/views/pricing-rules/list.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/pricing-rules/list.tsx
@@ -19,16 +19,17 @@ import {
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
-import { Badge } from '@wordpress/ui';
+import { notAllowed, published, scheduled } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-import { DataViews, Router, WizardBanner } from '../../../../../packages/components/src';
+import { DataViews, Router, StatusIndicator, WizardBanner } from '../../../../../packages/components/src';
 import { formatCount } from '../../../../../packages/components/src/breadcrumbs/format-count';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 import CatalogImpact from './catalog-impact';
 import PricingRulesOnboarding from './onboarding';
+import { postStatusIcon } from '../../status-icons';
 import { intentLabel } from './recipes';
 import { pricingModelSentence } from './model-sentence';
 import { RULES_API_PATH as API_PATH, IMPACT_PREVIEW_API_PATH } from './constants';
@@ -51,7 +52,7 @@ const DEFAULT_VIEW: View = {
 // hold the whole screen behind the spinner indefinitely.
 const STATS_GATE_TIMEOUT_MS = 8000;
 
-const ACTIVE_STATE_INTENT = { active: 'stable', scheduled: 'informational', ended: 'none' } as const;
+const ACTIVE_STATE_ICON = { active: published, scheduled, ended: notAllowed } as const;
 
 const ACTIVE_STATE_LABEL: Record< PricingRuleRow[ 'active_state' ], string > = {
 	active: __( 'Active', 'newspack-plugin' ),
@@ -228,7 +229,7 @@ export default function PricingRulesList() {
 				id: 'status',
 				label: __( 'Status', 'newspack-plugin' ),
 				getValue: ( { item } ) => item.status,
-				render: ( { item } ) => <Badge intent={ item.status === 'publish' ? 'stable' : 'draft' }>{ item.status_label }</Badge>,
+				render: ( { item } ) => <StatusIndicator icon={ postStatusIcon( item.status ) }>{ item.status_label }</StatusIndicator>,
 				elements: statusElements,
 				filterBy: { operators: [ 'is' ] },
 			},
@@ -237,9 +238,9 @@ export default function PricingRulesList() {
 				label: __( 'Active window', 'newspack-plugin' ),
 				getValue: ( { item } ) => item.active_state,
 				render: ( { item } ) => (
-					<Badge intent={ ACTIVE_STATE_INTENT[ item.active_state ] ?? 'none' }>
+					<StatusIndicator icon={ ACTIVE_STATE_ICON[ item.active_state ] ?? notAllowed }>
 						{ ACTIVE_STATE_LABEL[ item.active_state ] ?? item.active_state }
-					</Badge>
+					</StatusIndicator>
 				),
 				enableSorting: false,
 			},

--- a/plugins/newspack-plugin/src/wizards/audience/views/setup/emails/emails.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/setup/emails/emails.test.js
@@ -109,6 +109,7 @@ jest.mock( '../../../../../../packages/components/src', () => {
 		},
 		Card: ( { children } ) => <div data-testid="card">{ children }</div>,
 		Notice: ( { noticeText } ) => <div data-testid="notice">{ noticeText }</div>,
+		StatusIndicator: ( { children } ) => <span data-testid="status-indicator">{ children }</span>,
 		utils: {
 			confirmAction: jest.fn( () => true ),
 		},

--- a/plugins/newspack-plugin/src/wizards/audience/views/setup/emails/emails.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/setup/emails/emails.tsx
@@ -10,12 +10,12 @@ import { useState, useEffect, useCallback, useMemo, Fragment } from '@wordpress/
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import type { Action, Field, View } from '@wordpress/dataviews';
 import { Button, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
-import { Badge } from '@wordpress/ui';
 
 /**
  * Internal dependencies.
  */
-import { DataViews, Notice, utils } from '../../../../../../packages/components/src';
+import { DataViews, Notice, StatusIndicator, utils } from '../../../../../../packages/components/src';
+import { postStatusIcon } from '../../../status-icons';
 import WizardsPluginCard from '../../../../wizards-plugin-card';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
 import EmailPreview from './email-preview';
@@ -311,9 +311,9 @@ const Emails = () => {
 				render: ( { item }: { item: EmailItem } ) => {
 					const isEnabled = item.status === 'publish';
 					return (
-						<Badge intent={ isEnabled ? 'stable' : 'draft' }>
+						<StatusIndicator icon={ postStatusIcon( item.status ) }>
 							{ isEnabled ? __( 'Enabled', 'newspack-plugin' ) : __( 'Disabled', 'newspack-plugin' ) }
-						</Badge>
+						</StatusIndicator>
 					);
 				},
 				elements: [

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscription-products/list.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscription-products/list.test.jsx
@@ -17,7 +17,7 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import SubscriptionProductsList, { AVAILABILITY_INTENT } from './list';
+import SubscriptionProductsList, { AVAILABILITY_ICON } from './list';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
@@ -156,20 +156,16 @@ describe( 'the Plans list header count', () => {
 	} );
 } );
 
-describe( 'AVAILABILITY_INTENT', () => {
+describe( 'AVAILABILITY_ICON', () => {
 	it( 'covers every availability tier the endpoint can report', () => {
-		expect( Object.keys( AVAILABILITY_INTENT ).sort() ).toEqual( [ 'free', 'private', 'public' ] );
+		expect( Object.keys( AVAILABILITY_ICON ).sort() ).toEqual( [ 'free', 'private', 'public' ] );
+		Object.values( AVAILABILITY_ICON ).forEach( icon => expect( icon ).toBeTruthy() );
 	} );
 
-	it( 'keeps Public quiet and gives Private and Free their own colour', () => {
-		// Public is the normal state, so it stays neutral. The other two have to read
-		// apart from it and from each other at a glance, which a second neutral would not.
-		expect( AVAILABILITY_INTENT.public ).toBe( 'none' );
-		const intents = Object.values( AVAILABILITY_INTENT );
-		expect( new Set( intents ).size ).toBe( intents.length );
-	} );
-
-	it( 'reads Private as context rather than a problem', () => {
-		expect( AVAILABILITY_INTENT.private ).toBe( 'informational' );
+	it( 'gives no two tiers the same glyph', () => {
+		// The column offers the three as separate filters, and the glyph is the only
+		// thing telling them apart: nothing here is tinted.
+		const icons = Object.values( AVAILABILITY_ICON );
+		expect( new Set( icons ).size ).toBe( icons.length );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscription-products/list.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscription-products/list.tsx
@@ -17,14 +17,16 @@ import apiFetch from '@wordpress/api-fetch';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import type { Action, Field, View } from '@wordpress/dataviews';
 import { Spinner, Notice, Button } from '@wordpress/components';
+import { gift, globe, lock } from '@wordpress/icons';
 import { Badge } from '@wordpress/ui';
 
 /**
  * Internal dependencies
  */
-import { DataViews, Router, WizardBanner } from '../../../../../packages/components/src';
+import { DataViews, Router, StatusIndicator, WizardBanner } from '../../../../../packages/components/src';
 import { formatCount } from '../../../../../packages/components/src/breadcrumbs/format-count';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
+import { postStatusIcon } from '../../status-icons';
 import { PolicyChips, EffectivePrice } from './policy-cells';
 
 const { useHistory } = Router;
@@ -55,7 +57,7 @@ const inScope = ( item: SubscriptionProduct, scope: Scope ): boolean => {
 // Availability is a configuration fact, not a problem, so Private is not a warning. Private
 // takes the `informational` the design system documents for it; Free takes `low` ("worth
 // noticing") so the three stay distinct. Public is the default state and stays quiet.
-export const AVAILABILITY_INTENT = { free: 'low', private: 'informational', public: 'none' } as const;
+export const AVAILABILITY_ICON = { free: gift, private: lock, public: globe } as const;
 
 // Breadcrumb leaf per scope. Kept in step with the tab labels in index.tsx.
 const SCOPE_LABELS: Record< Scope, string > = {
@@ -242,7 +244,7 @@ export default function SubscriptionProductsList( { scope = 'subscriptions' }: {
 				enableSorting: false,
 				render: ( { item } ) =>
 					item.is_group_subscription ? (
-						<Badge intent="informational">{ item.group_member_label }</Badge>
+						<span>{ item.group_member_label }</span>
 					) : (
 						<span className="newspack-subscription-products__muted">&mdash;</span>
 					),
@@ -296,7 +298,9 @@ export default function SubscriptionProductsList( { scope = 'subscriptions' }: {
 				id: 'availability',
 				label: __( 'Availability', 'newspack-plugin' ),
 				getValue: ( { item } ) => item.availability,
-				render: ( { item } ) => <Badge intent={ AVAILABILITY_INTENT[ item.availability ] ?? 'none' }>{ item.availability_label }</Badge>,
+				render: ( { item } ) => (
+					<StatusIndicator icon={ AVAILABILITY_ICON[ item.availability ] ?? globe }>{ item.availability_label }</StatusIndicator>
+				),
 				elements: [
 					{ value: 'public', label: __( 'Public', 'newspack-plugin' ) },
 					{ value: 'private', label: __( 'Private', 'newspack-plugin' ) },
@@ -329,7 +333,7 @@ export default function SubscriptionProductsList( { scope = 'subscriptions' }: {
 				id: 'status',
 				label: __( 'Status', 'newspack-plugin' ),
 				getValue: ( { item } ) => item.status,
-				render: ( { item } ) => <Badge intent={ item.status === 'publish' ? 'stable' : 'draft' }>{ item.status_label }</Badge>,
+				render: ( { item } ) => <StatusIndicator icon={ postStatusIcon( item.status ) }>{ item.status_label }</StatusIndicator>,
 				elements: statusElements,
 				filterBy: { operators: [ 'is' ] },
 			},

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/index.tsx
@@ -17,12 +17,12 @@ import { filterSortAndPaginate } from '@wordpress/dataviews';
 import type { Action, Field, View } from '@wordpress/dataviews';
 import { drafts, percent, published } from '@wordpress/icons';
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-import { Icon, __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components';
+import { __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components';
 
 /**
  * Internal dependencies.
  */
-import { Button, DataViews, Grid, Notice, SectionHeader, Waiting } from '../../../../../../../packages/components/src';
+import { Button, DataViews, Grid, Notice, SectionHeader, StatusIndicator, Waiting } from '../../../../../../../packages/components/src';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../../../packages/components/src/wizard/store';
 import Router from '../../../../../../../packages/components/src/proxied-imports/router';
 import { SEARCH_ENDPOINTS, WIZARD_ENDPOINT } from '../../constants';
@@ -158,10 +158,9 @@ function SubscriberDiscounts() {
 				filterBy: { operators: [ 'isAny' ] },
 				getValue: ( { item } ) => ( item.active ? 'active' : 'inactive' ),
 				render: ( { item } ) => (
-					<span className="newspack-subscriber-discounts__status">
-						<Icon className="newspack-subscriber-discounts__status-icon" icon={ item.active ? published : drafts } size={ 24 } />
-						<span>{ item.active ? __( 'Active', 'newspack-plugin' ) : __( 'Inactive', 'newspack-plugin' ) }</span>
-					</span>
+					<StatusIndicator icon={ item.active ? published : drafts }>
+						{ item.active ? __( 'Active', 'newspack-plugin' ) : __( 'Inactive', 'newspack-plugin' ) }
+					</StatusIndicator>
 				),
 			},
 			{

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/style.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/style.scss
@@ -36,18 +36,6 @@
 		font-weight: normal;
 	}
 
-	&__status {
-		align-items: center;
-		display: inline-flex;
-		gap: wp-vars.$grid-unit-10;
-	}
-
-	&__status-icon {
-		fill: currentcolor;
-		flex-shrink: 0;
-		margin: -4px;
-	}
-
 	&__preview {
 		border-collapse: collapse;
 		width: 100%;

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/index.tsx
@@ -13,12 +13,12 @@ import { useMemo, useState } from '@wordpress/element';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 import { __experimentalHStack as HStack, CheckboxControl } from '@wordpress/components';
-import { Badge } from '@wordpress/ui';
+import { drafts, published } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
  */
-import { Button, DataViews, Modal, Notice, SectionHeader, Waiting } from '../../../../../../../packages/components/src';
+import { Button, DataViews, Modal, Notice, SectionHeader, StatusIndicator, Waiting } from '../../../../../../../packages/components/src';
 import type { Action, Field, View } from '../../../../../../../packages/components/src/dataviews';
 import WizardsTab from '../../../../../wizards-tab';
 import WizardSection from '../../../../../wizards-section';
@@ -112,12 +112,11 @@ function SubscriberOnlyProducts() {
 				],
 				filterBy: { operators: [ 'isAny' as const ] },
 				getValue: ( { item }: { item: Restriction } ) => ( item.active ? 'active' : 'inactive' ),
-				render: ( { item }: { item: Restriction } ) =>
-					item.active ? (
-						<Badge intent="stable">{ __( 'Active', 'newspack-plugin' ) }</Badge>
-					) : (
-						<Badge intent="medium">{ __( 'Inactive', 'newspack-plugin' ) }</Badge>
-					),
+				render: ( { item }: { item: Restriction } ) => (
+					<StatusIndicator icon={ item.active ? published : drafts }>
+						{ item.active ? __( 'Active', 'newspack-plugin' ) : __( 'Inactive', 'newspack-plugin' ) }
+					</StatusIndicator>
+				),
 			},
 			{
 				id: 'created_at',

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
@@ -24,13 +24,13 @@ import { Badge } from '@wordpress/ui';
 /**
  * Internal dependencies.
  */
-import { Button, DataViews, Notice, Waiting } from '../../../../packages/components/src';
+import { Button, DataViews, Notice, StatusIndicator, Waiting } from '../../../../packages/components/src';
 import { fmtDate } from '../format';
 import './style.scss';
 import { SHOW_AVATARS, useAvatars } from '../data/use-avatars';
 import { useGroups } from '../data/use-groups';
 import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
-import { STATUS_LABELS, STATUS_BADGE_INTENT } from '../status';
+import { STATUS_ICONS, STATUS_LABELS } from '../status';
 import { GROUP_LABEL_PLURAL, groupCountLabel, groupLoadFailedLabel } from '../labels';
 import { SubscriptionLink } from '../links';
 
@@ -168,7 +168,7 @@ export default function GroupList() {
 				elements: Object.entries( STATUS_LABELS ).map( ( [ value, label ] ) => ( { value, label } ) ),
 				filterBy: { operators: [ 'isAny' ] },
 				getValue: ( { item } ) => item.status,
-				render: ( { item } ) => <Badge intent={ STATUS_BADGE_INTENT[ item.status ] }>{ STATUS_LABELS[ item.status ] }</Badge>,
+				render: ( { item } ) => <StatusIndicator icon={ STATUS_ICONS[ item.status ] }>{ STATUS_LABELS[ item.status ] }</StatusIndicator>,
 			},
 			{
 				id: 'createdAt',

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
@@ -20,12 +20,12 @@ import { useEffect, useMemo, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
-import { Badge } from '@wordpress/ui';
+import { Badge, Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies.
  */
-import { Button, DataViews, Notice, Router, Waiting } from '../../../../packages/components/src';
+import { Button, DataViews, Notice, Router, StatusIndicator, Waiting } from '../../../../packages/components/src';
 import { formatCount } from '../../../../packages/components/src/breadcrumbs/format-count';
 import './style.scss';
 import { fmtRelative, fmtDate } from '../format';
@@ -34,7 +34,7 @@ import { useSubscribers } from '../data/use-subscribers';
 import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
 import { GROUP_LABEL, ROLE_LABELS, groupRoleLabel } from '../labels';
 import { SubscriptionLink } from '../links';
-import { STATUS_LABELS, STATUS_BADGE_INTENT, displayStatuses, statusRank } from '../status';
+import { STATUS_ICONS, STATUS_LABELS, displayStatuses, statusRank } from '../status';
 
 // A subscriber's group memberships, in the shape the column helpers expect
 // ([{ group, role }]). The endpoint embeds them flat on the item as
@@ -171,14 +171,17 @@ export default function SubscriberList() {
 				// against the same reduced display set the badges use, so cancelled is
 				// hidden while any active or on-hold plan remains.
 				getValue: ( { item } ) => subscriberStatuses( item, groupEntriesOf( item ) ),
+				// A subscriber can hold several statuses at once, so they stack rather
+				// than sitting on one line, where two icon-and-label pairs would run
+				// together into one phrase.
 				render: ( { item } ) => (
-					<HStack spacing={ 2 } justify="flex-start" alignment="center" wrap>
+					<Stack direction="column" align="flex-start" gap="sm">
 						{ subscriberStatuses( item, groupEntriesOf( item ) ).map( status => (
-							<Badge key={ status } intent={ STATUS_BADGE_INTENT[ status ] }>
+							<StatusIndicator key={ status } icon={ STATUS_ICONS[ status ] }>
 								{ STATUS_LABELS[ status ] }
-							</Badge>
+							</StatusIndicator>
 						) ) }
-					</HStack>
+					</Stack>
 				),
 			},
 			{

--- a/plugins/newspack-plugin/src/wizards/subscribers/status.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/status.js
@@ -6,6 +6,7 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
+import { caution, drafts, notAllowed, published } from '@wordpress/icons';
 
 export const STATUS_LABELS = {
 	active: __( 'Active', 'newspack-plugin' ),
@@ -14,6 +15,19 @@ export const STATUS_LABELS = {
 	cancelled: __( 'Cancelled', 'newspack-plugin' ),
 };
 
+// Glyphs for the list Status columns. A Status column offers its statuses as
+// separate filters, so no two of them may share a glyph.
+export const STATUS_ICONS = {
+	active: published,
+	pending: drafts,
+	// On hold is usually a payment that needs attention, not a terminal state,
+	// so it takes the caution glyph and cancelled takes the closed one.
+	'on-hold': caution,
+	cancelled: notAllowed,
+};
+
+// The profile card and the person header still badge a single status, where an
+// attention marker is what a badge is for.
 /** @type {Record< string, import('../../../packages/components/src/types').BadgeIntent >} */
 export const STATUS_BADGE_INTENT = {
 	active: 'stable',

--- a/plugins/newspack-plugin/src/wizards/subscribers/status.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/status.js
@@ -6,7 +6,7 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { caution, drafts, notAllowed, published } from '@wordpress/icons';
+import { caution, notAllowed, pending, published } from '@wordpress/icons';
 
 export const STATUS_LABELS = {
 	active: __( 'Active', 'newspack-plugin' ),
@@ -19,7 +19,7 @@ export const STATUS_LABELS = {
 // separate filters, so no two of them may share a glyph.
 export const STATUS_ICONS = {
 	active: published,
-	pending: drafts,
+	pending,
 	// On hold is usually a payment that needs attention, not a terminal state,
 	// so it takes the caution glyph and cancelled takes the closed one.
 	'on-hold': caution,

--- a/plugins/newspack-plugin/src/wizards/subscribers/status.test.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/status.test.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { displayStatuses, STATUS_BADGE_INTENT, STATUS_LABELS } from './status';
+import { displayStatuses, STATUS_BADGE_INTENT, STATUS_ICONS, STATUS_LABELS } from './status';
 
 // The status-reduction rule these assertions pin is documented on the PHP side,
 // in Subscribers_Wizard::reduced_status(); the endpoint's `status` filter
@@ -43,6 +43,28 @@ describe( 'displayStatuses', () => {
 	} );
 } );
 
+describe( 'STATUS_ICONS', () => {
+	it( 'gives every labelled status a glyph', () => {
+		expect( Object.keys( STATUS_ICONS ) ).toEqual( Object.keys( STATUS_LABELS ) );
+		Object.values( STATUS_ICONS ).forEach( icon => expect( icon ).toBeTruthy() );
+	} );
+
+	// The list Status columns offer these as separate filters, so two statuses
+	// sharing a glyph leaves the reader unable to tell apart the results of two
+	// different filters.
+	it( 'gives no two statuses the same glyph', () => {
+		const icons = Object.values( STATUS_ICONS );
+		expect( new Set( icons ).size ).toBe( icons.length );
+	} );
+
+	it( 'separates a live subscription from one needing attention and one gone', () => {
+		expect( STATUS_ICONS.active ).not.toBe( STATUS_ICONS[ 'on-hold' ] );
+		expect( STATUS_ICONS[ 'on-hold' ] ).not.toBe( STATUS_ICONS.cancelled );
+	} );
+} );
+
+// The badge intents outlive the column: the profile card and the person header
+// still badge a single status, where an attention marker is what a badge is for.
 describe( 'STATUS_BADGE_INTENT', () => {
 	it( 'gives every labelled status an intent', () => {
 		expect( Object.keys( STATUS_BADGE_INTENT ) ).toEqual( Object.keys( STATUS_LABELS ) );

--- a/plugins/newspack-plugin/src/wizards/subscribers/status.test.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/status.test.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { displayStatuses, STATUS_BADGE_INTENT, STATUS_ICONS, STATUS_LABELS } from './status';
+import { postStatusIcon } from '../audience/status-icons';
 
 // The status-reduction rule these assertions pin is documented on the PHP side,
 // in Subscribers_Wizard::reduced_status(); the endpoint's `status` filter
@@ -60,6 +61,13 @@ describe( 'STATUS_ICONS', () => {
 	it( 'separates a live subscription from one needing attention and one gone', () => {
 		expect( STATUS_ICONS.active ).not.toBe( STATUS_ICONS[ 'on-hold' ] );
 		expect( STATUS_ICONS[ 'on-hold' ] ).not.toBe( STATUS_ICONS.cancelled );
+	} );
+
+	// The distinctness rule is per column, so nothing else stops one word from
+	// picking up two marks across the admin. Pending did, until this pinned it.
+	// Drop this once the glyph vocabulary moves into the shared component.
+	it( 'draws Pending the way the Audience lists draw it', () => {
+		expect( STATUS_ICONS.pending ).toBe( postStatusIcon( 'pending' ) );
 	} );
 } );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A badge is an attention marker. In a table where every row carries one it marks nothing, and it adds a block of colour to each row. The newsletters admin already did the quieter thing: a status glyph followed by a plain label, no fill. This moves the rest of the monorepo's DataViews Status columns onto that treatment, and extracts it into `packages/components` so both plugins share one component instead of copying the markup an eighth time.

This is not a revert of #868. `Badge` stays wherever a badge is right: the group seat-request marker, the person profile card, the activity-log detail modal, and the chip lists for bundled plans, unlocked gates and tags. Those are single markers or tag lists, not columns of them.

**New shared component.** `StatusIndicator` in `packages/components`, built on `Stack` from `@wordpress/ui` at `gap="sm"`. It brings across the negative margin that trims a WordPress icon's 4px of transparent viewBox padding, which is what makes the 8px gap measure 8px between the glyph and the label rather than 12px. The trim is unconditional now rather than scoped to table layouts, and the component renders correctly in grid layouts too.

**Nine fields moved off badges.** Status on Pricing rules, Plans, Subscriber-only products, Subscribers, Groups, Emails and the integration activity log, plus Pricing rules' Active window and Plans' Availability.

**Four adopted the shared component** with no visual change: newsletters Status and Visibility, ads Status, and Subscriber discounts Status. That last one is worth calling out: the discounts tab already carried this markup and its own copy of the trim inside `newspack-plugin`, so the pattern had leaked out of newsletters before this ticket started.

**One field dropped its badge without gaining a glyph.** Plans' Members column reads "Up to 10 members", which is a capacity rather than a state, so it is plain text now.

**Pending now draws the same mark everywhere.** Subscribers drew it with the half-filled circle the draft status uses, while Plans, Pricing rules, Emails and the activity log drew it with the pending glyph. The distinctness rule is per column, so nothing caught one word picking up two marks across the admin. Subscribers moves onto the pending glyph, and a test holds the two in step.

A few decisions worth recording:

* **No status is tinted.** The glyph carries the meaning and the component inherits its colour from the surrounding text, so nothing leans on colour alone. The trade is that a state which wants to shout cannot, which is the point of the quiet treatment.
* **No two statuses in one column may share a glyph.** A Status column offers its statuses as separate filters, so two that look identical make two different states indistinguishable in the one place the difference matters. This is the constraint the badge intents carried, and it survives the move: the tests that pinned distinct intents now pin distinct glyphs.
* **Availability moved even though it is a classification rather than a lifecycle state**, because it is filterable and because newsletters already treats its Visibility column this way. Public, Private and Free take a globe, a lock and a gift.
* **`STATUS_MAP` and `STATUS_BADGE_INTENT` now carry both a glyph and an intent**, because the activity log's detail modal and the subscriber profile card still badge a single status.

Since `newspack-newsletters` is a separate release unit, the shared component and both consumers land in one branch.

Subscribers, where all four subscription statuses appear in one column:

![Subscribers Status column, before and after](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/21/xdjke7e7-dsgnews-222-subscribers-before-after.png)

Plans, with Status and the Availability column enabled:

![Plans Status and Availability columns, before and after](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/21/f3tnmplp-dsgnews-222-plans-before-after.png)

Closes DSGNEWS-222.

### How to test the changes in this Pull Request:

1. Go to **Audience > Subscribers**. The Status column shows a glyph and a label rather than a coloured pill, and the four statuses read apart: Active takes a check, Pending a part-filled circle, On hold an exclamation and Cancelled a slash, all in the same circle family. A subscriber holding more than one status stacks them rather than putting them on one line.
2. Switch to the **Groups** tab and confirm the same treatment. A group with a seat request awaiting payment still shows a badge in the Members column, which is deliberate.
3. Go to **Audience > Plans**. Status reads as a glyph and a label. Enable **Availability** under View options and confirm Public, Private and Free take a globe, a lock and a gift. The Members column, also under View options, is plain text.
4. Go to **Audience > Subscriptions**, and compare the **Subscriber Discounts** and **Subscriber-only products** tabs. Both now render Active and Inactive identically, which they did not before.
5. Go to **Audience > Configuration > Emails**. Status reads as a glyph and a label in both the grid and the table layout.
6. Go to **Newsletters > All Newsletters** and **Advertising**. Nothing should look different: both lists already used this pattern and now get it from the shared component.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Full suites pass: 409 in `packages/components`, 1012 in `newspack-plugin`, 299 in `newspack-newsletters`. ESLint, Stylelint and both TypeScript checks are clean.


