### PR TITLE
fix(cli): keep exemption revocations when backfilling post exemptions (NPPD-2211)

### DIFF
--- a/plugins/newspack-plugin/includes/cli/class-membership-gates-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-membership-gates-migration.php
@@ -1592,8 +1592,10 @@ class Membership_Gates_Migration {
 	 * post" toggle. Nothing bridges the two, so without this step those posts are gated
 	 * the moment Memberships is deactivated.
 	 *
-	 * A post already carrying a falsy exemption row is overwritten, not skipped, and its
-	 * ID listed.
+	 * A falsy exemption row is left alone and reported. Turning the toggle off is what
+	 * records one, so overwriting it would undo a decision. Pass --overwrite-falsy for
+	 * rows that predate the toggle, where the falsy value is only the editor echoing the
+	 * registered default back on save.
 	 *
 	 * Migrates only the post types the exemption toggle is offered on. Posts on any other
 	 * type are counted and warned about rather than written: they can still be gated by a
@@ -1612,10 +1614,15 @@ class Membership_Gates_Migration {
 	 * [--live]
 	 * : Apply the changes. Without this flag the command runs as a dry-run and writes nothing.
 	 *
+	 * [--overwrite-falsy]
+	 * : Also record an exemption on posts whose exemption row is already set to a falsy
+	 * value. Only for rows known to predate the exemption toggle.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp newspack migrate-post-exemptions
 	 *     wp newspack migrate-post-exemptions --live
+	 *     wp newspack migrate-post-exemptions --live --overwrite-falsy
 	 *
 	 * @param array $args       Positional args (unused).
 	 * @param array $assoc_args Named args.
@@ -1623,7 +1630,8 @@ class Membership_Gates_Migration {
 	 * @return void
 	 */
 	public function migrate_post_exemptions( $args, $assoc_args ) {
-		$dry_run = ! (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'live', false );
+		$dry_run         = ! (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'live', false );
+		$overwrite_falsy = (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'overwrite-falsy', false );
 
 		if ( ! class_exists( 'Newspack\Content_Restriction_Control' ) ) {
 			WP_CLI::error( 'Newspack\Content_Restriction_Control class not found, so the exemption meta key and its post types cannot be resolved. Aborting.' );
@@ -1664,6 +1672,7 @@ class Membership_Gates_Migration {
 
 		$missing   = [];
 		$falsy     = [];
+		$preserved = [];
 		$failed    = [];
 		$breakdown = [];
 		// Classify and write a chunk at a time, so the meta cache neither grows with the
@@ -1685,6 +1694,10 @@ class Membership_Gates_Migration {
 				++$breakdown[ $key ][ $state ];
 
 				if ( 'already' === $state ) {
+					continue;
+				}
+				if ( 'falsy' === $state && ! $overwrite_falsy ) {
+					$preserved[] = $post_id;
 					continue;
 				}
 				if ( ! $dry_run && ! \update_post_meta( $post_id, \Newspack\Content_Restriction_Control::IS_EXEMPT_META_KEY, true ) ) {
@@ -1734,10 +1747,20 @@ class Membership_Gates_Migration {
 			);
 		}
 
+		if ( ! empty( $preserved ) ) {
+			WP_CLI::warning(
+				sprintf(
+					'%d post(s) are forced public by Memberships but carry a falsy exemption row, so they stay gated after cutover. That row is what turning the toggle off records, so it is left alone. Re-run with --overwrite-falsy for any that predate the toggle: %s',
+					count( $preserved ),
+					self::format_post_id_list( $preserved )
+				)
+			);
+		}
+
 		if ( ! empty( $falsy ) ) {
 			WP_CLI::warning(
 				sprintf(
-					'%d post(s) carried a falsy exemption row and %s: %s',
+					'%d falsy exemption row(s) %s, per --overwrite-falsy: %s',
 					count( $falsy ),
 					$dry_run ? 'would be overwritten' : 'were overwritten',
 					self::format_post_id_list( $falsy )
@@ -1754,12 +1777,13 @@ class Membership_Gates_Migration {
 
 		WP_CLI::success(
 			sprintf(
-				'Done. %d exemption(s) %s (%d with no row, %d overwriting a falsy row). %d post(s) were already exempt.',
+				'Done. %d exemption(s) %s (%d with no row, %d overwriting a falsy row). %d post(s) were already exempt, %d falsy row(s) left alone.',
 				count( $missing ) + count( $falsy ),
 				$dry_run ? 'would be recorded' : 'recorded',
 				count( $missing ),
 				count( $falsy ),
-				count( $in_scope ) - count( $missing ) - count( $falsy ) - count( $failed )
+				count( $in_scope ) - count( $missing ) - count( $falsy ) - count( $failed ) - count( $preserved ),
+				count( $preserved )
 			)
 		);
 

--- a/plugins/newspack-plugin/tests/unit-tests/cli/class-test-post-exemptions-migration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/cli/class-test-post-exemptions-migration.php
@@ -110,18 +110,29 @@ class Test_Post_Exemptions_Migration extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The row `get_post_meta()` cannot distinguish from no row at all. It is overwritten,
-	 * not skipped, and its ID reported.
+	 * A falsy row is what turning the exemption toggle off records, so it outranks the
+	 * Memberships flag and survives the run. Only --overwrite-falsy reverses it, for the
+	 * rows that predate the toggle and mean nothing.
 	 */
-	public function test_overwrites_a_falsy_exemption_row() {
+	public function test_preserves_a_falsy_exemption_row_unless_told_to_overwrite() {
 		$post_id = $this->create_force_public_post();
 		update_post_meta( $post_id, Content_Restriction_Control::IS_EXEMPT_META_KEY, '' );
 
 		$output = $this->run_migration( [ 'live' => true ] );
 
-		$this->assertTrue( $this->has_recorded_exemption( $post_id ) );
-		$this->assertStringContainsString( '1 post(s) carried a falsy exemption row', $output );
+		$this->assertFalse( $this->has_recorded_exemption( $post_id ) );
+		$this->assertStringContainsString( '1 post(s) are forced public by Memberships but carry a falsy exemption row', $output );
 		$this->assertStringContainsString( (string) $post_id, $output );
+
+		$output = $this->run_migration(
+			[
+				'live'            => true,
+				'overwrite-falsy' => true,
+			]
+		);
+
+		$this->assertTrue( $this->has_recorded_exemption( $post_id ) );
+		$this->assertStringContainsString( '1 falsy exemption row(s) were overwritten', $output );
 	}
 
 	/**
@@ -192,7 +203,7 @@ class Test_Post_Exemptions_Migration extends WP_UnitTestCase {
 
 	/**
 	 * Dry-run is the default: it reports the split it would write, and writes neither the
-	 * missing row nor the overwrite.
+	 * missing row nor the falsy one it leaves alone.
 	 */
 	public function test_dry_run_reports_the_split_and_writes_nothing() {
 		$missing_row_id = $this->create_force_public_post();
@@ -204,8 +215,9 @@ class Test_Post_Exemptions_Migration extends WP_UnitTestCase {
 		$this->assertFalse( metadata_exists( 'post', $missing_row_id, Content_Restriction_Control::IS_EXEMPT_META_KEY ) );
 		$this->assertFalse( $this->has_recorded_exemption( $falsy_row_id ) );
 		$this->assertStringContainsString(
-			'2 exemption(s) would be recorded (1 with no row, 1 overwriting a falsy row)',
+			'1 exemption(s) would be recorded (1 with no row, 0 overwriting a falsy row)',
 			$output
 		);
+		$this->assertStringContainsString( '1 falsy row(s) left alone', $output );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`wp newspack migrate-post-exemptions` (#934) overwrites a falsy `newspack_content_restriction_is_exempt` row unconditionally. That is right on a build without #855: there a falsy row is the block editor round-tripping the registered `'default' => false` back on save, so it carries no intent.

#855 gives the row meaning. `strip_inherited_exempt_meta()` preserves an explicit falsy value on purpose, because that is what makes turning the toggle off stick. Both are now on `main`, so the backfill silently reverses that, and every re-run before the flip reverses it again.

Falsy rows are now left alone and named for review, matching the policy already used for revoked Memberships flags: write what is unambiguous, report what is not. `--overwrite-falsy` opts back in for rows known to predate the toggle. Posts with no row at all are still written — the #855 fallback covers them at runtime, but a real row is the durable record and survives Memberships meta cleanup.

Closes NPPD-2211.

### How to test the changes in this Pull Request:

1. Publish two posts.
2. Add post meta `_wc_memberships_force_public` = `yes` to both.
3. Add post meta `newspack_content_restriction_is_exempt` = `` (empty) to the second post only.
4. Run `wp newspack migrate-post-exemptions --live`.
5. Confirm the first post gets `newspack_content_restriction_is_exempt` = `1`.
6. Confirm the second post keeps its empty value, and the summary names its ID.
7. Run `wp newspack migrate-post-exemptions --live --overwrite-falsy`.
8. Confirm the second post now has `newspack_content_restriction_is_exempt` = `1`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

**Timing:** this should land before the release cut that promotes #855 to sites. Until then `main` carries both changes and the unconditional overwrite.

**Ambiguity that stays with the operator:** on a build with both changes, a falsy row can be an old echo artefact that still needs the overwrite, or a deliberate revocation that must survive. Nothing in the data separates them, so the decision is per site, taken against the audit-query 5b-ii census.

A fleet census taken before #934 deployed found 1,413 falsy rows across 28 sites. Every one predates #855, so all of them are echo artefacts — running the backfill on those sites while that is still true avoids the judgement call entirely.