### PR TITLE
fix(content-gate): yield RSS feed restriction to WooCommerce Memberships (NPPM-3204)

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate-advanced-settings.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate-advanced-settings.php
@@ -337,7 +337,7 @@ class Content_Gate_Advanced_Settings {
 	 *
 	 * One exception: while WooCommerce Memberships is active the method returns
 	 * FEED_MODE_OFF ahead of the filter, so the filter cannot re-enable Access
-	 * Control feed restriction on a Memberships site — WCM owns feeds there.
+	 * Control feed restriction on a Memberships site. See NPPM-3204.
 	 *
 	 * @param array $context Context for the filter, as built by
 	 *                       get_feed_filter_context(): always a
@@ -348,13 +348,14 @@ class Content_Gate_Advanced_Settings {
 	 * @return string One of FEED_MODE_OFF, FEED_MODE_TRUNCATE, FEED_MODE_EXCLUDE.
 	 */
 	public static function get_feed_restriction_mode( $context = [] ): string {
-		// While WooCommerce Memberships is active it owns feed restriction, the
-		// same way it owns the front end until it is deactivated at migration.
-		// Access Control stays out entirely: a Memberships-only site inherits the
-		// shipped restrict_feeds/exclude defaults but has no Access Control UI to
-		// change them (the wizard registers only behind NEWSPACK_CONTENT_GATES),
-		// so acting here silently switched such sites to exclude-mode feeds with
-		// no setting to turn off. See NPPM-3204.
+		// While WooCommerce Memberships is active, Access Control's restriction
+		// strategy already stands down site-wide — see
+		// Content_Restriction_Control::is_post_restricted() — and WCM applies its
+		// own feed handling. Acting here would add a second layer the publisher
+		// cannot control: a Memberships-only site inherits the shipped
+		// restrict_feeds/exclude defaults but has no Access Control UI to change
+		// them, because the wizard registers only behind NEWSPACK_CONTENT_GATES.
+		// See NPPM-3204.
 		if ( Memberships::is_active() ) {
 			return self::FEED_MODE_OFF;
 		}

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate-advanced-settings.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate-advanced-settings.php
@@ -335,6 +335,10 @@ class Content_Gate_Advanced_Settings {
 	 * even when `restrict_feeds` is on, or a restricting mode to gate a feed even
 	 * when `restrict_feeds` is off.
 	 *
+	 * One exception: while WooCommerce Memberships is active the method returns
+	 * FEED_MODE_OFF ahead of the filter, so the filter cannot re-enable Access
+	 * Control feed restriction on a Memberships site — WCM owns feeds there.
+	 *
 	 * @param array $context Context for the filter, as built by
 	 *                       get_feed_filter_context(): always a
 	 *                       `[ 'query' => \WP_Query|null, 'post' => \WP_Post|null ]`
@@ -344,6 +348,16 @@ class Content_Gate_Advanced_Settings {
 	 * @return string One of FEED_MODE_OFF, FEED_MODE_TRUNCATE, FEED_MODE_EXCLUDE.
 	 */
 	public static function get_feed_restriction_mode( $context = [] ): string {
+		// While WooCommerce Memberships is active it owns feed restriction, the
+		// same way it owns the front end until it is deactivated at migration.
+		// Access Control stays out entirely: a Memberships-only site inherits the
+		// shipped restrict_feeds/exclude defaults but has no Access Control UI to
+		// change them (the wizard registers only behind NEWSPACK_CONTENT_GATES),
+		// so acting here silently switched such sites to exclude-mode feeds with
+		// no setting to turn off. See NPPM-3204.
+		if ( Memberships::is_active() ) {
+			return self::FEED_MODE_OFF;
+		}
 		$settings = self::get_settings();
 		$mode     = empty( $settings['restrict_feeds'] ) ? self::FEED_MODE_OFF : $settings['feed_restriction_mode'];
 

--- a/plugins/newspack-plugin/tests/mocks/wc-memberships-active-mock.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-memberships-active-mock.php
@@ -18,8 +18,8 @@ if ( ! class_exists( 'WC_Memberships' ) ) {
 if ( ! function_exists( 'wc_memberships' ) ) {
 	function wc_memberships() {
 		// The real function returns the plugin instance; a stub object keeps any
-		// caller that dereferences it from fataling, though is_active() only
-		// needs function_exists().
+		// caller that dereferences it from triggering a fatal error, though
+		// is_active() only needs function_exists().
 		return new WC_Memberships();
 	}
 }

--- a/plugins/newspack-plugin/tests/mocks/wc-memberships-active-mock.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-memberships-active-mock.php
@@ -1,0 +1,25 @@
+<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.ClassComment.Missing, WordPress.NamingConventions.PrefixAllGlobals, Universal.Files.SeparateFunctionsFromOO.Mixed
+/**
+ * Minimal stand-in for an active WooCommerce Memberships install, so
+ * Newspack\Memberships::is_active() (class_exists + function_exists) returns
+ * true. Global namespace on purpose — that is what is_active() checks.
+ *
+ * Require this only from isolated (separate-process) tests: declaring these for
+ * the whole suite would flip is_active() true everywhere and break every test
+ * that assumes Memberships is inactive.
+ *
+ * @package Newspack\Tests
+ */
+
+if ( ! class_exists( 'WC_Memberships' ) ) {
+	class WC_Memberships {}
+}
+
+if ( ! function_exists( 'wc_memberships' ) ) {
+	function wc_memberships() {
+		// The real function returns the plugin instance; a stub object keeps any
+		// caller that dereferences it from fataling, though is_active() only
+		// needs function_exists().
+		return new WC_Memberships();
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/feed-restriction.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/feed-restriction.php
@@ -313,7 +313,9 @@ class Test_Feed_Restriction extends \WP_UnitTestCase {
 		// which is what Memberships::is_active() checks).
 		require __DIR__ . '/../../mocks/wc-memberships-active-mock.php';
 
-		$this->set_feed_mode( 'exclude' );
+		// Leave feed_restriction_mode unset, as the affected Memberships-only sites
+		// do: the mode then resolves to the shipped exclude default, and the guard
+		// still has to override it to off.
 
 		$this->assertSame(
 			Content_Gate_Advanced_Settings::FEED_MODE_OFF,

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/feed-restriction.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/feed-restriction.php
@@ -296,6 +296,38 @@ class Test_Feed_Restriction extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * While WooCommerce Memberships is active it owns feed restriction, so Access
+	 * Control yields entirely — even under the shipped restrict_feeds/exclude
+	 * defaults a Memberships-only site cannot change (NPPM-3204). The effective
+	 * mode resolves to "off" and the restricted post stays in the feed, the
+	 * opposite of test_exclude_mode_drops_only_restricted_posts above.
+	 *
+	 * Runs isolated because WC_Memberships, once declared, would make
+	 * Memberships::is_active() true for every later feed test in this process.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_active_memberships_yields_feed_restriction_to_wcm() {
+		// Stand in for an active WooCommerce Memberships install (global scope,
+		// which is what Memberships::is_active() checks).
+		require __DIR__ . '/../../mocks/wc-memberships-active-mock.php';
+
+		$this->set_feed_mode( 'exclude' );
+
+		$this->assertSame(
+			Content_Gate_Advanced_Settings::FEED_MODE_OFF,
+			Content_Gate_Advanced_Settings::get_feed_restriction_mode(),
+			'With Memberships active, the effective feed mode should be off regardless of the exclude default.'
+		);
+		$this->assertContains(
+			$this->post_id,
+			$this->feed_post_ids(),
+			'With Memberships active, Access Control must not drop the restricted post from the feed.'
+		);
+	}
+
+	/**
 	 * Exclude mode back-fills the feed to `posts_per_rss` with older unrestricted
 	 * posts, matching WC Memberships. The newest posts are all restricted, so
 	 * without over-fetching the first page would be empty; with it, the feed

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/feed-restriction.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/feed-restriction.php
@@ -296,11 +296,17 @@ class Test_Feed_Restriction extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * While WooCommerce Memberships is active it owns feed restriction, so Access
-	 * Control yields entirely — even under the shipped restrict_feeds/exclude
+	 * While WooCommerce Memberships is active, Access Control yields feed
+	 * restriction entirely — even under the shipped restrict_feeds/exclude
 	 * defaults a Memberships-only site cannot change (NPPM-3204). The effective
-	 * mode resolves to "off" and the restricted post stays in the feed, the
-	 * opposite of test_exclude_mode_drops_only_restricted_posts above.
+	 * mode resolves to "off" and the restricted post survives, the opposite of
+	 * test_exclude_mode_drops_only_restricted_posts above.
+	 *
+	 * The gate cannot supply the restriction here — Content_Restriction_Control
+	 * bails on the same Memberships::is_active() check — so the post is marked
+	 * restricted through `newspack_is_post_restricted`, standing in for
+	 * Memberships restricting it. Without that nothing would drop the post
+	 * either way and the feed assertion would hold with or without the guard.
 	 *
 	 * Runs isolated because WC_Memberships, once declared, would make
 	 * Memberships::is_active() true for every later feed test in this process.
@@ -313,9 +319,14 @@ class Test_Feed_Restriction extends \WP_UnitTestCase {
 		// which is what Memberships::is_active() checks).
 		require __DIR__ . '/../../mocks/wc-memberships-active-mock.php';
 
-		// Leave feed_restriction_mode unset, as the affected Memberships-only sites
-		// do: the mode then resolves to the shipped exclude default, and the guard
-		// still has to override it to off.
+		// The affected sites had neither value written. set_up() persists
+		// restrict_feeds = 1, which is what the shipped default resolves to anyway,
+		// and feed_restriction_mode is left unset so it resolves to the shipped
+		// exclude default. The guard still has to override the result to off.
+
+		add_filter( 'newspack_is_post_restricted', '__return_true', 99 );
+		$feed_ids = $this->feed_post_ids();
+		remove_filter( 'newspack_is_post_restricted', '__return_true', 99 );
 
 		$this->assertSame(
 			Content_Gate_Advanced_Settings::FEED_MODE_OFF,
@@ -324,7 +335,7 @@ class Test_Feed_Restriction extends \WP_UnitTestCase {
 		);
 		$this->assertContains(
 			$this->post_id,
-			$this->feed_post_ids(),
+			$feed_ids,
 			'With Memberships active, Access Control must not drop the restricted post from the feed.'
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Part of NPPM-3204 (ask #1). Hotfix against `release`.

Access Control's RSS feed exclusion, shipped in 6.48.0 (NPPD-1750), applied to every site running WooCommerce Memberships — not just Access Control sites. The feed defaults (`restrict_feeds=1`, `feed_restriction_mode=exclude`) are never written to the database, so a Memberships-only site ran them with no admin surface to change them (the Access Control wizard registers only behind `NEWSPACK_CONTENT_GATES`). Restricted posts were dropped from those sites' RSS feeds.

`get_feed_restriction_mode()` now returns `FEED_MODE_OFF` while `Memberships::is_active()`, so Access Control yields RSS feeds to WooCommerce Memberships entirely. Once Memberships is deactivated at migration, Access Control takes over — the same handoff already used for the front end. Every feed path resolves through that method and treats `FEED_MODE_OFF` as a no-op, so one guard covers the over-fetch, per-item exclusion, and the truncation backstop.

Deliberately a hard yield: the guard runs ahead of the `newspack_content_gate_feed_restriction_mode` filter, so the filter cannot re-enable feed restriction while Memberships is active (documented on the method).

Follow-ups tracked separately: reconsidering the `exclude` default (NPPM-3204 ask #2) and migrating a site's WCM feed configuration into Access Control at flip.

### How to test the changes in this Pull Request:

1. Activate WooCommerce Memberships.
2. Add a content restriction rule covering the `post` post type.
3. Publish a post the rule restricts.
4. Leave every `newspack_content_gate_*` option unset.
5. Open `/feed/` while logged out.
6. Confirm the restricted post is present in the feed.
7. Deactivate WooCommerce Memberships, publish an Access Control gate restricting posts, reload `/feed/`.
8. Confirm Access Control now governs the feed (restricted post excluded under the default).
9. Run `n test-php --group content-gate` — the new `test_active_memberships_yields_feed_restriction_to_wcm` passes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
