### PR TITLE
chore(lint): drop dead PHPCS exemptions, scope duplicate class names (NPPM-2752)

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -15,7 +15,6 @@
 	<!-- Project-wide exclusions. AGENTS.md: short array syntax is allowed,
 	     Yoda conditions not required. -->
 	<rule ref="WordPress">
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>
 		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found"/>
 		<exclude name="Universal.Operators.DisallowStandalonePostIncrementDecrement.PostIncrementFound"/>
 		<exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction"/>
@@ -36,6 +35,15 @@
 				<element value="manage_woocommerce"/>
 			</property>
 		</properties>
+	</rule>
+
+	<!-- Each plugin is a separate deliverable, so a test double in one may
+	     legitimately declare a class another plugin ships. This sniff compares
+	     across every file in the run, so it fires only on a whole-tree
+	     `composer phpcs` and never in CI, which lints one directory at a time.
+	     Confining it to non-test code makes the two agree. -->
+	<rule ref="Generic.Classes.DuplicateClassName">
+		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
 	<!-- republication-tracker-tool's main file is named without the standard
@@ -70,16 +78,7 @@
 	<rule ref="Squiz.Commenting.InlineComment.InvalidEndChar">
 		<exclude-pattern>*/themes/newspack-theme/*</exclude-pattern>
 	</rule>
-	<rule ref="Squiz.Commenting.InlineComment.NotCapital">
-		<exclude-pattern>*/themes/newspack-theme/*</exclude-pattern>
-	</rule>
 	<rule ref="Generic.WhiteSpace.ScopeIndent.Incorrect">
-		<exclude-pattern>*/themes/newspack-theme/*</exclude-pattern>
-	</rule>
-	<rule ref="Generic.WhiteSpace.ScopeIndent.IncorrectExact">
-		<exclude-pattern>*/themes/newspack-theme/*</exclude-pattern>
-	</rule>
-	<rule ref="PEAR.Functions.FunctionCallSignature.Indent">
 		<exclude-pattern>*/themes/newspack-theme/*</exclude-pattern>
 	</rule>
 
@@ -125,7 +124,10 @@
 	<exclude-pattern>*/*.asset.php</exclude-pattern>
 	<exclude-pattern>*/tests/fixtures/*</exclude-pattern>
 
-	<!-- Skipped in legacy per-package configs; tests had laxer norms. -->
+	<!-- These two suites break WordPress runtime rules deliberately: stub
+	     classes, several object structures per file, direct filesystem calls,
+	     assignment to $GLOBALS['post']. Linting them would mean ~50
+	     suppressions asserting "this is a test double" against no real fix. -->
 	<exclude-pattern>*/plugins/newspack-blocks/tests/*</exclude-pattern>
 	<exclude-pattern>*/themes/newspack-theme/tests/*</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Four exemptions in the root `phpcs.xml` suppress nothing. Removed:

- `Generic.Arrays.DisallowShortArraySyntax.Found` — WPCS 3.0 replaced this sniff with `Universal.Arrays.DisallowShortArraySyntax`, excluded on the next line.
- `Squiz.Commenting.InlineComment.NotCapital` — already excluded by `WordPress-Docs`.
- `Generic.WhiteSpace.ScopeIndent.IncorrectExact` — `WordPress-Core` sets `exact=false`, so the code cannot fire.
- `PEAR.Functions.FunctionCallSignature.Indent` — live rule, zero violations in the theme it was scoped to.

The remaining exemptions all earn their place: each fires in nine or more packages, so none can be narrowed further.

Separately, `Generic.Classes.DuplicateClassName` is now excluded for `*/tests/*`. It compares class names across every file in a run, so it fires on a whole-tree `composer phpcs` (where a plugin's test double shadows a class another plugin ships) but never in CI, which lints one directory at a time. Root runs therefore disagreed with CI, and did so intermittently, since parallel workers partition the files differently each run.

Refs NPPM-2752 (Phase 6 cleanup).

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Run `composer phpcs` from the repository root.
3. Confirm the run reports no errors and no warnings.
4. On `main`, run `composer phpcs` a few times from the root.
5. Confirm some runs report duplicate class name warnings in `plugins/newspack-popups/tests/mocks/`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
