### PR TITLE
chore(tests): give the mocks one WC_Memberships declaration instead of two

### DIFF
--- a/plugins/newspack-plugin/tests/mocks/wc-memberships-active-mock.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-memberships-active-mock.php
@@ -11,9 +11,7 @@
  * @package Newspack\Tests
  */
 
-if ( ! class_exists( 'WC_Memberships' ) ) {
-	class WC_Memberships {}
-}
+require_once __DIR__ . '/wc-memberships-class-mock.php';
 
 if ( ! function_exists( 'wc_memberships' ) ) {
 	function wc_memberships() {

--- a/plugins/newspack-plugin/tests/mocks/wc-memberships-class-mock.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-memberships-class-mock.php
@@ -1,0 +1,16 @@
+<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Squiz.Commenting.ClassComment.Missing, WordPress.NamingConventions.PrefixAllGlobals
+/**
+ * The `WC_Memberships` class alone, in the global namespace, which is where
+ * Newspack\Memberships::is_active() looks for it.
+ *
+ * Two mock files need it and neither can hold it: `wc-memberships-mocks.php`
+ * brings a whole membership store with it, and `wc-memberships-active-mock.php`
+ * is deliberately minimal for isolated tests. Declaring it in both is a
+ * duplicate class name, which PHPCS reports and CI treats as a failure.
+ *
+ * @package Newspack\Tests
+ */
+
+if ( ! class_exists( 'WC_Memberships' ) ) {
+	class WC_Memberships {}
+}

--- a/plugins/newspack-plugin/tests/mocks/wc-memberships-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-memberships-mocks.php
@@ -26,9 +26,7 @@ $wc_memberships_plan_subscription_products = [];
 $wc_memberships_membership_subscriptions = [];
 
 // Satisfies Memberships::is_active()'s class_exists( 'WC_Memberships' ) check.
-if ( ! class_exists( 'WC_Memberships' ) ) {
-	class WC_Memberships {}
-}
+require_once __DIR__ . '/wc-memberships-class-mock.php';
 
 /**
  * A membership plan: knows which product IDs grant it.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`PHPCS / newspack` fails on `main`. `tests/mocks/wc-memberships-active-mock.php` and `tests/mocks/wc-memberships-mocks.php` both declare `class WC_Memberships`, which `Generic.Classes.DuplicateClassName` reports and this repo's CI treats as a failure. The `class_exists()` guards make it safe at runtime, but the sniff is static and does not read them.

Neither file can own the declaration: one carries a whole membership store, the other is deliberately minimal for isolated tests. So it moves to `tests/mocks/wc-memberships-class-mock.php` and both `require_once` it.

Whether the sniff fires depends on how PHPCS distributes files across its eight parallel workers, so it passed on the PR that introduced the second copy and started failing afterwards.

### How to test the changes in this Pull Request:

1. Check out `main`.
2. Run `./vendor/bin/phpcs --standard=phpcs.xml --parallel=1 plugins/newspack-plugin/tests/mocks/` from the repository root.
3. Confirm the duplicate class name warning.
4. Check out this branch.
5. Run the same command. Confirm it is clean.
6. Run `n test-php` in `plugins/newspack-plugin`. Confirm the suite passes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- 3505 tests, 9969 assertions, 9 skipped, 0 failures. -->