### PR TITLE
Use :focus-visible for link focus

### DIFF
--- a/themes/newspack-theme/newspack-theme/sass/navigation/_links.scss
+++ b/themes/newspack-theme/newspack-theme/sass/navigation/_links.scss
@@ -20,4 +20,9 @@ a {
 		outline: thin dotted;
 		text-decoration: underline;
 	}
+
+	// Keep the keyboard ring; hide the leftover outline after mouse/touch (Safari keeps :focus after click).
+	&:focus:not(:focus-visible) {
+		outline: none;
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Hide the leftover dotted outline on links after a mouse click or tap, while keeping Newspack’s keyboard focus ring.

The parent theme currently styles every focused link:

```scss
a:focus {
  outline: thin dotted;
  text-decoration: underline;
}
```

`:focus` stays on the link after pointer activation in Safari (and some other browsers) until focus moves elsewhere. The outline inherits the link color, so on sites with colored links it shows as a thin dotted or dashed box around the whole `<a>`. Homepage cards and listing thumbnails wrap image and title in one link, which makes that leftover ring large and easy to mistake for a layout bug.

This change keeps the existing `a:focus` rule and adds:

```scss
a:focus:not(:focus-visible) {
  outline: none;
}
```

`:focus-visible` is the browser’s signal that the focus change should be shown (typically keyboard). The extra rule removes the outline only when that signal is absent. Child themes inherit this from the parent compile; no child-theme override is needed.

#### Accessibility: old vs new

**Old style (`a:focus`)**

- Meets [WCAG 2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html): keyboard users get a visible indicator (dotted outline plus underline).
- Over-indicates for pointer users. After click or tap, the same ring remains. That is not a WCAG failure, but it is noisy, especially on large hit areas, and it is not what `:focus` was meant to communicate.
- Turning the outline off with `a:focus { outline: none }` would be the harmful fix. Keyboard users would lose their only focus indicator on links.

**New style (`a:focus` + `a:focus:not(:focus-visible)`)**

- Keyboard users still get the original dotted outline and underline when they Tab (or otherwise move focus in a way the browser treats as `:focus-visible`).
- Pointer users no longer see a leftover outline after click or tap.
- Browsers that do not implement `:focus-visible` ignore the second selector entirely (unknown pseudo-class drops the whole rule) and keep the original `a:focus` outline. There is no silent loss of the keyboard ring in older clients.
- This matches the usual recommendation for 2.4.7: a visible indicator for keyboard focus, not a ring on every pointer activation.
- [WCAG 2.4.13 Focus Appearance](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance.html) (AAA) is unchanged for keyboard focus: size and contrast of the dotted outline are the same as before.

**Intentionally unchanged**

- Form fields, skip links, buttons, and other `outline: thin dotted` rules still use `:focus`. Those controls often should show a ring on click, and skip links must remain visible when they receive focus.
- Link underline still applies on `:focus`, including after a pointer click. This PR only removes the outline for non-keyboard focus.

### Screenshots

Here are Safari examples of the red ring this PR is intended to remove.

#### macOS

<img width="3024" height="1613" alt="safari-macos" src="https://github.com/user-attachments/assets/e426a881-2209-4065-b7da-361b965a6840" />

#### iOS

<img width="1125" height="2436" alt="safari-mobile" src="https://github.com/user-attachments/assets/8aa5dedd-cc01-4d0b-90ba-6417197dfeec" />

### How to test the changes in this Pull Request:

1. Build the theme (`n build newspack-theme`) so compiled CSS picks up the SCSS change.
2. Keyboard: Tab through in-content links, nav links, and a linked homepage card. Each focused link should still show the thin dotted outline and underline.
3. Mouse: Click a text link, then a card or thumbnail that wraps image and title. No leftover dotted outline should remain on the clicked link. Repeat in Chrome and Safari.
4. Touch: Tap a linked card on a phone or in responsive mode. Confirm there is no leftover ring after the tap.
5. Skip link: Tab from the address bar. “Skip to content” should still appear with its existing focus styles.
6. Forms: Click into a search or comment field. The field focus treatment should be unchanged.
7. Admin bar: Confirm the WordPress admin bar is unaffected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?