### PR TITLE
ci: notify Slack when CI breaks on main

### DIFF
--- a/.github/scripts/notify-ci-failure.sh
+++ b/.github/scripts/notify-ci-failure.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Slack notification for a CI run that broke on main, posted from the
+# "Notify CI failure" workflow.
+#
+# The message names the failing jobs, not just the run, because CI's matrix is
+# per-package: "PHPUnit / @automattic/newspack-blocks" says which package to
+# look at, where "CI failed" does not.
+#
+# A failure here must never fail the workflow — the notification is the whole
+# job, and a red run reporting a second red run helps nobody. Set
+# SLACK_DRY_RUN=1 to print the payload instead of posting.
+
+set -euo pipefail
+
+trap 'echo "[notify-ci-failure] WARNING: unexpected error in: ${BASH_COMMAND}. Skipping notification."; exit 0' ERR
+
+TOKEN="${SLACK_AUTH_TOKEN:-}"
+CHANNEL="${SLACK_CHANNEL_ID:-}"
+
+if [ -z "$TOKEN" ] || [ -z "$CHANNEL" ]; then
+  echo "[notify-ci-failure] No Slack token and/or channel. Skipping."
+  exit 0
+fi
+
+# Failing job names, one per line. A run cancelled before any job reported
+# leaves this empty, which the message handles rather than treating as an error.
+FAILED_JOBS=$(
+  gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs?per_page=100" --paginate \
+    --jq '.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled") | .name' \
+    2>/dev/null || true
+)
+
+# The aggregate job fails whenever anything under it does, so listing it beside
+# the real culprits adds a line that names nothing.
+FAILED_JOBS=$(printf '%s\n' "$FAILED_JOBS" | grep -vx 'CI OK' || true)
+
+# Build the payload in node so commit subjects and job names are escaped safely.
+PAYLOAD=$(
+  CHANNEL="$CHANNEL" \
+  FAILED_JOBS="$FAILED_JOBS" \
+  SERVER="${GITHUB_SERVER_URL:-https://github.com}" \
+  REPO="${GITHUB_REPOSITORY:-}" \
+  node -e '
+    const jobs = process.env.FAILED_JOBS.split("\n").map(s => s.trim()).filter(Boolean);
+    const server = process.env.SERVER.replace(/\/+$/, "");
+    const repo = process.env.REPO;
+    const branch = process.env.HEAD_BRANCH;
+    const sha = process.env.HEAD_SHA;
+    const shortSha = sha.slice(0, 9);
+    const conclusion = process.env.RUN_CONCLUSION;
+
+    const verb = conclusion === "timed_out" ? "timed out" : conclusion === "cancelled" ? "was cancelled" : "failed";
+    let text = `:rotating_light: CI ${verb} on \`${branch}\`: <${process.env.RUN_URL}|view the run>`;
+
+    if (jobs.length) {
+      text += "\n" + jobs.map(j => `• ${j}`).join("\n");
+    }
+
+    // From the event payload rather than git: the checkout is shallow, so the
+    // commit the run was for is usually not in it. First line only.
+    const subject = (process.env.COMMIT_SUBJECT || "").split("\n")[0].trim();
+    const author = (process.env.COMMIT_AUTHOR || "").trim();
+    const commitUrl = `${server}/${repo}/commit/${sha}`;
+    text += `\n<${commitUrl}|${shortSha}>`;
+    if (subject) {
+      text += ` ${subject}`;
+    }
+    if (author) {
+      text += ` (${author})`;
+    }
+
+    // Why this needs saying out loud: the next push that touches a different
+    // package produces a green run, and the breakage stops being visible
+    // anywhere until someone touches this package again.
+    text += "\nThis will not show up on later runs unless they change the same package.";
+
+    process.stdout.write(JSON.stringify({ channel: process.env.CHANNEL, text }));
+  '
+)
+
+if [ -n "${SLACK_DRY_RUN:-}" ]; then
+  echo "[notify-ci-failure] DRY RUN -- would post to Slack:"
+  echo "$PAYLOAD"
+  exit 0
+fi
+
+RESPONSE=$(
+  curl -sS \
+    --data "$PAYLOAD" \
+    -H 'Content-type: application/json; charset=utf-8' \
+    -H "Authorization: Bearer $TOKEN" \
+    -X POST https://slack.com/api/chat.postMessage
+) || {
+  echo "[notify-ci-failure] WARNING: curl to Slack failed."
+  exit 0
+}
+
+if echo "$RESPONSE" | grep -q '"ok":true'; then
+  echo "[notify-ci-failure] Notified Slack about run ${RUN_ID}."
+else
+  echo "[notify-ci-failure] WARNING: Slack notification failed: $RESPONSE"
+fi
+exit 0

--- a/.github/workflows/notify-ci-failure.yml
+++ b/.github/workflows/notify-ci-failure.yml
@@ -1,0 +1,51 @@
+name: Notify CI failure
+
+# CI's job matrix is computed from the packages a push changes, so a package
+# whose tests break on main stays broken and invisible: later pushes that touch
+# other packages never create its jobs, and the run they do create reports
+# green. The failing run is the only signal, and nothing consumed it — this
+# turns it into a Slack message.
+#
+# workflow_run rather than a job inside ci.yml: it fires on the run's own
+# conclusion, so it still reports when a failure early in the graph leaves the
+# aggregate job skipped rather than failed, and it keeps the critical CI path
+# unchanged.
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+    branches: [main]
+
+# Reading the run's jobs is what lets the message name the failing ones.
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  notify:
+    name: Notify Slack
+    # Only pushes: a pull_request run is already reported on its PR, where
+    # someone is looking. `skipped` and `neutral` are not breakage.
+    if: >-
+      github.event.workflow_run.event == 'push' &&
+      contains(fromJSON('["failure", "timed_out", "cancelled"]'), github.event.workflow_run.conclusion)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Notify Slack of the failure
+        env:
+          # Reused from the release notifier and the legacy sync (a8c
+          # workspace). Unset on forks, where the script no-ops.
+          SLACK_AUTH_TOKEN: ${{ secrets.SLACK_AUTH_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          # From the event rather than the checkout, which is shallow and so
+          # rarely contains the commit the run was for.
+          COMMIT_SUBJECT: ${{ github.event.workflow_run.head_commit.message }}
+          COMMIT_AUTHOR: ${{ github.event.workflow_run.head_commit.author.name }}
+        run: ./.github/scripts/notify-ci-failure.sh


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

CI builds its job matrix from the packages a push changes, so a package that breaks on `main` goes quiet: later pushes touching other packages never create its jobs, and the run they do create reports green. The failing run is the only signal there is, and nothing consumes it.

This posts that run to Slack, naming the failing jobs — the matrix is per-package, so `PHPUnit / @automattic/newspack-blocks` says where to look where "CI failed" does not.

`workflow_run` rather than a job inside `ci.yml`: it fires on the run's own conclusion, so it still reports when a failure early in the graph leaves `CI OK` skipped rather than failed. Credentials are the a8c-workspace pair the release notifier already uses.

Scoped to `main` pushes; pull-request runs are already reported on the PR. #975 fixes the instance that prompted this.

### How to test the changes in this Pull Request:

`workflow_run` only fires from the default branch, so this starts working when it merges, not on this PR. The script runs standalone against any real run:

1. Check out this branch.
2. Run the command below. It targets the run that broke `main`.
3. Confirm the printed payload names `PHPUnit / @automattic/newspack-blocks` and links the run and the commit.

```sh
SLACK_DRY_RUN=1 SLACK_AUTH_TOKEN=x SLACK_CHANNEL_ID=x \
  GITHUB_REPOSITORY=Automattic/newspack-workspace \
  RUN_ID=32908197617 \
  RUN_URL=https://github.com/Automattic/newspack-workspace/actions/runs/32908197617 \
  RUN_CONCLUSION=failure HEAD_BRANCH=main \
  HEAD_SHA=7013787a1b5d6ed93f5a61f151938467a37bd57f \
  COMMIT_SUBJECT="chore(release): merge in release newspack@6.48.18" \
  COMMIT_AUTHOR="newspack-release-bot" \
  ./.github/scripts/notify-ci-failure.sh
```

Produces:

> :rotating_light: CI failed on `main`: view the run
> • PHPUnit / @automattic/newspack-blocks
> `7013787a1` chore(release): merge in release newspack@6.48.18 (newspack-release-bot)
> This will not show up on later runs unless they change the same package.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? `.github/scripts/` has no spec harness, so this follows `notify-release.sh`; the dry run above covers the failing, no-failing-jobs and cancelled paths.
* [x] Have you successfully run tests with your changes locally?

A failure in the notifier never fails the workflow — an alert about a red run that itself goes red helps nobody. It also no-ops when the credentials are absent, as on forks.
