### PR TITLE
fix(network): describe the images the receiving site actually stores

### DIFF
--- a/plugins/newspack-network/includes/class-content-distribution.php
+++ b/plugins/newspack-network/includes/class-content-distribution.php
@@ -478,7 +478,7 @@ class Content_Distribution {
 	 * @param WP_Post|Outgoing_Post|int $post              The post object or ID.
 	 * @param string                    $status_on_publish The post status on publish. Default is draft.
 	 *
-	 * @return void
+	 * @return void|WP_Error The error if the dispatch failed.
 	 */
 	public static function distribute_post( $post, $status_on_publish = 'draft' ) {
 		if ( ! class_exists( 'Newspack\Data_Events' ) ) {
@@ -497,7 +497,16 @@ class Content_Distribution {
 			if ( get_post_meta( $post->ID, self::PAYLOAD_HASH_META, true ) === $payload_hash ) {
 				return;
 			}
-			Data_Events::dispatch( 'network_post_updated', $payload );
+			$dispatched = Data_Events::dispatch( 'network_post_updated', $payload );
+
+			// The stored hash is the record of what the receiving site has, so it can
+			// only be written once the update is actually on its way. Storing it after
+			// a failed dispatch marks the post as delivered and every later save then
+			// short-circuits on the matching hash, leaving the post silently stale.
+			if ( is_wp_error( $dispatched ) ) {
+				return $dispatched;
+			}
+
 			// Store payload hash to prevent unnecessary updates.
 			update_post_meta( $post->ID, self::PAYLOAD_HASH_META, $payload_hash );
 		}
@@ -509,7 +518,7 @@ class Content_Distribution {
 	 * @param WP_Post|Outgoing_Post|int $post           The post object or ID.
 	 * @param string[]                  $post_data_keys The post data keys to update.
 	 *
-	 * @return void|WP_Error The error if the payload is invalid.
+	 * @return void|WP_Error The error if the payload is invalid or the dispatch failed.
 	 */
 	public static function distribute_post_partial( $post, $post_data_keys ) {
 		if ( ! class_exists( 'Newspack\Data_Events' ) ) {
@@ -524,17 +533,27 @@ class Content_Distribution {
 			$distributed_post = self::get_distributed_post( $post );
 		}
 		if ( $distributed_post ) {
-			$payload_hash = $distributed_post->get_payload_hash();
+			// The hash covers the whole payload, and the partial is a slice of that
+			// same payload, so build it once and use it for both.
+			$full_payload = $distributed_post->get_payload();
+			$payload_hash = $distributed_post->get_payload_hash( $full_payload );
 			$post         = $distributed_post->get_post();
 			// Skip if the payload hash is the same.
 			if ( get_post_meta( $post->ID, self::PAYLOAD_HASH_META, true ) === $payload_hash ) {
 				return;
 			}
-			$payload = $distributed_post->get_partial_payload( $post_data_keys );
+			$payload = $distributed_post->get_partial_payload( $post_data_keys, $full_payload );
 			if ( is_wp_error( $payload ) ) {
 				return $payload;
 			}
-			Data_Events::dispatch( 'network_post_updated', $payload );
+			$dispatched = Data_Events::dispatch( 'network_post_updated', $payload );
+
+			// See distribute_post(): the hash records what was delivered, so a failed
+			// dispatch must leave it alone.
+			if ( is_wp_error( $dispatched ) ) {
+				return $dispatched;
+			}
+
 			// Store payload hash to prevent unnecessary updates.
 			update_post_meta( $post->ID, self::PAYLOAD_HASH_META, $payload_hash );
 		}

--- a/plugins/newspack-network/includes/content-distribution/blocks/class-blocks.php
+++ b/plugins/newspack-network/includes/content-distribution/blocks/class-blocks.php
@@ -7,8 +7,6 @@
 
 namespace Newspack_Network\Content_Distribution;
 
-use Newspack_Network\Debugger;
-
 /**
  * Blocks class.
  */
@@ -192,12 +190,15 @@ class Blocks {
 			! function_exists( 'block_core_gallery_resolve_dynamic_source' ) ||
 			! function_exists( 'block_core_gallery_dynamic_image_link_attributes' )
 		) {
-			Debugger::log( 'Dynamic gallery found on a WordPress older than 7.1, flattening to an empty gallery.' );
+			Outgoing_Post::log(
+				'Dynamic gallery found on a WordPress older than 7.1, flattening to an empty gallery.',
+				[ 'post_id' => $post_id ]
+			);
 			return self::flatten_gallery( $block, [] );
 		}
 
 		if ( ! $post_id ) {
-			Debugger::log( 'Dynamic gallery: no post ID given, flattening to an empty gallery.' );
+			Outgoing_Post::log( 'Dynamic gallery: no post ID given, flattening to an empty gallery.' );
 			return self::flatten_gallery( $block, [] );
 		}
 
@@ -207,7 +208,10 @@ class Blocks {
 		);
 
 		if ( empty( $attachment_ids ) ) {
-			Debugger::log( sprintf( 'Dynamic gallery on post %d resolved no images.', $post_id ) );
+			// Not an error. Core renders nothing for a gallery whose source resolves to
+			// nothing, and this fires on every distribution of such a post, before the
+			// payload hash has had a chance to skip a no-op update.
+			Outgoing_Post::log( 'Dynamic gallery resolved no images.', [ 'post_id' => $post_id ], 'debug' );
 			return self::flatten_gallery( $block, [] );
 		}
 
@@ -233,10 +237,19 @@ class Blocks {
 		remove_filter( 'jetpack_photon_override_image_downsize', '__return_true' );
 
 		if ( empty( $image_blocks ) ) {
-			Debugger::log( sprintf( 'Dynamic gallery on post %d resolved %d images, none of which produced markup.', $post_id, count( $attachment_ids ) ) );
+			Outgoing_Post::log(
+				'Dynamic gallery resolved images, none of which produced markup.',
+				[
+					'post_id'        => $post_id,
+					'attachment_ids' => $attachment_ids,
+				]
+			);
 		}
 
-		return self::flatten_gallery( $block, $image_blocks );
+		// The images resolved, so the gallery keeps its caption whether or not any
+		// of them produced markup. Core does the same: only an unresolved source
+		// drops the caption.
+		return self::flatten_gallery( $block, $image_blocks, true );
 	}
 
 	/**
@@ -250,10 +263,11 @@ class Blocks {
 	 *
 	 * @param array $block        The original dynamic gallery block.
 	 * @param array $image_blocks The image blocks to nest, possibly empty.
+	 * @param bool  $keep_caption Whether the gallery caption should survive.
 	 *
 	 * @return array The flattened gallery block.
 	 */
-	private static function flatten_gallery( $block, $image_blocks ) {
+	private static function flatten_gallery( $block, $image_blocks, $keep_caption = false ) {
 		$attrs = $block['attrs'];
 		unset( $attrs['dynamicContent'] );
 
@@ -267,8 +281,8 @@ class Blocks {
 
 		// In dynamic mode `save.js` persists at most the gallery caption, so the
 		// block's own inner HTML is that `<figcaption>` or nothing. Core appends it
-		// after the images, and drops it when there are no images to caption.
-		$caption = $image_blocks ? trim( $block['innerHTML'] ?? '' ) : '';
+		// after the images, and drops it only when the source resolved to nothing.
+		$caption = $keep_caption ? trim( $block['innerHTML'] ?? '' ) : '';
 
 		$opening       = sprintf( '<figure %s>', $wrapper );
 		$closing       = $caption . '</figure>';

--- a/plugins/newspack-network/includes/content-distribution/class-outgoing-post.php
+++ b/plugins/newspack-network/includes/content-distribution/class-outgoing-post.php
@@ -8,6 +8,7 @@
 namespace Newspack_Network\Content_Distribution;
 
 use Newspack_Network\Content_Distribution as Content_Distribution_Class;
+use Newspack_Network\Debugger;
 use Newspack_Network\User_Update_Watcher;
 use Newspack_Network\Utils\Network;
 use WP_Error;
@@ -28,6 +29,13 @@ class Outgoing_Post {
 	 * @var WP_Post
 	 */
 	protected $post = null;
+
+	/**
+	 * The post content prepared for distribution, built once per payload.
+	 *
+	 * @var string|null
+	 */
+	protected $raw_post_content = null;
 
 	/**
 	 * Constructor.
@@ -99,6 +107,40 @@ class Outgoing_Post {
 	 */
 	public function get_post() {
 		return $this->post;
+	}
+
+	/**
+	 * Log a message about a post on its way out.
+	 *
+	 * Sends the message to the Newspack plugin's logger, which records without any
+	 * constant set, so a gallery that leaves without its images no longer does so
+	 * silently on a publisher site. This mirrors Incoming_Post::log().
+	 *
+	 * The debugger runs as well rather than instead. Newspack\Logger only fires an
+	 * action, and the plugin that listens for it is not present on a development or
+	 * staging site, so preferring one over the other would swallow the message in
+	 * exactly the setup someone defines `NEWSPACK_NETWORK_DEBUG` for. Debugger::log()
+	 * is a no-op without that constant, so running both costs nothing.
+	 *
+	 * @param string $message The message to log.
+	 * @param array  $context Context for the log entry, such as the post ID.
+	 * @param string $type    The log type. Either 'error' or 'debug'. Default 'error'.
+	 *
+	 * @return void
+	 */
+	public static function log( $message, $context = [], $type = 'error' ) {
+		if ( method_exists( 'Newspack\Logger', 'newspack_log' ) ) {
+			\Newspack\Logger::newspack_log( 'newspack_network_outgoing_post', $message, $context, $type );
+		}
+
+		$prefix = '[Outgoing Post]';
+		if ( ! empty( $context['post_id'] ) ) {
+			$prefix .= ' ' . $context['post_id'];
+			unset( $context['post_id'] );
+		}
+		$suffix = empty( $context ) ? '' : ' ' . wp_json_encode( $context );
+
+		Debugger::log( $prefix . ' ' . $message . $suffix );
 	}
 
 	/**
@@ -305,6 +347,11 @@ class Outgoing_Post {
 	 * @return array|WP_Error The post payload or WP_Error if the post is invalid.
 	 */
 	public function get_payload( $status_on_publish = 'draft' ) {
+		// One payload describes the post at one moment. Preparing the content is the
+		// expensive half and several fields below need it, so it is built once here
+		// and reused, then dropped so the next payload sees the post as it is then.
+		$this->raw_post_content = null;
+
 		$post_author = self::get_outgoing_wp_user_author( $this->post->post_author );
 
 		$payload = [
@@ -352,17 +399,22 @@ class Outgoing_Post {
 	/**
 	 * Get a partial payload for distribution.
 	 *
-	 * @param string[] $post_data_keys Keys in the post_data array to include in
-	 *                                 the partial payload.
+	 * @param string[]   $post_data_keys Keys in the post_data array to include in
+	 *                                   the partial payload.
+	 * @param array|null $payload        A payload already built for this post, to
+	 *                                   take the partial from rather than building
+	 *                                   a second identical one.
 	 *
 	 * @return array|WP_Error The partial payload or WP_Error if any of the keys were not found.
 	 */
-	public function get_partial_payload( $post_data_keys ) {
+	public function get_partial_payload( $post_data_keys, $payload = null ) {
 		if ( is_string( $post_data_keys ) ) {
 			$post_data_keys = [ $post_data_keys ];
 		}
 
-		$payload = $this->get_payload();
+		if ( empty( $payload ) ) {
+			$payload = $this->get_payload();
+		}
 		foreach ( $post_data_keys as $post_data_key ) {
 			if ( ! isset( $payload['post_data'][ $post_data_key ] ) ) {
 				return new WP_Error( 'key_not_found', __( 'Key not found in payload.', 'newspack-network' ) );
@@ -389,15 +441,24 @@ class Outgoing_Post {
 	/**
 	 * Get the raw post content for distribution.
 	 *
+	 * Built once per payload. Several payload fields read it, and a dynamic gallery
+	 * queries the database for its images on each pass, so a distribution used to
+	 * parse and serialize the post several times for one identical result.
+	 *
+	 * The payload is the boundary the cache follows: get_payload() drops it on the
+	 * way in, so two payloads from one Outgoing_Post each see the post as it stands
+	 * when they are built, and everything within one payload agrees.
+	 *
 	 * @return string The raw post content.
 	 */
 	protected function get_raw_post_content() {
-		if ( ! use_block_editor_for_post_type( $this->post->post_type ) ) {
-			return $this->post->post_content;
+		if ( null !== $this->raw_post_content ) {
+			return $this->raw_post_content;
 		}
 
-		if ( ! has_blocks( $this->post->post_content ) ) {
-			return $this->post->post_content;
+		if ( ! use_block_editor_for_post_type( $this->post->post_type ) || ! has_blocks( $this->post->post_content ) ) {
+			$this->raw_post_content = $this->post->post_content;
+			return $this->raw_post_content;
 		}
 
 		$post_id = $this->post->ID;
@@ -408,7 +469,9 @@ class Outgoing_Post {
 			parse_blocks( $this->post->post_content )
 		);
 
-		return serialize_blocks( $blocks );
+		$this->raw_post_content = serialize_blocks( $blocks );
+
+		return $this->raw_post_content;
 	}
 
 	/**

--- a/plugins/newspack-network/includes/content-distribution/class-outgoing-post.php
+++ b/plugins/newspack-network/includes/content-distribution/class-outgoing-post.php
@@ -528,8 +528,13 @@ class Outgoing_Post {
 			];
 		}
 
-		$content     = apply_filters( 'the_content', get_the_content( null, false, get_post( $this->post->ID ) ) );
-		$attachments = self::get_content_attachments( $content );
+		// Read the images out of the content that is actually being distributed.
+		// Blocks are rewritten on their way out, so the original content and the
+		// distributed content can name different images, and an image the node
+		// can't find here opens its lightbox at the wrong size. Scanning the raw
+		// content also keeps out images that only exist because a `the_content`
+		// filter injected them, such as ads or related posts.
+		$attachments = self::get_content_attachments( $this->get_raw_post_content() );
 		foreach ( $attachments as $attachment ) {
 			if ( isset( $attachment_data[ $attachment->ID ] ) ) {
 				continue;

--- a/plugins/newspack-network/includes/content-distribution/class-outgoing-post.php
+++ b/plugins/newspack-network/includes/content-distribution/class-outgoing-post.php
@@ -500,12 +500,40 @@ class Outgoing_Post {
 	}
 
 	/**
+	 * The content the receiving site will end up storing.
+	 *
+	 * `media_data` describes the images in the post so the receiving site can size
+	 * them, which only works if it describes the images that site actually has. The
+	 * two ends have to agree on which content that is: Incoming_Post::get_post_content()
+	 * keeps the block-processed content for a block post and the filtered content
+	 * for a classic one, so this branches the same way. Reading the original post
+	 * content instead, as this used to, misses a block rewritten on its way out,
+	 * a WordPress 7.1 dynamic gallery above all, since it carries no image IDs
+	 * until distribution resolves it.
+	 *
+	 * @return string The content the receiving site will store.
+	 */
+	protected function get_distributed_content() {
+		if ( use_block_editor_for_post_type( $this->post->post_type ) && has_blocks( $this->post->post_content ) ) {
+			return $this->get_raw_post_content();
+		}
+
+		return $this->get_processed_post_content();
+	}
+
+	/**
 	 * Get the post attachment data for distribution.
 	 *
 	 * @return array The post attachment data.
 	 */
 	protected function get_post_media_data() {
 		$attachment_data = [];
+
+		// Read the content before the CDN override goes on. Preparing it can run a
+		// block processor that installs and removes this same filter, and WordPress
+		// keys hook callbacks by name, so the inner removal would take this one with
+		// it and the URLs below would come back rewritten to the origin's CDN.
+		$content = $this->get_distributed_content();
 
 		add_filter( 'jetpack_photon_override_image_downsize', '__return_true' );
 
@@ -528,13 +556,7 @@ class Outgoing_Post {
 			];
 		}
 
-		// Read the images out of the content that is actually being distributed.
-		// Blocks are rewritten on their way out, so the original content and the
-		// distributed content can name different images, and an image the node
-		// can't find here opens its lightbox at the wrong size. Scanning the raw
-		// content also keeps out images that only exist because a `the_content`
-		// filter injected them, such as ads or related posts.
-		$attachments = self::get_content_attachments( $this->get_raw_post_content() );
+		$attachments = self::get_content_attachments( $content );
 		foreach ( $attachments as $attachment ) {
 			if ( isset( $attachment_data[ $attachment->ID ] ) ) {
 				continue;

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-content-distribution.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-content-distribution.php
@@ -7,6 +7,9 @@
 
 namespace Test\Content_Distribution;
 
+require_once __DIR__ . '/mock-data-events.php';
+
+use Newspack\Data_Events;
 use Newspack_Network\Content_Distribution as Content_Distribution_Class;
 use Newspack_Network\Content_Distribution\Outgoing_Post;
 use Newspack_Network\Hub\Node as Hub_Node;
@@ -41,6 +44,27 @@ class TestContentDistribution extends \WP_UnitTestCase {
 
 		// "Mock" the network node(s).
 		update_option( Hub_Node::HUB_NODES_SYNCED_OPTION, $this->network );
+
+		Data_Events::$mock_dispatch_return = true;
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		Data_Events::$mock_dispatch_return = true;
+		parent::tear_down();
+	}
+
+	/**
+	 * A post set up for distribution to the first node.
+	 *
+	 * @return Outgoing_Post
+	 */
+	private function distributed_post() {
+		$outgoing_post = new Outgoing_Post( $this->factory->post->create() );
+		$outgoing_post->set_distribution( [ $this->network[0]['url'] ] );
+		return $outgoing_post;
 	}
 
 	/**
@@ -97,5 +121,49 @@ class TestContentDistribution extends \WP_UnitTestCase {
 		$queue = Content_Distribution_Class::get_queued_distributions();
 		// Assert that the post is still queued for full distribution.
 		$this->assertTrue( $queue[ $post_id ] );
+	}
+
+	/**
+	 * The stored payload hash is the record of what the receiving site has, so a
+	 * dispatch that failed must not leave one behind. Storing it anyway marks the
+	 * post as delivered, and every later save then short-circuits on the matching
+	 * hash, so the update never reaches the node.
+	 */
+	public function test_failed_dispatch_does_not_store_the_payload_hash() {
+		$outgoing_post = $this->distributed_post();
+		$post_id       = $outgoing_post->get_post()->ID;
+
+		Data_Events::$mock_dispatch_return = new \WP_Error( 'dispatch_cancelled', 'Dispatch cancelled.' );
+
+		$result = Content_Distribution_Class::distribute_post( $outgoing_post );
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertEmpty( get_post_meta( $post_id, Content_Distribution_Class::PAYLOAD_HASH_META, true ) );
+
+		// With the dispatch working again, the same post still distributes.
+		Data_Events::$mock_dispatch_return = true;
+		Content_Distribution_Class::distribute_post( $outgoing_post );
+
+		$this->assertNotEmpty( get_post_meta( $post_id, Content_Distribution_Class::PAYLOAD_HASH_META, true ) );
+	}
+
+	/**
+	 * The same holds for a partial distribution.
+	 */
+	public function test_failed_partial_dispatch_does_not_store_the_payload_hash() {
+		$outgoing_post = $this->distributed_post();
+		$post_id       = $outgoing_post->get_post()->ID;
+
+		Data_Events::$mock_dispatch_return = new \WP_Error( 'dispatch_cancelled', 'Dispatch cancelled.' );
+
+		$result = Content_Distribution_Class::distribute_post_partial( $outgoing_post, 'post_meta' );
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertEmpty( get_post_meta( $post_id, Content_Distribution_Class::PAYLOAD_HASH_META, true ) );
+
+		Data_Events::$mock_dispatch_return = true;
+		Content_Distribution_Class::distribute_post_partial( $outgoing_post, 'post_meta' );
+
+		$this->assertNotEmpty( get_post_meta( $post_id, Content_Distribution_Class::PAYLOAD_HASH_META, true ) );
 	}
 }

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-dynamic-gallery.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-dynamic-gallery.php
@@ -341,4 +341,35 @@ class TestDynamicGallery extends \WP_UnitTestCase {
 		$blocks = parse_blocks( $markup );
 		$this->assertSame( $markup, serialize_blocks( [ Blocks::process_outgoing_block( $blocks[0], $this->post_id ) ] ) );
 	}
+
+	/**
+	 * A gallery whose images resolve but produce no markup keeps its caption, the
+	 * way core's own render does. Only an unresolved source drops it.
+	 */
+	public function test_keeps_the_caption_when_no_image_produces_markup() {
+		$this->requires_dynamic_galleries();
+
+		$caption = '<figcaption class="blocks-gallery-caption wp-element-caption">Scenes from the parade</figcaption>';
+
+		add_filter( 'wp_get_attachment_image_src', '__return_false' );
+		$output = $this->flatten( $this->dynamic_gallery( [], $caption ) );
+		remove_filter( 'wp_get_attachment_image_src', '__return_false' );
+
+		$this->assertStringNotContainsString( '<!-- wp:image ', $output, 'No image should have produced markup.' );
+		$this->assertStringContainsString( 'Scenes from the parade', $output );
+	}
+
+	/**
+	 * A gallery that resolves nothing at all has no images to caption, so the
+	 * caption goes with them.
+	 */
+	public function test_drops_the_caption_when_nothing_resolves() {
+		$this->requires_dynamic_galleries();
+
+		$caption = '<figcaption class="blocks-gallery-caption wp-element-caption">Scenes from the parade</figcaption>';
+		$empty   = self::factory()->post->create();
+		$output  = serialize_blocks( [ Blocks::process_outgoing_block( $this->dynamic_gallery( [], $caption ), $empty ) ] );
+
+		$this->assertStringNotContainsString( 'Scenes from the parade', $output );
+	}
 }

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-outgoing-post.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-outgoing-post.php
@@ -7,6 +7,7 @@
 
 namespace Test\Content_Distribution;
 
+use Newspack_Network\Content_Distribution\Blocks;
 use Newspack_Network\Content_Distribution\Outgoing_Post;
 use Newspack_Network\Hub\Node as Hub_Node;
 use WP_User;
@@ -577,5 +578,91 @@ class TestOutgoingPost extends \WP_UnitTestCase {
 			$this->assertSame( 900, $media_data[ $attachment_id ]['width'] );
 			$this->assertSame( 600, $media_data[ $attachment_id ]['height'] );
 		}
+	}
+
+	/**
+	 * A classic post is stored on the receiving site as filtered content, so an
+	 * image a shortcode or a filter puts there has to be described too. Scanning
+	 * the block-processed content alone would leave the node rendering an image
+	 * the payload says nothing about.
+	 */
+	public function test_media_data_covers_a_classic_post() {
+		$shortcode_image = $this->image_attachment();
+
+		add_shortcode(
+			'np_test_image',
+			function () use ( $shortcode_image ) {
+				return '<img src="http://example.org/shortcode.png" class="wp-image-' . $shortcode_image . '"/>';
+			}
+		);
+
+		$outgoing_post = $this->outgoing_post_with_content( 'Before. [np_test_image] After.' );
+		$media_data    = $outgoing_post->get_payload()['post_data']['media_data'];
+
+		remove_shortcode( 'np_test_image' );
+
+		$this->assertArrayHasKey( $shortcode_image, $media_data );
+	}
+
+	/**
+	 * Media discovery follows the content after the block processors have run, not
+	 * the content as authored. Pinned with a processor rather than a gallery so it
+	 * holds on every WordPress version.
+	 */
+	public function test_media_data_follows_the_processed_blocks() {
+		$authored     = $this->image_attachment();
+		$distributed  = $this->image_attachment();
+		$replacement  = $this->image_block( $distributed );
+
+		Blocks::register_block_processor(
+			'core/image',
+			function () use ( $replacement ) {
+				return parse_blocks( $replacement )[0];
+			}
+		);
+
+		$outgoing_post = $this->outgoing_post_with_content( $this->image_block( $authored ) );
+		$media_data    = $outgoing_post->get_payload()['post_data']['media_data'];
+
+		Blocks::reset_block_processors( 'core/image' );
+
+		$this->assertArrayHasKey( $distributed, $media_data, 'The image that reaches the node should be described.' );
+		$this->assertArrayNotHasKey( $authored, $media_data, 'The image the processor replaced should not be.' );
+	}
+
+	/**
+	 * Every media URL in the payload is read with the image-CDN override in place,
+	 * so a node gets the origin's own files rather than the origin's CDN.
+	 *
+	 * The override is a single named callback, and WordPress keys hooks by name, so
+	 * a block processor that installs and removes the same one, as the dynamic
+	 * gallery processor does, used to take this method's override down with it.
+	 */
+	public function test_media_data_keeps_the_cdn_override_for_every_image() {
+		Blocks::register_block_processor(
+			'core/image',
+			function ( $block ) {
+				add_filter( 'jetpack_photon_override_image_downsize', '__return_true' );
+				remove_filter( 'jetpack_photon_override_image_downsize', '__return_true' );
+				return $block;
+			}
+		);
+
+		// Fires once per media_data entry, and nowhere else in a payload build.
+		$overridden = [];
+		$probe      = function ( $caption ) use ( &$overridden ) {
+			$overridden[] = has_filter( 'jetpack_photon_override_image_downsize', '__return_true' );
+			return $caption;
+		};
+		add_filter( 'wp_get_attachment_caption', $probe );
+
+		$outgoing_post = $this->outgoing_post_with_content( $this->image_block( $this->image_attachment() ) );
+		$outgoing_post->get_payload();
+
+		remove_filter( 'wp_get_attachment_caption', $probe );
+		Blocks::reset_block_processors( 'core/image' );
+
+		$this->assertNotEmpty( $overridden, 'The probe should have seen at least one image.' );
+		$this->assertNotContains( false, $overridden );
 	}
 }

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-outgoing-post.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-outgoing-post.php
@@ -445,4 +445,137 @@ class TestOutgoingPost extends \WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'title', $partial_payload['post_data'] );
 		$this->assertArrayNotHasKey( 'content', $partial_payload['post_data'] );
 	}
+
+	/**
+	 * An attachment carrying dimensions, so media_data holds real sizes rather
+	 * than the 'none' the node's lightbox falls back to.
+	 *
+	 * @param int $post_parent The post to attach it to.
+	 * @param int $width       The image width.
+	 * @param int $height      The image height.
+	 *
+	 * @return int The attachment ID.
+	 */
+	private function image_attachment( $post_parent = 0, $width = 1200, $height = 800 ) {
+		$attachment_id = $this->factory->attachment->create_object(
+			[
+				'file'           => 'media-data-' . wp_rand() . '.png',
+				'post_parent'    => $post_parent,
+				'post_mime_type' => 'image/png',
+			]
+		);
+
+		wp_update_attachment_metadata(
+			$attachment_id,
+			[
+				'file'   => 'media-data.png',
+				'width'  => $width,
+				'height' => $height,
+			]
+		);
+
+		return $attachment_id;
+	}
+
+	/**
+	 * An image block in the shape the editor saves it.
+	 *
+	 * @param int $attachment_id The attachment ID.
+	 *
+	 * @return string The block markup.
+	 */
+	private function image_block( $attachment_id ) {
+		return sprintf(
+			'<!-- wp:image {"id":%1$d,"sizeSlug":"large"} --><figure class="wp-block-image size-large"><img src="%2$s" alt="" class="wp-image-%1$d"/></figure><!-- /wp:image -->',
+			$attachment_id,
+			wp_get_attachment_url( $attachment_id )
+		);
+	}
+
+	/**
+	 * A distributed post carrying the given content.
+	 *
+	 * @param string $content The post content.
+	 *
+	 * @return Outgoing_Post
+	 */
+	private function outgoing_post_with_content( $content ) {
+		$post = $this->factory->post->create_and_get(
+			[
+				'post_type'    => 'post',
+				'post_author'  => $this->some_editor->ID,
+				'post_content' => $content,
+			]
+		);
+
+		$outgoing_post = new Outgoing_Post( $post );
+		$outgoing_post->set_distribution( [ $this->network[0]['url'] ] );
+
+		return $outgoing_post;
+	}
+
+	/**
+	 * Every image in the distributed content is described in media_data, with the
+	 * dimensions the node needs to open it at full size.
+	 */
+	public function test_media_data_describes_the_content_images() {
+		$attachment_id = $this->image_attachment( 0, 1200, 800 );
+		$outgoing_post = $this->outgoing_post_with_content( $this->image_block( $attachment_id ) );
+
+		$media_data = $outgoing_post->get_payload()['post_data']['media_data'];
+
+		$this->assertArrayHasKey( $attachment_id, $media_data );
+		$this->assertSame( 1200, $media_data[ $attachment_id ]['width'] );
+		$this->assertSame( 800, $media_data[ $attachment_id ]['height'] );
+	}
+
+	/**
+	 * The payload follows the content being distributed, so an image that exists
+	 * only because a `the_content` filter injected it stays out of media_data.
+	 */
+	public function test_media_data_ignores_images_injected_by_filters() {
+		$in_content = $this->image_attachment();
+		$injected   = $this->image_attachment();
+
+		$inject = function ( $content ) use ( $injected ) {
+			return $content . '<img src="http://example.org/injected.png" class="wp-image-' . $injected . '"/>';
+		};
+		add_filter( 'the_content', $inject );
+
+		$outgoing_post = $this->outgoing_post_with_content( $this->image_block( $in_content ) );
+		$media_data    = $outgoing_post->get_payload()['post_data']['media_data'];
+
+		remove_filter( 'the_content', $inject );
+
+		$this->assertArrayHasKey( $in_content, $media_data );
+		$this->assertArrayNotHasKey( $injected, $media_data );
+	}
+
+	/**
+	 * The reported case. A WordPress 7.1 dynamic gallery stores no image IDs, so
+	 * the images it resolves to were missing from media_data and the node opened
+	 * them in its lightbox at unknown dimensions.
+	 */
+	public function test_media_data_covers_a_flattened_dynamic_gallery() {
+		if ( ! function_exists( 'block_core_gallery_resolve_dynamic_source' ) ) {
+			$this->markTestSkipped( 'Dynamic galleries require WordPress 7.1 or later; this suite runs ' . get_bloginfo( 'version' ) . '.' );
+		}
+
+		$outgoing_post = $this->outgoing_post_with_content(
+			'<!-- wp:gallery {"dynamicContent":{"source":"core/attached-media"}} --><!-- /wp:gallery -->'
+		);
+
+		$attachment_ids = [];
+		for ( $i = 0; $i < 3; $i++ ) {
+			$attachment_ids[] = $this->image_attachment( $outgoing_post->get_post()->ID, 900, 600 );
+		}
+
+		$media_data = $outgoing_post->get_payload()['post_data']['media_data'];
+
+		foreach ( $attachment_ids as $attachment_id ) {
+			$this->assertArrayHasKey( $attachment_id, $media_data );
+			$this->assertSame( 900, $media_data[ $attachment_id ]['width'] );
+			$this->assertSame( 600, $media_data[ $attachment_id ]['height'] );
+		}
+	}
 }

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-outgoing-post.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-outgoing-post.php
@@ -7,6 +7,9 @@
 
 namespace Test\Content_Distribution;
 
+require_once __DIR__ . '/mock-data-events.php';
+
+use Newspack_Network\Content_Distribution as Content_Distribution_Class;
 use Newspack_Network\Content_Distribution\Blocks;
 use Newspack_Network\Content_Distribution\Outgoing_Post;
 use Newspack_Network\Hub\Node as Hub_Node;
@@ -66,6 +69,20 @@ class TestOutgoingPost extends \WP_UnitTestCase {
 		);
 		$this->outgoing_post = new Outgoing_Post( $post );
 		$this->outgoing_post->set_distribution( [ $this->network[0]['url'] ] );
+	}
+
+	/**
+	 * Reset the block processors registered by the tests here.
+	 *
+	 * Blocks keeps them in a private static that the test framework does not
+	 * restore, so a test that registers one and then fails would leak it into every
+	 * test that follows.
+	 */
+	public function tear_down() {
+		foreach ( [ 'core/paragraph', 'core/image' ] as $block_name ) {
+			Blocks::reset_block_processors( $block_name );
+		}
+		parent::tear_down();
 	}
 
 	/**
@@ -610,9 +627,9 @@ class TestOutgoingPost extends \WP_UnitTestCase {
 	 * holds on every WordPress version.
 	 */
 	public function test_media_data_follows_the_processed_blocks() {
-		$authored     = $this->image_attachment();
-		$distributed  = $this->image_attachment();
-		$replacement  = $this->image_block( $distributed );
+		$authored    = $this->image_attachment();
+		$distributed = $this->image_attachment();
+		$replacement = $this->image_block( $distributed );
 
 		Blocks::register_block_processor(
 			'core/image',
@@ -623,8 +640,6 @@ class TestOutgoingPost extends \WP_UnitTestCase {
 
 		$outgoing_post = $this->outgoing_post_with_content( $this->image_block( $authored ) );
 		$media_data    = $outgoing_post->get_payload()['post_data']['media_data'];
-
-		Blocks::reset_block_processors( 'core/image' );
 
 		$this->assertArrayHasKey( $distributed, $media_data, 'The image that reaches the node should be described.' );
 		$this->assertArrayNotHasKey( $authored, $media_data, 'The image the processor replaced should not be.' );
@@ -660,9 +675,63 @@ class TestOutgoingPost extends \WP_UnitTestCase {
 		$outgoing_post->get_payload();
 
 		remove_filter( 'wp_get_attachment_caption', $probe );
-		Blocks::reset_block_processors( 'core/image' );
 
 		$this->assertNotEmpty( $overridden, 'The probe should have seen at least one image.' );
 		$this->assertNotContains( false, $overridden );
+	}
+
+	/**
+	 * Preparing the content for the wire is the expensive half of a payload, and a
+	 * payload reads it more than once. Doing it once keeps a dynamic gallery from
+	 * re-querying its images on every pass.
+	 */
+	public function test_content_is_prepared_once_per_payload() {
+		$calls = 0;
+		Blocks::register_block_processor(
+			'core/paragraph',
+			function ( $block ) use ( &$calls ) {
+				++$calls;
+				return $block;
+			}
+		);
+
+		$outgoing_post = $this->outgoing_post_with_content( '<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->' );
+		$outgoing_post->get_payload();
+
+		$this->assertSame( 1, $calls );
+	}
+
+	/**
+	 * A partial payload handed a payload takes its slice from that payload, rather
+	 * than quietly building a second one.
+	 */
+	public function test_partial_payload_comes_from_the_payload_it_is_given() {
+		$payload = $this->outgoing_post->get_payload();
+
+		$payload['post_data']['post_meta']['from_the_given_payload'] = [ 'yes' ];
+
+		$partial = $this->outgoing_post->get_partial_payload( 'post_meta', $payload );
+
+		$this->assertArrayHasKey( 'from_the_given_payload', $partial['post_data']['post_meta'] );
+		$this->assertSame( [ 'yes' ], $partial['post_data']['post_meta']['from_the_given_payload'] );
+	}
+
+	/**
+	 * A partial distribution builds one payload, not one for the change hash and a
+	 * second for the slice it sends.
+	 */
+	public function test_partial_distribution_builds_one_payload() {
+		$builds = 0;
+		$spy    = function ( $post_data ) use ( &$builds ) {
+			++$builds;
+			return $post_data;
+		};
+		add_filter( 'newspack_network_outgoing_payload_post_data', $spy );
+
+		Content_Distribution_Class::distribute_post_partial( $this->outgoing_post->get_post(), 'post_meta' );
+
+		remove_filter( 'newspack_network_outgoing_payload_post_data', $spy );
+
+		$this->assertSame( 1, $builds );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Five fixes on the outgoing side of content distribution. #982 was folded in here rather than merged separately.

**Distributed images opened at the wrong size.** A distributed post carries a description of its images so the receiving site can size them, and that description was built by re-rendering the original post content, which is not the content the receiving site ends up with. An image missing from it arrives without dimensions, so a reader clicking it gets a scaled copy in the lightbox where the same click on the origin opens the full-size file. Most visible on a WordPress 7.1 dynamic gallery, which carries no image IDs until distribution resolves it into images, so none of its images were described at all.

The description now comes from the content the receiving site will actually store, branching the same way the receiving side does: the block-processed content for a block post, the filtered content for a classic one. Images that exist only because a `the_content` filter injected them, such as ads or related posts, stop being described. Content after a "read more" or a page break, and every image in a password-protected post, start being described.

Reading that content also had to move above the image-CDN override this code installs. The dynamic gallery processor installs and removes the same named callback, and WordPress keys hooks by name, so the nested removal took the outer override down with it and the URLs after that point came back rewritten to the origin's CDN.

**One post save prepared the content for the wire six times.** Several payload fields need it, and a partial distribution built the whole payload twice, once for the change hash and once for the slice it sends. It is now prepared once per payload, and the partial takes its slice from the payload the hash already used, so a dynamic gallery stops re-querying its images on every pass.

**Outgoing logging was invisible in production.** It went through a debugger that writes nothing unless `NEWSPACK_NETWORK_DEBUG` is defined, so a gallery that left without its images left no trace of why. It now also reaches the Newspack plugin's logger, the way the receiving side already does. A gallery whose source resolves to nothing is logged as debug rather than error, since that is what an empty gallery normally is.

**A gallery whose images resolve but produce no markup keeps its caption**, matching what the origin shows.

**A distribution that failed to dispatch no longer records itself as delivered.** The stored payload hash is what tells the next save there is nothing to send, so writing it after a failed send left the post silently stale until someone edited it again. The editor's own distribute button already guarded this; the two background paths did not.

Closes NPPM-3181.

### How to test the changes in this Pull Request:

1. On a hub running WordPress 7.1, create a post and upload three images to it.
2. Remove the images from the content, leaving them attached to the post.
3. Insert a Gallery block, pick the images attached to the post, and add a gallery caption. Publish.
4. Distribute the post to a node, then pull it on the node. Images and caption match the hub.
5. Click a gallery image on the node. The lightbox opens the full-size file.
6. Click the same image on the hub. Both lightboxes open at the same size.
7. Repeat with a plain Image block, which should keep opening at full size.
8. Repeat with a classic-editor post holding a `[caption]` shortcode, which should also open at full size.
9. On the hub, change a custom field on the distributed post without touching the content.
10. Pull again on the node. The custom field follows and the content is unchanged.
11. Hook the `newspack_log` action on the hub, then distribute a gallery on a post with no attached images.
12. The action fires with code `newspack_network_outgoing_post`, no debug constant defined.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

An already-distributed post picks up the corrected image description on its next full distribution. If a background writer touches one of its post meta keys first, that sends a partial update and stores the new payload hash, which marks the correction as delivered without sending it. `wp newspack network distribute post <id>` forces it through per post. That partial-swallow behavior predates this PR and is left alone here.

Known gap: the Newspack logger branch of `Outgoing_Post::log()` is not covered by a test. Defining a `Newspack\Logger` mock would change which branch `Incoming_Post::log()` takes across the whole suite, so it needs its own test process rather than a mock file.
