### PR TITLE
docs(xdebug): correct the IDE path mappings for the monorepo layout (NPPM-2752)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,12 +235,22 @@ Batcache is also enabled by default. It relies on memcached to cache the end out
 
 X-debug is configured by default. In order to use it:
 
-- Set you browser extension to use the `DOCKERDEBUG` IDE Key.
-- Configure your IDE to use the same IDE Key, listen to port 9003 and add the necessary path mappings.
+- Set your browser extension to use the `DOCKERDEBUG` IDE Key.
+- Configure your IDE to use the same IDE Key, listen on port 9003 and add the path mappings below.
 
-Here's an example of a `launch.json` file for VSCode to be used for the `newspack-plugin` repo:
+WordPress reaches plugins and themes through symlinks under `html/wp-content/`, and PHP resolves a symlink before it reports the file to Xdebug. The paths the debugger sees are the mount points, not the `wp-content` ones, so map all five and a breakpoint works wherever you set it:
 
-```
+| Container path | Host path |
+| --- | --- |
+| `/newspack-monorepo` | repository root |
+| `/newspack-plugins` | `plugins/` |
+| `/newspack-themes` | `themes/` |
+| `/newspack-repos` | `repos/` |
+| `/var/www/html` | `html/` |
+
+A `launch.json` for VSCode, with the editor opened at the repository root:
+
+```jsonc
 {
   "version": "0.2.0",
   "configurations": [
@@ -250,7 +260,7 @@ Here's an example of a `launch.json` file for VSCode to be used for the `newspac
       "request": "launch",
       "port": 9003,
       "log": false,
-      "maxConnections": 1, // @see  https://github.com/xdebug/vscode-php-debug/issues/604
+      "maxConnections": 1, // @see https://github.com/xdebug/vscode-php-debug/issues/604
       "xdebugSettings": {
         "resolved_breakpoints": "0", // @see https://github.com/xdebug/vscode-php-debug/issues/629 and https://stackoverflow.com/a/69925257/3059883
         "max_data": 512,
@@ -258,12 +268,29 @@ Here's an example of a `launch.json` file for VSCode to be used for the `newspac
         "max_children": 128
       },
       "pathMappings": {
-        "/newspack-plugins/newspack-plugin": "${workspaceRoot}"
-      },
+        "/newspack-monorepo": "${workspaceFolder}",
+        "/newspack-plugins": "${workspaceFolder}/plugins",
+        "/newspack-themes": "${workspaceFolder}/themes",
+        "/newspack-repos": "${workspaceFolder}/repos",
+        "/var/www/html": "${workspaceFolder}/html"
+      }
     }
   ]
 }
 ```
+
+### Mapping an isolated environment
+
+An isolated environment mounts a worktree over the plugin or theme it overrides. The container path stays the same, so the mapping above sends the debugger to the shared checkout and breakpoints in the worktree never bind. Add one entry per overridden plugin, more specific than the shared one:
+
+```jsonc
+"pathMappings": {
+  "/newspack-plugins/newspack-plugin": "${workspaceFolder}/worktrees/fix-my-branch/plugins/newspack-plugin",
+  "/newspack-plugins": "${workspaceFolder}/plugins"
+}
+```
+
+The directory under `worktrees/` is the branch name with each `/` replaced by `-`. Run `n env list` to see which branch an environment has for each plugin.
 
 ## Isolated Environments (Git Worktrees)
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The README's X-Debug example still maps a single plugin onto the editor root, which was right when each plugin was its own repository. Open the monorepo at its root and that mapping resolves to the wrong directory, so breakpoints never bind.

Replaces it with the five container mount points and their host directories, and adds the isolated-environment case: a worktree changes the host path while the container path stays the same, so an environment needs one extra, more specific entry per overridden plugin.

The section also now states why the mappings use the mount paths rather than the `wp-content` ones: WordPress reaches plugins through symlinks, and PHP resolves a symlink before reporting the file, so the debugger only ever sees `/newspack-plugins/...`.

Refs NPPM-2752 (Phase 6 cleanup).

### How to test the changes in this Pull Request:

1. Open the repository root in VSCode.
2. Copy the `launch.json` from the updated README into `.vscode/launch.json`.
3. Start the debug configuration and confirm it listens on port 9003.
4. Set a breakpoint in `plugins/newspack-plugin/newspack.php`.
5. Load the local site.
6. Confirm the debugger stops on the breakpoint.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?