### PR TITLE
perf(rtt): skip the referrer title fetch when there is no referrer

### DIFF
--- a/plugins/republication-tracker-tool/includes/pixel-functions.php
+++ b/plugins/republication-tracker-tool/includes/pixel-functions.php
@@ -195,6 +195,10 @@ function wprtt_get_dedup_identity(): string {
  * @return string Title of the referring URL, or empty string if we can't find it.
  */
 function wprtt_get_referring_page_title( string $url ): string {
+	if ( '' === trim( $url ) ) {
+		return '';
+	}
+
 	// The 2-second timeout bounds how long a pixel request can hold a worker on
 	// this blocking outbound call — the endpoint is public, and with the
 	// counting guards on its responses are uncacheable. The VIP helper gets the


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The tracking pixel attaches the title of the referring page to its GA4 event, and fetches that title over HTTP. `wprtt_get_referring_page_title()` attempted the fetch even when handed an empty URL. It now returns an empty title straight away for a blank or whitespace-only URL.

The only caller screens the referrer with `wp_http_validate_url()` first, which already rejects blank values, so behavior on the current code path is unchanged. This puts the guard on the function itself.

Closes NPPM-2981.

### How to test the changes in this Pull Request:

1. From `plugins/republication-tracker-tool`, run `n test-php`. All 78 tests pass.
2. From the repository root, run `composer phpcs -- plugins/republication-tracker-tool/includes/pixel-functions.php`. No violations.
3. On a site with GA4 configured, request `?republication-pixel=1&post=<ID>&ga4=<measurement-id>` with no `Referer` header. The post's view counter increments.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? Tests n/a: the guard is unreachable from the only caller, so there is no reachable behavior to pin.
* [x] Have you successfully run tests with your changes locally?
