### PR TITLE
fix(newsletters): hide the filter count badge in the admin lists

### DIFF
--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/actions.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/actions.js
@@ -7,7 +7,7 @@
 
 import apiFetch from '@wordpress/api-fetch';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { edit, trash } from '@wordpress/icons';
+import { pencil, trash } from '@wordpress/icons';
 
 import { getAdminUrl } from '../../admin-globals';
 import ConfirmModal from '../../components/confirm-modal';
@@ -50,7 +50,7 @@ export function getActions( { refresh, openQuickEdit } ) {
 		id: 'quick-edit',
 		label: __( 'Quick Edit', 'newspack-newsletters' ),
 		isPrimary: true,
-		icon: edit,
+		icon: pencil,
 		isEligible: item => ! isTrashed( item ),
 		callback: items => {
 			const item = items[ 0 ];

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/actions.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/actions.js
@@ -8,7 +8,7 @@
 
 import apiFetch from '@wordpress/api-fetch';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { edit, trash } from '@wordpress/icons';
+import { pencil, trash } from '@wordpress/icons';
 
 import { getAdminUrl } from '../../admin-globals';
 import ConfirmModal from '../../components/confirm-modal';
@@ -98,7 +98,7 @@ export function getActions( { refresh, openQuickEdit } ) {
 		id: 'quick-edit',
 		label: __( 'Quick Edit', 'newspack-newsletters' ),
 		isPrimary: true,
-		icon: edit,
+		icon: pencil,
 		isEligible: item => ! isTrashed( item ),
 		callback: items => {
 			const item = items[ 0 ];

--- a/plugins/newspack-newsletters/src/admin-shell/style.scss
+++ b/plugins/newspack-newsletters/src/admin-shell/style.scss
@@ -225,6 +225,10 @@ body.newspack-newsletters-admin-screen .dataviews-filters__visibility-toggle[ari
 	display: none;
 }
 
+.newspack-newsletters-admin .dataviews-filters-toggle__count {
+	display: none;
+}
+
 // Muted item count portalled next to the breadcrumbs page title.
 .newspack-newsletters-header-count {
 	color: wp-colors.$gray-700;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Two small cleanups in the admin list screens.

The DataViews filter toggle is permanently disabled once a primary filter pins the filter row open, and we already hide it, but its count badge still renders. Applying a filter left an orphaned blue counter floating over the search box. The badge is now hidden across the newsletters admin.

| Before | After |
| --- | --- |
| ![Before: filter count badge overlapping the search box](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/22/qoa1qtxp-badge-before.png) | ![After: the badge is hidden](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/22/otqui0qu-badge-after.png) |

The newsletters and ads list Quick Edit actions also imported the `edit` icon from `@wordpress/icons`, which the resolved version no longer exports, so the icon was `undefined` and every build warned about it. They now use `pencil`. No visual change: DataViews renders these row actions as text buttons and never reads the icon.

### How to test the changes in this Pull Request:

1. Go to Newsletters > All Newsletters, open Filter and apply Status: Sent. No blue count badge appears on the search box.
2. Hover a row. The Quick Edit and Actions controls appear and work as before.
3. Run `n build newsletters`. The `export 'edit' was not found` warnings are gone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
