### PR TITLE
fix(newspack-plugin): restore the major revision controls (NPPM-3155)

### DIFF
--- a/e2e/e2e-setup.sh
+++ b/e2e/e2e-setup.sh
@@ -123,6 +123,11 @@ wp --skip-plugins --skip-themes config set NEWSPACK_EMAIL_CHANGE_ENABLED true --
 
 wp --skip-themes option update timezone_string 'America/New_York'
 
+# Revisions control is off until a publisher configures it, and its screen
+# controls only render while it is on, so turn it on for the suite.
+wp --skip-themes option update newspack_revisions_control \
+  '{"active":true,"number":5,"min_age":"-1 week"}' --format=json
+
 # Sync the e2e helper plugin from the repo copy so the running plugin always
 # matches the committed source. It's a single-file plugin that provisioning only
 # *activates*, so without this an edit to e2e-plugin.php would never reach the

--- a/e2e/tests/revisions.spec.ts
+++ b/e2e/tests/revisions.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from "@playwright/test";
+
+import { logIn, getEditorCanvas } from "./utils-admin";
+import { randomString } from "./utils";
+
+// Revisions control lets a publisher mark a revision as "major" so it survives
+// the retention limit that deletes older revisions. The controls live on the
+// classic revisions screen and are added by a plugin script, so this spec doubles
+// as the guard for that script actually being built and enqueued: when it 404s,
+// the screen still renders and only the Newspack controls silently disappear.
+test(
+  "Mark a revision as major",
+  {
+    tag: ["@vanilla"],
+  },
+  async ({ page }) => {
+    await logIn(page);
+
+    // Publish a post, then edit it, so it has a revision to mark.
+    await page.goto("/wp-admin/post-new.php");
+    const editor = await getEditorCanvas(page);
+    const postTitle = `Revisions test #${randomString(4)}`;
+    await editor.getByLabel("Add title").fill(postTitle);
+    await editor
+      .getByLabel("Empty block; start writing or")
+      .fill("First version.");
+
+    await page.getByRole("button", { name: "Publish", exact: true }).click();
+    await page
+      .getByLabel("Editor publish")
+      .getByRole("button", { name: "Publish", exact: true })
+      .click();
+    await expect(
+      page.getByTestId("snackbar").getByText("Post published.")
+    ).toBeVisible();
+
+    // Reopen the post rather than editing on: the post-publish panel covers the
+    // canvas until it is dismissed, and on a mobile viewport it covers all of it.
+    const postId = new URL(page.url()).searchParams.get("post");
+    await page.goto(`/wp-admin/post.php?post=${postId}&action=edit`);
+    const reopenedEditor = await getEditorCanvas(page);
+    await reopenedEditor.getByText("First version.").click();
+    await page.keyboard.type(" Second version.");
+    // Save with the keyboard rather than the header button: the button's label
+    // moves between WordPress versions, the shortcut doesn't.
+    await page.keyboard.press("ControlOrMeta+s");
+    await expect(
+      page.getByTestId("snackbar").getByText("Post updated.")
+    ).toBeVisible();
+
+    // The classic revisions screen is addressed by revision ID. Ask the REST API
+    // through the editor's own client: the editor's revisions entry point has
+    // changed shape across WordPress versions, this hasn't.
+    const revisionId = await page.evaluate(async (id) => {
+      const revisions = await (window as any).wp.apiFetch({
+        path: `/wp/v2/posts/${id}/revisions?per_page=1`,
+      });
+      return revisions[0].id;
+    }, postId);
+
+    await page.goto(`/wp-admin/revision.php?revision=${revisionId}`);
+
+    const markButton = page.getByRole("button", {
+      name: "Mark as a major revision",
+    });
+    const unmarkButton = page.getByRole("button", {
+      name: "Unmark as a major revision",
+    });
+    const majorLabel = page.getByText("Major revision", { exact: true });
+
+    await expect(markButton).toBeVisible();
+    await expect(majorLabel).not.toBeVisible();
+
+    await markButton.click();
+    await expect(unmarkButton).toBeVisible();
+    await expect(majorLabel).toBeVisible();
+
+    // Reload to prove the mark was stored, not just reflected in the page state.
+    await page.reload();
+    await expect(unmarkButton).toBeVisible();
+    await expect(majorLabel).toBeVisible();
+
+    await unmarkButton.click();
+    await expect(markButton).toBeVisible();
+    await page.reload();
+    await expect(markButton).toBeVisible();
+    await expect(majorLabel).not.toBeVisible();
+  }
+);

--- a/plugins/newspack-plugin/src/revisions-control/index.js
+++ b/plugins/newspack-plugin/src/revisions-control/index.js
@@ -1,6 +1,6 @@
 /* globals jQuery, newspack_revisions_control */
 
-import './newspack-revisions.scss';
+import './style.scss';
 
 ( function ( $ ) {
 	if ( typeof wp.revisions.view.MetaTo !== 'undefined' ) {
@@ -73,7 +73,8 @@ import './newspack-revisions.scss';
 			const button = document.createElement( 'input' );
 			button.type = 'button';
 			button.value = '';
-			button.className = 'mark-major button button-secondary';
+			// Match the size of core's neighbouring "Restore This Revision" button.
+			button.className = 'mark-major button button-secondary button-compact';
 
 			const t = this; // eslint-disable-line @typescript-eslint/no-this-alias
 			const revision_id = this.model.attributes.to.attributes.id;
@@ -83,19 +84,24 @@ import './newspack-revisions.scss';
 				t.getMessageSpan().html( labels.loading ).show();
 				toggleRevisionMajor( post_id, revision_id, function ( data ) {
 					t.getMessageSpan().html( labels.saved ).fadeOut( 1000 );
-					const response = jQuery.parseJSON( data );
+					const response = JSON.parse( data );
 					t.updateRevisionMajor( response.major );
 				} );
 			};
 
-			this.$el.find( '.mark-major' ).remove();
-			this.$el.append( button );
-
 			// Add feedback message Span
 			const message = document.createElement( 'span' );
 			message.className = 'mark-major-message';
-			message.style = 'margin-left:10px';
-			this.$el.append( message );
+
+			// Both are floated right, so the last one inserted sits furthest left:
+			// message, then this button, then core's "Restore This Revision".
+			this.$el.find( '.mark-major, .mark-major-message' ).remove();
+			const restoreButton = this.$el.find( '.restore-revision' );
+			if ( restoreButton.length ) {
+				restoreButton.after( button, message );
+			} else {
+				this.$el.append( button, message );
+			}
 
 			const label = document.createElement( 'span' );
 			label.className = 'major-label newspack-revisions-color';

--- a/plugins/newspack-plugin/src/revisions-control/style.scss
+++ b/plugins/newspack-plugin/src/revisions-control/style.scss
@@ -18,3 +18,15 @@
 .diff-meta-to.newspack-major .major-label {
 	display: inline;
 }
+
+/* Sit alongside core's "Restore This Revision" button, which floats right. */
+.diff-meta input.mark-major,
+.diff-meta .mark-major-message {
+	float: right;
+	margin-left: 6px;
+	margin-right: 6px;
+}
+
+.diff-meta .mark-major-message {
+	line-height: 30px;
+}

--- a/plugins/newspack-plugin/webpack.config.js
+++ b/plugins/newspack-plugin/webpack.config.js
@@ -73,6 +73,7 @@ const entry = {
 	'newspack-ui': resolveSource( 'src', 'newspack-ui', 'index' ),
 	bylines: resolveSource( 'src', 'bylines', 'index' ),
 	'nicename-change': resolveSource( 'src', 'nicename-change', 'index' ),
+	'revisions-control': resolveSource( 'src', 'revisions-control', 'index' ),
 	'collections-admin': resolveSource( 'src', 'collections', 'admin', 'index' ),
 	'collections-frontend': resolveSource( 'src', 'collections', 'frontend', 'index' ),
 	'group-subscription-admin': resolveSource( 'src', 'group-subscription', 'admin' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Cherry-pick of #900 onto `release`.

Revisions control lets a publisher mark a revision as major so the retention limit never deletes it. Those controls have not loaded since v5.0.0, when the enqueue moved to `dist/` during the `@wordpress/scripts` migration with no webpack entry to build the asset. Both files have 404'd ever since, so on an affected site the flag can only be set in the database.

This adds the entry and moves the source under `src/` alongside every other entry.

Going on `release` rather than waiting for the next cycle: sites with revisions control on are losing revisions now, and the nightly e2e run is red because it targets the stable channel, where the button does not exist.

Closes NPPM-3155.

**Before** — the screen as it ships in 6.48.14, with no controls:

![Revisions screen with no Mark as a major revision button](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/18/d5gjs6nc-wp71-revision-screen-no-button.png)

**After** — the same screen with the asset built:

![Revisions screen with the major revision button beside Restore This Revision](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/18/hjcgc554-wp71-revisions-control-fixed-v2.png)

### How to test the changes in this Pull Request:

1. Check out this branch. Build newspack-plugin.
2. Run `wp option update newspack_revisions_control '{"active":true,"number":5,"min_age":"-1 week"}' --format=json`. This activates the feature and is required.
3. Publish a post. Edit and save it twice.
4. Open `/wp-admin/revision.php?revision=<latest revision ID>`. A "Mark as a major revision" button appears beside "Restore This Revision".
5. Open the browser console. No 404 appears for `dist/revisions-control.js` or `.css`.
6. Select "Mark as a major revision". The button becomes "Unmark as a major revision" and a "Major revision" label appears.
7. Reload the page. The revision is still marked.
8. Select "Unmark as a major revision", then reload the page. The revision is no longer marked.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? `e2e/tests/revisions.spec.ts` came with #900 and fails when the asset is missing.
* [x] Have you successfully run tests with your changes locally? The spec is green on an isolated env built from this branch.
