### PR TITLE
chore(tests): give the blocks suite one WC_Order stub instead of two

### DIFF
--- a/plugins/newspack-blocks/tests/bootstrap.php
+++ b/plugins/newspack-blocks/tests/bootstrap.php
@@ -59,6 +59,7 @@ if ( ! $autoloader_loaded ) {
  */
 require_once __DIR__ . '/class-newspack-tag-labels-stub.php';
 require_once __DIR__ . '/class-newspack-block-visibility-stub.php';
+require_once __DIR__ . '/class-wc-order-stub.php';
 
 // Start up the WP testing environment.
 require $newspack_blocks_tests_dir . '/includes/bootstrap.php';

--- a/plugins/newspack-blocks/tests/class-wc-order-stub.php
+++ b/plugins/newspack-blocks/tests/class-wc-order-stub.php
@@ -3,9 +3,15 @@
  * Test stub for WooCommerce's WC_Order.
  *
  * The newspack-blocks test suite runs without WooCommerce loaded, so the real
- * WC_Order class is absent. This stub carries the two accessors the modal
- * checkout return-URL and tracking callbacks read, and satisfies both the
+ * WC_Order class is absent. This stub carries the accessors the modal checkout
+ * return-URL, tracking and cart-data paths read, and satisfies both the
  * is_a( $order, 'WC_Order' ) and instanceof checks those paths use.
+ *
+ * It is the suite's only definition of the class, loaded from bootstrap.php so
+ * it is in place before any test file runs. A second, partial definition in a
+ * test file would not merely duplicate this one: both guard on class_exists(),
+ * so whichever the suite happened to load first would win and silently take the
+ * other's methods away from every test.
  *
  * @package Newspack_Blocks
  */
@@ -21,7 +27,7 @@ if ( ! class_exists( 'WC_Order' ) ) {
 		 *
 		 * @var int
 		 */
-		private $id;
+		protected $id;
 
 		/**
 		 * Order key.
@@ -31,14 +37,23 @@ if ( ! class_exists( 'WC_Order' ) ) {
 		private $order_key;
 
 		/**
+		 * Line items.
+		 *
+		 * @var array
+		 */
+		protected $items = [];
+
+		/**
 		 * Constructor.
 		 *
 		 * @param int    $id        Order ID.
 		 * @param string $order_key Order key.
+		 * @param array  $items     Line items.
 		 */
-		public function __construct( $id = 0, $order_key = '' ) {
+		public function __construct( $id = 0, $order_key = '', $items = [] ) {
 			$this->id        = $id;
 			$this->order_key = $order_key;
+			$this->items     = $items;
 		}
 
 		/**
@@ -57,6 +72,27 @@ if ( ! class_exists( 'WC_Order' ) ) {
 		 */
 		public function get_order_key() {
 			return $this->order_key;
+		}
+
+		/**
+		 * Get the line items.
+		 *
+		 * @return array
+		 */
+		public function get_items() {
+			return $this->items;
+		}
+
+		/**
+		 * Get an order meta value.
+		 *
+		 * @param string $key Meta key.
+		 *
+		 * @return string
+		 */
+		public function get_meta( $key ) {
+			unset( $key );
+			return '';
 		}
 	}
 }

--- a/plugins/newspack-blocks/tests/test-modal-checkout-data.php
+++ b/plugins/newspack-blocks/tests/test-modal-checkout-data.php
@@ -193,51 +193,6 @@ if ( ! class_exists( 'WC_Order_Item_Product' ) ) {
 	}
 }
 
-if ( ! class_exists( 'WC_Order' ) ) {
-	/**
-	 * Minimal WooCommerce order stub.
-	 */
-	class WC_Order {
-		/**
-		 * Line items.
-		 *
-		 * @var array
-		 */
-		protected $items = [];
-
-		/**
-		 * Order ID.
-		 *
-		 * @var int
-		 */
-		protected $id;
-
-		/**
-		 * Constructor.
-		 *
-		 * @param array $items Line items.
-		 * @param int   $id    Order ID.
-		 */
-		public function __construct( $items = [], $id = 900 ) {
-			$this->items = $items;
-			$this->id    = $id;
-		}
-
-		public function get_id() {
-			return $this->id;
-		}
-
-		public function get_items() {
-			return $this->items;
-		}
-
-		public function get_meta( $key ) {
-			unset( $key );
-			return '';
-		}
-	}
-}
-
 if ( ! class_exists( 'WC_Subscription' ) ) {
 	/**
 	 * Minimal subscription stub. A subscription created by hand in wp-admin has
@@ -259,7 +214,7 @@ if ( ! class_exists( 'WC_Subscription' ) ) {
 		 * @param int            $id     Subscription ID.
 		 */
 		public function __construct( $items = [], $parent = false, $id = 901 ) {
-			parent::__construct( $items, $id );
+			parent::__construct( $id, '', $items );
 			$this->parent = $parent;
 		}
 
@@ -351,7 +306,7 @@ class Newspack_Blocks_Modal_Checkout_Data_Test extends WP_UnitTestCase_Blocks {
 			2171 => new WC_Product( 2171, 'subscription', [], '99', 'Annual Supporter' ),
 		];
 
-		$parent       = new WC_Order( [ new WC_Order_Item_Product( 2171, '99' ) ], 900 );
+		$parent       = new WC_Order( 900, '', [ new WC_Order_Item_Product( 2171, '99' ) ] );
 		$subscription = new WC_Subscription( [ new WC_Order_Item_Product( 2170, '25' ) ], $parent, 901 );
 
 		$data = Checkout_Data::get_checkout_data( $subscription );
@@ -374,7 +329,7 @@ class Newspack_Blocks_Modal_Checkout_Data_Test extends WP_UnitTestCase_Blocks {
 			2172 => new WC_Product( 2172, 'simple', [], '15', 'Monthly Donation' ),
 		];
 
-		$parent       = new WC_Order( [ new WC_Order_Item_Product( 2172, '15' ) ], 902 );
+		$parent       = new WC_Order( 902, '', [ new WC_Order_Item_Product( 2172, '15' ) ] );
 		$subscription = new WC_Subscription( [ new WC_Order_Item_Product( 2172, '15' ) ], $parent, 903 );
 
 		$data = Checkout_Data::get_checkout_data( $subscription );

--- a/plugins/newspack-blocks/tests/test-modal-checkout.php
+++ b/plugins/newspack-blocks/tests/test-modal-checkout.php
@@ -44,7 +44,6 @@ if ( ! function_exists( 'wcs_get_product_limitation' ) ) {
 }
 
 require_once __DIR__ . '/mocks/newspack-plugin-mocks.php';
-require_once __DIR__ . '/class-wc-order-stub.php';
 
 if ( ! function_exists( 'WC' ) ) {
 	/**

--- a/plugins/newspack-blocks/tests/test-tracking-data-events.php
+++ b/plugins/newspack-blocks/tests/test-tracking-data-events.php
@@ -7,7 +7,6 @@
 
 require_once __DIR__ . '/mocks/newspack-plugin-mocks.php';
 require_once __DIR__ . '/mocks/newspack-plugin-data-events-utils-mock.php';
-require_once __DIR__ . '/class-wc-order-stub.php';
 
 /**
  * Tests for the modal checkout Data Events tracking integration.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`PHPUnit / @automattic/newspack-blocks` fails on `main`. Two test files each defined `WC_Order` behind a `class_exists()` guard, so whichever the suite loaded first won and the other silently no-opped:

| | `tests/test-modal-checkout-data.php` | `tests/class-wc-order-stub.php` |
|---|---|---|
| Constructor | `( $items = [], $id = 900 )` | `( $id = 0, $order_key = '' )` |
| Methods | `get_id`, `get_items`, `get_meta` | `get_id`, `get_order_key` |

The data file sorts first, so the tests added with `newspack@6.48.18` ran against the wrong class: `get_order_key()` was undefined, and `new WC_Order( 123, 'wc_order_testkey' )` bound `$items = 123`, making the tracking callback return null instead of a payload.

This keeps one definition, carrying the union, loaded from `bootstrap.php` next to the other stubs — after the autoloader, so its guard can still yield to a real WooCommerce.

### How to test the changes in this Pull Request:

1. Check out `main`.
2. Run `n test-php` in `plugins/newspack-blocks`. Two tests fail.
3. Check out this branch.
4. Run `n test-php` again. All 170 tests pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? The two tests that could not run are the coverage; the existing suite already fails if the stub's shape drifts, verified by removing `get_order_key()` and watching it go red.
* [x] Have you successfully run tests with your changes locally? 170 tests, 354 assertions, 0 failures. PHPCS goes from 62 errors to 59, since the duplicate class is gone.

**Note on why `main` looks green:** `ci.yml` builds its job matrix from packages changed since the base ref, which for a push to `main` is the previous tip. Pushes after the breakage touched other packages, so the blocks jobs were never created. The last run that did create them — the `newspack@6.48.18` release merge — failed.