### PR TITLE
chore(release): merge in release newspack-network@2.22.2 (alpha)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,11 @@ jobs:
     needs: changed-packages
     if: needs.changed-packages.outputs.any == 'true' && needs.changed-packages.outputs.php-matrix != '{"include":[]}'
     runs-on: ubuntu-latest
+    # A stalled fetch in "Install WordPress test suite" used to hold a runner
+    # until the 6-hour default timeout killed it, with the PR's check reading
+    # as still-running the whole time. This job normally finishes in 3-6
+    # minutes, so 20 is slack for a slow runner and nothing more.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.changed-packages.outputs.php-matrix) }}
@@ -345,26 +350,75 @@ jobs:
           fi
       - name: Install WordPress test suite
         if: steps.check.outputs.has_tests == 'true'
+        # Below the job budget on purpose. A transfer slow enough to keep
+        # retrying but never trip the speed limit can burn --max-time on every
+        # attempt, and hitting the job timeout instead reports as a cancelled
+        # job that names no step. Failing here names this step.
+        timeout-minutes: 15
         run: |
-          # svn isn't on ubuntu-latest runners by default; the WP develop
-          # repo's phpunit test library is published over svn.
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq subversion
-          # Download WP core and test library.
+          # Every fetch below is a stall risk, and an unguarded one used to wedge
+          # here with no output naming the URL it was on. curl aborts a transfer
+          # that drops under 1KB/s for 30s and retries it, and each fetch
+          # announces itself so a log tail identifies the culprit.
+          fetch() {
+            curl --fail --location --silent --show-error \
+              --connect-timeout 15 --max-time 300 \
+              --speed-limit 1024 --speed-time 30 \
+              --retry 5 --retry-delay 5 --retry-max-time 300 --retry-all-errors "$@"
+          }
+
           mkdir -p "$WP_TESTS_DIR"
-          WP_TESTS_TAG=$(curl -s "https://api.wordpress.org/core/version-check/1.7/" | jq -r '.offers[0].version')
+
+          echo "Resolving the current WordPress version..."
+          WP_TESTS_TAG=$(fetch "https://api.wordpress.org/core/version-check/1.7/" | jq -r '.offers[0].version')
+          # An empty or null version would build URLs like wordpress-null.tar.gz,
+          # whose 404 surfaces as a confusing tar error several lines later.
+          if [ -z "$WP_TESTS_TAG" ] || [ "$WP_TESTS_TAG" = "null" ]; then
+            echo "Could not resolve a WordPress version from api.wordpress.org"
+            exit 1
+          fi
+          echo "WordPress $WP_TESTS_TAG"
+
+          # The two sources tag releases differently: wordpress.org names its
+          # core tarball with the version as published ("7.1"), while
+          # wordpress-develop tags are always three-part ("7.1.0"). They agree
+          # once a patch ships, so the develop tag 404s only between an x.y.0
+          # release and its first patch -- a window this job would otherwise
+          # spend entirely red. Derive the tag rather than sharing the variable.
+          WP_DEVELOP_TAG="$WP_TESTS_TAG"
+          case "$WP_DEVELOP_TAG" in
+            *.*.*) ;;
+            *) WP_DEVELOP_TAG="$WP_DEVELOP_TAG.0" ;;
+          esac
 
           # The tarball's top-level directory is "wordpress/". Extract to
           # $WP_CORE_DIR's parent and strip that prefix so files land at
           # $WP_CORE_DIR directly. Avoids the "mv: same file" failure when
           # $WP_CORE_DIR happens to be /tmp/wordpress.
+          echo "Fetching WordPress core..."
           rm -rf "$WP_CORE_DIR"
           mkdir -p "$WP_CORE_DIR"
-          curl -s "https://wordpress.org/wordpress-$WP_TESTS_TAG.tar.gz" \
+          fetch "https://wordpress.org/wordpress-$WP_TESTS_TAG.tar.gz" \
             | tar xz --strip-components=1 -C "$WP_CORE_DIR"
 
-          svn co --quiet "https://develop.svn.wordpress.org/tags/$WP_TESTS_TAG/tests/phpunit/includes/" "$WP_TESTS_DIR/includes"
-          svn co --quiet "https://develop.svn.wordpress.org/tags/$WP_TESTS_TAG/tests/phpunit/data/" "$WP_TESTS_DIR/data"
+          # The phpunit test library used to arrive via two `svn co` calls against
+          # develop.svn.wordpress.org. svn has no timeout of its own and those
+          # checkouts are what hung; it also had to be apt-installed on every run,
+          # since ubuntu-latest carries no subversion. The wordpress-develop tag
+          # holds the same tree and comes over the same HTTPS as core above, so one
+          # guarded fetch replaces both checkouts and the apt install.
+          echo "Fetching the phpunit test library..."
+          rm -rf "$WP_TESTS_DIR/includes" "$WP_TESTS_DIR/data"
+          fetch "https://github.com/WordPress/wordpress-develop/archive/refs/tags/$WP_DEVELOP_TAG.tar.gz" \
+            | tar xz --strip-components=3 -C "$WP_TESTS_DIR" \
+                "wordpress-develop-$WP_DEVELOP_TAG/tests/phpunit/includes" \
+                "wordpress-develop-$WP_DEVELOP_TAG/tests/phpunit/data"
+          # A silently-empty test library fails later as a cryptic "class
+          # WP_UnitTestCase not found", so assert the bootstrap actually landed.
+          if [ ! -f "$WP_TESTS_DIR/includes/bootstrap.php" ]; then
+            echo "The phpunit test library is missing $WP_TESTS_DIR/includes/bootstrap.php"
+            exit 1
+          fi
 
           # Write wp-tests-config.php.
           cat > "$WP_TESTS_DIR/wp-tests-config.php" << 'WPCFG'

--- a/plugins/newspack-network/CHANGELOG.md
+++ b/plugins/newspack-network/CHANGELOG.md
@@ -1,3 +1,10 @@
+## newspack-network [2.22.2](https://github.com/Automattic/newspack-workspace/compare/newspack-network@2.22.1...newspack-network@2.22.2) (2026-08-24)
+
+
+### Bug Fixes
+
+* **network:** escape node-supplied hub admin output ([#871](https://github.com/Automattic/newspack-workspace/issues/871)) ([4dbe67d](https://github.com/Automattic/newspack-workspace/commit/4dbe67d6c36c365254a4517d031ab725a57637e3))
+
 ## newspack-network [2.22.1](https://github.com/Automattic/newspack-workspace/compare/newspack-network@2.22.0...newspack-network@2.22.1) (2026-08-19)
 
 

--- a/plugins/newspack-network/includes/class-users.php
+++ b/plugins/newspack-network/includes/class-users.php
@@ -57,9 +57,12 @@ class Users {
 			if ( $remote_site ) {
 				return sprintf(
 					'<a href="%swp-admin/user-edit.php?user_id=%d">%s</a>',
-					trailingslashit( esc_url( $remote_site ) ),
+					// Escape last. esc_url() returns '' for a value it rejects, and
+					// trailingslashit( '' ) is '/', which would point the link at the
+					// hub's own user-edit screen rather than leaving the href empty.
+					esc_url( trailingslashit( $remote_site ) ),
 					$remote_id,
-					sprintf( '%s (#%d)', $remote_site, $remote_id )
+					sprintf( '%s (#%d)', esc_html( $remote_site ), $remote_id )
 				);
 			}
 		}
@@ -84,8 +87,8 @@ class Users {
 				return sprintf(
 					'%s: <code>%s</code><br><a href="%s">%s</a>',
 					__( 'Last Activity', 'newspack-network' ),
-					$last_activity[0]->get_summary(),
-					$event_log_url,
+					esc_html( $last_activity[0]->get_summary() ),
+					esc_url( $event_log_url ),
 					__( 'View all', 'newspack-network' )
 				);
 			} elseif ( Site_Role::is_node() ) {
@@ -98,7 +101,7 @@ class Users {
 				);
 				return sprintf(
 					'<a href="%s">%s</a>',
-					$event_log_url,
+					esc_url( $event_log_url ),
 					__( 'View activity', 'newspack-network' )
 				);
 			}

--- a/plugins/newspack-network/includes/hub/admin/class-event-log-list-table.php
+++ b/plugins/newspack-network/includes/hub/admin/class-event-log-list-table.php
@@ -143,16 +143,27 @@ class Event_Log_List_Table extends \WP_List_Table {
 	 * @return string
 	 */
 	protected function get_data_column( $item ) {
-		$str = wp_json_encode( $item->get_data(), JSON_PRETTY_PRINT );
-		if ( 300 > strlen( $str ) ) {
+		// Measure the raw JSON, not the escaped string. Escaping inflates every
+		// quote from one byte to six, so a payload of a few hundred bytes crosses
+		// the threshold on punctuation alone and renders collapsed when it should
+		// render inline. The cast covers wp_json_encode() returning false, which
+		// strlen() would otherwise take as a deprecated null-ish argument.
+		$json = (string) wp_json_encode( $item->get_data(), JSON_PRETTY_PRINT );
+
+		if ( 300 > strlen( $json ) ) {
 			return sprintf(
 				'<div class="newspack-network-data-column"><pre><code>%1$s</code></pre></div>',
-				$str
+				esc_html( $json )
 			);
 		}
+
+		// esc_textarea() rather than esc_html(): js/event-log.js reads this
+		// element's .value and copies it to the clipboard, and esc_html() does not
+		// double-encode, so data legitimately containing "&amp;" would decode back
+		// to "&" and reach the clipboard altered. esc_textarea() round-trips.
 		return sprintf(
 			'<div class="newspack-network-data-column"><textarea disabled>%1$s</textarea><button type="button" class="button button-secondary">%2$s</button></div>',
-			$str,
+			esc_textarea( $json ),
 			esc_html__( 'Copy to clipboard', 'newspack-network' )
 		);
 	}
@@ -171,11 +182,11 @@ class Event_Log_List_Table extends \WP_List_Table {
 			case 'date':
 				return gmdate( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $item->get_timestamp() );
 			case 'summary':
-				return $item->get_summary();
+				return esc_html( $item->get_summary() );
 			case 'node':
-				return $item->get_node_url() ? $item->get_node_url() : '-';
+				return $item->get_node_url() ? esc_html( $item->get_node_url() ) : '-';
 			case 'action_name':
-				return $item->get_action_name();
+				return esc_html( $item->get_action_name() );
 			case 'data':
 				return $this->get_data_column( $item );
 			default:

--- a/plugins/newspack-network/includes/hub/admin/class-membership-plans-table.php
+++ b/plugins/newspack-network/includes/hub/admin/class-membership-plans-table.php
@@ -84,10 +84,10 @@ class Membership_Plans_Table extends \WP_List_Table {
 
 		if ( $column_name === 'name' ) {
 			$edit_url = sprintf( '%s/wp-admin/post.php?post=%d&action=edit', $item['site_url'], $item['id'] );
-			return sprintf( '<a href="%s">%s</a>', esc_url( $edit_url ), $item[ $column_name ] . ' (#' . $item['id'] . ')' );
+			return sprintf( '<a href="%s">%s</a>', esc_url( $edit_url ), esc_html( $item[ $column_name ] . ' (#' . $item['id'] . ')' ) );
 		}
 		if ( $column_name === 'network_pass_id' && $item[ $column_name ] ) {
-			return sprintf( '<code>%s</code>', $item[ $column_name ] );
+			return sprintf( '<code>%s</code>', esc_html( $item[ $column_name ] ) );
 		}
 		if ( $column_name === 'network_pass_discrepancies' && isset( $item['network_pass_discrepancies'] ) && $item['network_pass_id'] ) {
 			$discrepancies = $item['network_pass_discrepancies'];
@@ -122,9 +122,9 @@ class Membership_Plans_Table extends \WP_List_Table {
 			return sprintf( '<a href="%s">%s</a>', esc_url( $memberships_list_url_with_emails_url ), esc_html( $message ) );
 		}
 		if ( $column_name === 'active_memberships_count' && isset( $item[ $column_name ] ) ) {
-			return sprintf( '<a href="%s">%s</a>', esc_url( $memberships_list_url ), $item[ $column_name ] );
+			return sprintf( '<a href="%s">%s</a>', esc_url( $memberships_list_url ), esc_html( $item[ $column_name ] ) );
 		}
-		return isset( $item[ $column_name ] ) ? $item[ $column_name ] : '';
+		return isset( $item[ $column_name ] ) && is_scalar( $item[ $column_name ] ) ? esc_html( $item[ $column_name ] ) : '';
 	}
 
 	/**

--- a/plugins/newspack-network/includes/hub/admin/class-orders.php
+++ b/plugins/newspack-network/includes/hub/admin/class-orders.php
@@ -48,15 +48,9 @@ class Orders extends Woo {
 
 		switch ( $column ) {
 			case 'order':
-				$output = sprintf(
-					'<a href="%s" target="_blank">%s</a> for %s on <a href="%s" target="_blank">%s</a>',
-					$item->get_edit_link(),
-					$item->get_title(),
-					$item->get_user_name(),
-					$item->get_node_url(),
-					$item->get_node_url()
-				);
-				echo $output; // phpcs:ignore
+				self::print_link( $item->get_edit_link(), $item->get_title() );
+				printf( ' for %s on ', esc_html( $item->get_user_name() ) );
+				self::print_link( $item->get_node_url(), $item->get_node_url() );
 				break;
 			case 'status':
 				?>

--- a/plugins/newspack-network/includes/hub/admin/class-subscriptions.php
+++ b/plugins/newspack-network/includes/hub/admin/class-subscriptions.php
@@ -81,31 +81,18 @@ class Subscriptions extends Woo {
 				);
 				break;
 			case 'subscription':
-				$output = sprintf(
-					'<a href="%s" target="_blank">%s</a> for %s on <a href="%s" target="_blank">%s</a>',
-					$item->get_edit_link(),
-					$item->get_title(),
-					$item->get_user_name(),
-					$item->get_node_url(),
-					$item->get_node_url()
-				);
-				echo $output; // phpcs:ignore
+				self::print_link( $item->get_edit_link(), $item->get_title() );
+				printf( ' for %s on ', esc_html( $item->get_user_name() ) );
+				self::print_link( $item->get_node_url(), $item->get_node_url() );
 				break;
 			case 'items':
-				$products = $item->get_products();
-				$output     = '';
-				foreach ( $products as $product ) {
-					$output .= sprintf(
-						'<a href="%s" target="_blank">%s</a><br />',
-						sprintf(
-							'%s/wp-admin/post.php?post=%d&action=edit',
-							$item->get_node_url(),
-							$product['id'] ?? ''
-						),
+				foreach ( $item->get_products() as $product ) {
+					self::print_link(
+						sprintf( '%s/wp-admin/post.php?post=%d&action=edit', $item->get_node_url(), $product['id'] ?? '' ),
 						$product['name'] ?? ''
 					);
+					echo '<br />';
 				}
-				echo $output; // phpcs:ignore
 				break;
 			case 'orders':
 				$link = sprintf(
@@ -113,10 +100,14 @@ class Subscriptions extends Woo {
 					$item->get_node_url(),
 					$item->get_remote_id()
 				);
-				printf( '<a href="%s" target="blank">%s</a>', $link, $item->get_payment_count() ); // phpcs:ignore
+				self::print_link( $link, $item->get_payment_count() );
 				break;
 			case 'total':
-				printf( '%s<br/>Via %s', $item->get_formatted_total(), $item->get_payment_method_title() ); // phpcs:ignore
+				printf(
+					'%s<br/>Via %s',
+					esc_html( $item->get_formatted_total() ),
+					esc_html( $item->get_payment_method_title() )
+				);
 				break;
 		}
 	}

--- a/plugins/newspack-network/includes/hub/admin/class-woo.php
+++ b/plugins/newspack-network/includes/hub/admin/class-woo.php
@@ -207,6 +207,33 @@ abstract class Woo {
 	}
 
 	/**
+	 * Echo an anchor with an escaped href and escaped text. Both arguments are
+	 * node-supplied and treated as untrusted.
+	 *
+	 * Lives on the base rather than on one table because Orders and
+	 * Subscriptions render equivalent anchors from the same Woo_Item getters,
+	 * so a helper reachable from only one of them leaves the other to
+	 * hand-roll its escaping.
+	 *
+	 * Woo_Item::get_edit_link() bare-returns null when remote_id or node_url is
+	 * missing, and esc_url() has no string cast before its ltrim(), which is a
+	 * deprecation on PHP 8.3. The cast keeps that latent case quiet.
+	 *
+	 * @param string $url    The href.
+	 * @param string $text   The link text.
+	 * @param string $target The link target attribute.
+	 * @return void
+	 */
+	protected static function print_link( $url, $text, $target = '_blank' ) {
+		printf(
+			'<a href="%s" target="%s">%s</a>',
+			esc_url( (string) $url ),
+			esc_attr( $target ),
+			esc_html( (string) $text )
+		);
+	}
+
+	/**
 	 * Modify columns on post type table
 	 *
 	 * @param array $columns Registered columns.

--- a/plugins/newspack-network/includes/woocommerce-memberships/class-admin.php
+++ b/plugins/newspack-network/includes/woocommerce-memberships/class-admin.php
@@ -278,7 +278,7 @@ class Admin {
 			return $actions;
 		}
 		$link     = self::get_edit_post_link( '', $post->ID );
-		$link_tag = sprintf( '<a href="%s" target="_blank">%s</a>', $link, $remote_url );
+		$link_tag = sprintf( '<a href="%s" target="_blank">%s</a>', esc_url( $link ), esc_html( $remote_url ) );
 		return [
 			'none' => sprintf(
 				// translators: %s is the site URL with a link to edit the post.

--- a/plugins/newspack-network/newspack-network.php
+++ b/plugins/newspack-network/newspack-network.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack Network
  * Description: The Newspack Network plugin.
- * Version: 2.22.1
+ * Version: 2.22.2
  * Author: Automattic
  * Author URI: https://newspack.com/
  * License: GPLv2 or later

--- a/plugins/newspack-network/package.json
+++ b/plugins/newspack-network/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack-network",
-	"version": "2.22.1",
+	"version": "2.22.2",
 	"description": "The Newspack Network plugin.",
 	"license": "GPL-2.0-or-later",
 	"repository": {

--- a/plugins/newspack-network/tests/unit-tests/test-event-log-list-table-escaping.php
+++ b/plugins/newspack-network/tests/unit-tests/test-event-log-list-table-escaping.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Tests that the hub Event Log list table escapes node-supplied column output.
+ *
+ * @package Newspack_Network_Hub
+ */
+
+use Newspack_Network\Hub\Admin\Event_Log_List_Table;
+
+/**
+ * Verify every dynamic Event Log column is escaped at output.
+ */
+class Test_Event_Log_List_Table_Escaping extends WP_UnitTestCase {
+
+	/**
+	 * Build a stub event-log item exposing the getters column_default reads.
+	 *
+	 * @param string $summary     Summary text.
+	 * @param string $node_url    Node URL.
+	 * @param string $action_name Action name.
+	 * @param mixed  $data        Decoded data payload.
+	 * @return object
+	 */
+	private function make_item( $summary, $node_url, $action_name, $data ) {
+		return new class( $summary, $node_url, $action_name, $data ) {
+			/**
+			 * Summary text.
+			 *
+			 * @var string
+			 */
+			public $summary;
+			/**
+			 * Node URL.
+			 *
+			 * @var string
+			 */
+			public $node_url;
+			/**
+			 * Action name.
+			 *
+			 * @var string
+			 */
+			public $action_name;
+			/**
+			 * Data payload.
+			 *
+			 * @var mixed
+			 */
+			public $data;
+			/**
+			 * Store the stub's data.
+			 *
+			 * @param string $summary     Summary.
+			 * @param string $node_url    Node URL.
+			 * @param string $action_name Action name.
+			 * @param mixed  $data        Data.
+			 */
+			public function __construct( $summary, $node_url, $action_name, $data ) {
+				$this->summary     = $summary;
+				$this->node_url    = $node_url;
+				$this->action_name = $action_name;
+				$this->data        = $data;
+			}
+			/**
+			 * Get the summary.
+			 *
+			 * @return string
+			 */
+			public function get_summary() {
+				return $this->summary; }
+			/**
+			 * Get the node URL.
+			 *
+			 * @return string
+			 */
+			public function get_node_url() {
+				return $this->node_url; }
+			/**
+			 * Get the action name.
+			 *
+			 * @return string
+			 */
+			public function get_action_name() {
+				return $this->action_name; }
+			/**
+			 * Get the data payload.
+			 *
+			 * @return mixed
+			 */
+			public function get_data() {
+				return $this->data; }
+		};
+	}
+
+	/**
+	 * The summary, node and action_name columns must be HTML-escaped.
+	 */
+	public function test_text_columns_are_escaped() {
+		$payload = '<img src=x onerror=NPPM3042>';
+		$table   = new Event_Log_List_Table();
+		$item    = $this->make_item( $payload, $payload, $payload, [ 'note' => $payload ] );
+
+		foreach ( [ 'summary', 'node', 'action_name' ] as $column ) {
+			$out = $table->column_default( $item, $column );
+			$this->assertStringNotContainsString( '<img src=x', $out, "Column {$column} rendered a live tag" );
+			$this->assertStringContainsString( '&lt;img src=x onerror=NPPM3042&gt;', $out, "Column {$column} not escaped" );
+		}
+	}
+
+	/**
+	 * The data column JSON must be HTML-escaped, including quotes/slashes and a
+	 * </textarea> breakout in the large-payload branch.
+	 */
+	public function test_data_column_is_escaped() {
+		$table = new Event_Log_List_Table();
+
+		// Small payload -> <pre><code> branch.
+		$small = $this->make_item( 's', 'n', 'a', [ 'note' => '<img src=x onerror=NPPM3042>' ] );
+		$out   = $table->column_default( $small, 'data' );
+		$this->assertStringNotContainsString( '<img src=x', $out );
+		$this->assertStringContainsString( '&lt;img src=x onerror=NPPM3042&gt;', $out );
+
+		// Large payload (>300 chars) -> <textarea> branch, with a breakout attempt.
+		$big_note = str_repeat( 'A', 320 ) . '</textarea><img src=x onerror=NPPM3042>';
+		$big      = $this->make_item( 's', 'n', 'a', [ 'note' => $big_note ] );
+		$out      = $table->column_default( $big, 'data' );
+		$this->assertStringNotContainsString( '</textarea><img', $out );
+		$this->assertStringNotContainsString( '<img src=x', $out );
+		$this->assertStringContainsString( '&lt;img src=x onerror=NPPM3042&gt;', $out );
+	}
+
+	/**
+	 * The inline/collapsed threshold measures the raw JSON, not the escaped
+	 * string.
+	 *
+	 * Escaping turns each quote into six bytes, so a payload comfortably under
+	 * the limit can cross it on punctuation alone and render collapsed when it
+	 * should render inline. The two preconditions below are the point of the
+	 * test: they assert the fixture actually straddles the boundary, so the
+	 * assertion cannot quietly stop meaning anything if the limit moves.
+	 */
+	public function test_threshold_measures_unescaped_json() {
+		$data = [
+			'action'   => 'subscription_changed',
+			'status'   => 'active',
+			'node'     => 'example',
+			'user'     => 'reader',
+			'plan'     => 'monthly',
+			'ref'      => 'abc123',
+			'currency' => 'usd',
+			'gateway'  => 'stripe',
+		];
+		$json = wp_json_encode( $data, JSON_PRETTY_PRINT );
+
+		$this->assertLessThan( 300, strlen( $json ), 'Precondition: the raw JSON is under the limit.' );
+		$this->assertGreaterThan( 300, strlen( esc_html( $json ) ), 'Precondition: escaping pushes it over.' );
+
+		$out = ( new Event_Log_List_Table() )->column_default( $this->make_item( 's', 'n', 'a', $data ), 'data' );
+
+		$this->assertStringContainsString( '<pre><code>', $out, 'Payload under the limit rendered collapsed.' );
+		$this->assertStringNotContainsString( '<textarea', $out, 'Payload under the limit rendered collapsed.' );
+	}
+
+	/**
+	 * The collapsed branch must survive a clipboard round-trip.
+	 *
+	 * The clipboard script in js/event-log.js reads the textarea's .value and
+	 * copies it verbatim. The browser decodes entities on the way out, so the
+	 * escaper has to encode the ampersand of an existing entity, or the copied
+	 * text differs from the data.
+	 */
+	public function test_textarea_round_trips_entities() {
+		$note = str_repeat( 'A', 320 ) . ' &amp; more';
+		$out  = ( new Event_Log_List_Table() )->column_default(
+			$this->make_item( 's', 'n', 'a', [ 'note' => $note ] ),
+			'data'
+		);
+
+		$this->assertStringContainsString( '<textarea', $out, 'Precondition: the payload took the collapsed branch.' );
+		$this->assertStringContainsString( '&amp;amp;', $out, 'The ampersand was not encoded, so the clipboard copy alters the data.' );
+	}
+}

--- a/plugins/newspack-network/tests/unit-tests/test-membership-plans-table-escaping.php
+++ b/plugins/newspack-network/tests/unit-tests/test-membership-plans-table-escaping.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Tests that the hub Membership Plans list table escapes node-supplied output.
+ *
+ * @package Newspack_Network_Hub
+ */
+
+use Newspack_Network\Hub\Admin\Membership_Plans_Table;
+
+/**
+ * Verify membership-plan columns escape node-supplied values.
+ */
+class Test_Membership_Plans_Table_Escaping extends WP_UnitTestCase {
+
+	/**
+	 * Base item with a payload in every node-supplied field.
+	 *
+	 * @param string $payload The XSS marker.
+	 * @return array
+	 */
+	private function item( $payload ) {
+		return [
+			'id'                         => 9,
+			'name'                       => $payload,
+			'site_url'                   => $payload,
+			'network_pass_id'            => $payload,
+			'active_memberships_count'   => 4,
+			'network_pass_discrepancies' => [],
+		];
+	}
+
+	/**
+	 * The name, network_pass_id and default (site_url) columns must escape.
+	 */
+	public function test_columns_are_escaped() {
+		$payload = '<img src=x onerror=NPPM3042>';
+		$table   = new Membership_Plans_Table();
+		$item    = $this->item( $payload );
+
+		foreach ( [ 'name', 'network_pass_id', 'site_url' ] as $column ) {
+			$out = $table->column_default( $item, $column );
+			$this->assertStringNotContainsString( '<img src=x', $out, "Column {$column} rendered a live tag" );
+			$this->assertStringContainsString( '&lt;img src=x onerror=NPPM3042&gt;', $out, "Column {$column} not escaped" );
+		}
+	}
+
+	/**
+	 * A non-scalar value in the default case renders empty, not "Array" + notice.
+	 *
+	 * The column that actually reaches the guard is network_pass_discrepancies:
+	 * its own branch is gated on a truthy network_pass_id, so a falsy one drops
+	 * an array into the catch-all. Asserting on a column get_columns() never
+	 * produces would document a hypothetical instead.
+	 */
+	public function test_default_case_guards_non_scalar() {
+		$table = new Membership_Plans_Table();
+		$item  = $this->item( 'x' );
+
+		$item['network_pass_id']            = '';
+		$item['network_pass_discrepancies'] = [ 'reader@example.com' ];
+
+		$out = $table->column_default( $item, 'network_pass_discrepancies' );
+		$this->assertSame( '', $out, 'An array reaching the catch-all must render empty.' );
+	}
+
+	/**
+	 * The plan links escape their href, not only their text.
+	 *
+	 * The tag-shaped payload above is neutralised by the esc_html() on the link
+	 * text, so it would still pass with the href escaping removed. This payload
+	 * carries no `<` at all and can only be stopped at the attribute.
+	 */
+	public function test_plan_link_href_is_escaped() {
+		$table = new Membership_Plans_Table();
+		$item  = $this->item( 'https://node.test" onmouseover=NPPM3042 x="' );
+
+		$out = $table->column_default( $item, 'name' );
+
+		$this->assertSame( 2, substr_count( $out, '"' ), 'An attribute was broken out of: ' . $out );
+
+		preg_match( '/href="([^"]*)"/', $out, $matches );
+		$href = isset( $matches[1] ) ? $matches[1] : '';
+		$this->assertNotSame( '', $href, 'Precondition: the plan name links somewhere.' );
+		$this->assertStringContainsString( '%20', $href, 'esc_url() did not encode the injected whitespace.' );
+	}
+}

--- a/plugins/newspack-network/tests/unit-tests/test-orders-columns-escaping.php
+++ b/plugins/newspack-network/tests/unit-tests/test-orders-columns-escaping.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Tests that the hub Orders list table escapes node-supplied output.
+ *
+ * @package Newspack_Network_Hub
+ */
+
+use Newspack_Network\Hub\Admin\Orders;
+use Newspack_Network\Hub\Database\Orders as Orders_DB;
+
+/**
+ * Verify the order column escapes node-supplied values.
+ *
+ * Orders and Subscriptions render equivalent anchors from the same Woo_Item
+ * getters, so this file is the Orders half of the sibling Subscriptions suite.
+ */
+class Test_Orders_Columns_Escaping extends WP_UnitTestCase {
+
+	/**
+	 * The XSS marker. Breaks out of an unescaped attribute without needing `<`,
+	 * so it survives a filter that only strips tags.
+	 */
+	const PAYLOAD = '" onmouseover=NPPM3042 x="';
+
+	/**
+	 * Create an order CPT post whose node-supplied fields carry the payload.
+	 *
+	 * The title is set with wp_update_post rather than at creation: the create
+	 * path runs wp_filter_post_kses, which would neutralise the payload and
+	 * leave the assertion passing on core's filtering instead of on the
+	 * escaping under test.
+	 *
+	 * remote_id carries the payload too, because get_edit_link() concatenates
+	 * it into the href. Without that, every URL in the fixture descends from
+	 * get_node_url(), which falls back to get_bloginfo( 'url' ) when no node
+	 * post exists -- a well-formed local URL that esc_url() returns unchanged,
+	 * leaving the href escaping unpinned.
+	 *
+	 * @return int Post ID.
+	 */
+	private function make_order() {
+		$post_id = self::factory()->post->create( [ 'post_type' => Orders_DB::POST_TYPE_SLUG ] );
+
+		wp_update_post(
+			[
+				'ID'         => $post_id,
+				'post_title' => self::PAYLOAD,
+			]
+		);
+
+		update_post_meta( $post_id, 'user_name', self::PAYLOAD );
+		update_post_meta( $post_id, 'remote_id', '42' . self::PAYLOAD );
+
+		return $post_id;
+	}
+
+	/**
+	 * Render a column and return the echoed HTML.
+	 *
+	 * @param string $column  Column key.
+	 * @param int    $post_id Post ID.
+	 * @return string
+	 */
+	private function render( $column, $post_id ) {
+		ob_start();
+		Orders::posts_columns_values( $column, $post_id );
+		return ob_get_clean();
+	}
+
+	/**
+	 * The order column must not emit a breakable attribute or a live handler.
+	 */
+	public function test_order_column_is_escaped() {
+		$out = $this->render( 'order', $this->make_order() );
+
+		$this->assertNotSame( '', $out, 'Precondition: the column rendered something.' );
+
+		// The marker text survives inside the href as inert characters, which is
+		// what escaping does -- it neutralises the quote that would leave the
+		// attribute, it does not delete the word. So assert on the quote rather
+		// than on the word: the payload must never appear as written.
+		$this->assertStringNotContainsString( self::PAYLOAD, $out, 'The raw payload survived: ' . $out );
+
+		// Two anchors, each carrying its two href quotes and two target quotes.
+		// A reflected value that escaped an attribute would add a ninth.
+		$this->assertSame( 8, substr_count( $out, '"' ), 'An attribute was broken out of: ' . $out );
+	}
+
+	/**
+	 * The href is escaped, not merely absent: the payload reaches it through
+	 * remote_id and must come back neutralised rather than dropped.
+	 */
+	public function test_edit_link_href_is_escaped() {
+		$out = $this->render( 'order', $this->make_order() );
+
+		preg_match( '/href="([^"]*)"/', $out, $matches );
+		$href = isset( $matches[1] ) ? $matches[1] : '';
+
+		$this->assertNotSame( '', $href, 'Precondition: the edit link has an href.' );
+		$this->assertStringContainsString( 'post=42', $href, 'The remote id is still in the href.' );
+
+		// esc_url() percent-encodes the whitespace the payload injects. Asserting
+		// that encoding is what pins esc_url() to this call site: without it the
+		// href would be a well-formed local URL that esc_url() returns unchanged,
+		// and removing the escaper would leave this test green.
+		$this->assertStringContainsString( '%20', $href, 'esc_url() did not encode the injected whitespace.' );
+	}
+
+	/**
+	 * The user name is plain text and must be escaped where it is interpolated
+	 * between the two anchors.
+	 */
+	public function test_user_name_is_escaped() {
+		$out = $this->render( 'order', $this->make_order() );
+
+		$this->assertStringContainsString( '&quot; onmouseover=NPPM3042 x=&quot;', $out, 'The user name was not escaped.' );
+	}
+}

--- a/plugins/newspack-network/tests/unit-tests/test-subscriptions-columns-escaping.php
+++ b/plugins/newspack-network/tests/unit-tests/test-subscriptions-columns-escaping.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Tests that the hub Subscriptions list table escapes node-supplied output.
+ *
+ * @package Newspack_Network_Hub
+ */
+
+use Newspack_Network\Hub\Admin\Subscriptions;
+use Newspack_Network\Hub\Database\Subscriptions as Subscriptions_DB;
+
+/**
+ * Verify the subscription/items/total columns escape node-supplied values.
+ */
+class Test_Subscriptions_Columns_Escaping extends WP_UnitTestCase {
+
+	/**
+	 * Create a subscription CPT post carrying payload-bearing meta.
+	 *
+	 * @param string $payload The XSS marker payload.
+	 * @return int Post ID.
+	 */
+	private function make_subscription( $payload ) {
+		$post_id = self::factory()->post->create( [ 'post_type' => Subscriptions_DB::POST_TYPE_SLUG ] );
+
+		// wp_filter_post_kses runs for any user without unfiltered_html, on create
+		// and update alike, and strips this payload to an empty string. A title
+		// written as the default user therefore never reaches get_title(), and the
+		// subscription column's assertion passes on the adjacent escaped
+		// get_user_name() instead of on the title. Writing it as an administrator
+		// (who holds unfiltered_html on single site, which is how these run) puts
+		// the payload where the column can render it, so the escaping under test
+		// is what has to neutralise it.
+		$previous = get_current_user_id();
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		wp_update_post(
+			[
+				'ID'         => $post_id,
+				'post_title' => $payload, // Read back by get_title().
+			]
+		);
+		wp_set_current_user( $previous );
+		update_post_meta( $post_id, 'user_name', $payload );
+		update_post_meta( $post_id, 'formatted_total', $payload );
+		update_post_meta( $post_id, 'payment_method_title', $payload );
+		update_post_meta( $post_id, 'payment_count', $payload );
+		update_post_meta( $post_id, 'remote_id', '42' );
+		add_post_meta(
+			$post_id,
+			'products',
+			[
+				'id'   => 5,
+				'name' => $payload,
+			]
+		);
+		return $post_id;
+	}
+
+	/**
+	 * Render a column and return the echoed HTML.
+	 *
+	 * @param string $column  Column key.
+	 * @param int    $post_id Post ID.
+	 * @return string
+	 */
+	private function render( $column, $post_id ) {
+		ob_start();
+		Subscriptions::posts_columns_values( $column, $post_id );
+		return ob_get_clean();
+	}
+
+	/**
+	 * The subscription, items and total columns must be escaped.
+	 */
+	public function test_columns_are_escaped() {
+		$payload = '<img src=x onerror=NPPM3042>';
+		$post_id = $this->make_subscription( $payload );
+
+		foreach ( [ 'subscription', 'items', 'orders', 'total' ] as $column ) {
+			$out = $this->render( $column, $post_id );
+			$this->assertStringNotContainsString( '<img src=x', $out, "Column {$column} rendered a live tag" );
+			$this->assertStringContainsString( '&lt;img src=x onerror=NPPM3042&gt;', $out, "Column {$column} not escaped" );
+		}
+	}
+
+	/**
+	 * The formatted_total meta is plain text: a mixed legit+malicious value
+	 * is fully escaped (no executable payload survives).
+	 */
+	public function test_total_neutralizes_mixed_payload() {
+		$post_id = $this->make_subscription( 'x' );
+		update_post_meta( $post_id, 'formatted_total', '<span class="amount">$1</span><script>x()</script>' );
+
+		$out = $this->render( 'total', $post_id );
+		$this->assertStringNotContainsString( '<script>', $out );
+		$this->assertStringNotContainsString( '<span class="amount">', $out );
+		$this->assertStringContainsString( '&lt;script&gt;', $out );
+	}
+}

--- a/plugins/newspack-network/tests/unit-tests/test-users-columns-escaping.php
+++ b/plugins/newspack-network/tests/unit-tests/test-users-columns-escaping.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Tests that the Users-list network columns escape node-supplied output.
+ *
+ * @package Newspack_Network_Hub
+ */
+
+use Newspack_Network\Users;
+use Newspack_Network\Site_Role;
+use Newspack_Network\Utils\Users as Users_Utils;
+
+/**
+ * Verify the Network User and Network Activity columns are escaped.
+ */
+class Test_Users_Columns_Escaping extends WP_UnitTestCase {
+
+	/**
+	 * Restore the site-role option so it cannot leak into later tests.
+	 */
+	public function tear_down() {
+		delete_option( Site_Role::OPTION_NAME );
+		parent::tear_down();
+	}
+
+	/**
+	 * The Network User column must escape the remote-site anchor text.
+	 */
+	public function test_network_user_column_escapes_remote_site() {
+		$payload = '<img src=x onerror=NPPM3042>';
+		$user_id = self::factory()->user->create();
+		update_user_meta( $user_id, Users_Utils::USER_META_REMOTE_SITE, $payload );
+		update_user_meta( $user_id, Users_Utils::USER_META_REMOTE_ID, 7 );
+
+		$out = Users::manage_users_custom_column( '', 'newspack_network_user', $user_id );
+		$this->assertStringNotContainsString( '<img src=x', $out );
+		$this->assertStringContainsString( '&lt;img src=x onerror=NPPM3042&gt;', $out );
+	}
+
+	/**
+	 * A remote-site URL that esc_url() rejects must not link back to the hub.
+	 *
+	 * A rejected value comes back from esc_url() as '', and trailingslashit( '' )
+	 * is '/', so escaping first would make the href an absolute hub path: the
+	 * hub's own user-edit screen for whatever id the node sent. Escaping last
+	 * leaves the href relative, which resolves nowhere.
+	 */
+	public function test_rejected_remote_site_url_does_not_link_to_the_hub() {
+		$user_id = self::factory()->user->create();
+		update_user_meta( $user_id, Users_Utils::USER_META_REMOTE_SITE, 'notaprotocol:example.com' );
+		update_user_meta( $user_id, Users_Utils::USER_META_REMOTE_ID, 7 );
+
+		$out = Users::manage_users_custom_column( '', 'newspack_network_user', $user_id );
+
+		$this->assertSame( 1, preg_match( '/href="([^"]*)"/', $out, $matches ) );
+		$this->assertStringStartsNotWith( '/', $matches[1] );
+	}
+
+	/**
+	 * The Network Activity column must escape the node event summary.
+	 *
+	 * `canonical_url_updated` events derive their summary from the event's
+	 * `data.url` field (not from `email`, which doubles as the Event_Log
+	 * lookup key), so the payload can be carried there while the row's email
+	 * stays a plain, matchable value.
+	 */
+	public function test_network_activity_column_escapes_summary() {
+		update_option( Site_Role::OPTION_NAME, Site_Role::HUB_ROLE );
+
+		$payload = '<img src=x onerror=NPPM3042>';
+		$user    = self::factory()->user->create_and_get();
+
+		global $wpdb;
+		// Ensure the event-log table exists; it's created lazily on first access.
+		$table_name = \Newspack_Network\Hub\Database\Event_Log::get_table_name();
+		$wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$table_name,
+			[
+				'action_name' => 'canonical_url_updated',
+				'node_id'     => 0,
+				'email'       => $user->user_email,
+				'data'        => wp_json_encode( [ 'url' => $payload ] ),
+				'timestamp'   => time(),
+			],
+			[ '%s', '%d', '%s', '%s', '%d' ]
+		);
+
+		$out = Users::manage_users_custom_column( '', 'newspack_network_activity', $user->ID );
+		$this->assertStringNotContainsString( '<img src=x', $out );
+		$this->assertStringContainsString( '&lt;img src=x onerror=NPPM3042&gt;', $out );
+	}
+}

--- a/plugins/newspack-network/tests/unit-tests/test-wc-memberships-admin-escaping.php
+++ b/plugins/newspack-network/tests/unit-tests/test-wc-memberships-admin-escaping.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Tests that the WC Memberships admin row action escapes the node site URL.
+ *
+ * @package Newspack_Network_Hub
+ */
+
+use Newspack_Network\Woocommerce_Memberships\Admin;
+
+/**
+ * Verify the "Managed in <site>" row action escapes node-supplied values.
+ */
+class Test_WC_Memberships_Admin_Escaping extends WP_UnitTestCase {
+
+	/**
+	 * The row action must escape the node site URL in href and text.
+	 */
+	public function test_row_action_escapes_site_url() {
+		$payload = '<img src=x onerror=NPPM3042>';
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, Admin::NETWORK_MANAGED_META_KEY, '1' );
+		update_post_meta( $post_id, Admin::SITE_URL_META_KEY, $payload );
+		update_post_meta( $post_id, Admin::REMOTE_ID_META_KEY, '11' );
+
+		$actions = Admin::post_row_actions( [], get_post( $post_id ) );
+		$html    = implode( ' ', $actions );
+
+		$this->assertStringNotContainsString( '<img src=x', $html );
+		$this->assertStringContainsString( '&lt;img src=x onerror=NPPM3042&gt;', $html );
+	}
+
+	/**
+	 * The href is escaped, and this is the assertion that says so.
+	 *
+	 * The site URL reaches both the link text and, through get_edit_post_link(),
+	 * the href. A tag-shaped payload is neutralised by the esc_html() on the text
+	 * alone, so the test above passes with or without the esc_url() on the href.
+	 * This one uses a payload that only escaping the attribute can stop, and
+	 * pins the transformation esc_url() performs.
+	 */
+	public function test_row_action_escapes_the_href() {
+		$payload = 'https://node.test" onmouseover=NPPM3042 x="';
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, Admin::NETWORK_MANAGED_META_KEY, '1' );
+		update_post_meta( $post_id, Admin::SITE_URL_META_KEY, $payload );
+		update_post_meta( $post_id, Admin::REMOTE_ID_META_KEY, '11' );
+
+		$html = implode( ' ', Admin::post_row_actions( [], get_post( $post_id ) ) );
+
+		// One anchor: two href quotes and two target quotes. A value that escaped
+		// the attribute would add a fifth.
+		$this->assertSame( 4, substr_count( $html, '"' ), 'An attribute was broken out of: ' . $html );
+
+		preg_match( '/href="([^"]*)"/', $html, $matches );
+		$href = isset( $matches[1] ) ? $matches[1] : '';
+		$this->assertNotSame( '', $href, 'Precondition: the row action has an href.' );
+		$this->assertStringContainsString( '%20', $href, 'esc_url() did not encode the injected whitespace.' );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Completes the `release` → `alpha` sync that the post-release job could not push. The release published `newspack-network@2.22.2`; the job's merge succeeded and its push was refused, because the token it runs under cannot write `.github/workflows/ci.yml`. The script exits at that push, so `main` was never attempted either — both branches were left 4 commits behind `release`.

This is that merge, made by hand. A companion PR does the same for `main`, where the same files conflict and need combining.

### How to test the changes in this Pull Request:

1. Check the merge commit subject is `chore(release): merge in release newspack-network@2.22.2`, matching what the job would have written.
2. After merge, confirm `alpha` contains the release tip: `git merge-base --is-ancestor origin/release origin/alpha` exits 0.
3. Confirm CI passes on `alpha`.

### Other information:

* [x] Explanation of the change: above.
* [ ] Tests: n/a — this carries existing commits forward, adding no new code.
* [x] Ran locally: the merge is clean, and `alpha` contains `release` afterwards.
