### PR TITLE
docs(content-gate): correct the active-gate cache invalidation rationale

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-block-visibility.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-block-visibility.php
@@ -478,17 +478,22 @@ class Block_Visibility {
 	 * The blog id is in the key because gate ids are per-site post ids, so a
 	 * switch_to_blog() mid-request would otherwise answer for the wrong site.
 	 *
-	 * Not flushed when a gate is written, because only one of the two stale answers
-	 * can change an outcome. A stale true is re-derived downstream:
-	 * compute_gate_rules_match() re-checks each gate's status itself and returns a
-	 * pass-through when none are active, so it cannot withhold a block whose gates
-	 * went away mid-request. A stale false returns early from is_hidden_for_user()
-	 * and the block renders -- which needs one request to check a gate set, publish a
-	 * gate in it, and then render or excerpt a block carrying that same set. Both
-	 * readers matter here: the render filter bypasses admin and REST, but the excerpt
-	 * path reaches this predicate from strip_hidden() with no such guard. A caller
-	 * that does all three needs an invalidation hook here, the way Content_Gate
-	 * flushes its own cache on save_post and the post-meta writes.
+	 * Not flushed when a gate is written, and neither stale answer is safe. A stale
+	 * false returns early from is_hidden_for_user() and renders a block whose gates
+	 * have just become active. A stale true reaches compute_gate_rules_match(), which
+	 * passes through when no gate is active -- and under visibility "hidden" that
+	 * pass-through inverts into withholding a block that should have rendered.
+	 *
+	 * What bounds this is the write window, not the direction. A stale entry takes one
+	 * request that reads a gate set, changes the publish status of a gate in it, then
+	 * reads that same set again. Neither reader writes gates -- filter_render_block()
+	 * renders, strip_hidden() strips for the excerpt -- so it takes a caller outside
+	 * this file interleaving a gate write between two reads, and none is known to. The
+	 * stale true additionally needs the second read to miss $rules_match_cache, which
+	 * happens across user ids: filter_render_block() uses the current reader, while
+	 * strip_hidden() always uses 0. Anything that closes that window needs an
+	 * invalidation hook here, the way Content_Gate flushes its own cache on save_post
+	 * and the post-meta writes.
 	 *
 	 * @var bool[]
 	 */

--- a/plugins/newspack-plugin/includes/content-gate/class-block-visibility.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-block-visibility.php
@@ -478,12 +478,17 @@ class Block_Visibility {
 	 * The blog id is in the key because gate ids are per-site post ids, so a
 	 * switch_to_blog() mid-request would otherwise answer for the wrong site.
 	 *
-	 * Not flushed when a gate is written. The only reader is the render path, which
-	 * returns early under is_admin(), and the gate-editing endpoints return gate data
-	 * rather than rendered post content -- so no request both writes a gate and renders
-	 * a block gated by it. A caller that breaks that assumption needs an invalidation
-	 * hook here, the way Content_Gate flushes its own cache on save_post and the
-	 * post-meta writes.
+	 * Not flushed when a gate is written, because only one of the two stale answers
+	 * can change an outcome. A stale true is re-derived downstream:
+	 * compute_gate_rules_match() re-checks each gate's status itself and returns a
+	 * pass-through when none are active, so it cannot withhold a block whose gates
+	 * went away mid-request. A stale false returns early from is_hidden_for_user()
+	 * and the block renders -- which needs one request to check a gate set, publish a
+	 * gate in it, and then render or excerpt a block carrying that same set. Both
+	 * readers matter here: the render filter bypasses admin and REST, but the excerpt
+	 * path reaches this predicate from strip_hidden() with no such guard. A caller
+	 * that does all three needs an invalidation hook here, the way Content_Gate
+	 * flushes its own cache on save_post and the post-meta writes.
 	 *
 	 * @var bool[]
 	 */
@@ -538,10 +543,10 @@ class Block_Visibility {
 	 * @return bool
 	 */
 	private static function has_active_gates( $gate_ids ) {
-		// Normalized because the answer does not depend on order or repetition, but the
-		// caller's list does: the ids arrive from a block attribute in editor order, and
-		// array_filter() preserves keys, so dropping a zero would otherwise encode as an
-		// object rather than a list and key differently again.
+		// The answer does not depend on the order or the repetition of the ids, but the
+		// caller's list carries both -- they arrive from a block attribute in editor
+		// order. Normalizing first lets every block gated by the same set, however its
+		// author happened to arrange them, share one entry.
 		$ids = array_values( array_unique( array_map( 'intval', $gate_ids ) ) );
 		sort( $ids, SORT_NUMERIC );
 		$cache_key = get_current_blog_id() . ':' . implode( ',', $ids );

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-block-visibility.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-block-visibility.php
@@ -995,6 +995,13 @@ class Newspack_Test_Block_Visibility extends WP_UnitTestCase {
 
 		remove_filter( 'get_post_metadata', $counter, 10 );
 
+		// Without this the invariant below is satisfied by a counter that never fired,
+		// so a filter that stopped matching would leave the test green.
+		$this->assertGreaterThan(
+			0,
+			$after_first,
+			'The first render must reconstruct the gate, or this test measures nothing.'
+		);
 		$this->assertSame(
 			$after_first,
 			$fetches,
@@ -1045,6 +1052,11 @@ class Newspack_Test_Block_Visibility extends WP_UnitTestCase {
 
 		remove_filter( 'get_post_metadata', $counter, 10 );
 
+		$this->assertGreaterThan(
+			0,
+			$after_forward,
+			'The first render must reconstruct the gates, or this test measures nothing.'
+		);
 		$this->assertSame(
 			$after_forward,
 			$fetches,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`main` currently explains that the active-gate cache is never flushed because its only reader is the render path, which bypasses under `is_admin()`. That is false. `strip_hidden()` reaches the same predicate from the excerpt filter with no such guard, so the stated justification does not hold, and the next person weighing an invalidation hook would be reasoning from it.

The behaviour is fine; only the explanation was wrong — and the first correction was wrong too, which review caught. Neither stale answer is safe. A stale `false` renders a block whose gates just became active. A stale `true` reaches `compute_gate_rules_match()`, which passes through when no gate is active, and under `visibility: "hidden"` that pass-through inverts into withholding a block that should have rendered. Any rationale built on one direction being harmless is wrong, including mine.

What bounds the risk is the write window: a stale entry takes one request that reads a gate set, changes a gate's publish status, then reads that same set again, and neither reader in this file writes gates. The docblock now says that, and records the `$rules_match_cache` user-keying that makes the second read reachable at all.

**Alternatives.** A `save_post` flush is the stronger fix and is deferred rather than rejected — it removes the hazard instead of documenting it, and most of this docblock with it. It is a behaviour change and belongs in its own review, so it follows separately along with two things raised here: the lookup loop iterating `$gate_ids` rather than the normalized `$ids`, and a dead `array_values()` ahead of `sort()`. Deleting the paragraph instead of correcting it was rejected for the reason it was written — someone will weigh invalidation here again.

Two tests in #908 asserted that a fetch counter did not grow between renders, which `0 === 0` satisfies — they passed whether or not the counter ever fired. Both now assert it fired. Verified by mutation: breaking the counter turns them red, and leaves them green on `main`.

Deliberately out of scope: the cross-site concern from NPPM-3170.

Raised on NPPM-3161 (https://linear.app/a8c/issue/NPPM-3161), which #908 closed.

### How to test the changes in this Pull Request:

1. Read the `$active_gates_cache` docblock against `strip_hidden()` and its callers in `newspack-blocks`, `newspack-listings` and `class-content-gate-excerpt.php`. Confirm the excerpt path reaches `is_hidden_for_user()` without an admin guard — the thing the old text denied.
2. Confirm the hardened tests can actually fail, which CI cannot show you. In the two `active_gate_check` tests, change the watched meta key from `gate_priority` to anything else, then run `n test-php --filter Block_Visibility` from `plugins/newspack-plugin`. Both fail with "this test measures nothing." Against `main` today the same mutation leaves them green, which is the defect being fixed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? — no new tests; the change is to what two existing tests assert. Step 2 above verifies the assertions bite.
* [x] Have you successfully run tests with your changes locally? — 46/46 in `Block_Visibility`, PHPCS clean against the root ruleset.
