### PR TITLE
fix(components): confirm before the footer's destructive actions

### DIFF
--- a/packages/components/src/footer/index.js
+++ b/packages/components/src/footer/index.js
@@ -36,9 +36,9 @@ const Footer = ( { simple = undefined } ) => {
 	} );
 
 	const starterContentDialog = useConfirmDialog( {
-		title: __( 'Remove starter content?', 'newspack-plugin' ),
+		title: __( 'Remove Starter Content?', 'newspack-plugin' ),
 		message: __( 'This deletes the posts, pages and categories created as starter content. This cannot be undone.', 'newspack-plugin' ),
-		confirmButtonText: __( 'Remove starter content', 'newspack-plugin' ),
+		confirmButtonText: __( 'Remove Starter Content', 'newspack-plugin' ),
 		isDestructive: true,
 	} );
 

--- a/packages/components/src/footer/index.js
+++ b/packages/components/src/footer/index.js
@@ -11,6 +11,7 @@ import { ExternalLink } from '@wordpress/components';
 /**
  * Internal dependencies.
  */
+import useConfirmDialog from '../hooks/use-confirm-dialog';
 import './style.scss';
 
 const Footer = ( { simple = undefined } ) => {
@@ -23,6 +24,23 @@ const Footer = ( { simple = undefined } ) => {
 		remove_starter_content: removeStarterContent = false,
 		support_email: supportEmail,
 	} = window.newspack_urls || {};
+
+	const resetDialog = useConfirmDialog( {
+		title: __( 'Reset Newspack?', 'newspack-plugin' ),
+		message: __(
+			'This deletes every Newspack setting on this site and returns you to the setup wizard. Your posts, pages and users are not affected. This cannot be undone.',
+			'newspack-plugin'
+		),
+		confirmButtonText: __( 'Reset Newspack', 'newspack-plugin' ),
+		isDestructive: true,
+	} );
+
+	const starterContentDialog = useConfirmDialog( {
+		title: __( 'Remove starter content?', 'newspack-plugin' ),
+		message: __( 'This deletes the posts, pages and categories created as starter content. This cannot be undone.', 'newspack-plugin' ),
+		confirmButtonText: __( 'Remove starter content', 'newspack-plugin' ),
+		isDestructive: true,
+	} );
 
 	const footerElements = [
 		{
@@ -57,12 +75,14 @@ const Footer = ( { simple = undefined } ) => {
 		footerElements.push( {
 			label: __( 'Reset Newspack', 'newspack-plugin' ),
 			url: resetUrl,
+			confirm: resetDialog.requestConfirm,
 		} );
 	}
 	if ( removeStarterContent ) {
 		footerElements.push( {
 			label: __( 'Remove Starter Content', 'newspack-plugin' ),
 			url: removeStarterContent,
+			confirm: starterContentDialog.requestConfirm,
 		} );
 	}
 	if ( supportEmail ) {
@@ -71,15 +91,39 @@ const Footer = ( { simple = undefined } ) => {
 			url: `mailto:${ supportEmail }`,
 		} );
 	}
+	const renderLink = ( { url, label, external, confirm } ) => {
+		if ( external ) {
+			return <ExternalLink href={ url }>{ label }</ExternalLink>;
+		}
+		if ( ! confirm ) {
+			return <a href={ url }>{ label }</a>;
+		}
+		return (
+			<a
+				href={ url }
+				onClick={ event => {
+					event.preventDefault();
+					confirm( () => {
+						window.location.href = url;
+					} );
+				} }
+			>
+				{ label }
+			</a>
+		);
+	};
+
 	return (
 		<div className="newspack-footer">
 			{ ! simple && (
 				<ul>
-					{ footerElements.map( ( { url, label, external }, index ) => (
-						<li key={ index }>{ external ? <ExternalLink href={ url }>{ label }</ExternalLink> : <a href={ url }>{ label }</a> }</li>
+					{ footerElements.map( ( element, index ) => (
+						<li key={ index }>{ renderLink( element ) }</li>
 					) ) }
 				</ul>
 			) }
+			{ resetDialog.confirmDialog }
+			{ starterContentDialog.confirmDialog }
 		</div>
 	);
 };

--- a/packages/components/src/footer/index.js
+++ b/packages/components/src/footer/index.js
@@ -91,8 +91,6 @@ const Footer = ( { simple = undefined } ) => {
 			url: `mailto:${ supportEmail }`,
 		} );
 	}
-	// onClick only sees primary clicks, so an href here would let a middle-click
-	// or "Open link in new tab" reach the URL unguarded.
 	const renderItem = ( { url, label, external, confirm } ) => {
 		if ( external ) {
 			return <ExternalLink href={ url }>{ label }</ExternalLink>;
@@ -100,6 +98,8 @@ const Footer = ( { simple = undefined } ) => {
 		if ( ! confirm ) {
 			return <a href={ url }>{ label }</a>;
 		}
+		// onClick only sees primary clicks, so an href here would let a middle-click
+		// or "Open link in new tab" reach the URL unguarded.
 		return (
 			<button
 				type="button"

--- a/packages/components/src/footer/index.js
+++ b/packages/components/src/footer/index.js
@@ -28,7 +28,7 @@ const Footer = ( { simple = undefined } ) => {
 	const resetDialog = useConfirmDialog( {
 		title: __( 'Reset Newspack?', 'newspack-plugin' ),
 		message: __(
-			'This deletes every Newspack setting on this site and returns you to the setup wizard. Your posts, pages and users are not affected. This cannot be undone.',
+			'This deletes the Newspack settings on this site and returns you to the setup wizard. Your posts, pages and users are not affected. This cannot be undone.',
 			'newspack-plugin'
 		),
 		confirmButtonText: __( 'Reset Newspack', 'newspack-plugin' ),
@@ -91,7 +91,9 @@ const Footer = ( { simple = undefined } ) => {
 			url: `mailto:${ supportEmail }`,
 		} );
 	}
-	const renderLink = ( { url, label, external, confirm } ) => {
+	// onClick only sees primary clicks, so an href here would let a middle-click
+	// or "Open link in new tab" reach the URL unguarded.
+	const renderItem = ( { url, label, external, confirm } ) => {
 		if ( external ) {
 			return <ExternalLink href={ url }>{ label }</ExternalLink>;
 		}
@@ -99,17 +101,16 @@ const Footer = ( { simple = undefined } ) => {
 			return <a href={ url }>{ label }</a>;
 		}
 		return (
-			<a
-				href={ url }
-				onClick={ event => {
-					event.preventDefault();
+			<button
+				type="button"
+				onClick={ () =>
 					confirm( () => {
 						window.location.href = url;
-					} );
-				} }
+					} )
+				}
 			>
 				{ label }
-			</a>
+			</button>
 		);
 	};
 
@@ -118,7 +119,7 @@ const Footer = ( { simple = undefined } ) => {
 			{ ! simple && (
 				<ul>
 					{ footerElements.map( ( element, index ) => (
-						<li key={ index }>{ renderLink( element ) }</li>
+						<li key={ index }>{ renderItem( element ) }</li>
 					) ) }
 				</ul>
 			) }

--- a/packages/components/src/footer/index.test.js
+++ b/packages/components/src/footer/index.test.js
@@ -12,10 +12,15 @@ import Footer from './';
 // useHistory() has no Router above it. That is the case worth pinning.
 describe( 'Footer', () => {
 	const RESET_URL = 'https://example.test/wp-admin/admin.php?page=newspack-dashboard&newspack_reset=reset';
+	const STARTER_CONTENT_URL = 'https://example.test/wp-admin/admin.php?page=newspack-dashboard&newspack_reset=starter-content';
 	let assigned;
+	let originalLocation;
+	let originalUrls;
 
 	beforeEach( () => {
 		assigned = [];
+		originalLocation = window.location;
+		originalUrls = window.newspack_urls;
 		delete window.location;
 		window.location = {
 			get href() {
@@ -28,11 +33,22 @@ describe( 'Footer', () => {
 		window.newspack_urls = {
 			support: 'https://help.newspack.com/',
 			reset_url: RESET_URL,
+			remove_starter_content: STARTER_CONTENT_URL,
 			plugin_version: { label: 'Newspack 1.0.0' },
 		};
 	} );
 
-	it( 'does not reset on the first click', async () => {
+	afterEach( () => {
+		delete window.location;
+		window.location = originalLocation;
+		if ( undefined === originalUrls ) {
+			delete window.newspack_urls;
+		} else {
+			window.newspack_urls = originalUrls;
+		}
+	} );
+
+	it( 'does not reset on the first click', () => {
 		render( <Footer /> );
 		fireEvent.click( screen.getByRole( 'link', { name: 'Reset Newspack' } ) );
 		expect( assigned ).toEqual( [] );
@@ -60,7 +76,26 @@ describe( 'Footer', () => {
 		expect( assigned ).toEqual( [ RESET_URL ] );
 	} );
 
-	it( 'does not guard the non-destructive links', async () => {
+	it( 'does not remove the starter content on the first click', () => {
+		render( <Footer /> );
+		fireEvent.click( screen.getByRole( 'link', { name: 'Remove Starter Content' } ) );
+		expect( assigned ).toEqual( [] );
+	} );
+
+	it( 'asks before removing the starter content', async () => {
+		render( <Footer /> );
+		fireEvent.click( screen.getByRole( 'link', { name: 'Remove Starter Content' } ) );
+		expect( await screen.findByText( /created as starter content/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'removes the starter content once confirmed', async () => {
+		render( <Footer /> );
+		fireEvent.click( screen.getByRole( 'link', { name: 'Remove Starter Content' } ) );
+		fireEvent.click( await screen.findByRole( 'button', { name: 'Remove Starter Content' } ) );
+		expect( assigned ).toEqual( [ STARTER_CONTENT_URL ] );
+	} );
+
+	it( 'does not guard the non-destructive links', () => {
 		window.newspack_urls.setup_wizard = 'https://example.test/wp-admin/admin.php?page=newspack-setup-wizard';
 		render( <Footer /> );
 		const link = screen.getByRole( 'link', { name: 'Setup Wizard' } );

--- a/packages/components/src/footer/index.test.js
+++ b/packages/components/src/footer/index.test.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies.
+ */
+import Footer from './';
+
+// Footer renders outside the wizard's HashRouter, so the confirm dialog's
+// useHistory() has no Router above it. That is the case worth pinning.
+describe( 'Footer', () => {
+	const RESET_URL = 'https://example.test/wp-admin/admin.php?page=newspack-dashboard&newspack_reset=reset';
+	let assigned;
+
+	beforeEach( () => {
+		assigned = [];
+		delete window.location;
+		window.location = {
+			get href() {
+				return 'https://example.test/wp-admin/admin.php?page=newspack-dashboard';
+			},
+			set href( value ) {
+				assigned.push( value );
+			},
+		};
+		window.newspack_urls = {
+			support: 'https://help.newspack.com/',
+			reset_url: RESET_URL,
+			plugin_version: { label: 'Newspack 1.0.0' },
+		};
+	} );
+
+	it( 'does not reset on the first click', async () => {
+		render( <Footer /> );
+		fireEvent.click( screen.getByRole( 'link', { name: 'Reset Newspack' } ) );
+		expect( assigned ).toEqual( [] );
+	} );
+
+	it( 'asks before resetting', async () => {
+		render( <Footer /> );
+		fireEvent.click( screen.getByRole( 'link', { name: 'Reset Newspack' } ) );
+		expect( await screen.findByText( /deletes every Newspack setting/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'leaves the site alone when the reset is cancelled', async () => {
+		render( <Footer /> );
+		fireEvent.click( screen.getByRole( 'link', { name: 'Reset Newspack' } ) );
+		// The modal's close icon also carries aria-label="Cancel"; this is the text button.
+		const cancel = ( await screen.findAllByRole( 'button', { name: 'Cancel' } ) ).find( button => 'Cancel' === button.textContent );
+		fireEvent.click( cancel );
+		expect( assigned ).toEqual( [] );
+	} );
+
+	it( 'resets once confirmed', async () => {
+		render( <Footer /> );
+		fireEvent.click( screen.getByRole( 'link', { name: 'Reset Newspack' } ) );
+		fireEvent.click( await screen.findByRole( 'button', { name: 'Reset Newspack' } ) );
+		expect( assigned ).toEqual( [ RESET_URL ] );
+	} );
+
+	it( 'does not guard the non-destructive links', async () => {
+		window.newspack_urls.setup_wizard = 'https://example.test/wp-admin/admin.php?page=newspack-setup-wizard';
+		render( <Footer /> );
+		const link = screen.getByRole( 'link', { name: 'Setup Wizard' } );
+		expect( link ).toHaveAttribute( 'href', window.newspack_urls.setup_wizard );
+		fireEvent.click( link );
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/packages/components/src/footer/index.test.js
+++ b/packages/components/src/footer/index.test.js
@@ -54,8 +54,6 @@ describe( 'Footer', () => {
 		render( <Footer /> );
 		expect( screen.getByRole( 'button', { name: 'Reset Newspack' } ) ).not.toHaveAttribute( 'href' );
 		expect( screen.getByRole( 'button', { name: 'Remove Starter Content' } ) ).not.toHaveAttribute( 'href' );
-		expect( screen.queryByRole( 'link', { name: 'Reset Newspack' } ) ).not.toBeInTheDocument();
-		expect( screen.queryByRole( 'link', { name: 'Remove Starter Content' } ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'does not reset on the first click', () => {

--- a/packages/components/src/footer/index.test.js
+++ b/packages/components/src/footer/index.test.js
@@ -1,21 +1,23 @@
 /**
  * External dependencies.
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 
 /**
  * Internal dependencies.
  */
 import Footer from './';
 
-// Footer renders outside the wizard's HashRouter, so the confirm dialog's
-// useHistory() has no Router above it. That is the case worth pinning.
+// Footer renders outside the wizard's HashRouter, so there is no MemoryRouter
+// wrapper here on purpose.
 describe( 'Footer', () => {
 	const RESET_URL = 'https://example.test/wp-admin/admin.php?page=newspack-dashboard&newspack_reset=reset';
 	const STARTER_CONTENT_URL = 'https://example.test/wp-admin/admin.php?page=newspack-dashboard&newspack_reset=starter-content';
 	let assigned;
 	let originalLocation;
 	let originalUrls;
+
+	const confirmIn = async name => within( await screen.findByRole( 'dialog' ) ).getByRole( 'button', { name } );
 
 	beforeEach( () => {
 		assigned = [];
@@ -48,21 +50,29 @@ describe( 'Footer', () => {
 		}
 	} );
 
+	it( 'offers no link for a browser gesture to follow', () => {
+		render( <Footer /> );
+		expect( screen.getByRole( 'button', { name: 'Reset Newspack' } ) ).not.toHaveAttribute( 'href' );
+		expect( screen.getByRole( 'button', { name: 'Remove Starter Content' } ) ).not.toHaveAttribute( 'href' );
+		expect( screen.queryByRole( 'link', { name: 'Reset Newspack' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: 'Remove Starter Content' } ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'does not reset on the first click', () => {
 		render( <Footer /> );
-		fireEvent.click( screen.getByRole( 'link', { name: 'Reset Newspack' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Reset Newspack' } ) );
 		expect( assigned ).toEqual( [] );
 	} );
 
 	it( 'asks before resetting', async () => {
 		render( <Footer /> );
-		fireEvent.click( screen.getByRole( 'link', { name: 'Reset Newspack' } ) );
-		expect( await screen.findByText( /deletes every Newspack setting/ ) ).toBeInTheDocument();
+		fireEvent.click( screen.getByRole( 'button', { name: 'Reset Newspack' } ) );
+		expect( await screen.findByText( /deletes the Newspack settings/ ) ).toBeInTheDocument();
 	} );
 
 	it( 'leaves the site alone when the reset is cancelled', async () => {
 		render( <Footer /> );
-		fireEvent.click( screen.getByRole( 'link', { name: 'Reset Newspack' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Reset Newspack' } ) );
 		// The modal's close icon also carries aria-label="Cancel"; this is the text button.
 		const cancel = ( await screen.findAllByRole( 'button', { name: 'Cancel' } ) ).find( button => 'Cancel' === button.textContent );
 		fireEvent.click( cancel );
@@ -71,27 +81,27 @@ describe( 'Footer', () => {
 
 	it( 'resets once confirmed', async () => {
 		render( <Footer /> );
-		fireEvent.click( screen.getByRole( 'link', { name: 'Reset Newspack' } ) );
-		fireEvent.click( await screen.findByRole( 'button', { name: 'Reset Newspack' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Reset Newspack' } ) );
+		fireEvent.click( await confirmIn( 'Reset Newspack' ) );
 		expect( assigned ).toEqual( [ RESET_URL ] );
 	} );
 
 	it( 'does not remove the starter content on the first click', () => {
 		render( <Footer /> );
-		fireEvent.click( screen.getByRole( 'link', { name: 'Remove Starter Content' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Remove Starter Content' } ) );
 		expect( assigned ).toEqual( [] );
 	} );
 
 	it( 'asks before removing the starter content', async () => {
 		render( <Footer /> );
-		fireEvent.click( screen.getByRole( 'link', { name: 'Remove Starter Content' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Remove Starter Content' } ) );
 		expect( await screen.findByText( /created as starter content/ ) ).toBeInTheDocument();
 	} );
 
 	it( 'removes the starter content once confirmed', async () => {
 		render( <Footer /> );
-		fireEvent.click( screen.getByRole( 'link', { name: 'Remove Starter Content' } ) );
-		fireEvent.click( await screen.findByRole( 'button', { name: 'Remove Starter Content' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Remove Starter Content' } ) );
+		fireEvent.click( await confirmIn( 'Remove Starter Content' ) );
 		expect( assigned ).toEqual( [ STARTER_CONTENT_URL ] );
 	} );
 

--- a/packages/components/src/footer/style.scss
+++ b/packages/components/src/footer/style.scss
@@ -31,7 +31,8 @@
 	li {
 		margin: 8px;
 
-		a {
+		a,
+		button {
 			align-items: flex-end;
 			color: inherit;
 			display: flex;
@@ -41,6 +42,15 @@
 			&:hover {
 				color: wp-colors.$gray-900;
 			}
+		}
+
+		button {
+			appearance: none;
+			background: none;
+			border: 0;
+			cursor: pointer;
+			font: inherit;
+			padding: 0;
 		}
 	}
 }

--- a/packages/components/src/footer/style.scss
+++ b/packages/components/src/footer/style.scss
@@ -52,6 +52,7 @@
 			cursor: pointer;
 			font: inherit;
 			padding: 0;
+			text-decoration: underline;
 
 			&:focus-visible {
 				@include mixins.wpds-focus-ring;

--- a/packages/components/src/footer/style.scss
+++ b/packages/components/src/footer/style.scss
@@ -2,6 +2,7 @@
  * Footer
  */
 
+@use "../mixins" as mixins;
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
 .newspack-footer {
@@ -51,6 +52,10 @@
 			cursor: pointer;
 			font: inherit;
 			padding: 0;
+
+			&:focus-visible {
+				@include mixins.wpds-focus-ring;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I clicked "Reset Newspack" in the wizard footer by accident this afternoon, and it went straight through. It is a plain `<a href>` sitting between "Setup Wizard" and "Contact Support", and one click deletes every option prefixed `newspack` or `_newspack` and redirects to the setup wizard. There is no confirmation and no undo.

The blast radius is worth being precise about, because it sounds worse than it is: `handle_resets()` only touches `wp_options` rows with those prefixes. Posts, pages, users and orders are untouched. What goes is the whole Newspack configuration, and on the site I did it to that was enough to make the admin pages inaccessible until setup runs again.

Both destructive links in the footer now raise a confirmation first, using the package's own `ConfirmDialog` in its destructive variant. "Remove Starter Content" is guarded too: it sits directly beside the reset link and is destructive in the same way, so guarding one and not the other would be odd.

Non-destructive links are untouched and still navigate on the first click.

#### One thing worth a reviewer's eye

`ConfirmDialog` calls `useHistory()`, and `Footer` renders *outside* the wizard's `HashRouter` (`wizard/index.js` closes the router before the footer) and inside `withWizard`, which has no router at all. That turned out to be fine, because `useHistory()` returns undefined rather than throwing and the dialog guards on it, but it is the thing most likely to break here, so there is a test pinning it.

#### Not in this PR

The reset also has no nonce, so it fires on any GET an administrator can be led to follow. Debug mode gates it, which limits the exposure to development sites, but a confirmation dialog is a UI guard and not a CSRF one. Happy to add a nonce here or separately, whichever you prefer.

### How to test the changes in this Pull Request:

1. Run `pnpm -w run build:packages`, then build `newspack-plugin`.
2. Make sure the site is in debug mode, so the reset link renders.
3. Open any wizard, for example Settings, and look at the footer.
4. Click "Reset Newspack". A confirmation appears rather than the site resetting.
5. Click "Cancel", or press Escape. Nothing happens, and the site is unchanged.
6. Click "Remove Starter Content". The same, with its own wording.
7. Click "Setup Wizard" or "Documentation". These still navigate on the first click.
8. Only if you have a site you are willing to lose the Newspack settings on: click "Reset Newspack" and confirm. It resets as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Tests pass: newspack-components 417 (five new, covering the first click not resetting, the dialog appearing, cancel leaving the site alone, confirm going through, and non-destructive links staying unguarded), newspack-plugin 1014. TypeScript and ESLint are clean and newspack-plugin builds.

I have not been able to check this one in a browser yet: the site I would have tested it on is the one I reset, so its admin pages are unavailable until I run setup again. The behaviour is covered by the tests above, including the no-router case, but a visual pass from someone with a working site would be welcome.
