### PR TITLE
fix(reader-activation): keep password login reachable after OTP request

### DIFF
--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
@@ -2189,21 +2189,23 @@ final class Reader_Activation {
 
 		switch ( $action ) {
 			case 'signin':
-				if ( Magic_Link::has_active_token( $user ) ) {
-					$payload['action'] = 'otp';
+				// A reader who set a password can always sign in with it. Offer the password
+				// step on email submit even when an OTP token is still active — the reader may
+				// have requested a code, then decided to use their password instead (NPPM-3054).
+				if ( ! self::is_reader_without_password( $user ) ) {
+					$payload['action'] = 'pwd';
 					break;
 				}
-				if ( self::is_reader_without_password( $user ) ) {
+				// No password on file: a one-time code is the only way in. Reuse an active
+				// token if one exists; otherwise send a fresh code.
+				if ( ! Magic_Link::has_active_token( $user ) ) {
 					$sent = Magic_Link::send_email( $user, $redirect );
 					if ( true !== $sent ) {
 						return self::send_auth_form_response( new \WP_Error( 'unauthorized', \is_wp_error( $sent ) ? $sent->get_error_message() : __( 'We encountered an error sending an authentication link. Please try again.', 'newspack-plugin' ) ) );
 					}
-					$payload['action'] = 'otp';
-					break;
-				} else {
-					$payload['action'] = 'pwd';
-					break;
 				}
+				$payload['action'] = 'otp';
+				break;
 			case 'pwd':
 				if ( empty( $password ) ) {
 					return self::send_auth_form_response( new \WP_Error( 'invalid_password', __( 'Password not recognized, try again.', 'newspack-plugin' ) ) );

--- a/plugins/newspack-plugin/src/reader-activation-auth/auth-form-helpers.js
+++ b/plugins/newspack-plugin/src/reader-activation-auth/auth-form-helpers.js
@@ -11,3 +11,18 @@
  * @return {'pwd'|'signin'} The step to navigate back to.
  */
 export const getBackTarget = ( formAction, readerHasPassword ) => ( formAction === 'otp' && readerHasPassword ? 'pwd' : 'signin' );
+
+/**
+ * Whether "email me a code" should reuse the reader's existing one-time code instead of
+ * requesting a new one from the server.
+ *
+ * A reader who already requested a code and returned to the password step can choose the
+ * code again; reusing the active code shows the code-entry step without restarting the
+ * resend cooldown or stranding the code already in their inbox (NPPM-3054). The resend
+ * button always requests a new code, so it never reuses.
+ *
+ * @param {boolean} isSendCodeButton Whether the "email me a code" button was clicked, not resend.
+ * @param {boolean} hasActiveCode    Whether an active one-time code already exists for the reader.
+ * @return {boolean} True to reuse the existing code and skip the server request.
+ */
+export const shouldReuseActiveCode = ( isSendCodeButton, hasActiveCode ) => isSendCodeButton && hasActiveCode;

--- a/plugins/newspack-plugin/src/reader-activation-auth/auth-form-helpers.js
+++ b/plugins/newspack-plugin/src/reader-activation-auth/auth-form-helpers.js
@@ -13,16 +13,18 @@
 export const getBackTarget = ( formAction, readerHasPassword ) => ( formAction === 'otp' && readerHasPassword ? 'pwd' : 'signin' );
 
 /**
- * Whether "email me a code" should reuse the reader's existing one-time code instead of
- * requesting a new one from the server.
+ * Whether "email me a code" should reuse a one-time code already sent in this session
+ * instead of requesting a new one from the server.
  *
  * A reader who already requested a code and returned to the password step can choose the
- * code again; reusing the active code shows the code-entry step without restarting the
- * resend cooldown or stranding the code already in their inbox (NPPM-3054). The resend
- * button always requests a new code, so it never reuses.
+ * code again; reusing it shows the code-entry step without restarting the resend cooldown
+ * or stranding the code already in their inbox (NPPM-3054). The resend button always
+ * requests a new code, so it never reuses. The signal is a per-session "a code was sent"
+ * flag, not the persistent np_otp_hash cookie (which lingers ~29 minutes across sessions
+ * and would make a genuine first request skip the send).
  *
  * @param {boolean} isSendCodeButton Whether the "email me a code" button was clicked, not resend.
- * @param {boolean} hasActiveCode    Whether an active one-time code already exists for the reader.
+ * @param {boolean} codeAlreadySent  Whether a one-time code has already been sent in this session.
  * @return {boolean} True to reuse the existing code and skip the server request.
  */
-export const shouldReuseActiveCode = ( isSendCodeButton, hasActiveCode ) => isSendCodeButton && hasActiveCode;
+export const shouldReuseActiveCode = ( isSendCodeButton, codeAlreadySent ) => isSendCodeButton && codeAlreadySent;

--- a/plugins/newspack-plugin/src/reader-activation-auth/auth-form-helpers.js
+++ b/plugins/newspack-plugin/src/reader-activation-auth/auth-form-helpers.js
@@ -1,0 +1,13 @@
+/**
+ * Decide where the auth form's "Go Back" button returns to.
+ *
+ * From the one-time-code step, a reader who has a password returns to the password
+ * step so they don't have to retype their email (NPPM-3054). Every other case returns
+ * to the email ("signin") step, including "Go Back" from the password step itself,
+ * which lets the reader change their email.
+ *
+ * @param {string}  formAction        Current step: 'signin' | 'pwd' | 'otp' | 'success'.
+ * @param {boolean} readerHasPassword Whether the reader has a password on file.
+ * @return {'pwd'|'signin'} The step to navigate back to.
+ */
+export const getBackTarget = ( formAction, readerHasPassword ) => ( formAction === 'otp' && readerHasPassword ? 'pwd' : 'signin' );

--- a/plugins/newspack-plugin/src/reader-activation-auth/auth-form-helpers.test.js
+++ b/plugins/newspack-plugin/src/reader-activation-auth/auth-form-helpers.test.js
@@ -27,19 +27,19 @@ describe( 'getBackTarget', () => {
 } );
 
 describe( 'shouldReuseActiveCode', () => {
-	it( 'reuses the existing code when "email me a code" is clicked and a code is active', () => {
+	it( 'reuses the code when "email me a code" is clicked after one was already sent', () => {
 		expect( shouldReuseActiveCode( true, true ) ).toBe( true );
 	} );
 
-	it( 'requests a new code when "email me a code" is clicked and no code is active', () => {
+	it( 'requests a code when "email me a code" is clicked and none has been sent yet', () => {
 		expect( shouldReuseActiveCode( true, false ) ).toBe( false );
 	} );
 
-	it( 'never reuses for the resend button, even when a code is active', () => {
+	it( 'never reuses for the resend button, even after a code was sent', () => {
 		expect( shouldReuseActiveCode( false, true ) ).toBe( false );
 	} );
 
-	it( 'requests a new code for the resend button when none is active', () => {
+	it( 'requests a code for the resend button when none has been sent', () => {
 		expect( shouldReuseActiveCode( false, false ) ).toBe( false );
 	} );
 } );

--- a/plugins/newspack-plugin/src/reader-activation-auth/auth-form-helpers.test.js
+++ b/plugins/newspack-plugin/src/reader-activation-auth/auth-form-helpers.test.js
@@ -1,0 +1,19 @@
+import { getBackTarget } from './auth-form-helpers';
+
+describe( 'getBackTarget', () => {
+	it( 'returns to the password step from the code step when the reader has a password', () => {
+		expect( getBackTarget( 'otp', true ) ).toBe( 'pwd' );
+	} );
+
+	it( 'returns to the email step from the code step when the reader has no password', () => {
+		expect( getBackTarget( 'otp', false ) ).toBe( 'signin' );
+	} );
+
+	it( 'returns to the email step from the password step regardless of password state', () => {
+		expect( getBackTarget( 'pwd', true ) ).toBe( 'signin' );
+	} );
+
+	it( 'defaults to the email step when password state is unknown', () => {
+		expect( getBackTarget( 'otp', undefined ) ).toBe( 'signin' );
+	} );
+} );

--- a/plugins/newspack-plugin/src/reader-activation-auth/auth-form-helpers.test.js
+++ b/plugins/newspack-plugin/src/reader-activation-auth/auth-form-helpers.test.js
@@ -1,4 +1,4 @@
-import { getBackTarget } from './auth-form-helpers';
+import { getBackTarget, shouldReuseActiveCode } from './auth-form-helpers';
 
 describe( 'getBackTarget', () => {
 	it( 'returns to the password step from the code step when the reader has a password', () => {
@@ -23,5 +23,23 @@ describe( 'getBackTarget', () => {
 
 	it( 'returns to the email step from the success step', () => {
 		expect( getBackTarget( 'success', true ) ).toBe( 'signin' );
+	} );
+} );
+
+describe( 'shouldReuseActiveCode', () => {
+	it( 'reuses the existing code when "email me a code" is clicked and a code is active', () => {
+		expect( shouldReuseActiveCode( true, true ) ).toBe( true );
+	} );
+
+	it( 'requests a new code when "email me a code" is clicked and no code is active', () => {
+		expect( shouldReuseActiveCode( true, false ) ).toBe( false );
+	} );
+
+	it( 'never reuses for the resend button, even when a code is active', () => {
+		expect( shouldReuseActiveCode( false, true ) ).toBe( false );
+	} );
+
+	it( 'requests a new code for the resend button when none is active', () => {
+		expect( shouldReuseActiveCode( false, false ) ).toBe( false );
 	} );
 } );

--- a/plugins/newspack-plugin/src/reader-activation-auth/auth-form-helpers.test.js
+++ b/plugins/newspack-plugin/src/reader-activation-auth/auth-form-helpers.test.js
@@ -16,4 +16,12 @@ describe( 'getBackTarget', () => {
 	it( 'defaults to the email step when password state is unknown', () => {
 		expect( getBackTarget( 'otp', undefined ) ).toBe( 'signin' );
 	} );
+
+	it( 'returns to the email step from the email step itself', () => {
+		expect( getBackTarget( 'signin', true ) ).toBe( 'signin' );
+	} );
+
+	it( 'returns to the email step from the success step', () => {
+		expect( getBackTarget( 'success', true ) ).toBe( 'signin' );
+	} );
 } );

--- a/plugins/newspack-plugin/src/reader-activation-auth/auth-form.js
+++ b/plugins/newspack-plugin/src/reader-activation-auth/auth-form.js
@@ -8,7 +8,7 @@ import { getPendingCheckout } from '../reader-activation/checkout';
 import { openNewslettersSignupModal } from '../reader-activation-newsletters/newsletters-modal';
 import { openVerificationModal } from './verification-modal';
 import { maybeConfirmRegistration } from './confirmation-modal';
-import { getBackTarget } from './auth-form-helpers';
+import { getBackTarget, shouldReuseActiveCode } from './auth-form-helpers';
 
 import './google-oauth';
 import './otp-input';
@@ -231,6 +231,16 @@ window.newspackRAS.push( function ( readerActivation ) {
 					button.addEventListener( 'click', function ( ev ) {
 						ev.preventDefault();
 						form.setMessageContent();
+						// A reader who already requested a code and returned to the password step can
+						// choose the code again. Show the existing code-entry step instead of asking the
+						// server for a new code, which would restart the resend cooldown and strand the
+						// code already in their inbox. Only the "email me a code" button reuses; resend
+						// always requests a fresh code.
+						if ( shouldReuseActiveCode( ev.currentTarget === sendCodeButton, !! readerActivation.getOTPHash() ) ) {
+							container.setFormAction( 'otp' );
+							handleOTPTimer();
+							return;
+						}
 						form.startLoginFlow();
 						const body = new FormData();
 						body.set( 'reader-activation-auth-form', 1 );

--- a/plugins/newspack-plugin/src/reader-activation-auth/auth-form.js
+++ b/plugins/newspack-plugin/src/reader-activation-auth/auth-form.js
@@ -8,6 +8,7 @@ import { getPendingCheckout } from '../reader-activation/checkout';
 import { openNewslettersSignupModal } from '../reader-activation-newsletters/newsletters-modal';
 import { openVerificationModal } from './verification-modal';
 import { maybeConfirmRegistration } from './confirmation-modal';
+import { getBackTarget } from './auth-form-helpers';
 
 import './google-oauth';
 import './otp-input';
@@ -193,7 +194,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 						}
 					}
 					form.setMessageContent();
-					container.setFormAction( 'signin', true );
+					container.setFormAction( getBackTarget( formAction, container.readerHasPassword ), true );
 				} );
 			} );
 
@@ -561,6 +562,13 @@ window.newspackRAS.push( function ( readerActivation ) {
 											readerActivation.setReaderEmail( body.get( 'npe' ) );
 										}
 										if ( data.action ) {
+											// A `signin` response of 'pwd' means the reader has a password; 'otp' means
+											// they don't. Remember it so "Go Back" from the code step can return them to
+											// the password step (NPPM-3054). Other transitions (resend, verify) don't set
+											// data.action here, so the flag survives them.
+											if ( 'pwd' === data.action || 'otp' === data.action ) {
+												container.readerHasPassword = 'pwd' === data.action;
+											}
 											container.setFormAction( data.action, true );
 											if ( data.action === 'otp' ) {
 												readerActivation.setOTPTimer();

--- a/plugins/newspack-plugin/src/reader-activation-auth/auth-form.js
+++ b/plugins/newspack-plugin/src/reader-activation-auth/auth-form.js
@@ -98,6 +98,10 @@ window.newspackRAS.push( function ( readerActivation ) {
 			 * Handle auth form action selection.
 			 */
 			let formAction;
+			// Whether a one-time code has been sent in this modal session. A per-session flag,
+			// not the np_otp_hash cookie, which persists ~29 minutes across sessions and would
+			// make a genuine first "email me a code" click skip the send (NPPM-3054).
+			let codeSent = false;
 			container.setFormAction = ( action, shouldFocus = false ) => {
 				if ( ! FORM_ALLOWED_ACTIONS.includes( action ) ) {
 					action = 'signin';
@@ -236,7 +240,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 						// server for a new code, which would restart the resend cooldown and strand the
 						// code already in their inbox. Only the "email me a code" button reuses; resend
 						// always requests a fresh code.
-						if ( shouldReuseActiveCode( ev.currentTarget === sendCodeButton, !! readerActivation.getOTPHash() ) ) {
+						if ( shouldReuseActiveCode( ev.currentTarget === sendCodeButton, codeSent ) ) {
 							container.setFormAction( 'otp' );
 							handleOTPTimer();
 							return;
@@ -271,6 +275,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 									formAction === 'pwd' ? newspack_reader_activation_labels.code_sent : newspack_reader_activation_labels.code_resent
 								);
 								container.setFormAction( 'otp' );
+								codeSent = true;
 								if ( ! readerActivation.getOTPTimeRemaining() ) {
 									readerActivation.setOTPTimer();
 								}

--- a/plugins/newspack-plugin/tests/unit-tests/reader-activation-auth-signin-routing.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-activation-auth-signin-routing.php
@@ -141,11 +141,13 @@ class Newspack_Test_RA_Auth_Signin_Routing extends WP_Ajax_UnitTestCase {
 	 * A reader without a password and no active token is sent a code and routed to OTP.
 	 */
 	public function test_passwordless_reader_without_token_sends_code() {
-		$this->make_reader( 'fresh-otp@test.com', false );
+		$user_id = $this->make_reader( 'fresh-otp@test.com', false );
+		$this->assertSame( 0, $this->token_count( $user_id ), 'Reader should start with no tokens.' );
 
 		$response = $this->submit_signin( 'fresh-otp@test.com' );
 
 		$this->assertSame( 'otp', $response['data']['action'] ?? null );
+		$this->assertSame( 1, $this->token_count( $user_id ), 'A fresh code should be generated and sent.' );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/reader-activation-auth-signin-routing.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-activation-auth-signin-routing.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Tests the reader auth form's `signin` routing precedence (NPPM-3054).
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Reader_Activation;
+use Newspack\Magic_Link;
+
+/**
+ * The `signin` router must offer the password step to a reader who has a password,
+ * even while an OTP token is still active, so they aren't locked into OTP.
+ */
+class Newspack_Test_RA_Auth_Signin_Routing extends WP_Ajax_UnitTestCase {
+
+	/**
+	 * Set up each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		// process_auth_form() bails when logged in; ensure a logged-out visitor.
+		wp_set_current_user( 0 );
+		// Make magic-link email dispatch deterministic (no real mailer needed).
+		add_filter( 'pre_wp_mail', '__return_true' );
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		remove_filter( 'pre_wp_mail', '__return_true' );
+		unset(
+			$_POST['reader-activation-auth-form'],
+			$_POST['action'],
+			$_POST['npe'],
+			$_COOKIE[ Magic_Link::OTP_HASH_COOKIE ] // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		);
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a reader and set its password state explicitly.
+	 *
+	 * @param string $email        Reader email.
+	 * @param bool   $has_password Whether the reader has a password on file.
+	 * @return int Reader user ID.
+	 */
+	private function make_reader( $email, $has_password ) {
+		$user_id = Reader_Activation::register_reader( $email, 'Test Reader', false );
+		if ( $has_password ) {
+			delete_user_meta( $user_id, Reader_Activation::WITHOUT_PASSWORD );
+		} else {
+			update_user_meta( $user_id, Reader_Activation::WITHOUT_PASSWORD, true );
+		}
+		return $user_id;
+	}
+
+	/**
+	 * Mark a reader as having an active OTP token: a token in meta plus the hash cookie.
+	 *
+	 * @param int $user_id Reader user ID.
+	 */
+	private function activate_token( $user_id ) {
+		Magic_Link::generate_token( get_user_by( 'id', $user_id ) );
+		$_COOKIE[ Magic_Link::OTP_HASH_COOKIE ] = 'test-hash'; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+	}
+
+	/**
+	 * Count the reader's stored OTP tokens.
+	 *
+	 * @param int $user_id Reader user ID.
+	 * @return int Number of tokens on file.
+	 */
+	private function token_count( $user_id ) {
+		$tokens = get_user_meta( $user_id, Magic_Link::TOKENS_META, true );
+		return is_array( $tokens ) ? count( $tokens ) : 0;
+	}
+
+	/**
+	 * Submit the `signin` action for an email and capture the JSON response.
+	 *
+	 * Process_auth_form() ends in wp_send_json(), which echoes JSON then wp_die();
+	 * WP_Ajax_UnitTestCase's die handler throws and drains output into $this->_last_response.
+	 *
+	 * @param string $email Email to submit via the `npe` field.
+	 * @return array Decoded response body (top-level `message` + `data`), or [] if none.
+	 */
+	private function submit_signin( $email ) {
+		$_POST['reader-activation-auth-form'] = '1';
+		$_POST['action']                      = 'signin';
+		$_POST['npe']                         = $email;
+
+		$this->_last_response = '';
+		try {
+			Reader_Activation::process_auth_form();
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		} catch ( WPDieException $e ) {
+			unset( $e );
+		}
+		// Reopen a buffer so tear_down's buffer level matches (PHPUnit flags mismatches).
+		ob_start();
+
+		$decoded = json_decode( $this->_last_response, true );
+		return is_array( $decoded ) ? $decoded : [];
+	}
+
+	/**
+	 * A reader with a password gets the password step even when an OTP token is active,
+	 * and no new token is generated.
+	 */
+	public function test_password_reader_with_active_token_routes_to_pwd() {
+		$user_id = $this->make_reader( 'pwd-reader@test.com', true );
+		$this->activate_token( $user_id );
+		$before = $this->token_count( $user_id );
+
+		$response = $this->submit_signin( 'pwd-reader@test.com' );
+
+		$this->assertSame( 'pwd', $response['data']['action'] ?? null );
+		$after = $this->token_count( $user_id );
+		$this->assertSame( $before, $after, 'No new token should be generated.' );
+	}
+
+	/**
+	 * A reader without a password and an active token stays on OTP and reuses the token.
+	 */
+	public function test_passwordless_reader_with_active_token_reuses_token() {
+		$user_id = $this->make_reader( 'otp-reader@test.com', false );
+		$this->activate_token( $user_id );
+		$before = $this->token_count( $user_id );
+
+		$response = $this->submit_signin( 'otp-reader@test.com' );
+
+		$this->assertSame( 'otp', $response['data']['action'] ?? null );
+		$after = $this->token_count( $user_id );
+		$this->assertSame( $before, $after, 'Active token should be reused, not resent.' );
+	}
+
+	/**
+	 * A reader without a password and no active token is sent a code and routed to OTP.
+	 */
+	public function test_passwordless_reader_without_token_sends_code() {
+		$this->make_reader( 'fresh-otp@test.com', false );
+
+		$response = $this->submit_signin( 'fresh-otp@test.com' );
+
+		$this->assertSame( 'otp', $response['data']['action'] ?? null );
+	}
+
+	/**
+	 * Regression: a reader with a password and no active token still routes to pwd.
+	 */
+	public function test_password_reader_without_token_routes_to_pwd() {
+		$this->make_reader( 'plain-pwd@test.com', true );
+
+		$response = $this->submit_signin( 'plain-pwd@test.com' );
+
+		$this->assertSame( 'pwd', $response['data']['action'] ?? null );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A reader who set a password was locked into the one-time-code screen for about 30 minutes after requesting a code. The sign-in router checked for an active code before checking whether the reader had a password, so re-submitting the email or pressing "Go Back" kept returning to the code screen until the code expired.

Now a reader with a password is offered the password step on email submit, even while a code is active, and "Go Back" from the code screen returns them to the password field instead of the email step. Readers without a password are unchanged: a one-time code stays their only way in, and an active code is reused rather than resent.

Closes NPPM-3054.

### How to test the changes in this Pull Request:

1. Enable Reader Activation. Seed one reader with a password and one without.
2. Open the sign-in modal, enter the password reader's email, and Continue. The password field appears.
3. Choose "Email me a one-time code instead". The code-entry screen appears.
4. Press "Go Back". The password field appears, not the email step.
5. As the passwordless reader, reach the code screen the same way, then press "Go Back". The email step appears.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Verified in an isolated environment: both reader types through request-code then "Go Back", plus the code-screen landing on refresh or a new tab (intended, so a magic-link click still opens ready to enter the code).
