### PR TITLE
fix(content-gate): default RSS feed restriction to truncate, not exclude (NPPM-3204)

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate-advanced-settings.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate-advanced-settings.php
@@ -239,7 +239,7 @@ class Content_Gate_Advanced_Settings {
 		// '0' returned by get_option() as truthy.
 		$settings = [
 			'restrict_feeds'                 => (int) get_option( self::OPTION_PREFIX . 'restrict_feeds', 1 ),
-			'feed_restriction_mode'          => self::sanitize_feed_mode( get_option( self::OPTION_PREFIX . 'feed_restriction_mode', self::FEED_MODE_EXCLUDE ) ),
+			'feed_restriction_mode'          => self::sanitize_feed_mode( get_option( self::OPTION_PREFIX . 'feed_restriction_mode', self::FEED_MODE_TRUNCATE ) ),
 			'newsletter_link_bypass_enabled' => (int) get_option( self::OPTION_PREFIX . 'newsletter_link_bypass_enabled', 0 ),
 		];
 
@@ -251,15 +251,15 @@ class Content_Gate_Advanced_Settings {
 	 * Normalize a stored feed restriction mode to a known value.
 	 *
 	 * Only truncate/exclude are storable; anything else (including a legacy or
-	 * corrupt value) falls back to the exclude default, matching WC Memberships'
-	 * out-of-the-box behaviour of dropping restricted items from feeds.
+	 * corrupt value) falls back to the truncate default, which keeps items in the
+	 * feed with the gate teaser rather than dropping them.
 	 *
 	 * @param mixed $mode Raw mode value.
 	 *
 	 * @return string
 	 */
 	private static function sanitize_feed_mode( mixed $mode ): string {
-		return in_array( $mode, self::get_feed_restriction_modes(), true ) ? $mode : self::FEED_MODE_EXCLUDE;
+		return in_array( $mode, self::get_feed_restriction_modes(), true ) ? $mode : self::FEED_MODE_TRUNCATE;
 	}
 
 	/**
@@ -271,7 +271,8 @@ class Content_Gate_Advanced_Settings {
 	 * @return string[]
 	 */
 	public static function get_feed_restriction_modes(): array {
-		return [ self::FEED_MODE_EXCLUDE, self::FEED_MODE_TRUNCATE ];
+		// Truncate first so the default mode leads the wizard's select options.
+		return [ self::FEED_MODE_TRUNCATE, self::FEED_MODE_EXCLUDE ];
 	}
 
 	/**
@@ -377,8 +378,8 @@ class Content_Gate_Advanced_Settings {
 
 	/**
 	 * Remove restricted posts from RSS feed queries when the feed mode is
-	 * "exclude", matching WC Memberships' default of keeping restricted content
-	 * out of feeds entirely (not just blanking the body).
+	 * "exclude", matching WC Memberships' hide/redirect restriction modes, which
+	 * drop restricted items from feeds entirely rather than blanking the body.
 	 *
 	 * Runs on the `the_posts` filter rather than a `post__not_in` on
 	 * `pre_get_posts` because gate restriction is rule-based and per-reader:

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-content-gates.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-content-gates.php
@@ -97,13 +97,19 @@ class Audience_Content_Gates extends Wizard {
 			'newspackAudienceContentGates',
 			array_merge(
 				[
-					'api'                     => '/' . NEWSPACK_API_NAMESPACE . '/wizard/' . $this->slug,
-					'available_access_rules'  => Access_Rules::get_access_rules_for_client(),
-					'available_content_rules' => Content_Rules::get_content_rules(),
-					'edit_gate_layout_url'    => Content_Gate::get_edit_gate_layout_url(),
-					'presave_checks_enabled'  => Content_Gate::get_presave_checks_enabled(),
-					'default_gate_status'     => Content_Gate::get_default_new_gate_status(),
-					'feed_restriction_modes'  => Content_Gate_Advanced_Settings::get_feed_restriction_mode_options(),
+					'api'                           => '/' . NEWSPACK_API_NAMESPACE . '/wizard/' . $this->slug,
+					'available_access_rules'        => Access_Rules::get_access_rules_for_client(),
+					'available_content_rules'       => Content_Rules::get_content_rules(),
+					'edit_gate_layout_url'          => Content_Gate::get_edit_gate_layout_url(),
+					'presave_checks_enabled'        => Content_Gate::get_presave_checks_enabled(),
+					'default_gate_status'           => Content_Gate::get_default_new_gate_status(),
+					'feed_restriction_modes'        => Content_Gate_Advanced_Settings::get_feed_restriction_mode_options(),
+					// While Memberships is active it governs feeds and Access Control
+					// stands down, so the feed controls below still save but change
+					// nothing until cutover. The wizard says so rather than hiding
+					// them: the stored value is what takes effect once Memberships is
+					// deactivated. See Content_Gate_Advanced_Settings::get_feed_restriction_mode().
+					'feeds_governed_by_memberships' => Memberships::is_active(),
 				],
 				$this->get_audience_management_script_data()
 			)

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-content-gates.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-content-gates.php
@@ -195,7 +195,7 @@ class Audience_Content_Gates extends Wizard {
 						],
 						// Validate the whole object against the schema so the nested
 						// feed_restriction_mode enum is actually enforced (a bad value
-						// returns a 400 instead of being silently coerced to exclude).
+						// returns a 400 instead of being silently coerced to the default).
 						'validate_callback'    => 'rest_validate_request_arg',
 						'sanitize_callback'    => 'rest_sanitize_request_arg',
 					],
@@ -451,7 +451,7 @@ class Audience_Content_Gates extends Wizard {
 	private function prepare_advanced_settings_response( $advanced ) {
 		return [
 			'restrict_feeds'                 => (bool) ( $advanced['restrict_feeds'] ?? false ),
-			'feed_restriction_mode'          => (string) ( $advanced['feed_restriction_mode'] ?? Content_Gate_Advanced_Settings::FEED_MODE_EXCLUDE ),
+			'feed_restriction_mode'          => (string) ( $advanced['feed_restriction_mode'] ?? Content_Gate_Advanced_Settings::FEED_MODE_TRUNCATE ),
 			'newsletter_link_bypass_enabled' => (bool) ( $advanced['newsletter_link_bypass_enabled'] ?? false ),
 		];
 	}

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/advanced-settings.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/advanced-settings.tsx
@@ -14,7 +14,7 @@ import { useEffect, useRef, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { Button, Modal } from '../../../../../packages/components/src';
+import { Button, Modal, Notice } from '../../../../../packages/components/src';
 import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
@@ -23,6 +23,8 @@ import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
 // Modes and their labels come from PHP, where the same list backs the REST
 // schema's enum and the storage sanitizer.
 const feedRestrictionModes = window.newspackAudienceContentGates?.feed_restriction_modes || [];
+// Truthy check because wp_localize_script() delivers this as '1'/'' rather than a boolean.
+const feedsGovernedByMemberships = !! window.newspackAudienceContentGates?.feeds_governed_by_memberships;
 
 const AdvancedSettings = ( { closeModal, showModal }: { closeModal: () => void; showModal: boolean } ) => {
 	const wizardData = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as ContentGatesWizardData;
@@ -93,21 +95,33 @@ const AdvancedSettings = ( { closeModal, showModal }: { closeModal: () => void; 
 		showModal && (
 			<Modal onClose={ closeModal } size="medium" title={ __( 'Advanced Settings', 'newspack-plugin' ) } onRequestClose={ closeModal }>
 				<VStack>
-					<ToggleControl
-						label={ __( 'Restrict content in feeds', 'newspack-plugin' ) }
-						help={ __( 'Apply gate restrictions to articles in RSS feeds.', 'newspack-plugin' ) }
-						checked={ config?.restrict_feeds }
-						onChange={ value => setConfig( { ...config, restrict_feeds: value } ) }
-					/>
-					{ config?.restrict_feeds && feedRestrictionModes.length > 0 && (
-						<SelectControl
-							label={ __( 'Restricted articles in feeds', 'newspack-plugin' ) }
-							help={ __( 'The teaser is the same free preview readers see on the site.', 'newspack-plugin' ) }
-							value={ config?.feed_restriction_mode || feedRestrictionModes[ 0 ].value }
-							options={ feedRestrictionModes }
-							onChange={ ( value: string ) => setConfig( { ...config, feed_restriction_mode: value as FeedRestrictionMode } ) }
+					{ /* Grouped so the Memberships notice reads as covering the feed settings only, not the newsletter toggle below. */ }
+					<VStack>
+						{ feedsGovernedByMemberships && (
+							<Notice
+								isWarning
+								noticeText={ __(
+									'WooCommerce Memberships controls RSS feeds on this site, so these feed settings have no effect yet. What is saved here applies once Memberships is deactivated.',
+									'newspack-plugin'
+								) }
+							/>
+						) }
+						<ToggleControl
+							label={ __( 'Restrict content in feeds', 'newspack-plugin' ) }
+							help={ __( 'Apply gate restrictions to articles in RSS feeds.', 'newspack-plugin' ) }
+							checked={ config?.restrict_feeds }
+							onChange={ value => setConfig( { ...config, restrict_feeds: value } ) }
 						/>
-					) }
+						{ config?.restrict_feeds && feedRestrictionModes.length > 0 && (
+							<SelectControl
+								label={ __( 'Restricted articles in feeds', 'newspack-plugin' ) }
+								help={ __( 'The teaser is the same free preview readers see on the site.', 'newspack-plugin' ) }
+								value={ config?.feed_restriction_mode || feedRestrictionModes[ 0 ].value }
+								options={ feedRestrictionModes }
+								onChange={ ( value: string ) => setConfig( { ...config, feed_restriction_mode: value as FeedRestrictionMode } ) }
+							/>
+						) }
+					</VStack>
 					{ wizardData?.config?.has_newsletters && (
 						<ToggleControl
 							label={ __( 'Bypass restrictions for newsletter links', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/types/window.d.ts
+++ b/plugins/newspack-plugin/src/wizards/types/window.d.ts
@@ -100,6 +100,10 @@ declare global {
 			presave_checks_enabled: boolean | string;
 			default_gate_status: GateStatus;
 			feed_restriction_modes?: { value: FeedRestrictionMode; label: string }[];
+			// True while WooCommerce Memberships governs feeds, which makes the feed
+			// controls inert until cutover. Same wp_localize_script() stringification
+			// as presave_checks_enabled above ('1'/''), so read it truthily.
+			feeds_governed_by_memberships?: boolean | string;
 			// Audience Management is a prerequisite for content gates. Only ever the
 			// string wp_localize_script() produced ('1' on, '' off) - nothing writes a
 			// real boolean back, so typing it wider would invite a `=== true` that can

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/advanced-settings.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/advanced-settings.php
@@ -109,21 +109,22 @@ class Test_Advanced_Settings extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * With no stored mode, the feed restriction mode defaults to "exclude" to
-	 * match WooCommerce Memberships (restricted items dropped from feeds).
+	 * With no stored mode, the feed restriction mode defaults to "truncate":
+	 * restricted items stay in the feed with the gate teaser rather than being
+	 * dropped.
 	 */
-	public function test_feed_restriction_mode_defaults_to_exclude() {
+	public function test_feed_restriction_mode_defaults_to_truncate() {
 		$settings = Content_Gate_Advanced_Settings::get_settings();
-		$this->assertSame( 'exclude', $settings['feed_restriction_mode'] );
+		$this->assertSame( 'truncate', $settings['feed_restriction_mode'] );
 	}
 
 	/**
-	 * An unknown or corrupt stored mode is normalized back to the exclude default
+	 * An unknown or corrupt stored mode is normalized back to the truncate default
 	 * rather than silently disabling feed restriction.
 	 */
-	public function test_invalid_feed_restriction_mode_falls_back_to_exclude() {
+	public function test_invalid_feed_restriction_mode_falls_back_to_truncate() {
 		$updated = Content_Gate_Advanced_Settings::update_settings( [ 'feed_restriction_mode' => 'nonsense' ] );
-		$this->assertSame( 'exclude', $updated['feed_restriction_mode'] );
+		$this->assertSame( 'truncate', $updated['feed_restriction_mode'] );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/feed-restriction.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/feed-restriction.php
@@ -96,6 +96,12 @@ class Test_Feed_Restriction extends \WP_UnitTestCase {
 		// Feeds are consumed anonymously.
 		wp_set_current_user( 0 );
 		update_option( Content_Gate_Advanced_Settings::OPTION_PREFIX . 'restrict_feeds', 1, false );
+		// Most tests here exercise exclude-mode mechanics (over-fetch, drop,
+		// back-fill), so set that mode as the class precondition. The shipped
+		// default is truncate — proven in advanced-settings.php and in
+		// test_default_mode_truncates_restricted_post_in_feed below, which clears
+		// this to read the real default.
+		update_option( Content_Gate_Advanced_Settings::OPTION_PREFIX . 'feed_restriction_mode', 'exclude', false );
 		Content_Gate_Advanced_Settings::reset_cache();
 	}
 
@@ -251,20 +257,35 @@ class Test_Feed_Restriction extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Default mode (no stored value) is "exclude" for WC Memberships parity: a
-	 * restricted post is dropped from the feed query entirely.
+	 * Default mode (no stored value) is "truncate": a restricted post stays in
+	 * the feed with the gate teaser rather than being dropped, so a site that has
+	 * never chosen a mode keeps its feed intact.
 	 */
-	public function test_default_mode_excludes_restricted_post_from_feed() {
+	public function test_default_mode_truncates_restricted_post_in_feed() {
+		// Clear the exclude precondition set_up() applies, to read the real default.
+		delete_option( Content_Gate_Advanced_Settings::OPTION_PREFIX . 'feed_restriction_mode' );
+		Content_Gate_Advanced_Settings::reset_cache();
+
 		$this->assertSame(
-			'exclude',
+			'truncate',
 			Content_Gate_Advanced_Settings::get_feed_restriction_mode(),
-			'Default feed restriction mode should be exclude.'
+			'Default feed restriction mode should be truncate.'
 		);
-		$this->assertNotContains(
+		$this->assertContains(
 			$this->post_id,
 			$this->feed_post_ids(),
-			'Restricted post should be absent from the feed in exclude mode.'
+			'Restricted post should stay in the feed under the truncate default.'
 		);
+
+		// Present is not enough — prove the body is actually the teaser, so a
+		// truncate→off regression (which would also keep the post) is caught here.
+		$feed_content = $this->render_in_feed_loop(
+			function () {
+				return get_the_content_feed( 'rss2' );
+			}
+		);
+		$this->assertStringContainsString( 'FREE_ONE', $feed_content, 'Teaser should be present under the truncate default.' );
+		$this->assertStringNotContainsString( 'PAID_FIVE', $feed_content, 'Paid content must not leak under the truncate default.' );
 	}
 
 	/**
@@ -450,7 +471,7 @@ class Test_Feed_Restriction extends \WP_UnitTestCase {
 
 	/**
 	 * A filter that returns an unrecognized mode fails closed: it is ignored in
-	 * favour of the resolved mode (exclude, by default) rather than disabling
+	 * favour of the resolved mode (exclude, per set_up) rather than disabling
 	 * restriction and leaking full content to the feed.
 	 */
 	public function test_invalid_filter_return_falls_back_to_resolved_mode() {
@@ -663,7 +684,7 @@ class Test_Feed_Restriction extends \WP_UnitTestCase {
 		$this->assertSame(
 			'exclude',
 			Content_Gate_Advanced_Settings::get_feed_restriction_mode(),
-			'The rejected request must not have changed the stored mode.'
+			'The rejected request must not have changed the stored mode (exclude, per set_up).'
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Part of NPPM-3204 (ask #2).

The default Access Control RSS `feed_restriction_mode` changes from `exclude` (drop restricted posts from the feed) to `truncate` (keep the item, show the gate teaser). Truncate is the safer default — it never drops a publisher's items — and it matches WooCommerce Memberships' own out-of-the-box mode, `hide_content`, which keeps items in the feed. The affected publishers in NPPM-3204 wanted items kept.

Changed together so the default is consistent everywhere: the `get_settings()` default, the `sanitize_feed_mode()` fallback, the wizard REST config fallback, and the order of `get_feed_restriction_modes()` (truncate now leads the wizard's select).

**Scope of the change.** Only sites with no stored `feed_restriction_mode` pick up the new default. Two things to know:

- A site with an explicitly stored mode is unaffected. Because the wizard submits the whole advanced-settings object on any save, a site whose admin ever saved that panel already has `exclude` persisted and keeps it — so fewer sites flip than the default alone implies.
- Accurate per-site migration is a separate PR: `migrate-feed-settings` reads each site's WooCommerce Memberships feed configuration and writes the matching mode (truncate / exclude / feeds-off), so a site that genuinely wanted dropping gets `exclude` rather than relying on this default.

On a WooCommerce Memberships site the hotfix (NPPM-3204 ask #1) keeps Access Control out of feeds entirely, so this default only takes effect once Memberships is deactivated at migration. While Memberships is active the wizard now says so, rather than presenting controls that save but change nothing:

![Advanced Settings modal with the Memberships notice above the feed controls](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/26/e90h04qx-nppm3204-feed-settings-memberships-notice.png)

The feed toggle and mode sit in their own group under the notice, so it does not read as covering the newsletter-bypass toggle below, which is unaffected.

### How to test the changes in this Pull Request:

1. Enable `NEWSPACK_CONTENT_GATES` and publish a gate restricting all posts.
2. Publish a post the gate restricts. Leave `feed_restriction_mode` unset.
3. Open Audience > Access control > Advanced settings.
4. Confirm the feed-mode select leads with "Keep restricted articles in the feed, showing only the teaser".
5. Load `/feed/` while logged out.
6. Confirm the restricted post is present, with only the teaser (no paid paragraphs).
7. Activate WooCommerce Memberships.
8. Open Audience > Access control > Advanced settings again.
9. Confirm a notice above the feed controls says the settings have no effect yet.
10. Deactivate WooCommerce Memberships.
11. Confirm the notice is gone.
12. Run `n test-php --group content-gate`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
