### PR TITLE
fix(cli): migrate gate copy authored with no wrapper block (NPPD-2218)

### DIFF
--- a/plugins/newspack-plugin/includes/cli/class-membership-gates-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-membership-gates-migration.php
@@ -1895,7 +1895,7 @@ class Membership_Gates_Migration {
 		// remove, so there is nothing to gain from a round trip that could alter it.
 		if ( null === $layouts['registration'] && null === $layouts['custom_access'] ) {
 			$whole = trim( $gate_post->post_content );
-			// A gate post that is only references WordPress cannot resolve renders
+			// A gate post holding only references WordPress cannot resolve renders
 			// nothing. Carrying it would swap the seeded default — which does render —
 			// for markup that looks migrated and shows the reader an empty wall.
 			if ( '' === $whole || ! self::blocks_render_something( $blocks ) ) {
@@ -1909,19 +1909,25 @@ class Membership_Gates_Migration {
 				// as a paywall. apply_layout() is still gated on the group requiring one,
 				// so a signup-only group is unaffected.
 				'registration'  => $whole,
-				'custom_access' => '' === $whole ? null : $whole,
+				'custom_access' => $whole,
 			];
 		}
 
 		// Copy outside the wrappers was unconditional — WooCommerce Memberships rendered
-		// the gate post whole, so both audiences saw it — and belongs at the top of each
-		// layout that exists. A null custom_access means the publisher never authored a
-		// members view, which is a different thing from an empty one, so it stays null.
+		// the gate post whole, so both audiences saw it — and joins each layout the gate
+		// actually has. Relative position is not preserved: copy authored below a wrapper
+		// still lands above that wrapper's content.
+		//
+		// A null layout stays null, for both modes. Null means the publisher authored no
+		// view for that audience, and the seeded default is what the gate falls back to —
+		// for registration that default is the wall carrying the auth form, so filling it
+		// with a bare heading would leave the reader a wall with no way through it.
 		$unconditional = self::serialize_unconditional_blocks( $blocks );
 		if ( '' !== $unconditional ) {
-			$layouts['registration'] = $unconditional . ( $layouts['registration'] ?? '' );
-			if ( null !== $layouts['custom_access'] ) {
-				$layouts['custom_access'] = $unconditional . $layouts['custom_access'];
+			foreach ( [ 'registration', 'custom_access' ] as $mode ) {
+				if ( null !== $layouts[ $mode ] ) {
+					$layouts[ $mode ] = $unconditional . $layouts[ $mode ];
+				}
 			}
 		}
 
@@ -1942,6 +1948,11 @@ class Membership_Gates_Migration {
 	 * that unconditional copy sharing a group with a wrapper is not recovered, which is
 	 * a rarer shape than a heading or separator sitting above one.
 	 *
+	 * "Contains" reaches through a synced pattern, because the layouts were already
+	 * filled from inside that pattern: keeping the reference as well would render the
+	 * copy twice, and would put a member-content wrapper — which prints its inner
+	 * content to everyone once Memberships is deactivated — inside the non-member wall.
+	 *
 	 * @param array $blocks Parsed top-level blocks of the gate post.
 	 *
 	 * @return string Serialized block markup, empty when every block holds a wrapper.
@@ -1958,22 +1969,36 @@ class Membership_Gates_Migration {
 	}
 
 	/**
-	 * Whether a membership wrapper sits anywhere in a block's own subtree.
+	 * Whether a membership wrapper sits anywhere a block reaches.
 	 *
-	 * Reusable references are not followed: a wrapper reached only through one is
-	 * carried into the layout by reference either way, and
-	 * warn_on_wrapper_in_referenced_pattern() is what reports that.
+	 * Synced-pattern references are followed, because collect_gate_layout_markup()
+	 * follows them too: a wrapper behind a reference has already contributed its content
+	 * to a layout, so the reference is not unconditional copy.
 	 *
-	 * @param array $block A parsed block.
+	 * @param array $block   A parsed block.
+	 * @param array $visited Pattern IDs already followed on this path, keyed by ID.
 	 *
 	 * @return bool
 	 */
-	private static function block_tree_holds_wrapper( array $block ): bool {
-		if ( in_array( $block['blockName'] ?? null, self::MEMBERSHIP_WRAPPER_BLOCKS, true ) ) {
+	private static function block_tree_holds_wrapper( array $block, array $visited = [] ): bool {
+		$block_name = $block['blockName'] ?? null;
+		if ( in_array( $block_name, self::MEMBERSHIP_WRAPPER_BLOCKS, true ) ) {
 			return true;
 		}
+		if ( 'core/block' === $block_name ) {
+			$ref = (int) ( $block['attrs']['ref'] ?? 0 );
+			if ( ! $ref || isset( $visited[ $ref ] ) || ! self::pattern_reference_resolves( $ref ) ) {
+				return false;
+			}
+			foreach ( \parse_blocks( \get_post( $ref )->post_content ) as $referenced_block ) {
+				if ( self::block_tree_holds_wrapper( $referenced_block, $visited + [ $ref => true ] ) ) {
+					return true;
+				}
+			}
+			return false;
+		}
 		foreach ( $block['innerBlocks'] ?? [] as $child ) {
-			if ( self::block_tree_holds_wrapper( $child ) ) {
+			if ( self::block_tree_holds_wrapper( $child, $visited ) ) {
 				return true;
 			}
 		}
@@ -1983,16 +2008,18 @@ class Membership_Gates_Migration {
 	/**
 	 * Whether a block list would put anything on the page.
 	 *
-	 * Only the reference case is judged, because it is the one where present markup
-	 * renders as nothing: a gate post holding a reference to a pattern WordPress will
-	 * not resolve is indistinguishable, by length, from one holding real copy. Any
-	 * other block is taken at face value.
+	 * Only the reference case is really judged, because it is the one where present
+	 * markup renders as nothing: a gate post holding a reference to a pattern WordPress
+	 * will not resolve is indistinguishable, by length, from one holding real copy. Any
+	 * other block is taken at face value — but a container is judged by its children, so
+	 * a group whose only child is a dead reference does not pass as content.
 	 *
-	 * @param array $blocks Parsed blocks.
+	 * @param array $blocks  Parsed blocks.
+	 * @param array $visited Pattern IDs already followed on this path, keyed by ID.
 	 *
 	 * @return bool
 	 */
-	private static function blocks_render_something( array $blocks ): bool {
+	private static function blocks_render_something( array $blocks, array $visited = [] ): bool {
 		foreach ( $blocks as $block ) {
 			$block_name = $block['blockName'] ?? null;
 			if ( null === $block_name ) {
@@ -2004,7 +2031,19 @@ class Membership_Gates_Migration {
 				continue;
 			}
 			if ( 'core/block' === $block_name ) {
-				if ( self::pattern_reference_resolves( (int) ( $block['attrs']['ref'] ?? 0 ) ) ) {
+				$ref = (int) ( $block['attrs']['ref'] ?? 0 );
+				if ( ! $ref || isset( $visited[ $ref ] ) || ! self::pattern_reference_resolves( $ref ) ) {
+					continue;
+				}
+				// A published pattern can still be empty, or hold nothing but its own dead
+				// references, in which case it renders exactly as little as a missing one.
+				if ( self::blocks_render_something( \parse_blocks( \get_post( $ref )->post_content ), $visited + [ $ref => true ] ) ) {
+					return true;
+				}
+				continue;
+			}
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				if ( self::blocks_render_something( $block['innerBlocks'], $visited ) ) {
 					return true;
 				}
 				continue;
@@ -2077,16 +2116,10 @@ class Membership_Gates_Migration {
 				if ( ! $ref || isset( $visited[ $ref ] ) ) {
 					continue;
 				}
-				$referenced = \get_post( $ref );
-				// The same guards core/block's own render callback applies — post type,
-				// published status, and no password — so extraction sees what a reader
-				// would: a pattern core would not render contributes nothing here either.
-				if (
-					! $referenced instanceof \WP_Post
-					|| 'wp_block' !== $referenced->post_type
-					|| 'publish' !== $referenced->post_status
-					|| ! empty( $referenced->post_password )
-				) {
+				// The same guards core/block's own render callback applies, so extraction
+				// sees what a reader would: a pattern core would not render contributes
+				// nothing here either.
+				if ( ! self::pattern_reference_resolves( $ref ) ) {
 					WP_CLI::warning(
 						sprintf(
 							'Gate post %d references synced pattern %d, which is missing, unpublished or password-protected — any gate content it holds will not migrate.',
@@ -2096,7 +2129,7 @@ class Membership_Gates_Migration {
 					);
 					continue;
 				}
-				self::collect_gate_layout_markup( \parse_blocks( $referenced->post_content ), $layouts, $visited + [ $ref => true ], $gate_post_id );
+				self::collect_gate_layout_markup( \parse_blocks( \get_post( $ref )->post_content ), $layouts, $visited + [ $ref => true ], $gate_post_id );
 				continue;
 			}
 

--- a/plugins/newspack-plugin/includes/cli/class-membership-gates-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-membership-gates-migration.php
@@ -1895,10 +1895,10 @@ class Membership_Gates_Migration {
 		// remove, so there is nothing to gain from a round trip that could alter it.
 		if ( null === $layouts['registration'] && null === $layouts['custom_access'] ) {
 			$whole = trim( $gate_post->post_content );
-			// A gate post holding only references WordPress cannot resolve renders
+			// A gate post holding nothing but references WordPress cannot resolve renders
 			// nothing. Carrying it would swap the seeded default — which does render —
 			// for markup that looks migrated and shows the reader an empty wall.
-			if ( '' === $whole || ! self::blocks_render_something( $blocks ) ) {
+			if ( ! self::blocks_render_something( $blocks ) ) {
 				return [
 					'registration'  => '',
 					'custom_access' => null,
@@ -1953,6 +1953,12 @@ class Membership_Gates_Migration {
 	 * copy twice, and would put a member-content wrapper — which prints its inner
 	 * content to everyone once Memberships is deactivated — inside the non-member wall.
 	 *
+	 * A block that renders nothing is dropped for a different reason: prefixing a dead
+	 * reference turns a layout that extracted to '' into one that looks authored, and
+	 * apply_layout() then overwrites the seeded default with a wall the reader sees as
+	 * blank. It also keeps a reference to an unpublished pattern out of the layout,
+	 * where a wrapper inside it would start leaking the day someone publishes it.
+	 *
 	 * @param array $blocks Parsed top-level blocks of the gate post.
 	 *
 	 * @return string Serialized block markup, empty when every block holds a wrapper.
@@ -1960,7 +1966,7 @@ class Membership_Gates_Migration {
 	private static function serialize_unconditional_blocks( array $blocks ): string {
 		$kept = [];
 		foreach ( $blocks as $block ) {
-			if ( self::block_tree_holds_wrapper( $block ) ) {
+			if ( self::block_tree_holds_wrapper( $block ) || ! self::blocks_render_something( [ $block ] ) ) {
 				continue;
 			}
 			$kept[] = $block;
@@ -1986,11 +1992,12 @@ class Membership_Gates_Migration {
 			return true;
 		}
 		if ( 'core/block' === $block_name ) {
-			$ref = (int) ( $block['attrs']['ref'] ?? 0 );
-			if ( ! $ref || isset( $visited[ $ref ] ) || ! self::pattern_reference_resolves( $ref ) ) {
+			$ref     = (int) ( $block['attrs']['ref'] ?? 0 );
+			$pattern = isset( $visited[ $ref ] ) ? null : self::resolve_pattern_reference( $ref );
+			if ( null === $pattern ) {
 				return false;
 			}
-			foreach ( \parse_blocks( \get_post( $ref )->post_content ) as $referenced_block ) {
+			foreach ( \parse_blocks( $pattern->post_content ) as $referenced_block ) {
 				if ( self::block_tree_holds_wrapper( $referenced_block, $visited + [ $ref => true ] ) ) {
 					return true;
 				}
@@ -2008,11 +2015,13 @@ class Membership_Gates_Migration {
 	/**
 	 * Whether a block list would put anything on the page.
 	 *
-	 * Only the reference case is really judged, because it is the one where present
+	 * Only the reference case is judged closely, because it is the one where present
 	 * markup renders as nothing: a gate post holding a reference to a pattern WordPress
-	 * will not resolve is indistinguishable, by length, from one holding real copy. Any
-	 * other block is taken at face value — but a container is judged by its children, so
-	 * a group whose only child is a dead reference does not pass as content.
+	 * will not resolve is indistinguishable, by length, from one holding real copy. A
+	 * block with children is judged by them, so a group whose only child is a dead
+	 * reference does not pass as content. Anything else — including a childless block,
+	 * which may as legitimately be an image or a spacer as an empty group — is taken at
+	 * face value.
 	 *
 	 * @param array $blocks  Parsed blocks.
 	 * @param array $visited Pattern IDs already followed on this path, keyed by ID.
@@ -2031,13 +2040,14 @@ class Membership_Gates_Migration {
 				continue;
 			}
 			if ( 'core/block' === $block_name ) {
-				$ref = (int) ( $block['attrs']['ref'] ?? 0 );
-				if ( ! $ref || isset( $visited[ $ref ] ) || ! self::pattern_reference_resolves( $ref ) ) {
+				$ref     = (int) ( $block['attrs']['ref'] ?? 0 );
+				$pattern = isset( $visited[ $ref ] ) ? null : self::resolve_pattern_reference( $ref );
+				if ( null === $pattern ) {
 					continue;
 				}
 				// A published pattern can still be empty, or hold nothing but its own dead
 				// references, in which case it renders exactly as little as a missing one.
-				if ( self::blocks_render_something( \parse_blocks( \get_post( $ref )->post_content ), $visited + [ $ref => true ] ) ) {
+				if ( self::blocks_render_something( \parse_blocks( $pattern->post_content ), $visited + [ $ref => true ] ) ) {
 					return true;
 				}
 				continue;
@@ -2054,24 +2064,29 @@ class Membership_Gates_Migration {
 	}
 
 	/**
-	 * Whether a synced-pattern reference resolves to something WordPress will render.
+	 * The pattern a reference resolves to, if WordPress would render it.
 	 *
 	 * The guard render_block_core_block() applies: an existing published `wp_block`
 	 * with no password.
 	 *
 	 * @param int $ref The wp_block post ID.
 	 *
-	 * @return bool
+	 * @return \WP_Post|null The pattern, or null when core would render nothing for it.
 	 */
-	private static function pattern_reference_resolves( int $ref ): bool {
+	private static function resolve_pattern_reference( int $ref ): ?\WP_Post {
 		if ( ! $ref ) {
-			return false;
+			return null;
 		}
 		$referenced = \get_post( $ref );
-		return $referenced instanceof \WP_Post
-			&& 'wp_block' === $referenced->post_type
-			&& 'publish' === $referenced->post_status
-			&& empty( $referenced->post_password );
+		if (
+			! $referenced instanceof \WP_Post
+			|| 'wp_block' !== $referenced->post_type
+			|| 'publish' !== $referenced->post_status
+			|| ! empty( $referenced->post_password )
+		) {
+			return null;
+		}
+		return $referenced;
 	}
 
 	/**
@@ -2119,7 +2134,8 @@ class Membership_Gates_Migration {
 				// The same guards core/block's own render callback applies, so extraction
 				// sees what a reader would: a pattern core would not render contributes
 				// nothing here either.
-				if ( ! self::pattern_reference_resolves( $ref ) ) {
+				$referenced = self::resolve_pattern_reference( $ref );
+				if ( null === $referenced ) {
 					WP_CLI::warning(
 						sprintf(
 							'Gate post %d references synced pattern %d, which is missing, unpublished or password-protected — any gate content it holds will not migrate.',
@@ -2129,7 +2145,7 @@ class Membership_Gates_Migration {
 					);
 					continue;
 				}
-				self::collect_gate_layout_markup( \parse_blocks( \get_post( $ref )->post_content ), $layouts, $visited + [ $ref => true ], $gate_post_id );
+				self::collect_gate_layout_markup( \parse_blocks( $referenced->post_content ), $layouts, $visited + [ $ref => true ], $gate_post_id );
 				continue;
 			}
 

--- a/plugins/newspack-plugin/includes/cli/class-membership-gates-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-membership-gates-migration.php
@@ -1881,16 +1881,158 @@ class Membership_Gates_Migration {
 	 * @return array{registration: string, custom_access: string|null}
 	 */
 	private static function extract_gate_layouts( \WP_Post $gate_post ): array {
+		$blocks  = \parse_blocks( $gate_post->post_content );
 		$layouts = [
 			'registration'  => null,
 			'custom_access' => null,
 		];
-		self::collect_gate_layout_markup( \parse_blocks( $gate_post->post_content ), $layouts, [], $gate_post->ID );
+		self::collect_gate_layout_markup( $blocks, $layouts, [], $gate_post->ID );
+
+		// No wrapper anywhere (NPPD-2218). Nothing in the authoring flow adds one, so a
+		// gate written the plain way has none and its whole content is the message
+		// WooCommerce Memberships showed to non-members. The raw post content is used
+		// rather than a re-serialization of the parsed tree: there is no wrapper to
+		// remove, so there is nothing to gain from a round trip that could alter it.
+		if ( null === $layouts['registration'] && null === $layouts['custom_access'] ) {
+			$whole = trim( $gate_post->post_content );
+			// A gate post that is only references WordPress cannot resolve renders
+			// nothing. Carrying it would swap the seeded default — which does render —
+			// for markup that looks migrated and shows the reader an empty wall.
+			if ( '' === $whole || ! self::blocks_render_something( $blocks ) ) {
+				return [
+					'registration'  => '',
+					'custom_access' => null,
+				];
+			}
+			return [
+				// Also the paid layout, so a group whose plans require a purchase migrates
+				// as a paywall. apply_layout() is still gated on the group requiring one,
+				// so a signup-only group is unaffected.
+				'registration'  => $whole,
+				'custom_access' => '' === $whole ? null : $whole,
+			];
+		}
+
+		// Copy outside the wrappers was unconditional — WooCommerce Memberships rendered
+		// the gate post whole, so both audiences saw it — and belongs at the top of each
+		// layout that exists. A null custom_access means the publisher never authored a
+		// members view, which is a different thing from an empty one, so it stays null.
+		$unconditional = self::serialize_unconditional_blocks( $blocks );
+		if ( '' !== $unconditional ) {
+			$layouts['registration'] = $unconditional . ( $layouts['registration'] ?? '' );
+			if ( null !== $layouts['custom_access'] ) {
+				$layouts['custom_access'] = $unconditional . $layouts['custom_access'];
+			}
+		}
 
 		return [
 			'registration'  => $layouts['registration'] ?? '',
 			'custom_access' => $layouts['custom_access'],
 		];
+	}
+
+	/**
+	 * Serialize the top-level blocks that hold no membership wrapper in their subtree.
+	 *
+	 * These are the parts of the gate post every reader saw, whatever their membership,
+	 * so they belong in each migrated layout rather than in neither.
+	 *
+	 * A block that *contains* a wrapper is skipped whole rather than emptied. Keeping it
+	 * would put a container stripped of its only child into both layouts; the cost is
+	 * that unconditional copy sharing a group with a wrapper is not recovered, which is
+	 * a rarer shape than a heading or separator sitting above one.
+	 *
+	 * @param array $blocks Parsed top-level blocks of the gate post.
+	 *
+	 * @return string Serialized block markup, empty when every block holds a wrapper.
+	 */
+	private static function serialize_unconditional_blocks( array $blocks ): string {
+		$kept = [];
+		foreach ( $blocks as $block ) {
+			if ( self::block_tree_holds_wrapper( $block ) ) {
+				continue;
+			}
+			$kept[] = $block;
+		}
+		return trim( \serialize_blocks( $kept ) );
+	}
+
+	/**
+	 * Whether a membership wrapper sits anywhere in a block's own subtree.
+	 *
+	 * Reusable references are not followed: a wrapper reached only through one is
+	 * carried into the layout by reference either way, and
+	 * warn_on_wrapper_in_referenced_pattern() is what reports that.
+	 *
+	 * @param array $block A parsed block.
+	 *
+	 * @return bool
+	 */
+	private static function block_tree_holds_wrapper( array $block ): bool {
+		if ( in_array( $block['blockName'] ?? null, self::MEMBERSHIP_WRAPPER_BLOCKS, true ) ) {
+			return true;
+		}
+		foreach ( $block['innerBlocks'] ?? [] as $child ) {
+			if ( self::block_tree_holds_wrapper( $child ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Whether a block list would put anything on the page.
+	 *
+	 * Only the reference case is judged, because it is the one where present markup
+	 * renders as nothing: a gate post holding a reference to a pattern WordPress will
+	 * not resolve is indistinguishable, by length, from one holding real copy. Any
+	 * other block is taken at face value.
+	 *
+	 * @param array $blocks Parsed blocks.
+	 *
+	 * @return bool
+	 */
+	private static function blocks_render_something( array $blocks ): bool {
+		foreach ( $blocks as $block ) {
+			$block_name = $block['blockName'] ?? null;
+			if ( null === $block_name ) {
+				// Freeform markup, which parse_blocks() also emits for the whitespace
+				// between blocks.
+				if ( '' !== trim( $block['innerHTML'] ?? '' ) ) {
+					return true;
+				}
+				continue;
+			}
+			if ( 'core/block' === $block_name ) {
+				if ( self::pattern_reference_resolves( (int) ( $block['attrs']['ref'] ?? 0 ) ) ) {
+					return true;
+				}
+				continue;
+			}
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Whether a synced-pattern reference resolves to something WordPress will render.
+	 *
+	 * The guard render_block_core_block() applies: an existing published `wp_block`
+	 * with no password.
+	 *
+	 * @param int $ref The wp_block post ID.
+	 *
+	 * @return bool
+	 */
+	private static function pattern_reference_resolves( int $ref ): bool {
+		if ( ! $ref ) {
+			return false;
+		}
+		$referenced = \get_post( $ref );
+		return $referenced instanceof \WP_Post
+			&& 'wp_block' === $referenced->post_type
+			&& 'publish' === $referenced->post_status
+			&& empty( $referenced->post_password );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/cli/class-membership-gates-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-membership-gates-migration.php
@@ -229,12 +229,53 @@ class Membership_Gates_Migration {
 		// needs the split by product kind to know which access rules to build.
 		$products_by_group  = [];
 		$durations_by_group = [];
+		$layouts_by_group   = [];
 		foreach ( $plan_groups as $fingerprint => $group ) {
 			$gate_title                         = self::gate_title( $group );
 			$products_by_group[ $fingerprint ]  = self::resolve_product_ids( $group );
 			$durations_by_group[ $fingerprint ] = self::resolve_group_duration( $group, $duration_override );
+			$layouts_by_group[ $fingerprint ]   = self::resolve_group_layouts( $group );
 			self::report_dropped_product_ids( $gate_title, $products_by_group[ $fingerprint ]['dropped'], self::group_requires_purchase( $group ) );
 			self::report_duration_conflict( $gate_title, $durations_by_group[ $fingerprint ]['conflict'] );
+		}
+
+		// A paid gate whose layout gives the reader no way to buy restricts the article
+		// and then strands them there. The copy came from a WooCommerce Memberships gate
+		// post, which Newspack rendered as the whole restriction message — so a gate post
+		// with no purchase link stranded the reader before this migration too, and
+		// whether that was deliberate is not something this command can tell. It is named
+		// and refused rather than guessed at: migrating it reproduces the dead end, and
+		// substituting Newspack's seeded paywall silently discards copy the publisher
+		// wrote.
+		$needs_purchase_path = [];
+		foreach ( $plan_groups as $fingerprint => $group ) {
+			if ( ! self::group_requires_purchase( $group ) ) {
+				continue;
+			}
+			$paid_layout = $layouts_by_group[ $fingerprint ]['layouts']['custom_access'];
+			if ( null === $paid_layout || '' === trim( $paid_layout ) || self::layout_offers_a_purchase( $paid_layout ) ) {
+				continue;
+			}
+			$gate_post = $layouts_by_group[ $fingerprint ]['gate_post'];
+
+			$needs_purchase_path[ self::gate_title( $group ) ] = $gate_post ? $gate_post->ID : 0;
+		}
+		if ( ! empty( $needs_purchase_path ) ) {
+			WP_CLI::error(
+				sprintf(
+					'The paid access copy for %s offers the reader no way to buy — no checkout button, no donate block, and no link that leads anywhere. Migrating it would publish a paywall that stops the reader with nothing to click. Add a checkout button or a subscribe link to the gate post(s) named, then re-run. Nothing has been written.',
+					implode(
+						', ',
+						array_map(
+							fn( $title, $gate_post_id ) => $gate_post_id
+								? sprintf( '"%s" (gate post %d)', $title, $gate_post_id )
+								: sprintf( '"%s"', $title ),
+							array_keys( $needs_purchase_path ),
+							$needs_purchase_path
+						)
+					)
+				)
+			);
 		}
 
 		// A one-time product with no duration has no rule to write, and a gate that
@@ -310,22 +351,10 @@ class Membership_Gates_Migration {
 			$action  = array_key_exists( $gate_key, $existing_gates ) ? 'updated' : 'created';
 			$gate_id = $existing_gates[ $gate_key ] ?? null;
 
-			// Resolve layout content — try each plan in the group for a plan-specific gate.
-			$memberships_gate = null;
-			$group_plan_count = count( $group );
-			foreach ( $group as $i => $group_plan ) {
-				$is_last          = ( $i === $group_plan_count - 1 );
-				$memberships_gate = self::get_memberships_gate_for_plan( $group_plan['pid'], $is_last );
-				if ( $memberships_gate ) {
-					break;
-				}
-			}
-			$layouts = $memberships_gate
-				? self::extract_gate_layouts( $memberships_gate )
-				: [
-					'registration'  => '',
-					'custom_access' => null,
-				];
+			// Resolved in pre-flight, so the extraction warnings all landed before the
+			// prompt and this loop reads rather than re-reads.
+			$memberships_gate = $layouts_by_group[ $fingerprint ]['gate_post'];
+			$layouts          = $layouts_by_group[ $fingerprint ]['layouts'];
 
 			if ( ! $dry_run ) {
 				if ( null === $gate_id ) {
@@ -777,9 +806,96 @@ class Membership_Gates_Migration {
 			} elseif ( empty( $custom_access['access_rules'] ) ) {
 				$issues[] = 'its paid access mode is active but has no access rules, so it asks for no purchase — any registered reader would get in';
 			}
+
+			// A paid gate that restricts correctly and offers no way to pay reads as a
+			// success everywhere else in this run: the mode is active, the rules are
+			// there, and the layout is not empty.
+			$paid_layout = ( empty( $custom_access['active'] ) || empty( $custom_access['gate_layout_id'] ) )
+				? null
+				: \get_post( $custom_access['gate_layout_id'] );
+			if (
+				$paid_layout
+				&& '' !== trim( $paid_layout->post_content )
+				&& ! self::layout_offers_a_purchase( $paid_layout->post_content )
+			) {
+				$issues[] = sprintf(
+					'its paid access layout (post %d) has no checkout button and no link, so the reader is stopped with no way to buy',
+					$custom_access['gate_layout_id']
+				);
+			}
 		}
 
 		return $issues;
+	}
+
+	/**
+	 * The gate post a group migrates from, and the layouts extracted from it.
+	 *
+	 * Each plan in the group is tried in turn, so a group whose first plan has no
+	 * gate of its own still migrates from a sibling's. The last plan is allowed to
+	 * fall back to the site's primary gate.
+	 *
+	 * @param array $group The plan group.
+	 *
+	 * @return array{gate_post: \WP_Post|null, layouts: array{registration: string, custom_access: string|null}}
+	 */
+	private static function resolve_group_layouts( array $group ): array {
+		$gate_post        = null;
+		$group_plan_count = count( $group );
+		foreach ( $group as $i => $group_plan ) {
+			$gate_post = self::get_memberships_gate_for_plan( $group_plan['pid'], $i === $group_plan_count - 1 );
+			if ( $gate_post ) {
+				break;
+			}
+		}
+
+		return [
+			'gate_post' => $gate_post,
+			'layouts'   => $gate_post
+				? self::extract_gate_layouts( $gate_post )
+				: [
+					'registration'  => '',
+					'custom_access' => null,
+				],
+		];
+	}
+
+	/**
+	 * Whether a layout gives the reader a way to pay.
+	 *
+	 * Content_Gate::create_gate() seeds the paid-access layout from the pay-wall-one-tier
+	 * pattern, whose purchase affordance is a `newspack-blocks/checkout-button`. A
+	 * publisher's own "subscribe" link counts too, so long as it leads somewhere: the
+	 * reader being able to act is the thing, not the block being the Newspack one.
+	 *
+	 * @param string $content Layout block markup.
+	 *
+	 * @return bool
+	 */
+	private static function layout_offers_a_purchase( string $content ): bool {
+		foreach ( [ 'newspack-blocks/checkout-button', 'newspack-blocks/donate' ] as $purchase_block ) {
+			if ( \has_block( $purchase_block, $content ) ) {
+				return true;
+			}
+		}
+		if ( ! preg_match_all( '/<a\s[^>]*href=["\']([^"\']*)["\']/i', $content, $matches ) ) {
+			return false;
+		}
+		foreach ( $matches[1] as $href ) {
+			$href = trim( $href );
+			// An href that stays on the page or opens a mail client is not a purchase
+			// path. The seeded paywall proves the case: its "Sign in to an existing
+			// account" button is an anchor to #signin_modal, so counting any anchor
+			// would report every paywall as buyable.
+			if ( '' === $href || str_starts_with( $href, '#' ) || str_starts_with( $href, 'mailto:' ) ) {
+				continue;
+			}
+			if ( false !== strpos( $href, 'wp-login.php' ) ) {
+				continue;
+			}
+			return true;
+		}
+		return false;
 	}
 
 	/**
@@ -856,6 +972,7 @@ class Membership_Gates_Migration {
 		if ( $has_purchase && null !== $layouts['custom_access'] && '' === trim( $layouts['custom_access'] ) ) {
 			$issues[] = 'its paid access layout extracted to nothing, so the paid gate will show default content rather than the authored one';
 		}
+
 
 		if ( $has_purchase ) {
 			if ( null === $layouts['custom_access'] ) {
@@ -1876,6 +1993,15 @@ class Membership_Gates_Migration {
 	 * members-only sections. Each type's wrappers are concatenated in document order so
 	 * no authored content is dropped.
 	 *
+	 * Two shapes fall outside that. Copy sitting outside the wrappers was shown to every
+	 * reader, so it joins each layout the publisher actually authored. And a gate with no
+	 * wrapper anywhere — the ordinary authoring shape — migrates its whole content into
+	 * both layouts (NPPD-2218), which is what makes a purchase-backed group come across
+	 * as a paywall rather than a gate any registered reader passes.
+	 *
+	 * A layout the publisher left empty is returned empty rather than filled, so
+	 * apply_layout() keeps the seeded default and the dry run still reports it.
+	 *
 	 * @param \WP_Post $gate_post The np_memberships_gate post.
 	 *
 	 * @return array{registration: string, custom_access: string|null}
@@ -1890,25 +2016,28 @@ class Membership_Gates_Migration {
 
 		// No wrapper anywhere (NPPD-2218). Nothing in the authoring flow adds one, so a
 		// gate written the plain way has none and its whole content is the message
-		// WooCommerce Memberships showed to non-members. The raw post content is used
-		// rather than a re-serialization of the parsed tree: there is no wrapper to
-		// remove, so there is nothing to gain from a round trip that could alter it.
+		// WooCommerce Memberships showed to non-members. It goes through the same
+		// per-block filter the prefix path below uses — no block here holds a wrapper, so
+		// that reduces to the post's renderable blocks — rather than being copied raw:
+		// the two paths otherwise disagree about a reference to a pattern that is
+		// unpublished or gone, which renders nothing today and prints whatever it holds
+		// the day someone publishes it.
 		if ( null === $layouts['registration'] && null === $layouts['custom_access'] ) {
-			$whole = trim( $gate_post->post_content );
-			// A gate post holding nothing but references WordPress cannot resolve renders
-			// nothing. Carrying it would swap the seeded default — which does render —
-			// for markup that looks migrated and shows the reader an empty wall.
-			if ( ! self::blocks_render_something( $blocks ) ) {
+			$whole = self::serialize_unconditional_blocks( $blocks, $gate_post->ID );
+			if ( '' === $whole ) {
 				return [
 					'registration'  => '',
 					'custom_access' => null,
 				];
 			}
 			return [
-				// Also the paid layout, so a group whose plans require a purchase migrates
-				// as a paywall. apply_layout() is still gated on the group requiring one,
-				// so a signup-only group is unaffected.
 				'registration'  => $whole,
+				// Also the paid layout, so a group whose plans require a purchase migrates
+				// as a paywall rather than a gate any registered reader walks through.
+				// apply_layout() is gated on the group requiring a purchase, so a
+				// signup-only group is unaffected. Whether that copy gives the reader a
+				// way to buy is settled in pre-flight, which refuses the run rather than
+				// guess.
 				'custom_access' => $whole,
 			];
 		}
@@ -1918,15 +2047,18 @@ class Membership_Gates_Migration {
 		// actually has. Relative position is not preserved: copy authored below a wrapper
 		// still lands above that wrapper's content.
 		//
-		// A null layout stays null, for both modes. Null means the publisher authored no
-		// view for that audience, and the seeded default is what the gate falls back to —
-		// for registration that default is the wall carrying the auth form, so filling it
-		// with a bare heading would leave the reader a wall with no way through it.
-		$unconditional = self::serialize_unconditional_blocks( $blocks );
+		// A layout with nothing of its own is left that way, for both modes — a wrapper
+		// the publisher never wrote (null) and one written empty ('') are both "no
+		// authored view for that audience", and the seeded default is what the gate falls
+		// back to. For registration that default is the wall carrying the auth form, so
+		// filling it with a bare heading would leave the reader a wall with no way
+		// through it. Leaving it empty is also what keeps the dry run's
+		// "no registration layout content could be extracted" warning firing.
+		$unconditional = self::serialize_unconditional_blocks( $blocks, $gate_post->ID );
 		if ( '' !== $unconditional ) {
 			foreach ( [ 'registration', 'custom_access' ] as $mode ) {
-				if ( null !== $layouts[ $mode ] ) {
-					$layouts[ $mode ] = $unconditional . $layouts[ $mode ];
+				if ( ! empty( $layouts[ $mode ] ) ) {
+					$layouts[ $mode ] = $unconditional . "\n\n" . $layouts[ $mode ];
 				}
 			}
 		}
@@ -1953,25 +2085,85 @@ class Membership_Gates_Migration {
 	 * copy twice, and would put a member-content wrapper — which prints its inner
 	 * content to everyone once Memberships is deactivated — inside the non-member wall.
 	 *
-	 * A block that renders nothing is dropped for a different reason: prefixing a dead
-	 * reference turns a layout that extracted to '' into one that looks authored, and
-	 * apply_layout() then overwrites the seeded default with a wall the reader sees as
-	 * blank. It also keeps a reference to an unpublished pattern out of the layout,
-	 * where a wrapper inside it would start leaking the day someone publishes it.
+	 * A block that renders nothing is dropped for the reason blocks_render_something()
+	 * gives, and to keep a top-level reference to an unpublished pattern out of the
+	 * layout, where a wrapper inside it would start leaking the day someone publishes it.
+	 * The test is per top-level block, so a dead reference nested beside rendering copy
+	 * still rides along; collect_gate_layout_markup() warns about it either way.
 	 *
-	 * @param array $blocks Parsed top-level blocks of the gate post.
+	 * @param array $blocks       Parsed top-level blocks of the gate post.
+	 * @param int   $gate_post_id The gate post being extracted, for warning context.
 	 *
-	 * @return string Serialized block markup, empty when every block holds a wrapper.
+	 * @return string Serialized block markup, empty when every block either holds a
+	 *                wrapper or renders nothing.
 	 */
-	private static function serialize_unconditional_blocks( array $blocks ): string {
-		$kept = [];
+	private static function serialize_unconditional_blocks( array $blocks, int $gate_post_id ): string {
+		$kept     = [];
+		$warned   = false;
 		foreach ( $blocks as $block ) {
-			if ( self::block_tree_holds_wrapper( $block ) || ! self::blocks_render_something( [ $block ] ) ) {
+			if ( self::block_tree_holds_wrapper( $block ) ) {
+				// Dropping a container drops whatever else it held. The operator is told,
+				// because this is the one case where the command discards authored copy
+				// deliberately rather than failing to reach it.
+				if ( ! $warned && self::block_holds_copy_outside_wrappers( $block ) ) {
+					$warned = true;
+					WP_CLI::warning(
+						sprintf(
+							'Gate post %d has copy sharing a container with a membership wrapper. That copy will not migrate — review the generated layouts before cutover.',
+							$gate_post_id
+						)
+					);
+				}
+				continue;
+			}
+			if ( ! self::blocks_render_something( [ $block ] ) ) {
 				continue;
 			}
 			$kept[] = $block;
 		}
-		return trim( \serialize_blocks( $kept ) );
+		return trim( implode( "\n\n", array_map( 'serialize_block', $kept ) ) );
+	}
+
+	/**
+	 * Whether a block holds content of its own alongside a membership wrapper.
+	 *
+	 * Distinguishes a container wrapping only a wrapper, which loses nothing when it is
+	 * skipped, from one that also carries copy every reader saw, which does. Only a leaf
+	 * counts: a container's own markup is chrome, so a group holding just a wrapper is
+	 * not treated as copy.
+	 *
+	 * @param array $block   A parsed block.
+	 * @param array $visited Pattern IDs already followed on this path, keyed by ID.
+	 *
+	 * @return bool
+	 */
+	private static function block_holds_copy_outside_wrappers( array $block, array $visited = [] ): bool {
+		$block_name = $block['blockName'] ?? null;
+		if ( in_array( $block_name, self::MEMBERSHIP_WRAPPER_BLOCKS, true ) ) {
+			return false;
+		}
+		if ( 'core/block' === $block_name ) {
+			$ref = (int) ( $block['attrs']['ref'] ?? 0 );
+			if ( isset( $visited[ $ref ] ) ) {
+				return false;
+			}
+			$pattern = self::resolve_pattern_reference( $ref );
+			if ( null === $pattern ) {
+				return false;
+			}
+			foreach ( \parse_blocks( $pattern->post_content ) as $referenced_block ) {
+				if ( self::block_holds_copy_outside_wrappers( $referenced_block, $visited + [ $ref => true ] ) ) {
+					return true;
+				}
+			}
+			return false;
+		}
+		foreach ( $block['innerBlocks'] ?? [] as $child ) {
+			if ( self::block_holds_copy_outside_wrappers( $child, $visited ) ) {
+				return true;
+			}
+		}
+		return empty( $block['innerBlocks'] ) && self::blocks_render_something( [ $block ], $visited );
 	}
 
 	/**
@@ -1992,8 +2184,11 @@ class Membership_Gates_Migration {
 			return true;
 		}
 		if ( 'core/block' === $block_name ) {
-			$ref     = (int) ( $block['attrs']['ref'] ?? 0 );
-			$pattern = isset( $visited[ $ref ] ) ? null : self::resolve_pattern_reference( $ref );
+			$ref = (int) ( $block['attrs']['ref'] ?? 0 );
+			if ( isset( $visited[ $ref ] ) ) {
+				return false;
+			}
+			$pattern = self::resolve_pattern_reference( $ref );
 			if ( null === $pattern ) {
 				return false;
 			}
@@ -2015,13 +2210,19 @@ class Membership_Gates_Migration {
 	/**
 	 * Whether a block list would put anything on the page.
 	 *
+	 * This is the rule the whole extraction leans on: markup that renders as nothing must
+	 * not become a layout, because apply_layout() would then swap a seeded default that
+	 * does render for a wall the reader sees as blank.
+	 *
 	 * Only the reference case is judged closely, because it is the one where present
 	 * markup renders as nothing: a gate post holding a reference to a pattern WordPress
 	 * will not resolve is indistinguishable, by length, from one holding real copy. A
 	 * block with children is judged by them, so a group whose only child is a dead
-	 * reference does not pass as content. Anything else — including a childless block,
-	 * which may as legitimately be an image or a spacer as an empty group — is taken at
-	 * face value.
+	 * reference does not pass as content — at the cost of a block whose own markup is the
+	 * visible part, a cover with a background image whose single child is a dead
+	 * reference, which is judged to render nothing. Anything else — including a childless
+	 * block, which may as legitimately be an image or a spacer as an empty group — is
+	 * taken at face value.
 	 *
 	 * @param array $blocks  Parsed blocks.
 	 * @param array $visited Pattern IDs already followed on this path, keyed by ID.
@@ -2040,8 +2241,11 @@ class Membership_Gates_Migration {
 				continue;
 			}
 			if ( 'core/block' === $block_name ) {
-				$ref     = (int) ( $block['attrs']['ref'] ?? 0 );
-				$pattern = isset( $visited[ $ref ] ) ? null : self::resolve_pattern_reference( $ref );
+				$ref = (int) ( $block['attrs']['ref'] ?? 0 );
+				if ( isset( $visited[ $ref ] ) ) {
+					continue;
+				}
+				$pattern = self::resolve_pattern_reference( $ref );
 				if ( null === $pattern ) {
 					continue;
 				}
@@ -2066,8 +2270,8 @@ class Membership_Gates_Migration {
 	/**
 	 * The pattern a reference resolves to, if WordPress would render it.
 	 *
-	 * The guard render_block_core_block() applies: an existing published `wp_block`
-	 * with no password.
+	 * The guard render_block_core_block() applies, so extraction sees what a reader
+	 * would.
 	 *
 	 * @param int $ref The wp_block post ID.
 	 *

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-membership-gates-migration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-membership-gates-migration.php
@@ -1077,6 +1077,9 @@ HTML
 		$layouts = $this->invoke_private_static( 'extract_gate_layouts', [ $gate_post ] );
 
 		$this->assertStringContainsString( 'Available only to members.', $layouts['registration'], 'The authored copy migrates rather than being dropped.' );
+		// The paid layout too, so a group whose plans require a purchase migrates as a
+		// paywall rather than as a gate any registered reader passes.
+		$this->assertSame( $layouts['registration'], $layouts['custom_access'], 'Both modes get a layout to activate against.' );
 	}
 
 	/**
@@ -1099,6 +1102,98 @@ HTML;
 
 		$this->assertStringContainsString( 'Subscribe to read.', $layouts['registration'] );
 		$this->assertStringContainsString( 'This post is only available to members.', $layouts['registration'], 'Copy outside the wrapper is part of the gate the reader saw.' );
+		$this->assertLessThan(
+			strpos( $layouts['registration'], 'Subscribe to read.' ),
+			strpos( $layouts['registration'], 'This post is only available to members.' ),
+			'The unconditional copy leads the layout.'
+		);
+		// Filling a layout the publisher never authored would activate paid access
+		// against a members view that does not exist.
+		$this->assertNull( $layouts['custom_access'], 'Unconditional copy does not create a paid layout.' );
+	}
+
+	/**
+	 * A gate whose only authored view is for members keeps the seeded registration wall.
+	 *
+	 * That default carries the auth form. Filling the registration layout with the
+	 * gate's unconditional copy would overwrite it, leaving a reader looking at a
+	 * heading with no way through the wall.
+	 */
+	public function test_extract_gate_layouts_leaves_a_registration_layout_unauthored() {
+		$gate_content = <<<'HTML'
+<!-- wp:heading --><h2>Members only</h2><!-- /wp:heading -->
+<!-- wp:woocommerce-memberships/member-content -->
+<!-- wp:paragraph --><p>Thanks for supporting us.</p><!-- /wp:paragraph -->
+<!-- /wp:woocommerce-memberships/member-content -->
+HTML;
+		$gate_post = $this->create_gate_post( $gate_content );
+
+		$layouts = $this->invoke_private_static( 'extract_gate_layouts', [ $gate_post ] );
+
+		$this->assertSame( '', $layouts['registration'], 'No non-member view was authored, so the seeded wall stands.' );
+		$this->assertStringContainsString( 'Members only', $layouts['custom_access'], 'The unconditional copy still joins the layout that exists.' );
+	}
+
+	/**
+	 * A reference whose pattern holds the wrappers is not also carried in as
+	 * unconditional copy.
+	 *
+	 * The walk already resolved that reference and took the wrappers' content, so
+	 * keeping the reference too would render the upsell twice — and would put a
+	 * member-content wrapper inside the non-member wall, where it prints its inner
+	 * content to everyone once WooCommerce Memberships is deactivated.
+	 */
+	public function test_extract_gate_layouts_does_not_repeat_a_wrapper_bearing_pattern() {
+		$pattern_id = $this->create_pattern_post(
+			'<!-- wp:woocommerce-memberships/non-member-content -->'
+			. '<!-- wp:paragraph --><p>Subscribe to read.</p><!-- /wp:paragraph -->'
+			. '<!-- /wp:woocommerce-memberships/non-member-content -->'
+			. '<!-- wp:woocommerce-memberships/member-content -->'
+			. '<!-- wp:paragraph --><p>Members only secret.</p><!-- /wp:paragraph -->'
+			. '<!-- /wp:woocommerce-memberships/member-content -->'
+		);
+		$gate_post  = $this->create_gate_post( sprintf( '<!-- wp:block {"ref":%d} /-->', $pattern_id ) );
+
+		$layouts = $this->invoke_private_static( 'extract_gate_layouts', [ $gate_post ] );
+
+		$this->assertStringContainsString( 'Subscribe to read.', $layouts['registration'] );
+		$this->assertStringNotContainsString( 'wp:block', $layouts['registration'], 'The reference is not carried in alongside the content taken from it.' );
+		$this->assertStringNotContainsString( 'Members only secret.', $layouts['registration'] );
+		$this->assertStringContainsString( 'Members only secret.', $layouts['custom_access'] );
+	}
+
+	/**
+	 * A container holding nothing but a dead reference is not mistaken for content.
+	 *
+	 * The group renders as an empty div, so migrating it would replace a seeded default
+	 * that does render with a wall the reader sees as blank.
+	 */
+	public function test_extract_gate_layouts_returns_empty_for_a_container_holding_a_dead_reference() {
+		$draft_pattern_id = $this->create_pattern_post( '<!-- wp:paragraph --><p>Never published.</p><!-- /wp:paragraph -->', 'draft' );
+		$gate_post        = $this->create_gate_post(
+			'<!-- wp:group --><div class="wp-block-group">'
+			. sprintf( '<!-- wp:block {"ref":%d} /-->', $draft_pattern_id )
+			. '</div><!-- /wp:group -->'
+		);
+
+		$layouts = $this->invoke_private_static( 'extract_gate_layouts', [ $gate_post ] );
+
+		$this->assertSame( '', $layouts['registration'] );
+		$this->assertNull( $layouts['custom_access'] );
+	}
+
+	/**
+	 * A reference to a published but empty pattern renders nothing, and is treated as
+	 * nothing — the guard is about what reaches the reader, not what resolves.
+	 */
+	public function test_extract_gate_layouts_returns_empty_for_a_reference_to_an_empty_pattern() {
+		$empty_pattern_id = $this->create_pattern_post( '' );
+		$gate_post        = $this->create_gate_post( sprintf( '<!-- wp:block {"ref":%d} /-->', $empty_pattern_id ) );
+
+		$layouts = $this->invoke_private_static( 'extract_gate_layouts', [ $gate_post ] );
+
+		$this->assertSame( '', $layouts['registration'] );
+		$this->assertNull( $layouts['custom_access'] );
 	}
 
 	/**
@@ -1130,19 +1225,6 @@ HTML;
 
 		$this->assertSame( '', $layouts['registration'], 'A reference that renders nothing does not become the layout.' );
 		$this->assertNull( $layouts['custom_access'] );
-	}
-
-	/**
-	 * The fallback also fills the paid layout, so a group whose plans require a purchase
-	 * migrates as a paywall instead of a gate any registered reader passes.
-	 */
-	public function test_extract_gate_layouts_fallback_fills_the_paid_layout_too() {
-		$gate_post = $this->create_gate_post( '<!-- wp:paragraph --><p>Subscribe for full access.</p><!-- /wp:paragraph -->' );
-
-		$layouts = $this->invoke_private_static( 'extract_gate_layouts', [ $gate_post ] );
-
-		$this->assertStringContainsString( 'Subscribe for full access.', $layouts['custom_access'], 'A wrapper-less gate gives the paid mode a layout to activate against.' );
-		$this->assertSame( $layouts['registration'], $layouts['custom_access'], 'Both modes carry the copy the publisher wrote.' );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-membership-gates-migration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-membership-gates-migration.php
@@ -1062,17 +1062,87 @@ HTML
 	}
 
 	/**
-	 * With no wrapper anywhere in the tree, registration comes back as an empty string
-	 * and custom_access as null. apply_layout() reads that distinction to leave the
-	 * gate's seeded default layout alone rather than blanking it.
+	 * NPPD-2218: a gate authored with no wrapper block at all still migrates its copy.
+	 *
+	 * Nothing in the authoring flow adds a wrapper, so a gate written the plain way has
+	 * none — and its whole content is the message WooCommerce Memberships showed to
+	 * non-members. Extracting nothing there hands the publisher Newspack's seeded
+	 * default in place of the copy they wrote.
 	 */
-	public function test_extract_gate_layouts_returns_empty_when_no_wrapper_exists() {
-		$gate_post = $this->create_gate_post( '<!-- wp:paragraph --><p>Just an article.</p><!-- /wp:paragraph -->' );
+	public function test_extract_gate_layouts_falls_back_to_the_whole_post_when_no_wrapper_exists() {
+		$gate_content = '<!-- wp:separator --><hr class="wp-block-separator"/><!-- /wp:separator -->'
+			. '<!-- wp:paragraph --><p>Available only to members. Sign up as a monthly donor.</p><!-- /wp:paragraph -->';
+		$gate_post    = $this->create_gate_post( $gate_content );
+
+		$layouts = $this->invoke_private_static( 'extract_gate_layouts', [ $gate_post ] );
+
+		$this->assertStringContainsString( 'Available only to members.', $layouts['registration'], 'The authored copy migrates rather than being dropped.' );
+	}
+
+	/**
+	 * NPPD-2218: content sitting outside the wrappers migrates too.
+	 *
+	 * WooCommerce Memberships renders the gate post whole, so a heading above the
+	 * wrapper is shown alongside whichever wrapper applies. Reading only the wrappers'
+	 * own children drops it.
+	 */
+	public function test_extract_gate_layouts_keeps_content_outside_the_wrappers() {
+		$gate_content = <<<'HTML'
+<!-- wp:paragraph --><p>This post is only available to members.</p><!-- /wp:paragraph -->
+<!-- wp:woocommerce-memberships/non-member-content -->
+<!-- wp:paragraph --><p>Subscribe to read.</p><!-- /wp:paragraph -->
+<!-- /wp:woocommerce-memberships/non-member-content -->
+HTML;
+		$gate_post = $this->create_gate_post( $gate_content );
+
+		$layouts = $this->invoke_private_static( 'extract_gate_layouts', [ $gate_post ] );
+
+		$this->assertStringContainsString( 'Subscribe to read.', $layouts['registration'] );
+		$this->assertStringContainsString( 'This post is only available to members.', $layouts['registration'], 'Copy outside the wrapper is part of the gate the reader saw.' );
+	}
+
+	/**
+	 * An empty gate post returns an empty registration layout and a null custom_access
+	 * one. apply_layout() reads that distinction to leave the gate's seeded default
+	 * alone rather than blanking it, and there is no authored copy here to prefer.
+	 */
+	public function test_extract_gate_layouts_returns_empty_for_an_empty_gate_post() {
+		$gate_post = $this->create_gate_post( '' );
 
 		$layouts = $this->invoke_private_static( 'extract_gate_layouts', [ $gate_post ] );
 
 		$this->assertSame( '', $layouts['registration'] );
 		$this->assertNull( $layouts['custom_access'] );
+	}
+
+	/**
+	 * A gate post holding only a reference WordPress cannot resolve is treated as empty.
+	 *
+	 * The markup is there, so a length check would call it migrated, but an unpublished
+	 * pattern renders nothing — so carrying it would swap a seeded default that does
+	 * render for a wall the reader sees as blank.
+	 */
+	public function test_extract_gate_layouts_returns_empty_for_an_unresolvable_reference_only_gate() {
+		$draft_pattern_id = $this->create_pattern_post( '<!-- wp:paragraph --><p>Never published.</p><!-- /wp:paragraph -->', 'draft' );
+		$gate_post        = $this->create_gate_post( sprintf( '<!-- wp:block {"ref":%d} /-->', $draft_pattern_id ) );
+
+		$layouts = $this->invoke_private_static( 'extract_gate_layouts', [ $gate_post ] );
+
+		$this->assertSame( '', $layouts['registration'], 'A reference that renders nothing does not become the layout.' );
+		$this->assertNull( $layouts['custom_access'] );
+	}
+
+	/**
+	 * The fallback also fills the paid layout, so a group whose plans require a purchase
+	 * migrates as a paywall instead of a gate any registered reader passes.
+	 */
+	public function test_extract_gate_layouts_fallback_fills_the_paid_layout_too() {
+		$gate_post = $this->create_gate_post( '<!-- wp:paragraph --><p>Subscribe for full access.</p><!-- /wp:paragraph -->' );
+
+		$layouts = $this->invoke_private_static( 'extract_gate_layouts', [ $gate_post ] );
+
+		$this->assertStringContainsString( 'Subscribe for full access.', $layouts['custom_access'], 'A wrapper-less gate gives the paid mode a layout to activate against.' );
+		$this->assertSame( $layouts['registration'], $layouts['custom_access'], 'Both modes carry the copy the publisher wrote.' );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-membership-gates-migration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-membership-gates-migration.php
@@ -1197,6 +1197,30 @@ HTML;
 	}
 
 	/**
+	 * A dead reference sitting outside the wrappers is not carried in as unconditional
+	 * copy.
+	 *
+	 * It renders nothing, so prefixing it would turn a layout that extracted to nothing
+	 * into one that looks authored — and the seeded default, which does render, would be
+	 * overwritten with a wall the reader sees as blank.
+	 */
+	public function test_extract_gate_layouts_drops_an_unrenderable_block_from_unconditional_copy() {
+		$draft_pattern_id = $this->create_pattern_post( '<!-- wp:paragraph --><p>Never published.</p><!-- /wp:paragraph -->', 'draft' );
+		$gate_post        = $this->create_gate_post(
+			sprintf( '<!-- wp:block {"ref":%d} /-->', $draft_pattern_id )
+			. '<!-- wp:woocommerce-memberships/member-content -->'
+			. '<!-- wp:paragraph --><p>Thanks for supporting us.</p><!-- /wp:paragraph -->'
+			. '<!-- /wp:woocommerce-memberships/member-content -->'
+		);
+
+		$layouts = $this->invoke_private_static( 'extract_gate_layouts', [ $gate_post ] );
+
+		$this->assertStringNotContainsString( 'wp:block', $layouts['custom_access'], 'A reference that renders nothing is not unconditional copy.' );
+		$this->assertStringContainsString( 'Thanks for supporting us.', $layouts['custom_access'] );
+		$this->assertSame( '', $layouts['registration'], 'The layout that extracted to nothing stays empty, so the seeded default stands.' );
+	}
+
+	/**
 	 * An empty gate post returns an empty registration layout and a null custom_access
 	 * one. apply_layout() reads that distinction to leave the gate's seeded default
 	 * alone rather than blanking it, and there is no authored copy here to prefer.

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-membership-gates-migration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-membership-gates-migration.php
@@ -1078,7 +1078,8 @@ HTML
 
 		$this->assertStringContainsString( 'Available only to members.', $layouts['registration'], 'The authored copy migrates rather than being dropped.' );
 		// The paid layout too, so a group whose plans require a purchase migrates as a
-		// paywall rather than as a gate any registered reader passes.
+		// paywall rather than as a gate any registered reader passes. Whether that copy
+		// lets the reader buy is pre-flight's call, not extraction's.
 		$this->assertSame( $layouts['registration'], $layouts['custom_access'], 'Both modes get a layout to activate against.' );
 	}
 
@@ -1163,40 +1164,6 @@ HTML;
 	}
 
 	/**
-	 * A container holding nothing but a dead reference is not mistaken for content.
-	 *
-	 * The group renders as an empty div, so migrating it would replace a seeded default
-	 * that does render with a wall the reader sees as blank.
-	 */
-	public function test_extract_gate_layouts_returns_empty_for_a_container_holding_a_dead_reference() {
-		$draft_pattern_id = $this->create_pattern_post( '<!-- wp:paragraph --><p>Never published.</p><!-- /wp:paragraph -->', 'draft' );
-		$gate_post        = $this->create_gate_post(
-			'<!-- wp:group --><div class="wp-block-group">'
-			. sprintf( '<!-- wp:block {"ref":%d} /-->', $draft_pattern_id )
-			. '</div><!-- /wp:group -->'
-		);
-
-		$layouts = $this->invoke_private_static( 'extract_gate_layouts', [ $gate_post ] );
-
-		$this->assertSame( '', $layouts['registration'] );
-		$this->assertNull( $layouts['custom_access'] );
-	}
-
-	/**
-	 * A reference to a published but empty pattern renders nothing, and is treated as
-	 * nothing — the guard is about what reaches the reader, not what resolves.
-	 */
-	public function test_extract_gate_layouts_returns_empty_for_a_reference_to_an_empty_pattern() {
-		$empty_pattern_id = $this->create_pattern_post( '' );
-		$gate_post        = $this->create_gate_post( sprintf( '<!-- wp:block {"ref":%d} /-->', $empty_pattern_id ) );
-
-		$layouts = $this->invoke_private_static( 'extract_gate_layouts', [ $gate_post ] );
-
-		$this->assertSame( '', $layouts['registration'] );
-		$this->assertNull( $layouts['custom_access'] );
-	}
-
-	/**
 	 * A dead reference sitting outside the wrappers is not carried in as unconditional
 	 * copy.
 	 *
@@ -1221,34 +1188,101 @@ HTML;
 	}
 
 	/**
-	 * An empty gate post returns an empty registration layout and a null custom_access
-	 * one. apply_layout() reads that distinction to leave the gate's seeded default
-	 * alone rather than blanking it, and there is no authored copy here to prefer.
+	 * Markup that renders nothing does not become a layout, whatever shape it takes.
+	 *
+	 * A length check would call all four of these migrated. The seeded default does
+	 * render, so swapping it for any of them shows the reader a blank wall.
 	 */
-	public function test_extract_gate_layouts_returns_empty_for_an_empty_gate_post() {
-		$gate_post = $this->create_gate_post( '' );
+	public function test_extract_gate_layouts_treats_content_that_renders_nothing_as_empty() {
+		$draft_pattern_id = $this->create_pattern_post( '<!-- wp:paragraph --><p>Never published.</p><!-- /wp:paragraph -->', 'draft' );
+		$empty_pattern_id = $this->create_pattern_post( '' );
+		$dead_reference   = sprintf( '<!-- wp:block {"ref":%d} /-->', $draft_pattern_id );
 
-		$layouts = $this->invoke_private_static( 'extract_gate_layouts', [ $gate_post ] );
+		$shapes = [
+			'an empty gate post'                           => '',
+			'a reference to an unpublished pattern'        => $dead_reference,
+			'a reference to a published but empty pattern' => sprintf( '<!-- wp:block {"ref":%d} /-->', $empty_pattern_id ),
+			'a container holding nothing but a dead reference' => '<!-- wp:group --><div class="wp-block-group">' . $dead_reference . '</div><!-- /wp:group -->',
+		];
 
-		$this->assertSame( '', $layouts['registration'] );
-		$this->assertNull( $layouts['custom_access'] );
+		foreach ( $shapes as $shape => $gate_content ) {
+			$layouts = $this->invoke_private_static( 'extract_gate_layouts', [ $this->create_gate_post( $gate_content ) ] );
+
+			$this->assertSame( '', $layouts['registration'], $shape . ' does not become the registration layout.' );
+			$this->assertNull( $layouts['custom_access'], $shape . ' does not become a paid layout.' );
+		}
 	}
 
 	/**
-	 * A gate post holding only a reference WordPress cannot resolve is treated as empty.
+	 * The no-wrapper fallback drops the blocks that render nothing rather than copying
+	 * the post whole.
 	 *
-	 * The markup is there, so a length check would call it migrated, but an unpublished
-	 * pattern renders nothing — so carrying it would swap a seeded default that does
-	 * render for a wall the reader sees as blank.
+	 * A reference to an unpublished pattern renders nothing today, so carrying it buys
+	 * the layout nothing — and it starts printing whatever it holds the day someone
+	 * publishes the pattern, which for a member-content wrapper means members-only copy
+	 * served from the wall built to withhold it.
 	 */
-	public function test_extract_gate_layouts_returns_empty_for_an_unresolvable_reference_only_gate() {
+	public function test_extract_gate_layouts_drops_unrenderable_blocks_from_the_no_wrapper_fallback() {
 		$draft_pattern_id = $this->create_pattern_post( '<!-- wp:paragraph --><p>Never published.</p><!-- /wp:paragraph -->', 'draft' );
-		$gate_post        = $this->create_gate_post( sprintf( '<!-- wp:block {"ref":%d} /-->', $draft_pattern_id ) );
+		$gate_post        = $this->create_gate_post(
+			'<!-- wp:paragraph --><p>Subscribe to keep reading.</p><!-- /wp:paragraph -->'
+			. sprintf( '<!-- wp:block {"ref":%d} /-->', $draft_pattern_id )
+		);
 
 		$layouts = $this->invoke_private_static( 'extract_gate_layouts', [ $gate_post ] );
 
-		$this->assertSame( '', $layouts['registration'], 'A reference that renders nothing does not become the layout.' );
-		$this->assertNull( $layouts['custom_access'] );
+		$this->assertStringContainsString( 'Subscribe to keep reading.', $layouts['registration'] );
+		$this->assertStringNotContainsString( 'wp:block', $layouts['registration'], 'The dead reference is not carried into the layout.' );
+	}
+
+	/**
+	 * A wrapper the publisher left empty is not an authored view.
+	 *
+	 * Prefixing unconditional copy onto it would make it look authored, and
+	 * apply_layout() would then overwrite the seeded registration wall — the one
+	 * carrying the auth form — with a bare heading the reader cannot act on.
+	 */
+	public function test_extract_gate_layouts_leaves_an_empty_wrapper_empty() {
+		$gate_post = $this->create_gate_post(
+			'<!-- wp:heading --><h2>Members</h2><!-- /wp:heading -->'
+			. '<!-- wp:woocommerce-memberships/non-member-content --><!-- /wp:woocommerce-memberships/non-member-content -->'
+			. '<!-- wp:woocommerce-memberships/member-content -->'
+			. '<!-- wp:paragraph --><p>Thanks for supporting us.</p><!-- /wp:paragraph -->'
+			. '<!-- /wp:woocommerce-memberships/member-content -->'
+		);
+
+		$layouts = $this->invoke_private_static( 'extract_gate_layouts', [ $gate_post ] );
+
+		$this->assertSame( '', $layouts['registration'], 'An empty wrapper keeps the seeded default rather than taking the heading.' );
+		$this->assertStringContainsString( 'Members', $layouts['custom_access'], 'The layout that was authored still gets the unconditional copy.' );
+		$this->assertStringContainsString( 'Thanks for supporting us.', $layouts['custom_access'] );
+	}
+
+	/**
+	 * Copy sharing a container with a wrapper is dropped, and the operator is told.
+	 *
+	 * Recovering it positionally is not feasible, so the migration discards it — but
+	 * this is the one case where it discards authored copy deliberately rather than
+	 * failing to reach it, and a silent drop gives the operator nothing to review.
+	 */
+	public function test_extract_gate_layouts_warns_when_copy_shares_a_container_with_a_wrapper() {
+		\WP_CLI::$messages = [];
+		$gate_post         = $this->create_gate_post(
+			'<!-- wp:group --><div class="wp-block-group">'
+			. '<!-- wp:heading --><h2>Standalone heading.</h2><!-- /wp:heading -->'
+			. '<!-- wp:woocommerce-memberships/non-member-content -->'
+			. '<!-- wp:paragraph --><p>Become a member.</p><!-- /wp:paragraph -->'
+			. '<!-- /wp:woocommerce-memberships/non-member-content -->'
+			. '</div><!-- /wp:group -->'
+		);
+
+		$layouts = $this->invoke_private_static( 'extract_gate_layouts', [ $gate_post ] );
+
+		$this->assertStringContainsString( 'Become a member.', $layouts['registration'] );
+		$this->assertStringNotContainsString( 'Standalone heading.', $layouts['registration'], 'The container is skipped whole, so its other copy is lost.' );
+		$warnings = array_filter( \WP_CLI::$messages, fn( $message ) => 'warning' === $message[0] );
+		$this->assertNotEmpty( $warnings, 'The dropped copy is reported.' );
+		$this->assertStringContainsString( 'sharing a container', implode( ' ', array_column( $warnings, 1 ) ) );
 	}
 
 	/**
@@ -1396,7 +1430,7 @@ HTML;
 			$gate_id,
 			[
 				'active'         => true,
-				'gate_layout_id' => \Newspack\Content_Gate::create_gate_layout( 'Paid access fixture layout', '' ),
+				'gate_layout_id' => \Newspack\Content_Gate::create_gate_layout( 'Paid access fixture layout', '<!-- wp:newspack-blocks/checkout-button /-->' ),
 				'access_rules'   => [],
 			]
 		);
@@ -1405,6 +1439,83 @@ HTML;
 
 		$this->assertCount( 1, $issues );
 		$this->assertStringContainsString( 'no access rules', $issues[0] );
+	}
+
+	/**
+	 * What counts as a way to buy.
+	 *
+	 * A pre-flight abort turns on this answer, so the boundary is worth stating: the
+	 * seeded paywall pairs its checkout button with a "Sign in to an existing account"
+	 * anchor to #signin_modal, and counting that would report every paywall as buyable.
+	 *
+	 * @dataProvider purchase_affordance_provider
+	 *
+	 * @param bool   $expected Whether the markup offers a purchase.
+	 * @param string $content  Layout block markup.
+	 * @param string $case     What the markup stands for.
+	 */
+	public function test_layout_offers_a_purchase( bool $expected, string $content, string $case ) {
+		$this->assertSame( $expected, $this->invoke_private_static( 'layout_offers_a_purchase', [ $content ] ), $case );
+	}
+
+	/**
+	 * Markup shapes for test_layout_offers_a_purchase().
+	 *
+	 * @return array[]
+	 */
+	public function purchase_affordance_provider(): array {
+		return [
+			[ true, '<!-- wp:newspack-blocks/checkout-button /-->', 'the seeded paywall\'s checkout button' ],
+			[ true, '<!-- wp:newspack-blocks/donate /-->', 'a donate block, the other Newspack block that takes money' ],
+			[ true, '<p><a href="https://example.com/subscribe">Subscribe</a></p>', 'a publisher\'s own subscribe link' ],
+			[ false, '<p>Available only to members.</p>', 'prose with nothing to click' ],
+			[ false, '<p><a href="#signin_modal">Sign in to an existing account</a></p>', 'the seeded paywall\'s own sign-in anchor' ],
+			[ false, '<p><a href="mailto:hello@example.com">Email us</a></p>', 'a support address' ],
+			[ false, '<p><a href="/wp-login.php">Log in</a></p>', 'a log-in link' ],
+			[ false, '<p>Ask about newspack-blocks/checkout-button in your email.</p>', 'the block name appearing in copy rather than as a block' ],
+		];
+	}
+
+	/**
+	 * A written paid layout that gives the reader no way to buy is reported.
+	 *
+	 * This is the live-run half of the check: by the time verify_migrated_gate() runs,
+	 * the seeded paywall and the checkout button it carried have already been replaced.
+	 * Every other signal reads clean — the mode is active, the access rules are there,
+	 * and the layout is not empty — so without this the run reports the gate as created.
+	 */
+	public function test_verify_migrated_gate_flags_a_paid_layout_with_no_way_to_buy() {
+		$gate_id = $this->create_enforceable_gate(
+			[
+				[
+					'slug'  => 'post_types',
+					'value' => [ 'post' ],
+				],
+			]
+		);
+		\Newspack\Content_Gate::update_custom_access_settings(
+			$gate_id,
+			[
+				'active'         => true,
+				'gate_layout_id' => \Newspack\Content_Gate::create_gate_layout(
+					'Paid access fixture layout',
+					'<!-- wp:paragraph --><p>Available only to members.</p><!-- /wp:paragraph -->'
+				),
+				'access_rules'   => [
+					[
+						[
+							'slug'  => 'subscription',
+							'value' => [ 123 ],
+						],
+					],
+				],
+			]
+		);
+
+		$issues = $this->invoke_private_static( 'verify_migrated_gate', [ $gate_id, true ] );
+
+		$this->assertCount( 1, $issues );
+		$this->assertStringContainsString( 'no checkout button and no link', $issues[0] );
 	}
 
 	/**
@@ -1424,7 +1535,7 @@ HTML;
 			$gate_id,
 			[
 				'active'         => true,
-				'gate_layout_id' => \Newspack\Content_Gate::create_gate_layout( 'Paid access fixture layout', '' ),
+				'gate_layout_id' => \Newspack\Content_Gate::create_gate_layout( 'Paid access fixture layout', '<!-- wp:newspack-blocks/checkout-button /-->' ),
 				'access_rules'   => [
 					[
 						[
@@ -1838,7 +1949,7 @@ HTML;
 		];
 		$layouts  = [
 			'registration'  => '<p>Upsell.</p>',
-			'custom_access' => '<p>Member content.</p>',
+			'custom_access' => '<p>Member content.</p><!-- wp:newspack-blocks/checkout-button /-->',
 		];
 
 		$issues = $this->invoke_private_static(
@@ -1941,7 +2052,7 @@ HTML;
 		];
 		$layouts  = [
 			'registration'  => '<p>Upsell.</p>',
-			'custom_access' => '<p>Welcome.</p>',
+			'custom_access' => '<p>Welcome.</p><!-- wp:newspack-blocks/checkout-button /-->',
 		];
 
 		$this->assertSame(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`migrate-membership-gates` built a gate's layouts from the inner content of the WooCommerce Memberships wrapper blocks. Nothing in the authoring flow adds those wrappers, so a gate written the plain way has none, extracted to nothing, and the publisher went live with Newspack's seeded default in place of their own copy. Four sites on the rollout roster are in that shape, none with gates staged yet.

A gate with no wrapper anywhere now migrates its whole content, paid layout included, so a group whose plans require a purchase migrates as a paywall rather than a gate any registered reader passes. Copy outside the wrappers prefixes each layout the publisher authored; a layout they left empty stays empty, so the seeded default stands. Markup that renders nothing is excluded throughout, since it would replace a default that does render with a blank wall.

Pre-flight refuses a paid gate whose copy offers the reader no way to buy — no checkout button, no donate block, no link that leads anywhere. The seeded paid layout is where the checkout button comes from, so migrating such copy over it publishes a wall that stops the reader with nothing to click. Whether that was deliberate is not the command's call, so it names the gate posts and writes nothing.

Closes NPPD-2218.

### How to test the changes in this Pull Request:

1. Create an env with WooCommerce, WooCommerce Subscriptions and WooCommerce Memberships active.
2. Create a subscription product.
3. Create a membership plan. Set its access method to purchase and grant it by that product.
4. Add a content restriction rule to the plan.
5. Create a published `np_memberships_gate` post. Write one paragraph in it. Add no member-content or non-member-content block.
6. Set the gate's `plans` meta to the plan ID.
7. Run `wp newspack migrate-membership-gates --plan=<plan_id>`.
8. The command errors. It names the gate post and asks for a checkout button or a subscribe link.
9. Add a link to an off-site URL inside the paragraph from step 5.
10. Run the same command again. The summary reports no warning.
11. Run the command with `--live`.
12. Read the new gate's `registration` and `custom_access` meta. Both are active.
13. Both layouts hold the paragraph and its link. The paid access rules name the product from step 2.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<details>
<summary>Review notes</summary>

The pre-flight refusal and three other changes in `b0c811df1` came out of a local multi-reviewer pass (deep, standards, Newspack WP expert, and one external model; Codex was unavailable for the run). The others:

- The no-wrapper path copied raw `post_content`, carrying a `core/block` reference to an unpublished or deleted pattern into both layouts where the sibling path filters it out. A wrapper behind such a reference starts printing its inner content the day someone publishes the pattern.
- `null !== $layouts[$mode]` treated an empty-but-present wrapper as an authored view, so unconditional copy was prefixed onto it. That overwrote the seeded registration wall carrying the auth form, and silenced `compute_pre_write_issues()`'s own warning about it.
- Copy sharing a container with a wrapper is dropped so an emptied container is not migrated. The operator is now told when that happens.
- Gate-post resolution and layout extraction moved into pre-flight, so their warnings land before the confirmation prompt rather than after it, and extraction runs once per group instead of twice.

Left for follow-up: three walkers each re-implement `core/block` resolution and the per-path `$visited` copy, and a structurally-present-but-empty text block still counts as rendering something.

Unit tests are 104 green (up from 95), with five mutations run to confirm the new tests fail without their fix. The full CLI command was not exercised end to end — WooCommerce Memberships is not available in the test env — so the pre-flight refusal is covered by unit tests and by the purchase-affordance predicate run against real markup in a WordPress runtime, not by a live migration.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEoRpcircdkpiR5bYvuU1J
