### PR TITLE
feat(content-gate): prompt to verify when an email-domain rule denies (NPPD-2221)

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
@@ -852,18 +852,26 @@ class Access_Rules {
 	 * hypothetical into a real answer — which is the hole the email-domain rule's
 	 * verification requirement exists to close.
 	 *
+	 * The first constraint is enforced for the one memo the replay is known to reach:
+	 * `Institution`'s per-request matching cache is cleared on the way out, so a name
+	 * map computed under the assumption is recomputed for real by whatever reads it
+	 * next (GA4 access labels, ESP contact metadata). A callback that memoises
+	 * elsewhere is still the caller's responsibility, and can tell it is inside a
+	 * hypothetical via {@see self::is_verification_assumed_for()}.
+	 *
 	 * @param int      $user_id  The reader to treat as verified.
 	 * @param callable $callback Callback to run.
 	 *
 	 * @return mixed The callback's return value.
 	 */
 	public static function with_assumed_verification( $user_id, $callback ) {
-		$previous                      = self::$assumed_verified_user_id;
+		$previous                       = self::$assumed_verified_user_id;
 		self::$assumed_verified_user_id = (int) $user_id;
 		try {
 			return $callback();
 		} finally {
 			self::$assumed_verified_user_id = $previous;
+			Institution::reset_matching_cache();
 		}
 	}
 

--- a/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
@@ -41,6 +41,14 @@ class Access_Rules {
 	private static $one_time_purchase_memo = [];
 
 	/**
+	 * Reader ID the email-domain rule should treat as verified for the duration of a
+	 * hypothetical evaluation. Zero outside one. See with_assumed_verification().
+	 *
+	 * @var int
+	 */
+	private static $assumed_verified_user_id = 0;
+
+	/**
 	 * Context for the evaluation currently in progress, set by evaluate_rules()
 	 * / evaluate_rule() from the settings of the gate being evaluated. Rule
 	 * callbacks read it via get_evaluation_context(). Empty outside an
@@ -745,6 +753,30 @@ class Access_Rules {
 	}
 
 	/**
+	 * Whether an email address sits on one of the given domains.
+	 *
+	 * This is the domain comparison alone. It says nothing about whether the reader has
+	 * verified the address, which {@see self::is_email_domain_whitelisted()} requires
+	 * before granting access — so a caller that needs the match itself, rather than the
+	 * access decision built on it, uses this directly.
+	 *
+	 * @param string $email   Email address.
+	 * @param string $domains Comma- or newline-delimited list of domains.
+	 * @return bool
+	 */
+	public static function email_matches_domains( $email, $domains ) {
+		if ( empty( $email ) || empty( $domains ) ) {
+			return false;
+		}
+		$domains      = str_replace( PHP_EOL, ',', $domains );
+		$domains      = explode( ',', $domains );
+		$domains      = array_map( 'trim', $domains );
+		$domains      = array_map( 'strtolower', $domains );
+		$email_domain = strtolower( substr( $email, strrpos( $email, '@' ) + 1 ) );
+		return in_array( $email_domain, $domains, true );
+	}
+
+	/**
 	 * Whether the user’s email address contains one of the given domains.
 	 *
 	 * @param int    $user_id User ID.
@@ -756,11 +788,7 @@ class Access_Rules {
 		if ( empty( $domains ) ) {
 			return true;
 		}
-		$domains = str_replace( PHP_EOL, ',', $domains );
-		$domains = explode( ',', $domains );
-		$domains = array_map( 'trim', $domains );
-		$domains = array_map( 'strtolower', $domains );
-		$user    = \get_userdata( $user_id );
+		$user = \get_userdata( $user_id );
 		if ( ! $user ) {
 			return false;
 		}
@@ -768,11 +796,75 @@ class Access_Rules {
 		if ( ! $email ) {
 			return false;
 		}
-		if ( Reader_Activation::is_reader_verified( $user ) === false ) {
+		if ( ! self::is_verification_satisfied( $user ) ) {
 			return false;
 		}
-		$email_domain = strtolower( substr( $email, strrpos( $email, '@' ) + 1 ) );
-		return in_array( $email_domain, $domains, true );
+		return self::email_matches_domains( $email, $domains );
+	}
+
+	/**
+	 * Whether the reader satisfies the email-domain rule's verification requirement.
+	 *
+	 * Normally that means the reader has verified their address. During a hypothetical
+	 * evaluation opened by {@see self::with_assumed_verification()} it is also satisfied
+	 * for the one reader that evaluation is about, so a caller can ask "would this gate
+	 * grant access if this reader verified?" without relaxing the rule for a real
+	 * access decision.
+	 *
+	 * @param \WP_User $user The user being evaluated.
+	 * @return bool
+	 */
+	private static function is_verification_satisfied( $user ) {
+		if ( self::is_verification_assumed_for( $user->ID ) ) {
+			return true;
+		}
+		return false !== Reader_Activation::is_reader_verified( $user );
+	}
+
+	/**
+	 * Whether a hypothetical evaluation is currently treating this reader as verified.
+	 *
+	 * For the other places a gate decides access on verification. Those read the stored
+	 * state directly, and a hypothetical that only reached the email-domain rule would
+	 * answer "still restricted" for a gate whose registration wall the same act of
+	 * verifying would also satisfy — suppressing the prompt on exactly the
+	 * configuration it is for.
+	 *
+	 * @param int $user_id The reader being evaluated.
+	 *
+	 * @return bool
+	 */
+	public static function is_verification_assumed_for( $user_id ) {
+		return (bool) self::$assumed_verified_user_id && (int) $user_id === self::$assumed_verified_user_id;
+	}
+
+	/**
+	 * Run a callback with one reader treated as verified by the email-domain rule.
+	 *
+	 * The return value is a hypothetical, never an access decision. Nothing about the
+	 * reader's stored verification state changes, and the flag is cleared before the
+	 * call returns.
+	 *
+	 * Two constraints on callers, because the flag is process-wide for the callback's
+	 * duration and the callback runs rule callbacks that third parties can register:
+	 * nothing computed inside may be cached anywhere that outlives the call, and no
+	 * value returned from it may be used to grant access. Either one turns a
+	 * hypothetical into a real answer — which is the hole the email-domain rule's
+	 * verification requirement exists to close.
+	 *
+	 * @param int      $user_id  The reader to treat as verified.
+	 * @param callable $callback Callback to run.
+	 *
+	 * @return mixed The callback's return value.
+	 */
+	public static function with_assumed_verification( $user_id, $callback ) {
+		$previous                      = self::$assumed_verified_user_id;
+		self::$assumed_verified_user_id = (int) $user_id;
+		try {
+			return $callback();
+		} finally {
+			self::$assumed_verified_user_id = $previous;
+		}
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -207,6 +207,7 @@ class Content_Gate {
 		include __DIR__ . '/class-premium-newsletters.php';
 		include __DIR__ . '/class-block-visibility.php';
 		include __DIR__ . '/class-gate-preview.php';
+		include __DIR__ . '/class-email-verification-prompt.php';
 
 		Content_Gate\Gate_Preview::init();
 	}

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -992,6 +992,12 @@ class Content_Gate {
 	/**
 	 * Whether the post is restricted for the current user.
 	 *
+	 * Callbacks on `newspack_is_post_restricted` may run inside a hypothetical replay
+	 * asking what a reader would see if they verified their email address. A callback
+	 * that branches on verification state, or that memoises anything derived from it,
+	 * must check `Access_Rules::is_verification_assumed_for()` — the reader is not
+	 * verified, and a value cached from that answer would be read back later as fact.
+	 *
 	 * @param int $post_id Post ID.
 	 *
 	 * @return int|bool Gate ID restricting the post, false if not restricted, or true if restricted by a Woo Memberships plan.

--- a/plugins/newspack-plugin/includes/content-gate/class-content-restriction-control.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-restriction-control.php
@@ -454,9 +454,13 @@ class Content_Restriction_Control {
 					$is_restricted  = ! $anonymous_bypass_passed;
 					$gate_layout_id = $gate['registration']['gate_layout_id'] ?? $gate['id'];
 				} elseif ( ! empty( $gate['registration']['require_verification'] ) ) {
-					// Check if email verification is required.
+					// Check if email verification is required. A hypothetical evaluation
+					// asking what this reader would see if they verified has to be answered
+					// here too, or a gate that both walls registration behind verification
+					// and grants by email domain reports itself still restricting for a
+					// reader whose one act of verifying would satisfy both.
 					$user = get_user_by( 'id', $user_id );
-					if ( ! $user || ! \get_user_meta( $user->ID, Reader_Activation::EMAIL_VERIFIED, true ) ) {
+					if ( ! $user || ( ! \get_user_meta( $user->ID, Reader_Activation::EMAIL_VERIFIED, true ) && ! Access_Rules::is_verification_assumed_for( $user->ID ) ) ) {
 						$is_restricted  = true;
 						$gate_layout_id = $gate['registration']['gate_layout_id'] ?? $gate['id'];
 					}
@@ -538,6 +542,35 @@ class Content_Restriction_Control {
 			return self::$post_gate_layout_id_map[ $post_id . '_' . $user_id ];
 		}
 		return false;
+	}
+
+	/**
+	 * Run a callback without this request's resolved gate, then put it back.
+	 *
+	 * `is_post_restricted()` memoises which gate denied a post for a user, and
+	 * short-circuits to `true` on a second call once that entry exists. A caller
+	 * asking a hypothetical question — "would this post still be restricted if
+	 * something about the reader changed?" — therefore has to start from an
+	 * unresolved state, and must not leave the hypothetical's answer behind as the
+	 * request's real gate: `Content_Gate::get_gate_post_id()` and
+	 * `get_gate_layout_id()` read those maps to decide what renders.
+	 *
+	 * @param callable $callback Callback to run.
+	 *
+	 * @return mixed The callback's return value.
+	 */
+	public static function with_gate_resolution_isolated( $callback ) {
+		$gate_ids   = self::$post_gate_id_map;
+		$layout_ids = self::$post_gate_layout_id_map;
+
+		self::$post_gate_id_map        = [];
+		self::$post_gate_layout_id_map = [];
+		try {
+			return $callback();
+		} finally {
+			self::$post_gate_id_map        = $gate_ids;
+			self::$post_gate_layout_id_map = $layout_ids;
+		}
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/content-gate/class-email-verification-prompt.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-email-verification-prompt.php
@@ -26,14 +26,14 @@ defined( 'ABSPATH' ) || exit;
 class Email_Verification_Prompt {
 
 	/**
-	 * Per-request memo of prompt contexts, keyed by gate ID and reader ID. `false`
-	 * records a reader already found ineligible for that gate, so the rule walk and
-	 * the hypothetical evaluation run at most once per pair per request.
+	 * Per-request memo of prompt contexts, keyed by post ID, gate ID and reader ID.
+	 * `false` records a reader already found ineligible there, so the rule walk and the
+	 * hypothetical evaluation run at most once per combination per request.
 	 *
-	 * The reader is part of the key because the context carries their address: a
-	 * process that resolves the same gate for several readers — a CLI worker, a REST
-	 * callback iterating a list — would otherwise hand the second reader the first
-	 * one's prompt.
+	 * The reader is part of the key because the context carries their address, and the
+	 * post because the verdict answers whether *that* post opens: a process resolving
+	 * the same gate for several readers or several posts — a CLI worker, a REST
+	 * callback iterating a list — would otherwise read back another one's verdict.
 	 *
 	 * @var array<string,array|false>
 	 */
@@ -78,7 +78,7 @@ class Email_Verification_Prompt {
 	/**
 	 * Resolve the prompt context for the gate denying the current reader.
 	 *
-	 * Cheap before expensive. The first stage walks the gate's rules for a domain the
+	 * Cheap before expensive. The first stage walks the post's gates for a domain the
 	 * reader's address matches, which rules out every visitor but the handful the
 	 * prompt is for. Only those reach the second, which asks what the reader would see
 	 * if they verified — the question the prompt is about to make a promise about, and
@@ -117,7 +117,11 @@ class Email_Verification_Prompt {
 		if ( ! $gate_id ) {
 			return false;
 		}
-		$cache_key = $gate_id . '_' . $user->ID;
+		$post_id = (int) \get_queried_object_id();
+		if ( ! $post_id ) {
+			return false;
+		}
+		$cache_key = $post_id . '_' . $gate_id . '_' . $user->ID;
 		if ( isset( self::$context_cache[ $cache_key ] ) ) {
 			return self::$context_cache[ $cache_key ];
 		}
@@ -125,33 +129,48 @@ class Email_Verification_Prompt {
 		// `newspack_is_post_restricted` chain, and a callback on it that reaches back
 		// here would find no memo and recurse.
 		self::$context_cache[ $cache_key ] = false;
-		self::$context_cache[ $cache_key ] = self::build_prompt_context( $user, $gate_id );
+		self::$context_cache[ $cache_key ] = self::build_prompt_context( $user, $post_id );
 		return self::$context_cache[ $cache_key ];
 	}
 
 	/**
-	 * Build the prompt context for a reader and gate, uncached.
+	 * Build the prompt context for a reader and post, uncached.
+	 *
+	 * Every gate covering the post is walked, not only the one that denied. The gate a
+	 * reader is stopped at need not be the one their address would let them past: a
+	 * registration gate walling verification can deny at priority 1 while an
+	 * institution gate at priority 2 is the route in, and the same act of verifying
+	 * clears both.
 	 *
 	 * @param \WP_User $user    The reader.
-	 * @param int      $gate_id The gate denying them.
+	 * @param int      $post_id The post they were denied.
 	 *
 	 * @return array|false
 	 */
-	private static function build_prompt_context( \WP_User $user, int $gate_id ) {
-		$custom_access = Content_Gate::get_custom_access_settings( $gate_id );
-		if ( empty( $custom_access['active'] ) || empty( $custom_access['access_rules'] ) ) {
-			return false;
+	private static function build_prompt_context( \WP_User $user, int $post_id ) {
+		$matching_groups = [];
+		foreach ( Content_Restriction_Control::get_post_gates( $post_id ) as $gate ) {
+			$custom_access = $gate['custom_access'] ?? [];
+			if ( empty( $custom_access['active'] ) || empty( $custom_access['access_rules'] ) ) {
+				continue;
+			}
+			$matching_groups = array_merge(
+				$matching_groups,
+				self::get_domain_matching_groups(
+					$user->user_email,
+					$custom_access['access_rules'],
+					$custom_access['payment_recovery_grace'] ?? true
+				)
+			);
 		}
-
-		$matching_groups = self::get_domain_matching_groups( $user->user_email, $custom_access['access_rules'] );
 		if ( empty( $matching_groups ) ) {
 			return false;
 		}
 
 		$institutions = Access_Rules::with_assumed_verification(
 			$user->ID,
-			function () use ( $user, $custom_access, $matching_groups ) {
-				return self::get_unlocking_institution_names( $user, $custom_access, $matching_groups );
+			function () use ( $user, $post_id, $matching_groups ) {
+				return self::get_unlocking_institution_names( $user, $post_id, $matching_groups );
 			}
 		);
 		if ( null === $institutions ) {
@@ -174,15 +193,21 @@ class Email_Verification_Prompt {
 	 * because they memoise a result that GA4 labels and ESP contact metadata read back
 	 * as fact.
 	 *
-	 * @param string $email        The reader's email address.
-	 * @param array  $access_rules The gate's access rules, in grouped format.
+	 * @param string $email                   The reader's email address.
+	 * @param array  $access_rules            The gate's access rules, in grouped format.
+	 * @param bool   $payment_recovery_grace  The gate's payment recovery grace setting, carried
+	 *                                        on each group so the hypothetical evaluates it
+	 *                                        under the settings of the gate it came from.
 	 *
-	 * @return array<int,array{rules: array, institutions: string[]}> One entry per group
-	 *         holding a rule the address matches, carrying that group's rules and the
-	 *         names of the matched institutions (empty for a bare email-domain rule).
+	 * @return array<int,array{rules: array, institutions: string[], payment_recovery_grace: bool}>
+	 *         One entry per group holding a rule the address matches, carrying that group's
+	 *         rules and the names of the matched institutions (empty for a bare email-domain
+	 *         rule).
 	 */
-	private static function get_domain_matching_groups( string $email, array $access_rules ): array {
-		$institutions    = Institution::get_cached_institutions();
+	private static function get_domain_matching_groups( string $email, array $access_rules, bool $payment_recovery_grace ): array {
+		// Read lazily: a gate whose rules are all non-institution never touches the
+		// transient, which keeps the cheap stage cheap for the readers it rules out.
+		$institutions    = null;
 		$matching_groups = [];
 
 		foreach ( Access_Rules::normalize_rules( $access_rules ) as $group ) {
@@ -202,6 +227,9 @@ class Email_Verification_Prompt {
 				if ( 'institution' !== $slug || empty( $rule['value'] ) || ! is_array( $rule['value'] ) ) {
 					continue;
 				}
+				if ( null === $institutions ) {
+					$institutions = Institution::get_cached_institutions();
+				}
 				foreach ( $rule['value'] as $institution_id ) {
 					$institution_id = absint( $institution_id );
 					if ( empty( $institutions[ $institution_id ]['email_domain'] ) ) {
@@ -219,8 +247,9 @@ class Email_Verification_Prompt {
 			}
 			if ( $matched ) {
 				$matching_groups[] = [
-					'rules'        => $group,
-					'institutions' => $names,
+					'rules'                  => $group,
+					'institutions'           => $names,
+					'payment_recovery_grace' => $payment_recovery_grace,
 				];
 			}
 		}
@@ -237,18 +266,18 @@ class Email_Verification_Prompt {
 	 * another gate on the post denies regardless, there is no route in at all.
 	 *
 	 * @param \WP_User $user            The reader.
-	 * @param array    $custom_access   The gate's custom access settings.
+	 * @param int      $post_id         The post they were denied.
 	 * @param array    $matching_groups Groups from {@see self::get_domain_matching_groups()}.
 	 *
 	 * @return string[]|null Institution names (possibly empty, for a bare email-domain
 	 *                       rule), or null when verifying would not unlock the article.
 	 */
-	private static function get_unlocking_institution_names( \WP_User $user, array $custom_access, array $matching_groups ): ?array {
-		$rule_context = [ 'payment_recovery_grace' => $custom_access['payment_recovery_grace'] ];
-		$names        = [];
-		$unlocks      = false;
+	private static function get_unlocking_institution_names( \WP_User $user, int $post_id, array $matching_groups ): ?array {
+		$names   = [];
+		$unlocks = false;
 
 		foreach ( $matching_groups as $group ) {
+			$rule_context = [ 'payment_recovery_grace' => $group['payment_recovery_grace'] ];
 			if ( ! Access_Rules::evaluate_rules( [ $group['rules'] ], $user->ID, $rule_context ) ) {
 				continue;
 			}
@@ -256,7 +285,7 @@ class Email_Verification_Prompt {
 			$names   = array_merge( $names, $group['institutions'] );
 		}
 
-		if ( ! $unlocks || self::is_post_restricted_hypothetically() ) {
+		if ( ! $unlocks || self::is_post_restricted_hypothetically( $post_id ) ) {
 			return null;
 		}
 
@@ -274,12 +303,16 @@ class Email_Verification_Prompt {
 	 * starts granting. Isolated from the request's own gate resolution so the
 	 * hypothetical neither reads it nor replaces it.
 	 *
+	 * @param int $post_id The post to re-evaluate.
+	 *
 	 * @return bool
 	 */
-	private static function is_post_restricted_hypothetically(): bool {
-		$post_id = \get_queried_object_id();
+	private static function is_post_restricted_hypothetically( int $post_id ): bool {
+		// No post is an unanswerable hypothetical, and the prompt's promise is that this
+		// article opens. Answer "still restricted" so the promise is never made on a
+		// check that did not run.
 		if ( ! $post_id ) {
-			return false;
+			return true;
 		}
 		return (bool) Content_Restriction_Control::with_gate_resolution_isolated(
 			function () use ( $post_id ) {
@@ -319,7 +352,7 @@ class Email_Verification_Prompt {
 					<?php Newspack_UI_Icons::print_svg( 'login' ); ?>
 				</span>
 				<h2><?php echo \esc_html( self::get_headline( $prompt_context['institutions'] ) ); ?></h2>
-				<p data-error-target role="status">
+				<p>
 					<?php
 					echo \wp_kses_post(
 						sprintf(
@@ -330,6 +363,8 @@ class Email_Verification_Prompt {
 					);
 					?>
 				</p>
+				<?php // Errors land in their own paragraph, so the line naming the reader's address survives a failed send and still orients them on the retry. ?>
+				<p data-error-target role="status" hidden></p>
 				<p>
 					<button type="button" class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide" data-send-otp>
 						<?php \esc_html_e( 'Send code', 'newspack-plugin' ); ?>

--- a/plugins/newspack-plugin/includes/content-gate/class-email-verification-prompt.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-email-verification-prompt.php
@@ -1,0 +1,392 @@
+<?php
+/**
+ * Newspack Content Gate email verification prompt.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Prompts a denied reader to verify their email when that is all that stands
+ * between them and the article.
+ *
+ * The email-domain access rule grants access only to a reader who has verified
+ * their address, so a reader on a whitelisted domain who registered without
+ * verifying sees the ordinary paywall and no indication of why. This class spots
+ * that state at gate-render time and prepends a verification prompt to the gate,
+ * above the layout — which keeps the layout's own subscribe CTA as the reader's
+ * alternative.
+ *
+ * The rule itself is untouched: verifying is what grants access, and a reader who
+ * does not verify is denied exactly as they would be without this class.
+ */
+class Email_Verification_Prompt {
+
+	/**
+	 * Per-request memo of prompt contexts, keyed by gate ID and reader ID. `false`
+	 * records a reader already found ineligible for that gate, so the rule walk and
+	 * the hypothetical evaluation run at most once per pair per request.
+	 *
+	 * The reader is part of the key because the context carries their address: a
+	 * process that resolves the same gate for several readers — a CLI worker, a REST
+	 * callback iterating a list — would otherwise hand the second reader the first
+	 * one's prompt.
+	 *
+	 * @var array<string,array|false>
+	 */
+	private static array $context_cache = [];
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init(): void {
+		\add_filter( 'newspack_gate_layout_content', [ __CLASS__, 'prepend_prompt' ], 10, 2 );
+	}
+
+	/**
+	 * Prepend the verification prompt to the gate layout content.
+	 *
+	 * Hooked on the raw layout content rather than the rendered gate HTML so the
+	 * prompt lands inside the gate wrapper for both the inline and the overlay
+	 * layout, above content the reader was already going to see.
+	 *
+	 * @param string $content        The gate layout content.
+	 * @param int    $gate_layout_id The gate layout ID.
+	 *
+	 * @return string
+	 */
+	public static function prepend_prompt( $content, $gate_layout_id ): string {
+		$content = (string) $content;
+		if ( Content_Gate\Gate_Preview::is_preview_request() ) {
+			return $content;
+		}
+		// Another layout on the page (a preview, a second gate rendered by a third
+		// party) is not the gate that denied this reader.
+		if ( (int) $gate_layout_id !== (int) Content_Gate::get_gate_layout_id() ) {
+			return $content;
+		}
+		$prompt_context = self::get_prompt_context();
+		if ( ! $prompt_context ) {
+			return $content;
+		}
+		return self::render( $prompt_context ) . $content;
+	}
+
+	/**
+	 * Resolve the prompt context for the gate denying the current reader.
+	 *
+	 * Cheap before expensive. The first stage walks the gate's rules for a domain the
+	 * reader's address matches, which rules out every visitor but the handful the
+	 * prompt is for. Only those reach the second, which asks what the reader would see
+	 * if they verified — the question the prompt is about to make a promise about, and
+	 * one a single rule cannot answer: rules are ANDed within a group, and a post can
+	 * be covered by several gates in priority order, so verification can satisfy the
+	 * email-domain rule and leave the reader on a paywall either way.
+	 *
+	 * @return array|false {
+	 *     The prompt context, or false when no prompt should render.
+	 *
+	 *     @type string[] $institutions Names of the institutions the reader's verified
+	 *                                  address would grant access through. Empty when
+	 *                                  the route in is a gate's own email-domain rule
+	 *                                  rather than an institution.
+	 *     @type string   $email        The reader's email address.
+	 * }
+	 */
+	public static function get_prompt_context() {
+		if ( ! Content_Gate::is_gating_active() || Memberships::is_active() ) {
+			return false;
+		}
+		// The prompt hands the reader to the auth modal to enter their code. Where that
+		// modal is filtered off the site, sending a code strands them with nowhere to
+		// type it.
+		if ( ! Reader_Activation::should_render_auth_modal() ) {
+			return false;
+		}
+		if ( ! \is_user_logged_in() ) {
+			return false;
+		}
+		$user = \wp_get_current_user();
+		if ( ! Reader_Activation::is_user_reader( $user ) || Reader_Activation::is_reader_verified( $user ) ) {
+			return false;
+		}
+		$gate_id = (int) Content_Gate::get_gate_post_id();
+		if ( ! $gate_id ) {
+			return false;
+		}
+		$cache_key = $gate_id . '_' . $user->ID;
+		if ( isset( self::$context_cache[ $cache_key ] ) ) {
+			return self::$context_cache[ $cache_key ];
+		}
+		// Seeded before the build, not after: the build runs the whole
+		// `newspack_is_post_restricted` chain, and a callback on it that reaches back
+		// here would find no memo and recurse.
+		self::$context_cache[ $cache_key ] = false;
+		self::$context_cache[ $cache_key ] = self::build_prompt_context( $user, $gate_id );
+		return self::$context_cache[ $cache_key ];
+	}
+
+	/**
+	 * Build the prompt context for a reader and gate, uncached.
+	 *
+	 * @param \WP_User $user    The reader.
+	 * @param int      $gate_id The gate denying them.
+	 *
+	 * @return array|false
+	 */
+	private static function build_prompt_context( \WP_User $user, int $gate_id ) {
+		$custom_access = Content_Gate::get_custom_access_settings( $gate_id );
+		if ( empty( $custom_access['active'] ) || empty( $custom_access['access_rules'] ) ) {
+			return false;
+		}
+
+		$matching_groups = self::get_domain_matching_groups( $user->user_email, $custom_access['access_rules'] );
+		if ( empty( $matching_groups ) ) {
+			return false;
+		}
+
+		$institutions = Access_Rules::with_assumed_verification(
+			$user->ID,
+			function () use ( $user, $custom_access, $matching_groups ) {
+				return self::get_unlocking_institution_names( $user, $custom_access, $matching_groups );
+			}
+		);
+		if ( null === $institutions ) {
+			return false;
+		}
+
+		return [
+			'institutions' => $institutions,
+			'email'        => $user->user_email,
+		];
+	}
+
+	/**
+	 * Find the rule groups on a gate whose domain lists the reader's address matches.
+	 *
+	 * Deliberately ignores verification — that is the whole point of the prompt — and
+	 * reads the domain lists straight off the rules rather than through the rule
+	 * callbacks, which apply the verification requirement this stage has to look past.
+	 * `Institution`'s own matching helpers are wrong here for the same reason, and
+	 * because they memoise a result that GA4 labels and ESP contact metadata read back
+	 * as fact.
+	 *
+	 * @param string $email        The reader's email address.
+	 * @param array  $access_rules The gate's access rules, in grouped format.
+	 *
+	 * @return array<int,array{rules: array, institutions: string[]}> One entry per group
+	 *         holding a rule the address matches, carrying that group's rules and the
+	 *         names of the matched institutions (empty for a bare email-domain rule).
+	 */
+	private static function get_domain_matching_groups( string $email, array $access_rules ): array {
+		$institutions    = Institution::get_cached_institutions();
+		$matching_groups = [];
+
+		foreach ( Access_Rules::normalize_rules( $access_rules ) as $group ) {
+			if ( ! is_array( $group ) ) {
+				continue;
+			}
+			$matched = false;
+			$names   = [];
+			foreach ( $group as $rule ) {
+				$slug = $rule['slug'] ?? '';
+				if ( 'email_domain' === $slug ) {
+					if ( ! empty( $rule['value'] ) && Access_Rules::email_matches_domains( $email, $rule['value'] ) ) {
+						$matched = true;
+					}
+					continue;
+				}
+				if ( 'institution' !== $slug || empty( $rule['value'] ) || ! is_array( $rule['value'] ) ) {
+					continue;
+				}
+				foreach ( $rule['value'] as $institution_id ) {
+					$institution_id = absint( $institution_id );
+					if ( empty( $institutions[ $institution_id ]['email_domain'] ) ) {
+						continue;
+					}
+					if ( ! Access_Rules::email_matches_domains( $email, $institutions[ $institution_id ]['email_domain'] ) ) {
+						continue;
+					}
+					$matched = true;
+					$name    = Institution::get_decoded_name( $institution_id );
+					if ( '' !== $name ) {
+						$names[] = $name;
+					}
+				}
+			}
+			if ( $matched ) {
+				$matching_groups[] = [
+					'rules'        => $group,
+					'institutions' => $names,
+				];
+			}
+		}
+
+		return $matching_groups;
+	}
+
+	/**
+	 * The institutions a verified address would actually let the reader in through.
+	 *
+	 * Must run inside {@see Access_Rules::with_assumed_verification()}. A group is a
+	 * route in only if it passes as a whole, so a group that ANDs the matched rule with
+	 * one the reader still fails contributes no names — and if no group passes, or
+	 * another gate on the post denies regardless, there is no route in at all.
+	 *
+	 * @param \WP_User $user            The reader.
+	 * @param array    $custom_access   The gate's custom access settings.
+	 * @param array    $matching_groups Groups from {@see self::get_domain_matching_groups()}.
+	 *
+	 * @return string[]|null Institution names (possibly empty, for a bare email-domain
+	 *                       rule), or null when verifying would not unlock the article.
+	 */
+	private static function get_unlocking_institution_names( \WP_User $user, array $custom_access, array $matching_groups ): ?array {
+		$rule_context = [ 'payment_recovery_grace' => $custom_access['payment_recovery_grace'] ];
+		$names        = [];
+		$unlocks      = false;
+
+		foreach ( $matching_groups as $group ) {
+			if ( ! Access_Rules::evaluate_rules( [ $group['rules'] ], $user->ID, $rule_context ) ) {
+				continue;
+			}
+			$unlocks = true;
+			$names   = array_merge( $names, $group['institutions'] );
+		}
+
+		if ( ! $unlocks || self::is_post_restricted_hypothetically() ) {
+			return null;
+		}
+
+		$names = array_values( array_unique( $names ) );
+		sort( $names, SORT_NATURAL | SORT_FLAG_CASE );
+		return $names;
+	}
+
+	/**
+	 * Whether the post would still be restricted with the assumption in place.
+	 *
+	 * Re-runs the whole restriction decision, not just this gate's: a post can be
+	 * covered by several gates, and the check stops at the first that denies, so a
+	 * lower-priority gate the reader also fails stays invisible until the gate above it
+	 * starts granting. Isolated from the request's own gate resolution so the
+	 * hypothetical neither reads it nor replaces it.
+	 *
+	 * @return bool
+	 */
+	private static function is_post_restricted_hypothetically(): bool {
+		$post_id = \get_queried_object_id();
+		if ( ! $post_id ) {
+			return false;
+		}
+		return (bool) Content_Restriction_Control::with_gate_resolution_isolated(
+			function () use ( $post_id ) {
+				return Content_Gate::is_post_restricted( $post_id );
+			}
+		);
+	}
+
+	/**
+	 * Render the prompt markup.
+	 *
+	 * The nonce rides on the element rather than the gate's localized script data
+	 * because the prompt is decided while the gate renders, after the script payload
+	 * has been assembled. It authorizes the same OTP request the registration block's
+	 * inline verification box makes, which is not gated on the site's post-registration
+	 * verification setting — so the prompt works whether or not a publisher has that
+	 * setting on.
+	 *
+	 * Returned on one line: the gate content pipeline leaves `wpautop` in place for a
+	 * layout carrying no block markup, and the icon SVG spans several lines.
+	 *
+	 * @param array $prompt_context Prompt context from get_prompt_context().
+	 *
+	 * @return string
+	 */
+	private static function render( array $prompt_context ): string {
+		ob_start();
+		?>
+		<div
+			class="newspack-content-gate__verification-prompt newspack-ui"
+			data-verification-url="<?php echo \esc_url( \admin_url( 'admin-ajax.php' ) ); ?>"
+			data-verification-nonce="<?php echo \esc_attr( \wp_create_nonce( 'newspack_reader_registration_verification' ) ); ?>"
+			data-error-message="<?php \esc_attr_e( 'Something went wrong. Please try again.', 'newspack-plugin' ); ?>"
+		>
+			<div class="newspack-ui__box newspack-ui__box--x-large newspack-ui__box--text-center">
+				<span class="newspack-ui__icon newspack-ui__icon--neutral">
+					<?php Newspack_UI_Icons::print_svg( 'login' ); ?>
+				</span>
+				<h2><?php echo \esc_html( self::get_headline( $prompt_context['institutions'] ) ); ?></h2>
+				<p data-error-target role="status">
+					<?php
+					echo \wp_kses_post(
+						sprintf(
+							// translators: %s is the reader's email address.
+							__( 'We\'ll send a verification code to %s.', 'newspack-plugin' ),
+							'<strong class="email-address">' . \esc_html( $prompt_context['email'] ) . '</strong>'
+						)
+					);
+					?>
+				</p>
+				<p>
+					<button type="button" class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide" data-send-otp>
+						<?php \esc_html_e( 'Send code', 'newspack-plugin' ); ?>
+					</button>
+				</p>
+			</div>
+		</div>
+		<?php
+		return trim( preg_replace( '/\s*\R\s*/', ' ', (string) ob_get_clean() ) );
+	}
+
+	/**
+	 * The prompt's headline, naming the institutions that grant access.
+	 *
+	 * Several institutions are alternatives — any one of them lets the reader in — so
+	 * they are joined with "or" rather than `wp_sprintf( '%l' )`'s "and".
+	 *
+	 * @param string[] $institutions Institution names.
+	 *
+	 * @return string
+	 */
+	private static function get_headline( array $institutions ): string {
+		if ( empty( $institutions ) ) {
+			return __( 'Your email address gives you access to this article. Verify it to keep reading.', 'newspack-plugin' );
+		}
+		return sprintf(
+			// translators: %s is the name of one institution, or a list of institution names.
+			__( 'Your %s email address gives you access to this article. Verify it to keep reading.', 'newspack-plugin' ),
+			self::join_alternatives( $institutions )
+		);
+	}
+
+	/**
+	 * Join names into an "A, B or C" list.
+	 *
+	 * @param string[] $names Names to join.
+	 *
+	 * @return string
+	 */
+	private static function join_alternatives( array $names ): string {
+		if ( count( $names ) < 2 ) {
+			return (string) reset( $names );
+		}
+		$last = array_pop( $names );
+		return sprintf(
+			// translators: 1: a comma-separated list of institution names. 2: the last institution name.
+			__( '%1$s or %2$s', 'newspack-plugin' ),
+			implode( ', ', $names ),
+			$last
+		);
+	}
+
+	/**
+	 * Reset the per-request context cache. For tests and long-running workers.
+	 */
+	public static function reset_cache(): void {
+		self::$context_cache = [];
+	}
+}
+Email_Verification_Prompt::init();

--- a/plugins/newspack-plugin/includes/content-gate/class-institution.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-institution.php
@@ -355,10 +355,8 @@ class Institution {
 	 * Without that the same `$user_id` could legitimately resolve to different sets across
 	 * requests in a long-running worker that swaps the current user.
 	 *
-	 * IDs are read with `get_post_field( 'post_title', ... )` rather than `get_the_title( ... )`
-	 * so the value going to GA4/ESP is a raw post title, not one that's been through
-	 * `the_title` filters (texturization, third-party plugins) that can introduce entities
-	 * or markup.
+	 * Names come from {@see self::get_decoded_name()}, which is where the rule for reading
+	 * a raw title lives.
 	 *
 	 * @param int        $user_id            User ID.
 	 * @param array|null $institution_filter Optional list of institution post IDs.
@@ -389,12 +387,28 @@ class Institution {
 				continue;
 			}
 			if ( self::user_matches_institution( $user_id, $rules ) ) {
-				$map[ $inst_id ] = html_entity_decode( (string) \get_post_field( 'post_title', $inst_id ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+				$map[ $inst_id ] = self::get_decoded_name( $inst_id );
 			}
 		}
 
 		self::$names_cache[ $cache_key ] = $map;
 		return $map;
+	}
+
+	/**
+	 * An institution's title as a plain string.
+	 *
+	 * Read with `get_post_field( 'post_title', ... )` rather than `get_the_title( ... )`
+	 * so the value going to GA4/ESP is a raw post title, not one that's been through
+	 * `the_title` filters (texturization, third-party plugins) that can introduce
+	 * entities or markup.
+	 *
+	 * @param int $institution_id Institution post ID.
+	 *
+	 * @return string
+	 */
+	public static function get_decoded_name( $institution_id ) {
+		return html_entity_decode( (string) \get_post_field( 'post_title', (int) $institution_id ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
@@ -1561,7 +1561,7 @@ final class Reader_Activation {
 	 *
 	 * @return bool
 	 */
-	private static function should_render_auth_modal() {
+	public static function should_render_auth_modal() {
 		/**
 		 * Filters whether to render reader auth form.
 		 *

--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
@@ -1642,6 +1642,8 @@ final class Reader_Activation {
 				);
 				?>
 			</p>
+			<?php // Errors land in their own paragraph, so the line naming the reader's address survives a failed send and still orients them on the retry. ?>
+			<p data-error-target role="status" hidden></p>
 		</div>
 		<button type="button" class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide" data-send-otp>
 			<?php esc_html_e( 'Send code', 'newspack-plugin' ); ?>
@@ -2294,6 +2296,11 @@ final class Reader_Activation {
 
 	/**
 	 * Check if current reader has its email verified.
+	 *
+	 * Reports stored state only. A content-gate decision that has to answer "what
+	 * would this reader see if they verified?" must also accept
+	 * `Access_Rules::is_verification_assumed_for( $user->ID )`, or the hypothetical
+	 * reports the reader still walled by the very requirement it is asking about.
 	 *
 	 * @param \WP_User $user User object.
 	 *

--- a/plugins/newspack-plugin/src/blocks/reader-registration/index.php
+++ b/plugins/newspack-plugin/src/blocks/reader-registration/index.php
@@ -117,7 +117,7 @@ function render_verification_box() {
 			<span class="newspack-ui__icon newspack-ui__icon--neutral">
 				<?php Newspack_UI_Icons::print_svg( 'login' ); ?>
 			</span>
-			<p>
+			<p data-error-target role="status">
 				<?php
 				echo wp_kses_post(
 					sprintf(

--- a/plugins/newspack-plugin/src/blocks/reader-registration/index.php
+++ b/plugins/newspack-plugin/src/blocks/reader-registration/index.php
@@ -82,6 +82,7 @@ function enqueue_scripts() {
 		[
 			'verification_url'   => \admin_url( 'admin-ajax.php' ),
 			'verification_nonce' => \wp_create_nonce( 'newspack_reader_registration_verification' ),
+			'verification_error' => __( 'Something went wrong. Please try again.', 'newspack-plugin' ),
 		]
 	);
 }
@@ -117,7 +118,7 @@ function render_verification_box() {
 			<span class="newspack-ui__icon newspack-ui__icon--neutral">
 				<?php Newspack_UI_Icons::print_svg( 'login' ); ?>
 			</span>
-			<p data-error-target role="status">
+			<p>
 				<?php
 				echo wp_kses_post(
 					sprintf(
@@ -128,6 +129,8 @@ function render_verification_box() {
 				);
 				?>
 			</p>
+			<?php // Errors land in their own paragraph, so the line naming the reader's address survives a failed send and still orients them on the retry. ?>
+			<p data-error-target role="status" hidden></p>
 			<p>
 				<button type="button" class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide" data-send-otp>
 					<?php esc_html_e( 'Send code', 'newspack-plugin' ); ?>

--- a/plugins/newspack-plugin/src/blocks/reader-registration/view.js
+++ b/plugins/newspack-plugin/src/blocks/reader-registration/view.js
@@ -62,7 +62,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 			wireInlineVerificationBox( box, {
 				url: reader_registration_block_config.verification_url,
 				nonce: reader_registration_block_config.verification_nonce,
-				errorText: 'Something went wrong. Please try again.',
+				errorText: reader_registration_block_config.verification_error,
 				onSent: () => {
 					readerActivation.setOTPTimer();
 					openAuth( 'otp' );

--- a/plugins/newspack-plugin/src/blocks/reader-registration/view.js
+++ b/plugins/newspack-plugin/src/blocks/reader-registration/view.js
@@ -8,32 +8,11 @@ import { openAuthModal } from '../../reader-activation-auth/auth-modal';
 import { openVerificationModal } from '../../reader-activation-auth/verification-modal';
 import { maybeConfirmRegistration } from '../../reader-activation-auth/confirmation-modal';
 import { openNewslettersSignupModal } from '../../reader-activation-newsletters/newsletters-modal';
+import { wireInlineVerificationBox } from '../../reader-activation-auth/inline-verification';
 
 window.newspackRAS = window.newspackRAS || [];
 
 window.newspackRAS.push( function ( readerActivation ) {
-	/**
-	 * Send verification OTP via the dedicated AJAX endpoint.
-	 *
-	 * @return {Promise} Resolves on success, rejects on failure.
-	 */
-	const sendVerificationOTP = () => {
-		const body = new FormData();
-		body.set( 'action', 'newspack_reader_registration_verification' );
-		body.set( 'nonce', reader_registration_block_config.verification_nonce );
-		return fetch( reader_registration_block_config.verification_url, {
-			method: 'POST',
-			headers: { Accept: 'application/json' },
-			body,
-		} ).then( res => {
-			if ( ! res.ok ) {
-				throw new Error( res.statusText );
-			}
-			readerActivation.setOTPTimer();
-			return res.json();
-		} );
-	};
-
 	const openAuth = ( initialState = 'otp', overrides = {} ) => {
 		openAuthModal( {
 			skipAuthenticatedCheck: true,
@@ -80,24 +59,14 @@ window.newspackRAS.push( function ( readerActivation ) {
 			box => ! box.querySelector( '.newspack-ui__modal-container' )
 		);
 		inlineVerificationBoxes.forEach( box => {
-			const sendOtpButton = box.querySelector( '[data-send-otp]' );
-			if ( ! sendOtpButton ) {
-				return;
-			}
-			sendOtpButton.addEventListener( 'click', () => {
-				sendOtpButton.disabled = true;
-				sendVerificationOTP()
-					.then( () => {
-						openAuth( 'otp' );
-					} )
-					.catch( () => {
-						sendOtpButton.disabled = false;
-						sendOtpButton.textContent = sendOtpButton.textContent.trim();
-						const errorP = box.querySelector( 'p:not(:has(button))' );
-						if ( errorP ) {
-							errorP.textContent = 'Something went wrong. Please try again.';
-						}
-					} );
+			wireInlineVerificationBox( box, {
+				url: reader_registration_block_config.verification_url,
+				nonce: reader_registration_block_config.verification_nonce,
+				errorText: 'Something went wrong. Please try again.',
+				onSent: () => {
+					readerActivation.setOTPTimer();
+					openAuth( 'otp' );
+				},
 			} );
 		} );
 

--- a/plugins/newspack-plugin/src/content-gate/gate.js
+++ b/plugins/newspack-plugin/src/content-gate/gate.js
@@ -7,6 +7,7 @@ import { getEventPayload, sendEvent } from '../reader-activation/analytics';
 import { debugLog } from '../reader-activation/utils';
 import { persistCtaAttribution } from '../shared/js/cta-attribution';
 import { propagateGatePreviewParams } from './preview-links';
+import { wireInlineVerificationBox } from '../reader-activation-auth/inline-verification';
 
 const EVENT_NAME = 'np_gate_interaction';
 
@@ -110,6 +111,62 @@ function initReloadHandler() {
 
 		ras.on( 'overlay', refreshPage ); // When an overlay is closed.
 		ras.on( 'activity', refreshPage ); // When a newly registered reader is detected.
+	} );
+}
+
+/**
+ * Wire the email verification prompts rendered above the gate layout for a reader
+ * whose address is on a whitelisted domain but unverified.
+ *
+ * Sends the OTP, then hands the reader to the auth modal's OTP state. Verifying
+ * reloads the article, which the gate now grants.
+ */
+function initVerificationPrompts() {
+	const boxes = [ ...document.querySelectorAll( '.newspack-content-gate__verification-prompt' ) ];
+	if ( ! boxes.length ) {
+		return;
+	}
+	window.newspackRAS = window.newspackRAS || [];
+	window.newspackRAS.push( function ( ras ) {
+		boxes.forEach( box => {
+			wireInlineVerificationBox( box, {
+				url: box.dataset.verificationUrl,
+				nonce: box.dataset.verificationNonce,
+				errorText: box.dataset.errorMessage,
+				onSent: () => {
+					ras.setOTPTimer();
+					// Both checks run before the call, not after: the code is already sent
+					// by this point, and openAuthModal's own early returns invoke
+					// onSuccess — so a modal that never opened would reload the page past
+					// the reader instead of handing control back. `_openAuthModal` is read
+					// at click time because the auth bundle attaches it on its own RAS
+					// callback and nothing orders the two pushes.
+					if (
+						typeof ras._openAuthModal !== 'function' ||
+						! document.querySelector( '.newspack-reader-auth-modal .newspack-reader-auth' )
+					) {
+						return false;
+					}
+					ras._openAuthModal( {
+						skipAuthenticatedCheck: true,
+						skipNewslettersSignup: true,
+						backButtonClosesModal: true,
+						initialState: 'otp',
+						closeOnSuccess: true,
+						skipSuccess: false,
+						// Reload on close rather than only on success: the modal holds a
+						// success step the reader dismisses, and the gate's own reload
+						// handler stands down while an overlay is open. onSuccess covers
+						// the path where the modal closes itself. Reloading either way is
+						// safe — a reader who dismissed without verifying gets the same
+						// gate back.
+						onSuccess: () => window.location.reload(),
+						onClose: () => window.location.reload(),
+					} );
+					return true;
+				},
+			} );
+		} );
 	} );
 }
 
@@ -415,6 +472,7 @@ domReady( function () {
 	// it renders, and an inline gate's 'seen' handler only runs once it scrolls into
 	// view. A CTA click must always persist attribution.
 	manageCtaClicks( gate );
+	initVerificationPrompts();
 
 	initReloadHandler();
 	if ( gate.classList.contains( 'newspack-content-gate__overlay-gate' ) ) {

--- a/plugins/newspack-plugin/src/content-gate/gate.js
+++ b/plugins/newspack-plugin/src/content-gate/gate.js
@@ -128,6 +128,17 @@ function initVerificationPrompts() {
 	}
 	window.newspackRAS = window.newspackRAS || [];
 	window.newspackRAS.push( function ( ras ) {
+		// The modal reaches both onSuccess and onClose on the Continue path — it closes
+		// itself and then reports success — so the reload is claimed once rather than
+		// fired from each.
+		let reloading = false;
+		const reloadOnce = () => {
+			if ( reloading ) {
+				return;
+			}
+			reloading = true;
+			window.location.reload();
+		};
 		boxes.forEach( box => {
 			wireInlineVerificationBox( box, {
 				url: box.dataset.verificationUrl,
@@ -160,8 +171,8 @@ function initVerificationPrompts() {
 						// the path where the modal closes itself. Reloading either way is
 						// safe — a reader who dismissed without verifying gets the same
 						// gate back.
-						onSuccess: () => window.location.reload(),
-						onClose: () => window.location.reload(),
+						onSuccess: reloadOnce,
+						onClose: reloadOnce,
 					} );
 					return true;
 				},

--- a/plugins/newspack-plugin/src/content-gate/gate.js
+++ b/plugins/newspack-plugin/src/content-gate/gate.js
@@ -149,16 +149,17 @@ function initVerificationPrompts() {
 					// Both checks run before the call, not after: the code is already sent
 					// by this point, and openAuthModal's own early returns invoke
 					// onSuccess — so a modal that never opened would reload the page past
-					// the reader instead of handing control back. `_openAuthModal` is read
-					// at click time because the auth bundle attaches it on its own RAS
-					// callback and nothing orders the two pushes.
+					// the reader instead of handing control back. The method is absent
+					// when RAS is disabled; the container is rendered by the auth bundle,
+					// which loads on its own RAS callback with nothing ordering the two
+					// pushes, so both are read at click time.
 					if (
-						typeof ras._openAuthModal !== 'function' ||
+						typeof ras.openAuthModal !== 'function' ||
 						! document.querySelector( '.newspack-reader-auth-modal .newspack-reader-auth' )
 					) {
 						return false;
 					}
-					ras._openAuthModal( {
+					ras.openAuthModal( {
 						skipAuthenticatedCheck: true,
 						skipNewslettersSignup: true,
 						backButtonClosesModal: true,

--- a/plugins/newspack-plugin/src/content-gate/gate.scss
+++ b/plugins/newspack-plugin/src/content-gate/gate.scss
@@ -110,3 +110,9 @@ body {
 		}
 	}
 }
+
+// The verification prompt sits above the publisher's gate layout. Twice the box
+// default separates them enough to read as two offers rather than one block.
+.newspack-ui.newspack-content-gate__verification-prompt > .newspack-ui__box {
+	margin-bottom: var(--newspack-ui-spacer-9);
+}

--- a/plugins/newspack-plugin/src/reader-activation-auth/inline-verification.js
+++ b/plugins/newspack-plugin/src/reader-activation-auth/inline-verification.js
@@ -13,6 +13,8 @@
  * @param {string} config.nonce Nonce authorizing the OTP request.
  *
  * @return {Promise<any>} Resolves with the JSON response on success, rejects on failure.
+ *                        A rejection carrying `isServerMessage` has the server's own
+ *                        localized wording in `message`.
  */
 export function sendVerificationOTP( { url, nonce } ) {
 	const body = new FormData();
@@ -34,7 +36,13 @@ export function sendVerificationOTP( { url, nonce } ) {
 			// caller's .catch() runs and the button is re-enabled, instead of advancing to
 			// OTP entry for a code that was never sent.
 			if ( ! json?.success ) {
-				throw new Error( json?.data || 'Failed to send verification code.' );
+				const isServerMessage = typeof json?.data === 'string' && !! json.data;
+				const error = new Error( isServerMessage ? json.data : 'Failed to send verification code.' );
+				// The handler answers every refusal with a localized string, so that message
+				// can be shown to the reader. An unexpected exception's message cannot, which
+				// is what this flag lets the caller tell apart.
+				error.isServerMessage = isServerMessage;
+				throw error;
 			}
 			return json;
 		} );
@@ -52,7 +60,7 @@ export function sendVerificationOTP( { url, nonce } ) {
  * @param {string}      config.url         The admin-ajax URL to POST to.
  * @param {string}      config.nonce       Nonce authorizing the OTP request.
  * @param {Function}    config.onSent      Called once the code is on its way. Return false if it could not proceed.
- * @param {string}      [config.errorText] Message to show in the box when the send fails.
+ * @param {string}      [config.errorText] Message to show in the box when the send fails for a reason the server did not name.
  *
  * @return {boolean} Whether the box was wired.
  */
@@ -66,18 +74,32 @@ export function wireInlineVerificationBox( box, { url, nonce, onSent, errorText 
 	button.dataset.otpWired = '1';
 
 	// The box marks its own error element. Deriving one structurally would land on a
-	// different paragraph in each of the two markups that use this.
-	const showError = () => {
+	// different paragraph in each of the markups that use this.
+	const showError = error => {
 		button.disabled = false;
+		button.removeAttribute( 'aria-busy' );
 		button.textContent = button.textContent.trim();
+		// Disabling the button dropped focus to <body>. Put it back, so a keyboard or
+		// screen-reader reader can retry without traversing the page again.
+		button.focus();
 		const errorEl = box.querySelector( '[data-error-target]' );
-		if ( errorEl && errorText ) {
-			errorEl.textContent = errorText;
+		if ( ! errorEl ) {
+			return;
 		}
+		// The server's own wording wherever there is one. The refusal readers actually
+		// hit is the one-minute resend limit, which has to read as "a code is already on
+		// its way" rather than as a failure.
+		const message = error?.isServerMessage ? error.message : errorText;
+		if ( ! message ) {
+			return;
+		}
+		errorEl.textContent = message;
+		errorEl.hidden = false;
 	};
 
 	button.addEventListener( 'click', () => {
 		button.disabled = true;
+		button.setAttribute( 'aria-busy', 'true' );
 		sendVerificationOTP( { url, nonce } )
 			.then( () => {
 				if ( typeof onSent !== 'function' ) {

--- a/plugins/newspack-plugin/src/reader-activation-auth/inline-verification.js
+++ b/plugins/newspack-plugin/src/reader-activation-auth/inline-verification.js
@@ -1,0 +1,93 @@
+/**
+ * Shared wiring for inline "send me a verification code" boxes — the registration
+ * block's box for a logged-in unverified reader, and the content gate's
+ * verification prompt. Both send the same OTP request and then hand the reader to
+ * the auth modal's OTP state; only what happens after they verify differs.
+ */
+
+/**
+ * Send the verification OTP email.
+ *
+ * @param {Object} config
+ * @param {string} config.url   The admin-ajax URL to POST to.
+ * @param {string} config.nonce Nonce authorizing the OTP request.
+ *
+ * @return {Promise<any>} Resolves with the JSON response on success, rejects on failure.
+ */
+export function sendVerificationOTP( { url, nonce } ) {
+	const body = new FormData();
+	body.set( 'action', 'newspack_reader_registration_verification' );
+	body.set( 'nonce', nonce );
+	return fetch( url, {
+		method: 'POST',
+		headers: { Accept: 'application/json' },
+		body,
+	} )
+		.then( res => {
+			if ( ! res.ok ) {
+				throw new Error( res.statusText );
+			}
+			return res.json();
+		} )
+		.then( json => {
+			// wp_send_json_error() returns HTTP 200 with { success: false }. Reject so the
+			// caller's .catch() runs and the button is re-enabled, instead of advancing to
+			// OTP entry for a code that was never sent.
+			if ( ! json?.success ) {
+				throw new Error( json?.data || 'Failed to send verification code.' );
+			}
+			return json;
+		} );
+}
+
+/**
+ * Wire an inline verification box's "Send code" button.
+ *
+ * `onSent` may throw or return false to report that it could not take the reader
+ * onward — the code is already in their inbox by then, so the box has to come back
+ * to a state they can act on rather than leaving them a dead button.
+ *
+ * @param {HTMLElement} box                The box element.
+ * @param {Object}      config
+ * @param {string}      config.url         The admin-ajax URL to POST to.
+ * @param {string}      config.nonce       Nonce authorizing the OTP request.
+ * @param {Function}    config.onSent      Called once the code is on its way. Return false if it could not proceed.
+ * @param {string}      [config.errorText] Message to show in the box when the send fails.
+ *
+ * @return {boolean} Whether the box was wired.
+ */
+export function wireInlineVerificationBox( box, { url, nonce, onSent, errorText } ) {
+	const button = box?.querySelector( '[data-send-otp]' );
+	// A box can be reachable from more than one script on the page; wiring it twice
+	// would fire one POST per handler on a single click.
+	if ( ! button || button.dataset.otpWired ) {
+		return false;
+	}
+	button.dataset.otpWired = '1';
+
+	// The box marks its own error element. Deriving one structurally would land on a
+	// different paragraph in each of the two markups that use this.
+	const showError = () => {
+		button.disabled = false;
+		button.textContent = button.textContent.trim();
+		const errorEl = box.querySelector( '[data-error-target]' );
+		if ( errorEl && errorText ) {
+			errorEl.textContent = errorText;
+		}
+	};
+
+	button.addEventListener( 'click', () => {
+		button.disabled = true;
+		sendVerificationOTP( { url, nonce } )
+			.then( () => {
+				if ( typeof onSent !== 'function' ) {
+					return;
+				}
+				if ( onSent() === false ) {
+					showError();
+				}
+			} )
+			.catch( showError );
+	} );
+	return true;
+}

--- a/plugins/newspack-plugin/src/reader-activation-auth/inline-verification.test.js
+++ b/plugins/newspack-plugin/src/reader-activation-auth/inline-verification.test.js
@@ -1,0 +1,146 @@
+/**
+ * The inline verification box mails a code and then hands the reader to the auth
+ * modal. These pin the parts a reader pays for when they are wrong: a code that
+ * was never sent must not advance them to the code-entry step, a refusal must say
+ * what the server said, and a box wired twice must not mail two codes on one click.
+ */
+
+import { sendVerificationOTP, wireInlineVerificationBox } from './inline-verification';
+
+const CONFIG = { url: 'https://example.test/wp-admin/admin-ajax.php', nonce: 'nonce-123' };
+
+/**
+ * Stub fetch with one JSON response.
+ *
+ * @param {Object}  json     The parsed JSON body to resolve with.
+ * @param {boolean} [ok]     Whether the response is an HTTP success.
+ * @param {string}  [status] Status text, used as the error message when not ok.
+ */
+function mockFetchJSON( json, ok = true, status = 'Internal Server Error' ) {
+	global.fetch = jest.fn( () => Promise.resolve( { ok, statusText: status, json: () => Promise.resolve( json ) } ) );
+}
+
+/**
+ * Render a box in the shape both markups share.
+ *
+ * @return {HTMLElement} The box element.
+ */
+function renderBox() {
+	document.body.innerHTML = `
+		<div class="box">
+			<p>We'll send a verification code to <strong class="email-address">reader@example.test</strong>.</p>
+			<p data-error-target role="status" hidden></p>
+			<p><button type="button" data-send-otp>Send code</button></p>
+		</div>
+	`;
+	return document.querySelector( '.box' );
+}
+
+/**
+ * Let the click handler's promise chain settle.
+ */
+const flush = () => new Promise( resolve => setTimeout( resolve, 0 ) );
+
+afterEach( () => {
+	delete global.fetch;
+	document.body.innerHTML = '';
+} );
+
+describe( 'sendVerificationOTP', () => {
+	it( 'rejects on a wp_send_json_error body, which arrives as HTTP 200', async () => {
+		mockFetchJSON( { success: false, data: 'Please wait a minute before requesting another authorization code.' } );
+
+		await expect( sendVerificationOTP( CONFIG ) ).rejects.toMatchObject( {
+			message: 'Please wait a minute before requesting another authorization code.',
+			// Flags the message as the server's own localized wording, so a caller can
+			// show it to the reader. An unexpected exception's message is not shown.
+			isServerMessage: true,
+		} );
+	} );
+
+	it( 'resolves on success', async () => {
+		mockFetchJSON( { success: true, data: 'OTP sent' } );
+
+		await expect( sendVerificationOTP( CONFIG ) ).resolves.toEqual( { success: true, data: 'OTP sent' } );
+	} );
+} );
+
+describe( 'wireInlineVerificationBox', () => {
+	it( 'sends one code per click however many times the box is wired', async () => {
+		const box = renderBox();
+		mockFetchJSON( { success: true } );
+
+		expect( wireInlineVerificationBox( box, { ...CONFIG, onSent: () => true } ) ).toBe( true );
+		expect( wireInlineVerificationBox( box, { ...CONFIG, onSent: () => true } ) ).toBe( false );
+
+		box.querySelector( '[data-send-otp]' ).click();
+		await flush();
+
+		expect( global.fetch ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( "shows the server's wording and returns the reader to a button they can press", async () => {
+		const box = renderBox();
+		const onSent = jest.fn();
+		mockFetchJSON( { success: false, data: 'Please wait a minute before requesting another authorization code.' } );
+
+		wireInlineVerificationBox( box, { ...CONFIG, onSent, errorText: 'Something went wrong. Please try again.' } );
+		const button = box.querySelector( '[data-send-otp]' );
+		button.click();
+		await flush();
+
+		expect( onSent ).not.toHaveBeenCalled();
+		expect( box.querySelector( '[data-error-target]' ).textContent ).toBe( 'Please wait a minute before requesting another authorization code.' );
+		expect( box.querySelector( '[data-error-target]' ).hidden ).toBe( false );
+		// The line naming the reader's address is a separate node, so a failed send
+		// leaves them still able to see which address the code is going to.
+		expect( box.querySelector( '.email-address' ) ).not.toBeNull();
+		expect( button.disabled ).toBe( false );
+		expect( button.hasAttribute( 'aria-busy' ) ).toBe( false );
+		expect( document.activeElement ).toBe( button );
+	} );
+
+	it( "falls back to the caller's copy when the failure is not the server refusing", async () => {
+		const box = renderBox();
+		mockFetchJSON( {}, false, 'Bad Gateway' );
+
+		wireInlineVerificationBox( box, { ...CONFIG, onSent: () => true, errorText: 'Something went wrong. Please try again.' } );
+		box.querySelector( '[data-send-otp]' ).click();
+		await flush();
+
+		expect( box.querySelector( '[data-error-target]' ).textContent ).toBe( 'Something went wrong. Please try again.' );
+	} );
+
+	it( 'recovers the box when onSent cannot take the reader onward', async () => {
+		const box = renderBox();
+		mockFetchJSON( { success: true } );
+
+		// The code is already in the reader's inbox at this point, so a false return
+		// has to leave a pressable button rather than a dead one.
+		wireInlineVerificationBox( box, { ...CONFIG, onSent: () => false, errorText: 'Something went wrong. Please try again.' } );
+		const button = box.querySelector( '[data-send-otp]' );
+		button.click();
+		await flush();
+
+		expect( button.disabled ).toBe( false );
+		expect( box.querySelector( '[data-error-target]' ).textContent ).toBe( 'Something went wrong. Please try again.' );
+	} );
+
+	it( 'leaves the box alone when onSent takes over', async () => {
+		const box = renderBox();
+		mockFetchJSON( { success: true } );
+
+		wireInlineVerificationBox( box, { ...CONFIG, onSent: () => true, errorText: 'Something went wrong. Please try again.' } );
+		box.querySelector( '[data-send-otp]' ).click();
+		await flush();
+
+		expect( box.querySelector( '[data-error-target]' ).hidden ).toBe( true );
+		expect( box.querySelector( '[data-send-otp]' ).disabled ).toBe( true );
+	} );
+
+	it( 'reports a box with no send button as unwired', () => {
+		document.body.innerHTML = '<div class="box"></div>';
+
+		expect( wireInlineVerificationBox( document.querySelector( '.box' ), CONFIG ) ).toBe( false );
+	} );
+} );

--- a/plugins/newspack-plugin/src/reader-activation-auth/verification-modal.js
+++ b/plugins/newspack-plugin/src/reader-activation-auth/verification-modal.js
@@ -82,13 +82,23 @@ export function openVerificationModal( config = {} ) {
 					config.onSendCode();
 				}
 			} )
-			.catch( () => {
+			.catch( error => {
 				sendOtpButton.disabled = false;
 				sendOtpButton.textContent = sendOtpButton.textContent.trim();
-				const errorP = modal.querySelector( '.newspack-ui__box p:not(:has(button))' );
-				if ( errorP ) {
-					errorP.textContent = newspack_reader_activation_labels?.verification_error || '';
+				sendOtpButton.focus();
+				const errorP = modal.querySelector( '[data-error-target]' );
+				if ( ! errorP ) {
+					return;
 				}
+				// The server's own wording wherever there is one — the refusal readers
+				// actually hit is the one-minute resend limit, which has to read as "a code
+				// is already on its way" rather than as a failure.
+				const message = error?.isServerMessage ? error.message : newspack_reader_activation_labels?.verification_error || '';
+				if ( ! message ) {
+					return;
+				}
+				errorP.textContent = message;
+				errorP.hidden = false;
 			} );
 	}
 

--- a/plugins/newspack-plugin/src/reader-activation-auth/verification-modal.js
+++ b/plugins/newspack-plugin/src/reader-activation-auth/verification-modal.js
@@ -4,6 +4,7 @@
  * Internal dependencies.
  */
 import * as a11y from './accessibility.js';
+import { sendVerificationOTP } from './inline-verification.js';
 
 /**
  * Helpers for the post-registration verification modal rendered in wp_footer
@@ -22,38 +23,6 @@ const MODAL_ID = 'newspack-my-account__newspack-reader-verification';
  * @type {AbortController|null}
  */
 let currentController = null;
-
-/**
- * Send the verification OTP email.
- *
- * @param {string} nonce Verification nonce.
- * @return {Promise<any>} Resolves with the JSON response on success, rejects on network/HTTP error.
- */
-function sendVerificationOTP( nonce ) {
-	const body = new FormData();
-	body.set( 'action', 'newspack_reader_registration_verification' );
-	body.set( 'nonce', nonce );
-	return fetch( newspack_ras_config.verification_url, {
-		method: 'POST',
-		headers: { Accept: 'application/json' },
-		body,
-	} )
-		.then( res => {
-			if ( ! res.ok ) {
-				throw new Error( res.statusText );
-			}
-			return res.json();
-		} )
-		.then( json => {
-			// wp_send_json_error() returns HTTP 200 with { success: false }. Reject so the
-			// caller's .catch() runs and the "Send code" button is re-enabled, instead of the
-			// modal silently advancing to OTP entry for an OTP that was never sent.
-			if ( ! json?.success ) {
-				throw new Error( json?.data || 'Failed to send verification code.' );
-			}
-			return json;
-		} );
-}
 
 /**
  * Open the post-registration verification modal.
@@ -100,7 +69,7 @@ export function openVerificationModal( config = {} ) {
 
 	function handleSendClick() {
 		sendOtpButton.disabled = true;
-		sendVerificationOTP( config.verificationNonce )
+		sendVerificationOTP( { url: newspack_ras_config.verification_url, nonce: config.verificationNonce } )
 			.then( () => {
 				codeSent = true;
 				if ( typeof config.setOTPTimer === 'function' ) {

--- a/plugins/newspack-plugin/src/reader-activation/index.js
+++ b/plugins/newspack-plugin/src/reader-activation/index.js
@@ -152,6 +152,10 @@ const authStrategies = [ 'pwd', 'link' ];
 /**
  * Start the authentication modal with an optional custom callback.
  *
+ * Pass `skipAuthenticatedCheck` to open the modal for a reader who is already
+ * logged in — the content gate's verification prompt needs it, since an
+ * unverified reader is authenticated but still has to enter an OTP.
+ *
  * @param {Object} config Config.
  */
 export function openAuthModal( config = {} ) {
@@ -161,6 +165,7 @@ export function openAuthModal( config = {} ) {
 		onError: null,
 		initialState: null,
 		skipSuccess: false,
+		skipAuthenticatedCheck: false,
 		skipNewslettersSignup: false,
 		labels: {
 			signin: {
@@ -176,7 +181,7 @@ export function openAuthModal( config = {} ) {
 		...config,
 	};
 
-	if ( newspack_ras_config.is_logged_in ) {
+	if ( ! config.skipAuthenticatedCheck && newspack_ras_config.is_logged_in ) {
 		if ( config.onSuccess && typeof config.onSuccess === 'function' ) {
 			config.onSuccess();
 		}

--- a/plugins/newspack-plugin/src/reader-activation/open-auth-modal.test.js
+++ b/plugins/newspack-plugin/src/reader-activation/open-auth-modal.test.js
@@ -1,0 +1,44 @@
+/**
+ * The public `openAuthModal` normally refuses to open for a logged-in reader and
+ * reports success instead. `skipAuthenticatedCheck` is the documented way past
+ * that, for the one case where being logged in is not the same as being done:
+ * the content gate's verification prompt, whose reader is authenticated but
+ * unverified and still owes an OTP.
+ *
+ * Lives in its own file so the module mock does not reach the rest of the
+ * reader-activation suite.
+ */
+
+jest.mock( '../reader-activation-auth/auth-modal.js', () => ( {
+	openAuthModal: jest.fn(),
+	getModalContainer: jest.fn(),
+	SIGN_IN_MODAL_HASHES: [],
+} ) );
+
+import { openAuthModal } from './index';
+import { openAuthModal as openModal } from '../reader-activation-auth/auth-modal.js';
+
+describe( 'openAuthModal() for a logged-in reader', () => {
+	beforeEach( () => {
+		openModal.mockClear();
+		window.newspack_ras_config = { is_logged_in: true };
+		window.newspack_reader_activation_labels = {
+			signin: { title: 'Sign in' },
+			register: { title: 'Register' },
+		};
+	} );
+
+	it( 'reports success without opening the modal by default', () => {
+		const onSuccess = jest.fn();
+		openAuthModal( { onSuccess } );
+		expect( openModal ).not.toHaveBeenCalled();
+		expect( onSuccess ).toHaveBeenCalled();
+	} );
+
+	it( 'opens the modal and leaves onSuccess to it when the check is skipped', () => {
+		const onSuccess = jest.fn();
+		openAuthModal( { onSuccess, skipAuthenticatedCheck: true, initialState: 'otp' } );
+		expect( onSuccess ).not.toHaveBeenCalled();
+		expect( openModal ).toHaveBeenCalledWith( expect.objectContaining( { skipAuthenticatedCheck: true, initialState: 'otp' } ) );
+	} );
+} );

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-email-verification-prompt.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-email-verification-prompt.php
@@ -1,0 +1,641 @@
+<?php
+/**
+ * Tests for the content gate's email verification prompt (NPPD-2221).
+ *
+ * @package Newspack
+ */
+
+use Newspack\Access_Rules;
+use Newspack\Content_Gate;
+use Newspack\Content_Restriction_Control;
+use Newspack\Email_Verification_Prompt;
+use Newspack\Institution;
+use Newspack\Reader_Activation;
+
+/**
+ * A reader whose email domain is whitelisted but unverified is denied by the
+ * email-domain access rule with nothing on the paywall saying why. These tests
+ * pin when the gate offers them the verification prompt instead, and — the part
+ * that is easy to get wrong — when it must not, because verifying would leave
+ * them looking at the same paywall.
+ *
+ * @group Content_Gate_Verification_Prompt
+ */
+class Test_Email_Verification_Prompt extends WP_UnitTestCase {
+
+	/**
+	 * Institution post IDs to clean up.
+	 *
+	 * @var int[]
+	 */
+	private $institution_ids = [];
+
+	/**
+	 * Setup.
+	 */
+	public function set_up() {
+		parent::set_up();
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+		add_filter( 'newspack_reader_activation_enabled', '__return_true' );
+	}
+
+	/**
+	 * Teardown.
+	 */
+	public function tear_down() {
+		foreach ( $this->institution_ids as $institution_id ) {
+			wp_delete_post( $institution_id, true );
+		}
+		$this->institution_ids = [];
+		foreach ( Content_Gate::get_gates() as $gate ) {
+			wp_delete_post( $gate['id'], true );
+		}
+		Institution::invalidate_cache();
+		Institution::reset_matching_cache();
+		Content_Gate::flush_gates_cache();
+		$this->reset_caches();
+		remove_filter( 'newspack_reader_activation_enabled', '__return_true' );
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Clear the request-scoped memos that would otherwise carry a previous test's
+	 * gate resolution and prompt decision into the next one.
+	 */
+	private function reset_caches() {
+		Email_Verification_Prompt::reset_cache();
+		foreach ( [ 'post_gates_map', 'post_gate_id_map', 'post_gate_layout_id_map' ] as $property_name ) {
+			$property = new ReflectionProperty( Content_Restriction_Control::class, $property_name );
+			$property->setAccessible( true );
+			$property->setValue( null, [] );
+		}
+	}
+
+	/**
+	 * Create a reader.
+	 *
+	 * @param string $email    Email address.
+	 * @param bool   $verified Whether the address is verified.
+	 *
+	 * @return int User ID.
+	 */
+	private function create_reader( $email, $verified = false ) {
+		$user_id = self::factory()->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_email' => $email,
+			]
+		);
+		update_user_meta( $user_id, Reader_Activation::READER, true );
+		if ( $verified ) {
+			update_user_meta( $user_id, Reader_Activation::EMAIL_VERIFIED, true );
+		}
+		return $user_id;
+	}
+
+	/**
+	 * Create a published institution granting access by email domain.
+	 *
+	 * @param string $name    Institution name.
+	 * @param string $domains Comma-delimited domain list.
+	 *
+	 * @return int Institution post ID.
+	 */
+	private function create_institution( $name, $domains ) {
+		$institution_id          = Institution::create( $name, '', [ 'email_domain' => $domains ] );
+		$this->institution_ids[] = $institution_id;
+		Institution::invalidate_cache();
+		return $institution_id;
+	}
+
+	/**
+	 * Create a published gate over all posts, gating on the given access rules.
+	 *
+	 * @param array $access_rules Access rules in grouped format.
+	 * @param int   $priority     Gate priority. Lower gates are evaluated first.
+	 * @param array $registration Registration-mode settings, if the gate has any.
+	 *
+	 * @return int Gate ID.
+	 */
+	private function create_gate( $access_rules, $priority = 1, $registration = [] ) {
+		$gate_id = Content_Gate::create_gate( [ 'title' => 'Gate ' . $priority ] );
+		Content_Gate::update_gate_settings(
+			$gate_id,
+			[
+				'title'         => 'Gate ' . $priority,
+				'status'        => 'publish',
+				'priority'      => $priority,
+				'content_rules' => [
+					[
+						'slug'  => 'post_types',
+						'value' => [ 'post' ],
+					],
+				],
+				'registration'  => $registration,
+				'custom_access' => [
+					'active'       => true,
+					'access_rules' => $access_rules,
+				],
+			]
+		);
+		Content_Gate::flush_gates_cache();
+		$this->reset_caches();
+		return $gate_id;
+	}
+
+	/**
+	 * Put a reader in front of a gated post, as a front-end request would: on the
+	 * singular view, with the restriction check having written the gate resolution
+	 * that the prompt and the layout filter both read back.
+	 *
+	 * @param int $user_id Reader ID.
+	 *
+	 * @return bool Whether the post came out restricted.
+	 */
+	private function visit_gated_post_as( $user_id ) {
+		$this->reset_caches();
+		$gated_post_id = self::factory()->post->create();
+		wp_set_current_user( $user_id );
+		$this->go_to( get_permalink( $gated_post_id ) );
+		wp_set_current_user( $user_id );
+		return Content_Gate::is_post_restricted( $gated_post_id );
+	}
+
+	/**
+	 * The headline names the institution, so the reader is told what verifying buys
+	 * them rather than being asked for a code with no stated reason.
+	 */
+	public function test_prompts_unverified_reader_matching_an_institution() {
+		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$this->create_gate(
+			[
+				[
+					[
+						'slug'  => 'institution',
+						'value' => [ $institution_id ],
+					],
+				],
+			]
+		);
+		$reader_id = $this->create_reader( 'reader@voyager.example' );
+
+		$this->assertTrue( $this->visit_gated_post_as( $reader_id ), 'Sanity: the unverified reader is denied.' );
+
+		$prompt_context = Email_Verification_Prompt::get_prompt_context();
+		$this->assertNotFalse( $prompt_context, 'The denied reader is offered the verification prompt.' );
+		$this->assertSame( [ 'Voyager Technologies' ], $prompt_context['institutions'] );
+		$this->assertSame( 'reader@voyager.example', $prompt_context['email'] );
+	}
+
+	/**
+	 * A gate's own email-domain rule denies for the same reason and gets the same
+	 * prompt, with no institution to name.
+	 */
+	public function test_prompts_on_a_bare_email_domain_rule() {
+		$this->create_gate(
+			[
+				[
+					[
+						'slug'  => 'email_domain',
+						'value' => 'voyager.example',
+					],
+				],
+			]
+		);
+		$reader_id = $this->create_reader( 'reader@voyager.example' );
+
+		$this->assertTrue( $this->visit_gated_post_as( $reader_id ), 'Sanity: the unverified reader is denied.' );
+
+		$prompt_context = Email_Verification_Prompt::get_prompt_context();
+		$this->assertNotFalse( $prompt_context, 'The denied reader is offered the verification prompt.' );
+		$this->assertSame( [], $prompt_context['institutions'] );
+	}
+
+	/**
+	 * The whole point of the hypothetical re-evaluation: the institution rule ANDed
+	 * with a rule the reader also fails means verifying returns them to the same
+	 * paywall, so the prompt must not promise otherwise.
+	 */
+	public function test_no_prompt_when_verification_would_not_unlock_the_gate() {
+		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$this->create_gate(
+			[
+				[
+					[
+						'slug'  => 'institution',
+						'value' => [ $institution_id ],
+					],
+					[
+						'slug'  => 'reader_data',
+						'value' => 'plan=premium',
+					],
+				],
+			]
+		);
+		$reader_id = $this->create_reader( 'reader@voyager.example' );
+
+		$this->assertTrue( $this->visit_gated_post_as( $reader_id ), 'Sanity: the unverified reader is denied.' );
+		$this->assertFalse(
+			Email_Verification_Prompt::get_prompt_context(),
+			'Verifying would not satisfy the rule ANDed with the institution, so no prompt is offered.'
+		);
+	}
+
+	/**
+	 * A domain the gate does not reference is not a reason to ask for verification —
+	 * and where a reader's address matches two institutions but the gate grants access
+	 * through only one, the prompt names that one alone.
+	 */
+	public function test_only_institutions_the_gate_grants_through_are_named() {
+		$granted_institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$this->create_institution( 'Unrelated Institute', 'voyager.example' );
+		$this->create_gate(
+			[
+				[
+					[
+						'slug'  => 'institution',
+						'value' => [ $granted_institution_id ],
+					],
+				],
+			]
+		);
+		$matching_reader_id     = $this->create_reader( 'reader@voyager.example' );
+		$non_matching_reader_id = $this->create_reader( 'reader@elsewhere.example' );
+
+		$this->assertTrue( $this->visit_gated_post_as( $non_matching_reader_id ), 'Sanity: the unverified reader is denied.' );
+		$this->assertFalse(
+			Email_Verification_Prompt::get_prompt_context(),
+			'An address on no institution the gate references is not a reason to prompt.'
+		);
+
+		$this->visit_gated_post_as( $matching_reader_id );
+		$prompt_context = Email_Verification_Prompt::get_prompt_context();
+		$this->assertNotFalse( $prompt_context );
+		$this->assertSame(
+			[ 'Voyager Technologies' ],
+			$prompt_context['institutions'],
+			'Only the institution this gate grants access through is named, not every institution the address matches.'
+		);
+	}
+
+	/**
+	 * The prompt names the institutions that are actually a route in. Where the reader's
+	 * address matches institutions in two groups and only one group passes, naming both
+	 * would tell them an institution unlocks the article when it never will.
+	 */
+	public function test_only_institutions_in_a_passing_group_are_named() {
+		$unlocking_institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$blocked_institution_id   = $this->create_institution( 'Grounded Institute', 'voyager.example' );
+		$this->create_gate(
+			[
+				[
+					[
+						'slug'  => 'institution',
+						'value' => [ $unlocking_institution_id ],
+					],
+				],
+				[
+					[
+						'slug'  => 'institution',
+						'value' => [ $blocked_institution_id ],
+					],
+					[
+						'slug'  => 'reader_data',
+						'value' => 'plan=premium',
+					],
+				],
+			]
+		);
+		$reader_id = $this->create_reader( 'reader@voyager.example' );
+
+		$this->assertTrue( $this->visit_gated_post_as( $reader_id ), 'Sanity: the unverified reader is denied.' );
+
+		$prompt_context = Email_Verification_Prompt::get_prompt_context();
+		$this->assertNotFalse( $prompt_context );
+		$this->assertSame(
+			[ 'Voyager Technologies' ],
+			$prompt_context['institutions'],
+			'Grounded Institute is ANDed with a rule the reader fails, so verifying never opens that route.'
+		);
+	}
+
+	/**
+	 * A gate can be one of several covering a post, and the restriction check stops at
+	 * the first that denies. Verifying past this gate only to be held by the next one
+	 * is the promise the prompt must not make.
+	 */
+	public function test_no_prompt_when_a_lower_priority_gate_still_denies() {
+		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$this->create_gate(
+			[
+				[
+					[
+						'slug'  => 'institution',
+						'value' => [ $institution_id ],
+					],
+				],
+			]
+		);
+		// Priority 2, so it is evaluated only once the institution gate starts granting.
+		$this->create_gate(
+			[
+				[
+					[
+						'slug'  => 'reader_data',
+						'value' => 'plan=premium',
+					],
+				],
+			],
+			2
+		);
+		$reader_id = $this->create_reader( 'reader@voyager.example' );
+
+		$this->assertTrue( $this->visit_gated_post_as( $reader_id ), 'Sanity: the unverified reader is denied.' );
+		$this->assertFalse(
+			Email_Verification_Prompt::get_prompt_context(),
+			'Verifying would clear the first gate and leave the reader held by the second, so no prompt is offered.'
+		);
+	}
+
+	/**
+	 * The rule keeps its verification requirement. Simulating verification decides
+	 * whether to prompt and nothing else — an unverified reader is still denied.
+	 */
+	public function test_simulation_does_not_grant_access() {
+		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$this->create_gate(
+			[
+				[
+					[
+						'slug'  => 'institution',
+						'value' => [ $institution_id ],
+					],
+				],
+			]
+		);
+		$reader_id = $this->create_reader( 'reader@voyager.example' );
+		$this->visit_gated_post_as( $reader_id );
+
+		$this->assertNotFalse( Email_Verification_Prompt::get_prompt_context(), 'Sanity: the prompt evaluated, running the simulation.' );
+		$this->assertFalse(
+			Access_Rules::is_email_domain_whitelisted( $reader_id, 'voyager.example' ),
+			'The email-domain rule still denies an unverified reader after the prompt has evaluated it.'
+		);
+
+		update_user_meta( $reader_id, Reader_Activation::EMAIL_VERIFIED, true );
+		$this->assertTrue(
+			Access_Rules::is_email_domain_whitelisted( $reader_id, 'voyager.example' ),
+			'Verifying is what grants access.'
+		);
+	}
+
+	/**
+	 * The assumption covers the one reader the prompt is being evaluated for. Marking a
+	 * reader verified destroys their other sessions, so a hypothetical that reached a
+	 * second reader would be a real change to someone who never asked for one.
+	 */
+	public function test_assumption_does_not_reach_another_reader() {
+		$reader_a_id = $this->create_reader( 'a@voyager.example' );
+		$reader_b_id = $this->create_reader( 'b@voyager.example' );
+
+		$verdicts = Access_Rules::with_assumed_verification(
+			$reader_a_id,
+			function () use ( $reader_a_id, $reader_b_id ) {
+				return [
+					'a' => Access_Rules::is_email_domain_whitelisted( $reader_a_id, 'voyager.example' ),
+					'b' => Access_Rules::is_email_domain_whitelisted( $reader_b_id, 'voyager.example' ),
+				];
+			}
+		);
+
+		$this->assertTrue( $verdicts['a'], 'The reader the assumption is about passes the rule.' );
+		$this->assertFalse( $verdicts['b'], 'Every other reader is still held to the verification requirement.' );
+	}
+
+	/**
+	 * Rule callbacks are third-party-registerable, so one can throw mid-evaluation. The
+	 * assumption must not survive that and leak into the next real access decision.
+	 */
+	public function test_assumption_is_cleared_when_the_callback_throws() {
+		$reader_id = $this->create_reader( 'reader@voyager.example' );
+
+		try {
+			Access_Rules::with_assumed_verification(
+				$reader_id,
+				function () {
+					throw new \RuntimeException( 'rule callback blew up' );
+				}
+			);
+			$this->fail( 'The exception should propagate to the caller.' );
+		} catch ( \RuntimeException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Expected — what matters is the state left behind.
+		}
+
+		$this->assertFalse(
+			Access_Rules::is_email_domain_whitelisted( $reader_id, 'voyager.example' ),
+			'The rule denies the unverified reader again once the hypothetical has unwound.'
+		);
+	}
+
+	/**
+	 * A verified reader on a whitelisted domain is not denied in the first place, and a
+	 * non-reader account on the same domain is out of the flow whatever its state.
+	 */
+	public function test_no_prompt_for_a_verified_reader_or_a_non_reader() {
+		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$this->create_gate(
+			[
+				[
+					[
+						'slug'  => 'institution',
+						'value' => [ $institution_id ],
+					],
+				],
+			]
+		);
+		$reader_id = $this->create_reader( 'reader@voyager.example', true );
+
+		$this->assertFalse( $this->visit_gated_post_as( $reader_id ), 'A verified reader on the domain is granted access.' );
+		$this->assertFalse( Email_Verification_Prompt::get_prompt_context() );
+
+		$editor_id = self::factory()->user->create(
+			[
+				'role'       => 'editor',
+				'user_email' => 'editor@voyager.example',
+			]
+		);
+		$this->visit_gated_post_as( $editor_id );
+		$this->assertFalse(
+			Email_Verification_Prompt::get_prompt_context(),
+			'A non-reader account is not asked to verify, whatever its email domain.'
+		);
+	}
+
+	/**
+	 * A gate can wall registration behind verification and grant by email domain at the
+	 * same time. One act of verifying satisfies both, so asking what the reader would
+	 * see afterwards has to assume it at both seams — otherwise the prompt is suppressed
+	 * on the configuration it helps most.
+	 */
+	public function test_prompts_when_the_gate_also_walls_registration_behind_verification() {
+		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$this->create_gate(
+			[
+				[
+					[
+						'slug'  => 'institution',
+						'value' => [ $institution_id ],
+					],
+				],
+			],
+			1,
+			[
+				'active'               => true,
+				'require_verification' => true,
+			]
+		);
+		$reader_id = $this->create_reader( 'reader@voyager.example' );
+
+		$this->assertTrue( $this->visit_gated_post_as( $reader_id ), 'Sanity: the unverified reader is denied.' );
+		$this->assertNotFalse(
+			Email_Verification_Prompt::get_prompt_context(),
+			'Verifying satisfies the registration wall and the institution rule together, so the prompt is offered.'
+		);
+	}
+
+	/**
+	 * Resolving the prompt replays the restriction decision, which is memoised. The
+	 * request's own answer has to survive that: the gate render reads it back to decide
+	 * what to show, and a second read finding it wiped would drop the gate.
+	 */
+	public function test_resolving_the_prompt_leaves_the_gate_resolution_intact() {
+		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$gate_id        = $this->create_gate(
+			[
+				[
+					[
+						'slug'  => 'institution',
+						'value' => [ $institution_id ],
+					],
+				],
+			]
+		);
+		$reader_id = $this->create_reader( 'reader@voyager.example' );
+		$this->visit_gated_post_as( $reader_id );
+
+		$resolved_gate_id   = Content_Gate::get_gate_post_id();
+		$resolved_layout_id = Content_Gate::get_gate_layout_id();
+		$this->assertSame( $gate_id, $resolved_gate_id, 'Sanity: the request resolved to the gate under test.' );
+
+		$this->assertNotFalse( Email_Verification_Prompt::get_prompt_context() );
+
+		$this->assertSame( $resolved_gate_id, Content_Gate::get_gate_post_id(), 'The gate the request resolved to is unchanged.' );
+		$this->assertSame( $resolved_layout_id, Content_Gate::get_gate_layout_id(), 'The layout the request resolved to is unchanged.' );
+	}
+
+	/**
+	 * The prompt sends a code and hands the reader to the auth modal to enter it. Where
+	 * a site has filtered that modal off, offering the code would mail them something
+	 * they have nowhere to type.
+	 */
+	public function test_no_prompt_where_the_auth_modal_is_filtered_off() {
+		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$this->create_gate(
+			[
+				[
+					[
+						'slug'  => 'institution',
+						'value' => [ $institution_id ],
+					],
+				],
+			]
+		);
+		$reader_id = $this->create_reader( 'reader@voyager.example' );
+
+		$this->visit_gated_post_as( $reader_id );
+		$this->assertNotFalse( Email_Verification_Prompt::get_prompt_context(), 'Sanity: the reader is offered the prompt.' );
+
+		add_filter( 'newspack_reader_activation_should_render_auth', '__return_false' );
+		Email_Verification_Prompt::reset_cache();
+		$this->assertFalse(
+			Email_Verification_Prompt::get_prompt_context(),
+			'With no auth modal to enter the code into, no code is offered.'
+		);
+		remove_filter( 'newspack_reader_activation_should_render_auth', '__return_false' );
+	}
+
+	/**
+	 * Anonymous visitors are out of scope: there is no address to verify.
+	 */
+	public function test_no_prompt_for_anonymous_visitors() {
+		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$this->create_gate(
+			[
+				[
+					[
+						'slug'  => 'institution',
+						'value' => [ $institution_id ],
+					],
+				],
+			]
+		);
+
+		$this->assertTrue( $this->visit_gated_post_as( 0 ), 'Sanity: an anonymous visitor is denied.' );
+		$this->assertFalse( Email_Verification_Prompt::get_prompt_context() );
+	}
+
+	/**
+	 * The prompt renders inside the gate wrapper, above the layout content, so the
+	 * layout's own subscribe CTA remains the reader's alternative.
+	 */
+	public function test_prompt_is_prepended_to_the_gate_layout() {
+		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$this->create_gate(
+			[
+				[
+					[
+						'slug'  => 'institution',
+						'value' => [ $institution_id ],
+					],
+				],
+			]
+		);
+		$reader_id = $this->create_reader( 'reader@voyager.example' );
+		$this->visit_gated_post_as( $reader_id );
+
+		$layout_id      = Content_Gate::get_gate_layout_id();
+		$layout_content = '<p>Subscribe to keep reading.</p>';
+		$rendered       = apply_filters( 'newspack_gate_layout_content', $layout_content, $layout_id );
+
+		$this->assertStringContainsString( 'newspack-content-gate__verification-prompt', $rendered );
+		$this->assertStringContainsString( 'Voyager Technologies', $rendered );
+		$this->assertStringEndsWith( $layout_content, $rendered, 'The layout content is kept, with the prompt above it.' );
+	}
+
+	/**
+	 * A layout that is not the one denying this reader must not pick up the prompt.
+	 */
+	public function test_prompt_is_not_prepended_to_another_layout() {
+		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$this->create_gate(
+			[
+				[
+					[
+						'slug'  => 'institution',
+						'value' => [ $institution_id ],
+					],
+				],
+			]
+		);
+		$reader_id = $this->create_reader( 'reader@voyager.example' );
+		$this->visit_gated_post_as( $reader_id );
+
+		$other_layout_id = Content_Gate::get_gate_layout_id() + 1000;
+		$rendered        = apply_filters( 'newspack_gate_layout_content', '<p>Another layout.</p>', $other_layout_id );
+
+		$this->assertSame( '<p>Another layout.</p>', $rendered );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-email-verification-prompt.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-email-verification-prompt.php
@@ -169,7 +169,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 	 * them rather than being asked for a code with no stated reason.
 	 */
 	public function test_prompts_unverified_reader_matching_an_institution() {
-		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$institution_id = $this->create_institution( 'Example University', 'example.test' );
 		$this->create_gate(
 			[
 				[
@@ -180,14 +180,14 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 				],
 			]
 		);
-		$reader_id = $this->create_reader( 'reader@voyager.example' );
+		$reader_id = $this->create_reader( 'reader@example.test' );
 
 		$this->assertTrue( $this->visit_gated_post_as( $reader_id ), 'Sanity: the unverified reader is denied.' );
 
 		$prompt_context = Email_Verification_Prompt::get_prompt_context();
 		$this->assertNotFalse( $prompt_context, 'The denied reader is offered the verification prompt.' );
-		$this->assertSame( [ 'Voyager Technologies' ], $prompt_context['institutions'] );
-		$this->assertSame( 'reader@voyager.example', $prompt_context['email'] );
+		$this->assertSame( [ 'Example University' ], $prompt_context['institutions'] );
+		$this->assertSame( 'reader@example.test', $prompt_context['email'] );
 	}
 
 	/**
@@ -200,12 +200,12 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 				[
 					[
 						'slug'  => 'email_domain',
-						'value' => 'voyager.example',
+						'value' => 'example.test',
 					],
 				],
 			]
 		);
-		$reader_id = $this->create_reader( 'reader@voyager.example' );
+		$reader_id = $this->create_reader( 'reader@example.test' );
 
 		$this->assertTrue( $this->visit_gated_post_as( $reader_id ), 'Sanity: the unverified reader is denied.' );
 
@@ -220,7 +220,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 	 * paywall, so the prompt must not promise otherwise.
 	 */
 	public function test_no_prompt_when_verification_would_not_unlock_the_gate() {
-		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$institution_id = $this->create_institution( 'Example University', 'example.test' );
 		$this->create_gate(
 			[
 				[
@@ -235,7 +235,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 				],
 			]
 		);
-		$reader_id = $this->create_reader( 'reader@voyager.example' );
+		$reader_id = $this->create_reader( 'reader@example.test' );
 
 		$this->assertTrue( $this->visit_gated_post_as( $reader_id ), 'Sanity: the unverified reader is denied.' );
 		$this->assertFalse(
@@ -250,8 +250,8 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 	 * through only one, the prompt names that one alone.
 	 */
 	public function test_only_institutions_the_gate_grants_through_are_named() {
-		$granted_institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
-		$this->create_institution( 'Unrelated Institute', 'voyager.example' );
+		$granted_institution_id = $this->create_institution( 'Example University', 'example.test' );
+		$this->create_institution( 'Unrelated Institute', 'example.test' );
 		$this->create_gate(
 			[
 				[
@@ -262,8 +262,8 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 				],
 			]
 		);
-		$matching_reader_id     = $this->create_reader( 'reader@voyager.example' );
-		$non_matching_reader_id = $this->create_reader( 'reader@elsewhere.example' );
+		$matching_reader_id     = $this->create_reader( 'reader@example.test' );
+		$non_matching_reader_id = $this->create_reader( 'reader@elsewhere.test' );
 
 		$this->assertTrue( $this->visit_gated_post_as( $non_matching_reader_id ), 'Sanity: the unverified reader is denied.' );
 		$this->assertFalse(
@@ -275,7 +275,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 		$prompt_context = Email_Verification_Prompt::get_prompt_context();
 		$this->assertNotFalse( $prompt_context );
 		$this->assertSame(
-			[ 'Voyager Technologies' ],
+			[ 'Example University' ],
 			$prompt_context['institutions'],
 			'Only the institution this gate grants access through is named, not every institution the address matches.'
 		);
@@ -287,8 +287,8 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 	 * would tell them an institution unlocks the article when it never will.
 	 */
 	public function test_only_institutions_in_a_passing_group_are_named() {
-		$unlocking_institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
-		$blocked_institution_id   = $this->create_institution( 'Grounded Institute', 'voyager.example' );
+		$unlocking_institution_id = $this->create_institution( 'Example University', 'example.test' );
+		$blocked_institution_id   = $this->create_institution( 'Grounded Institute', 'example.test' );
 		$this->create_gate(
 			[
 				[
@@ -309,14 +309,14 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 				],
 			]
 		);
-		$reader_id = $this->create_reader( 'reader@voyager.example' );
+		$reader_id = $this->create_reader( 'reader@example.test' );
 
 		$this->assertTrue( $this->visit_gated_post_as( $reader_id ), 'Sanity: the unverified reader is denied.' );
 
 		$prompt_context = Email_Verification_Prompt::get_prompt_context();
 		$this->assertNotFalse( $prompt_context );
 		$this->assertSame(
-			[ 'Voyager Technologies' ],
+			[ 'Example University' ],
 			$prompt_context['institutions'],
 			'Grounded Institute is ANDed with a rule the reader fails, so verifying never opens that route.'
 		);
@@ -328,7 +328,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 	 * is the promise the prompt must not make.
 	 */
 	public function test_no_prompt_when_a_lower_priority_gate_still_denies() {
-		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$institution_id = $this->create_institution( 'Example University', 'example.test' );
 		$this->create_gate(
 			[
 				[
@@ -351,7 +351,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 			],
 			2
 		);
-		$reader_id = $this->create_reader( 'reader@voyager.example' );
+		$reader_id = $this->create_reader( 'reader@example.test' );
 
 		$this->assertTrue( $this->visit_gated_post_as( $reader_id ), 'Sanity: the unverified reader is denied.' );
 		$this->assertFalse(
@@ -365,7 +365,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 	 * whether to prompt and nothing else — an unverified reader is still denied.
 	 */
 	public function test_simulation_does_not_grant_access() {
-		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$institution_id = $this->create_institution( 'Example University', 'example.test' );
 		$this->create_gate(
 			[
 				[
@@ -376,18 +376,18 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 				],
 			]
 		);
-		$reader_id = $this->create_reader( 'reader@voyager.example' );
+		$reader_id = $this->create_reader( 'reader@example.test' );
 		$this->visit_gated_post_as( $reader_id );
 
 		$this->assertNotFalse( Email_Verification_Prompt::get_prompt_context(), 'Sanity: the prompt evaluated, running the simulation.' );
 		$this->assertFalse(
-			Access_Rules::is_email_domain_whitelisted( $reader_id, 'voyager.example' ),
+			Access_Rules::is_email_domain_whitelisted( $reader_id, 'example.test' ),
 			'The email-domain rule still denies an unverified reader after the prompt has evaluated it.'
 		);
 
 		update_user_meta( $reader_id, Reader_Activation::EMAIL_VERIFIED, true );
 		$this->assertTrue(
-			Access_Rules::is_email_domain_whitelisted( $reader_id, 'voyager.example' ),
+			Access_Rules::is_email_domain_whitelisted( $reader_id, 'example.test' ),
 			'Verifying is what grants access.'
 		);
 	}
@@ -398,15 +398,15 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 	 * second reader would be a real change to someone who never asked for one.
 	 */
 	public function test_assumption_does_not_reach_another_reader() {
-		$reader_a_id = $this->create_reader( 'a@voyager.example' );
-		$reader_b_id = $this->create_reader( 'b@voyager.example' );
+		$reader_a_id = $this->create_reader( 'a@example.test' );
+		$reader_b_id = $this->create_reader( 'b@example.test' );
 
 		$verdicts = Access_Rules::with_assumed_verification(
 			$reader_a_id,
 			function () use ( $reader_a_id, $reader_b_id ) {
 				return [
-					'a' => Access_Rules::is_email_domain_whitelisted( $reader_a_id, 'voyager.example' ),
-					'b' => Access_Rules::is_email_domain_whitelisted( $reader_b_id, 'voyager.example' ),
+					'a' => Access_Rules::is_email_domain_whitelisted( $reader_a_id, 'example.test' ),
+					'b' => Access_Rules::is_email_domain_whitelisted( $reader_b_id, 'example.test' ),
 				];
 			}
 		);
@@ -420,7 +420,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 	 * assumption must not survive that and leak into the next real access decision.
 	 */
 	public function test_assumption_is_cleared_when_the_callback_throws() {
-		$reader_id = $this->create_reader( 'reader@voyager.example' );
+		$reader_id = $this->create_reader( 'reader@example.test' );
 
 		try {
 			Access_Rules::with_assumed_verification(
@@ -435,7 +435,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 		}
 
 		$this->assertFalse(
-			Access_Rules::is_email_domain_whitelisted( $reader_id, 'voyager.example' ),
+			Access_Rules::is_email_domain_whitelisted( $reader_id, 'example.test' ),
 			'The rule denies the unverified reader again once the hypothetical has unwound.'
 		);
 	}
@@ -445,7 +445,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 	 * non-reader account on the same domain is out of the flow whatever its state.
 	 */
 	public function test_no_prompt_for_a_verified_reader_or_a_non_reader() {
-		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$institution_id = $this->create_institution( 'Example University', 'example.test' );
 		$this->create_gate(
 			[
 				[
@@ -456,7 +456,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 				],
 			]
 		);
-		$reader_id = $this->create_reader( 'reader@voyager.example', true );
+		$reader_id = $this->create_reader( 'reader@example.test', true );
 
 		$this->assertFalse( $this->visit_gated_post_as( $reader_id ), 'A verified reader on the domain is granted access.' );
 		$this->assertFalse( Email_Verification_Prompt::get_prompt_context() );
@@ -464,7 +464,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 		$editor_id = self::factory()->user->create(
 			[
 				'role'       => 'editor',
-				'user_email' => 'editor@voyager.example',
+				'user_email' => 'editor@example.test',
 			]
 		);
 		$this->visit_gated_post_as( $editor_id );
@@ -481,7 +481,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 	 * on the configuration it helps most.
 	 */
 	public function test_prompts_when_the_gate_also_walls_registration_behind_verification() {
-		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$institution_id = $this->create_institution( 'Example University', 'example.test' );
 		$this->create_gate(
 			[
 				[
@@ -497,7 +497,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 				'require_verification' => true,
 			]
 		);
-		$reader_id = $this->create_reader( 'reader@voyager.example' );
+		$reader_id = $this->create_reader( 'reader@example.test' );
 
 		$this->assertTrue( $this->visit_gated_post_as( $reader_id ), 'Sanity: the unverified reader is denied.' );
 		$this->assertNotFalse(
@@ -512,7 +512,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 	 * what to show, and a second read finding it wiped would drop the gate.
 	 */
 	public function test_resolving_the_prompt_leaves_the_gate_resolution_intact() {
-		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$institution_id = $this->create_institution( 'Example University', 'example.test' );
 		$gate_id        = $this->create_gate(
 			[
 				[
@@ -523,7 +523,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 				],
 			]
 		);
-		$reader_id = $this->create_reader( 'reader@voyager.example' );
+		$reader_id = $this->create_reader( 'reader@example.test' );
 		$this->visit_gated_post_as( $reader_id );
 
 		$resolved_gate_id   = Content_Gate::get_gate_post_id();
@@ -542,7 +542,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 	 * they have nowhere to type.
 	 */
 	public function test_no_prompt_where_the_auth_modal_is_filtered_off() {
-		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$institution_id = $this->create_institution( 'Example University', 'example.test' );
 		$this->create_gate(
 			[
 				[
@@ -553,7 +553,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 				],
 			]
 		);
-		$reader_id = $this->create_reader( 'reader@voyager.example' );
+		$reader_id = $this->create_reader( 'reader@example.test' );
 
 		$this->visit_gated_post_as( $reader_id );
 		$this->assertNotFalse( Email_Verification_Prompt::get_prompt_context(), 'Sanity: the reader is offered the prompt.' );
@@ -571,7 +571,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 	 * Anonymous visitors are out of scope: there is no address to verify.
 	 */
 	public function test_no_prompt_for_anonymous_visitors() {
-		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$institution_id = $this->create_institution( 'Example University', 'example.test' );
 		$this->create_gate(
 			[
 				[
@@ -592,7 +592,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 	 * layout's own subscribe CTA remains the reader's alternative.
 	 */
 	public function test_prompt_is_prepended_to_the_gate_layout() {
-		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$institution_id = $this->create_institution( 'Example University', 'example.test' );
 		$this->create_gate(
 			[
 				[
@@ -603,7 +603,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 				],
 			]
 		);
-		$reader_id = $this->create_reader( 'reader@voyager.example' );
+		$reader_id = $this->create_reader( 'reader@example.test' );
 		$this->visit_gated_post_as( $reader_id );
 
 		$layout_id      = Content_Gate::get_gate_layout_id();
@@ -611,7 +611,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 		$rendered       = apply_filters( 'newspack_gate_layout_content', $layout_content, $layout_id );
 
 		$this->assertStringContainsString( 'newspack-content-gate__verification-prompt', $rendered );
-		$this->assertStringContainsString( 'Voyager Technologies', $rendered );
+		$this->assertStringContainsString( 'Example University', $rendered );
 		$this->assertStringEndsWith( $layout_content, $rendered, 'The layout content is kept, with the prompt above it.' );
 	}
 
@@ -619,7 +619,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 	 * A layout that is not the one denying this reader must not pick up the prompt.
 	 */
 	public function test_prompt_is_not_prepended_to_another_layout() {
-		$institution_id = $this->create_institution( 'Voyager Technologies', 'voyager.example' );
+		$institution_id = $this->create_institution( 'Example University', 'example.test' );
 		$this->create_gate(
 			[
 				[
@@ -630,7 +630,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 				],
 			]
 		);
-		$reader_id = $this->create_reader( 'reader@voyager.example' );
+		$reader_id = $this->create_reader( 'reader@example.test' );
 		$this->visit_gated_post_as( $reader_id );
 
 		$other_layout_id = Content_Gate::get_gate_layout_id() + 1000;

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-email-verification-prompt.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-email-verification-prompt.php
@@ -136,7 +136,7 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 				],
 				'registration'  => $registration,
 				'custom_access' => [
-					'active'       => true,
+					'active'       => ! empty( $access_rules ),
 					'access_rules' => $access_rules,
 				],
 			]
@@ -504,6 +504,42 @@ class Test_Email_Verification_Prompt extends WP_UnitTestCase {
 			Email_Verification_Prompt::get_prompt_context(),
 			'Verifying satisfies the registration wall and the institution rule together, so the prompt is offered.'
 		);
+	}
+
+	/**
+	 * The gate a reader is stopped at need not be the gate their address would let them
+	 * past. Here a registration gate denies first and an institution gate two priorities
+	 * down is the route in — one act of verifying clears both, so scoping the walk to the
+	 * denying gate alone would suppress the prompt on a configuration it is exactly for.
+	 */
+	public function test_prompts_when_another_gate_on_the_post_is_the_route_in() {
+		$institution_id = $this->create_institution( 'Example University', 'example.test' );
+		$this->create_gate(
+			[],
+			1,
+			[
+				'active'               => true,
+				'require_verification' => true,
+			]
+		);
+		$this->create_gate(
+			[
+				[
+					[
+						'slug'  => 'institution',
+						'value' => [ $institution_id ],
+					],
+				],
+			],
+			2
+		);
+		$reader_id = $this->create_reader( 'reader@example.test' );
+
+		$this->assertTrue( $this->visit_gated_post_as( $reader_id ), 'Sanity: the unverified reader is denied.' );
+
+		$prompt_context = Email_Verification_Prompt::get_prompt_context();
+		$this->assertNotFalse( $prompt_context, 'The reader is offered the prompt, though the gate denying them holds no domain rule.' );
+		$this->assertSame( [ 'Example University' ], $prompt_context['institutions'] );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

An institution *that grants access by email domain* requires verification, so a logged-in but unverified reader on a whitelisted domain sees the ordinary paywall with nothing naming verification as the obstacle. On one migrated site, 36 readers have no route through the gate today.

A gate denying such a reader now prepends a verification prompt inside the gate wrapper, above the layout. The layout is untouched, so its own subscribe CTA remains the reader's alternative. "Send code" sends the OTP the registration block's inline box already sends, opens the reader-auth modal in its OTP state, and reloads the article once the modal closes.

The email-domain rule keeps its verification requirement. `Access_Rules::with_assumed_verification()` answers only "would verifying unlock this?", scoped to the requesting reader and unwound in a `finally`; its result decides whether to prompt and nothing else.

Whether to prompt is decided cheap-before-expensive: a walk of every gate covering the post for a domain the reader's address matches, then — only for those — a replay of the whole restriction decision with verification assumed. Both stages matter, because rules are ANDed within a group and a post can be covered by several gates in priority order: the gate a reader is stopped at need not be the gate their address would let them past.

Also covers a gate's own `email_domain` rule, with copy that names no institution.

Closes NPPD-2221.

### How to test the changes in this Pull Request:

1. Define `NEWSPACK_CONTENT_GATES` and enable Reader Activation.
2. Go to Audience > Access control > Institutions. Add an institution named `Example University` with email domain `example.test`.
3. Add a content gate covering all posts. Enable Custom access. Add an Institutional access rule and select `Example University`.
4. Publish a post. Give the gate layout a subscribe button.
5. Create a reader with the address `reader@example.test`. Do not verify it.
6. Open the post as that reader. The gate shows a prompt naming `Example University`, above the layout.
7. Click **Send code**. The auth modal opens in its code-entry state.
8. Enter the code from the email. Close the modal. The article is unlocked.
9. Log out. Open the post. The gate shows no prompt.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

**Verification.** Driven in Chrome against an isolated env. 17 new PHP tests and a JS suite for the shared inline-verification module; each guard was mutation-tested and turns exactly one red. Full suite 3521 tests / 10014 assertions, 6 pre-existing skips.

![Before: the reader sees the standard paywall with no indication that verification is the obstacle](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/27/xcau3uzj-step-1-before-plain-paywall-no-reason-given.png)

![After: the verification prompt names the institution, above the gate layout and its subscribe CTA](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/27/g8btkx1x-step-2-prompt-above-subscribe-cta.png)

![Send code opens the auth modal in its OTP state](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/27/q2vim97v-step-3-otp-modal-opens-after-send-code.png)

![After verifying, the reader lands on the unlocked article](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/27/92jsyra4-step-4-after-verifying-article-unlocked.png)

**Disclosures.**

* `Reader_Activation::should_render_auth_modal()` becomes public. The prompt stands down where a site has filtered the auth modal off, rather than mailing a code the reader has nowhere to enter.
* `Content_Restriction_Control::is_post_restricted()` now honours an assumed verification in its registration branch too. Without it, a gate that both walls registration behind verification and grants by email domain reported itself still restricting for a reader whose one act of verifying would satisfy both.
* Inline "send me a code" wiring moves to a shared module used by the gate prompt, the registration block and the verification modal. The extracted sender rejects a `{ success: false }` response, which the registration block previously treated as success. A refusal the server named — the one-minute resend limit, above all — is now shown in the server's own words, in all three boxes.
* Every inline verification box carries a dedicated `[data-error-target]` paragraph, so a failed send no longer overwrites the line naming the reader's address.
* Where a gate layout contains a reader-registration block and the site's post-registration verification setting is on, a reader can see two "Send code" buttons. Left as-is deliberately: suppressing either one removes an affordance a publisher placed, and which should win is a product decision.
* Inert unless a gate carries an institution or email-domain access rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WziCNTaYXesdsDibM5GSKD