### PR TITLE
fix(reader-data): recover non-JSON membership list values (NPPM-3205)

### DIFF
--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-data.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-data.php
@@ -275,7 +275,12 @@ final class Reader_Data {
 	 *
 	 * @return array List of IDs.
 	 */
-	private static function decode_item_list( $value ) {
+	private static function decode_item_list( mixed $value ): array {
+		// A writer that handed update_user_meta() a real array gets it back
+		// unserialized; pass it through rather than resetting the reader's list.
+		if ( is_array( $value ) ) {
+			return array_values( array_filter( $value, 'is_scalar' ) );
+		}
 		// Explicit empty-string check: a stored "0" is a value, not an absence,
 		// matching the falsy-zero contract documented on validate_prepared_item().
 		if ( ! is_string( $value ) || '' === $value ) {

--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-data.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-data.php
@@ -262,6 +262,37 @@ final class Reader_Data {
 	}
 
 	/**
+	 * Decode a stored list-type reader data item (active_memberships,
+	 * active_subscriptions) into an array of IDs.
+	 *
+	 * Values written through update_item() are JSON arrays, but legacy writers
+	 * stored a bare scalar (`123`) or a comma-separated list (`123,456`) — the
+	 * shapes the sync-memberships CLI produced before NPPM-3205. Recover those
+	 * instead of letting a data event handler fatal on them: the handler then
+	 * writes the list back through update_item(), repairing the stored value.
+	 *
+	 * @param mixed $value Stored item value.
+	 *
+	 * @return array List of IDs.
+	 */
+	private static function decode_item_list( $value ) {
+		if ( empty( $value ) || ! is_string( $value ) ) {
+			return [];
+		}
+		$decoded = json_decode( $value );
+		if ( is_array( $decoded ) ) {
+			return array_values( array_filter( $decoded, 'is_scalar' ) );
+		}
+		if ( is_numeric( $decoded ) ) {
+			return [ $decoded ];
+		}
+		if ( preg_match( '/^\d+(,\d+)*$/', $value ) ) {
+			return array_map( 'intval', explode( ',', $value ) );
+		}
+		return [];
+	}
+
+	/**
 	 * Stringify and sanitize a value for storage.
 	 *
 	 * @param mixed $value Value.
@@ -629,8 +660,7 @@ final class Reader_Data {
 			return;
 		}
 
-		$existing_subscriptions = self::get_data( $data['user_id'], 'active_subscriptions' );
-		$active_subscriptions   = $existing_subscriptions ? json_decode( $existing_subscriptions ) : [];
+		$active_subscriptions = self::decode_item_list( self::get_data( $data['user_id'], 'active_subscriptions' ) );
 		if ( WooCommerce_Connection::is_subscription_active( $data['status_after'] ) ) {
 			$active_subscriptions = array_merge( $active_subscriptions, $data['product_ids'] );
 		} else {
@@ -687,8 +717,7 @@ final class Reader_Data {
 			return;
 		}
 
-		$existing_memberships = self::get_data( $data['user_id'], 'active_memberships' );
-		$active_memberships   = $existing_memberships ? json_decode( $existing_memberships ) : [];
+		$active_memberships = self::decode_item_list( self::get_data( $data['user_id'], 'active_memberships' ) );
 		if ( ! isset( $data['status_after'] ) || in_array( $data['status_after'], Memberships::$active_statuses, true ) ) {
 			$active_memberships[] = $data['plan_id'];
 		} else {

--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-data.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-data.php
@@ -276,7 +276,9 @@ final class Reader_Data {
 	 * @return array List of IDs.
 	 */
 	private static function decode_item_list( $value ) {
-		if ( empty( $value ) || ! is_string( $value ) ) {
+		// Explicit empty-string check: a stored "0" is a value, not an absence,
+		// matching the falsy-zero contract documented on validate_prepared_item().
+		if ( ! is_string( $value ) || '' === $value ) {
 			return [];
 		}
 		$decoded = json_decode( $value );

--- a/plugins/newspack-plugin/includes/reader-activation/cli/class-sync-reader-data-cli.php
+++ b/plugins/newspack-plugin/includes/reader-activation/cli/class-sync-reader-data-cli.php
@@ -97,7 +97,9 @@ final class Sync_Reader_Data_CLI {
 				// Write through update_item() so the value is stored as the JSON
 				// array the data event handlers expect (NPPM-3205).
 				$update_result = Reader_Data::update_item( $reader_data->user_id, 'active_memberships', array_map( 'intval', $actual_membership_plan_ids ) );
-				if ( true === $update_result ) {
+				if ( \is_wp_error( $update_result ) ) {
+					\WP_CLI::warning( sprintf( 'Could not update user #%d reader data: %s', $reader_data->user_id, $update_result->get_error_message() ) );
+				} else {
 					\WP_CLI::success( sprintf( 'Updated user #%d reader data.', $reader_data->user_id ) );
 				}
 			} else {

--- a/plugins/newspack-plugin/includes/reader-activation/cli/class-sync-reader-data-cli.php
+++ b/plugins/newspack-plugin/includes/reader-activation/cli/class-sync-reader-data-cli.php
@@ -82,6 +82,13 @@ final class Sync_Reader_Data_CLI {
 		$reader_data_user_meta_key = Reader_Data::get_meta_key_name( 'active_memberships' );
 		$potentially_misaliged_members = $wpdb->get_results( $wpdb->prepare( $sql, $reader_data_user_meta_key ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		foreach ( $potentially_misaliged_members as $reader_data ) {
+			// A wc_user_membership post whose author was deleted groups into a
+			// user_id = NULL row: there is no reader to repair, and a write
+			// aimed at user 0 would report success while storing nothing.
+			if ( empty( $reader_data->user_id ) ) {
+				continue;
+			}
+
 			// Rule out false-positives.
 			$actual_membership_plan_ids = explode( ',', $reader_data->actual_membership_plan_ids ?? '' );
 			$stored_membership_plan_ids = explode( ',', $reader_data->stored_membership_plan_ids ?? '' );

--- a/plugins/newspack-plugin/includes/reader-activation/cli/class-sync-reader-data-cli.php
+++ b/plugins/newspack-plugin/includes/reader-activation/cli/class-sync-reader-data-cli.php
@@ -94,8 +94,10 @@ final class Sync_Reader_Data_CLI {
 			}
 
 			if ( $live ) {
-				$update_result = update_user_meta( $reader_data->user_id, $reader_data_user_meta_key, implode( ',', $actual_membership_plan_ids ) );
-				if ( $update_result !== false ) {
+				// Write through update_item() so the value is stored as the JSON
+				// array the data event handlers expect (NPPM-3205).
+				$update_result = Reader_Data::update_item( $reader_data->user_id, 'active_memberships', array_map( 'intval', $actual_membership_plan_ids ) );
+				if ( true === $update_result ) {
 					\WP_CLI::success( sprintf( 'Updated user #%d reader data.', $reader_data->user_id ) );
 				}
 			} else {

--- a/plugins/newspack-plugin/src/reader-activation/store.js
+++ b/plugins/newspack-plugin/src/reader-activation/store.js
@@ -344,7 +344,18 @@ export default function Store() {
 			if ( unsyncedKeys.includes( key ) && ! mergeStrategies.has( key ) ) {
 				continue;
 			}
-			rehydrateItem( key, decode( items[ key ] ) );
+			// Decode inside the loop's own guard: a single unparseable stored
+			// value (e.g. a legacy comma list, see NPPM-3205) must skip only
+			// its key, not abort hydration of every key after it.
+			let value;
+			try {
+				value = decode( items[ key ] );
+			} catch ( err ) {
+				// eslint-disable-next-line no-console
+				console.warn( `Unable to decode ${ key } for rehydration`, err );
+				continue;
+			}
+			rehydrateItem( key, value );
 		}
 	}
 

--- a/plugins/newspack-plugin/src/reader-activation/store.test.js
+++ b/plugins/newspack-plugin/src/reader-activation/store.test.js
@@ -169,6 +169,24 @@ describe( 'Store', () => {
 			expect( all.active_memberships ).toEqual( [ 1, 2 ] );
 		} );
 	} );
+	it( 'should rehydrate remaining items when one stored value is corrupt', () => {
+		window.newspack_reader_data = {
+			items: {
+				// A legacy comma list (NPPM-3205) — unparseable as JSON, and
+				// listed first so it would abort the keys after it if the
+				// decode failure escaped the rehydrate loop.
+				active_memberships: '123,456',
+				is_donor: 'true',
+			},
+		};
+		const warn = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+		const [ store ] = Store();
+		expect( () => store.rehydrate() ).not.toThrow();
+		expect( store.get( 'active_memberships' ) ).toBeNull();
+		expect( store.get( 'is_donor' ) ).toEqual( true );
+		expect( warn ).toHaveBeenCalledWith( expect.stringContaining( 'active_memberships' ), expect.any( SyntaxError ) );
+		warn.mockRestore();
+	} );
 	describe( 'Read-only keys', () => {
 		beforeEach( () => {
 			window.newspack_reader_data = {

--- a/plugins/newspack-plugin/tests/unit-tests/reader-data-membership-events.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-data-membership-events.php
@@ -39,7 +39,7 @@ class Newspack_Test_Reader_Data_Membership_Events extends WP_UnitTestCase {
 	 *
 	 * @param int    $user_id   User ID.
 	 * @param string $key       Item key.
-	 * @param string $raw_value Raw meta value.
+	 * @param mixed  $raw_value Raw meta value.
 	 */
 	private static function seed_raw_item( $user_id, $key, $raw_value ) {
 		update_user_meta( $user_id, 'newspack_reader_data_keys', [ $key ] );
@@ -117,11 +117,67 @@ class Newspack_Test_Reader_Data_Membership_Events extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The comma-separated shape on the active branch: the one legacy shape
+	 * whose pre-fix failure was silent — json_decode() yields null and the
+	 * append auto-vivifies — quietly dropping every other plan.
+	 */
+	public function test_active_event_recovers_comma_separated_value() {
+		$user_id = self::factory()->user->create();
+		self::seed_raw_item( $user_id, 'active_memberships', '123,456' );
+		Reader_Data::update_active_memberships(
+			time(),
+			[
+				'user_id'      => $user_id,
+				'plan_id'      => 789,
+				'status_after' => 'active',
+			]
+		);
+		self::assertSame( '[123,456,789]', Reader_Data::get_data( $user_id, 'active_memberships' ) );
+	}
+
+	/**
+	 * A value stored as a real PHP array (a raw update_user_meta() write,
+	 * returned unserialized on read) passes through instead of resetting
+	 * the reader's list.
+	 */
+	public function test_inactive_event_recovers_array_value() {
+		$user_id = self::factory()->user->create();
+		self::seed_raw_item( $user_id, 'active_memberships', [ 123, 456 ] );
+		Reader_Data::update_active_memberships(
+			time(),
+			[
+				'user_id'      => $user_id,
+				'plan_id'      => 123,
+				'status_after' => 'expired',
+			]
+		);
+		self::assertSame( '[456]', Reader_Data::get_data( $user_id, 'active_memberships' ) );
+	}
+
+	/**
 	 * An unrecoverable stored value starts the list fresh instead of crashing.
 	 */
 	public function test_active_event_starts_fresh_on_unrecoverable_value() {
 		$user_id = self::factory()->user->create();
 		self::seed_raw_item( $user_id, 'active_memberships', 'not-json' );
+		Reader_Data::update_active_memberships(
+			time(),
+			[
+				'user_id'      => $user_id,
+				'plan_id'      => 123,
+				'status_after' => 'active',
+			]
+		);
+		self::assertSame( '[123]', Reader_Data::get_data( $user_id, 'active_memberships' ) );
+	}
+
+	/**
+	 * A JSON object is not a plan list: previously a fatal on the active
+	 * branch, now the list starts fresh.
+	 */
+	public function test_active_event_starts_fresh_on_json_object_value() {
+		$user_id = self::factory()->user->create();
+		self::seed_raw_item( $user_id, 'active_memberships', '{"a":1}' );
 		Reader_Data::update_active_memberships(
 			time(),
 			[

--- a/plugins/newspack-plugin/tests/unit-tests/reader-data-membership-events.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-data-membership-events.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Tests for the membership and subscription data event handlers against
+ * legacy non-JSON `active_memberships` values (NPPM-3205).
+ *
+ * The reader-data sync-memberships CLI used to store plan IDs as a bare
+ * scalar (`123`) or comma list (`123,456`) instead of the JSON array the
+ * handlers write and expect, so a membership status change for an affected
+ * reader crashed the handler before it could repair the value.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Reader_Data;
+use Newspack\Sync_Reader_Data_CLI;
+
+require_once dirname( __DIR__ ) . '/mocks/wp-cli-mocks.php';
+
+/**
+ * Tests for Reader_Data::update_active_memberships(),
+ * Reader_Data::update_active_subscriptions() and the sync-memberships CLI.
+ *
+ * @group reader-data
+ */
+class Newspack_Test_Reader_Data_Membership_Events extends WP_UnitTestCase {
+
+	/**
+	 * Store a raw item value directly, bypassing update_item()'s JSON
+	 * encoding, the way legacy writers did.
+	 *
+	 * @param int    $user_id   User ID.
+	 * @param string $key       Item key.
+	 * @param string $raw_value Raw meta value.
+	 */
+	private static function seed_raw_item( $user_id, $key, $raw_value ) {
+		update_user_meta( $user_id, 'newspack_reader_data_keys', [ $key ] );
+		update_user_meta( $user_id, Reader_Data::get_meta_key_name( $key ), $raw_value );
+	}
+
+	/**
+	 * The healthy path: an inactive event removes the plan from a JSON list.
+	 */
+	public function test_inactive_event_removes_plan_from_json_list() {
+		$user_id = self::factory()->user->create();
+		Reader_Data::update_item( $user_id, 'active_memberships', [ 123, 456 ] );
+		Reader_Data::update_active_memberships(
+			time(),
+			[
+				'user_id'      => $user_id,
+				'plan_id'      => 123,
+				'status_after' => 'expired',
+			]
+		);
+		self::assertSame( '[456]', Reader_Data::get_data( $user_id, 'active_memberships' ) );
+	}
+
+	/**
+	 * A bare scalar stored value (single-plan legacy shape) is recovered as a
+	 * one-item list, so the inactive event can remove the plan.
+	 */
+	public function test_inactive_event_recovers_bare_scalar_value() {
+		$user_id = self::factory()->user->create();
+		self::seed_raw_item( $user_id, 'active_memberships', '123' );
+		Reader_Data::update_active_memberships(
+			time(),
+			[
+				'user_id'      => $user_id,
+				'plan_id'      => 123,
+				'status_after' => 'expired',
+			]
+		);
+		self::assertSame( '[]', Reader_Data::get_data( $user_id, 'active_memberships' ) );
+	}
+
+	/**
+	 * A bare scalar stored value survives an active event for another plan.
+	 */
+	public function test_active_event_recovers_bare_scalar_value() {
+		$user_id = self::factory()->user->create();
+		self::seed_raw_item( $user_id, 'active_memberships', '456' );
+		Reader_Data::update_active_memberships(
+			time(),
+			[
+				'user_id'      => $user_id,
+				'plan_id'      => 123,
+				'status_after' => 'active',
+			]
+		);
+		self::assertSame( '[456,123]', Reader_Data::get_data( $user_id, 'active_memberships' ) );
+	}
+
+	/**
+	 * A comma-separated stored value (multi-plan legacy shape) is recovered,
+	 * so the inactive event removes only the affected plan.
+	 */
+	public function test_inactive_event_recovers_comma_separated_value() {
+		$user_id = self::factory()->user->create();
+		self::seed_raw_item( $user_id, 'active_memberships', '123,456' );
+		Reader_Data::update_active_memberships(
+			time(),
+			[
+				'user_id'      => $user_id,
+				'plan_id'      => 123,
+				'status_after' => 'expired',
+			]
+		);
+		self::assertSame( '[456]', Reader_Data::get_data( $user_id, 'active_memberships' ) );
+	}
+
+	/**
+	 * An unrecoverable stored value starts the list fresh instead of crashing.
+	 */
+	public function test_active_event_starts_fresh_on_unrecoverable_value() {
+		$user_id = self::factory()->user->create();
+		self::seed_raw_item( $user_id, 'active_memberships', 'not-json' );
+		Reader_Data::update_active_memberships(
+			time(),
+			[
+				'user_id'      => $user_id,
+				'plan_id'      => 123,
+				'status_after' => 'active',
+			]
+		);
+		self::assertSame( '[123]', Reader_Data::get_data( $user_id, 'active_memberships' ) );
+	}
+
+	/**
+	 * The subscriptions handler shares the same decode, so it recovers a bare
+	 * scalar stored value too.
+	 */
+	public function test_subscription_event_recovers_bare_scalar_value() {
+		$user_id = self::factory()->user->create();
+		self::seed_raw_item( $user_id, 'active_subscriptions', '789' );
+		Reader_Data::update_active_subscriptions(
+			time(),
+			[
+				'user_id'         => $user_id,
+				'subscription_id' => 55,
+				'product_ids'     => [ 789 ],
+				'status_after'    => 'cancelled',
+			]
+		);
+		self::assertSame( '[]', Reader_Data::get_data( $user_id, 'active_subscriptions' ) );
+	}
+
+	/**
+	 * The sync-memberships CLI writes the JSON shape the handlers expect, not
+	 * a comma list.
+	 */
+	public function test_sync_cli_writes_json_list() {
+		$user_id = self::factory()->user->create();
+		self::factory()->post->create(
+			[
+				'post_type'   => 'wc_user_membership',
+				'post_status' => 'wcm-active',
+				'post_author' => $user_id,
+				'post_parent' => 123,
+			]
+		);
+		self::seed_raw_item( $user_id, 'active_memberships', '[456]' );
+		Sync_Reader_Data_CLI::fix_reader_data_and_membership_discrepancy( [], [ 'live' => true ] );
+		self::assertSame( '[123]', get_user_meta( $user_id, Reader_Data::get_meta_key_name( 'active_memberships' ), true ) );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/reader-data-membership-events.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-data-membership-events.php
@@ -25,6 +25,15 @@ require_once dirname( __DIR__ ) . '/mocks/wp-cli-mocks.php';
 class Newspack_Test_Reader_Data_Membership_Events extends WP_UnitTestCase {
 
 	/**
+	 * Clear the WP_CLI mock's static output buffers, so CLI transcripts don't
+	 * leak between tests.
+	 */
+	public function set_up() {
+		parent::set_up();
+		WP_CLI::reset();
+	}
+
+	/**
 	 * Store a raw item value directly, bypassing update_item()'s JSON
 	 * encoding, the way legacy writers did.
 	 *
@@ -125,6 +134,24 @@ class Newspack_Test_Reader_Data_Membership_Events extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A stored `0` is a value, not an absence: the decode must not drop it the
+	 * way an empty() check would.
+	 */
+	public function test_active_event_preserves_stored_zero() {
+		$user_id = self::factory()->user->create();
+		self::seed_raw_item( $user_id, 'active_memberships', '0' );
+		Reader_Data::update_active_memberships(
+			time(),
+			[
+				'user_id'      => $user_id,
+				'plan_id'      => 123,
+				'status_after' => 'active',
+			]
+		);
+		self::assertSame( '[0,123]', Reader_Data::get_data( $user_id, 'active_memberships' ) );
+	}
+
+	/**
 	 * The subscriptions handler shares the same decode, so it recovers a bare
 	 * scalar stored value too.
 	 */
@@ -160,5 +187,26 @@ class Newspack_Test_Reader_Data_Membership_Events extends WP_UnitTestCase {
 		self::seed_raw_item( $user_id, 'active_memberships', '[456]' );
 		Sync_Reader_Data_CLI::fix_reader_data_and_membership_discrepancy( [], [ 'live' => true ] );
 		self::assertSame( '[123]', get_user_meta( $user_id, Reader_Data::get_meta_key_name( 'active_memberships' ), true ) );
+	}
+
+	/**
+	 * A rejected write surfaces as a warning instead of a silent skip, so a
+	 * live run's transcript accounts for every flagged reader.
+	 */
+	public function test_sync_cli_warns_when_update_rejected() {
+		$user_id = self::factory()->user->create();
+		self::factory()->post->create(
+			[
+				'post_type'   => 'wc_user_membership',
+				'post_status' => 'wcm-active',
+				'post_author' => $user_id,
+				'post_parent' => 123,
+			]
+		);
+		// Force update_item() to reject the write for this reader's new key.
+		add_filter( 'newspack_reader_data_max_items', '__return_zero' );
+		Sync_Reader_Data_CLI::fix_reader_data_and_membership_discrepancy( [], [ 'live' => true ] );
+		self::assertNotEmpty( WP_CLI::$warnings );
+		self::assertSame( '', get_user_meta( $user_id, Reader_Data::get_meta_key_name( 'active_memberships' ), true ) );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Some readers have the `active_memberships` reader data item stored as a bare number (`123`) or a comma list (`123,456`) instead of a JSON array — the shape the `reader-data sync-memberships` CLI wrote. The membership and subscription data event handlers decode the stored value without checking for an array, so every membership status change for an affected reader throws (`array_diff(): Argument #1 ($array) must be of type array`), exhausts its retries, and the value never gets repaired.

This change:

- recovers legacy scalar, comma-list, and already-unserialized array values when decoding, so a handler repairs the stored value the next time it runs;
- makes the sync CLI write through `Reader_Data::update_item()`, which stores the JSON array shape;
- skips sync CLI rows for membership posts whose author was deleted (a `user_id = NULL` row previously reported success for a write that stored nothing, on every run);
- hardens the front-end reader store so one unparseable stored value skips only its own key instead of aborting hydration of every key after it — until repaired, affected readers read as having no memberships to campaign criteria on every page load.

Routing the CLI through `update_item()` intentionally does two things the old raw meta write didn't: it registers `active_memberships` in `newspack_reader_data_keys` (readers the old CLI wrote raw had membership data invisible to `get_data()`, hydration, and campaign criteria — a live run makes that cohort visible), and it fires `newspack_reader_data_updated` once per repaired reader (no plugin in the monorepo, newspack-manager, or newspack-manager-admin hooks that action).

Closes NPPM-3205.

### How to test the changes in this Pull Request:

1. On a site with reader activation and WooCommerce Memberships, give a reader an active membership.
2. Set the reader's `newspack_reader_data_item_active_memberships` user meta to a bare plan ID, e.g. `123`.
3. Cancel the membership. The `membership_status_inactive` data event completes and the stored meta becomes `[]`.
4. Reactivate the membership and set the meta to `[999]`, then run `wp newspack reader-data sync-memberships --live`.
5. The stored meta is a JSON array of the real plan ID (e.g. `[123]`), not a comma list.
6. Set the meta to `123,456` and load the site as that reader (with this branch built): the console logs a rehydration warning for `active_memberships`, the rest of the reader data still hydrates, and no error is thrown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Existing corrupt rows self-heal on the reader's next membership or subscription event; no bulk cleanup is included.
