### PR TITLE
ci(release): allow a manual dispatch on release and alpha (NPPM-2752)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,14 @@ on:
     branches:
       - release
       - alpha
+  # Recovery hatch. A push whose head commit message carries `[skip ci]` is
+  # dropped by GitHub Actions for every workflow on that push. The release
+  # commits this workflow makes carry that marker, so a promotion merge that
+  # quotes one of them in its body silences the release it was meant to
+  # trigger, and leaves no run to re-run. Dispatching on `release` or `alpha`
+  # does the work the push would have; the alternative is pushing an empty
+  # commit to the branch.
+  workflow_dispatch:
 
 concurrency:
   group: release-${{ github.ref }}
@@ -42,6 +50,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # workflow_dispatch accepts any branch; releasing is only ever correct from
+    # the two the push trigger names.
+    if: contains(fromJSON('["refs/heads/release", "refs/heads/alpha"]'), github.ref)
     # Dependent jobs must tell "released" from "ran and released nothing".
     # post-release.sh identifies what the release came from via `git log --skip
     # 1`, assuming an automated release commit at the tip. A no-release run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ on:
   # trigger, and leaves no run to re-run. Dispatching on `release` or `alpha`
   # does the work the push would have; the alternative is pushing an empty
   # commit to the branch.
+  #
+  # A dispatch runs the workflow file as it exists on the branch it targets,
+  # and GitHub refuses one whose target lacks this trigger. The hatch is
+  # therefore unusable on a branch until a promotion has carried this file to
+  # it -- the empty commit stays the fallback until then.
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`release.yml` triggers on push only. A push whose head commit message carries `[skip ci]` is dropped by GitHub Actions for every workflow on that push, and the release commits this workflow makes carry that marker. A promotion merge that quotes one of them in its body therefore silences the release it was meant to trigger, and leaves no run to re-run. Recovery today is pushing an empty commit to `release`.

Adds `workflow_dispatch`, guarded so the job runs only on `release` or `alpha` — dispatch accepts any branch, and a release from anywhere else is never correct. The workflow reads no push-only context, so a dispatched run does the same work as the push.

Closes out #88, which proposed `paths-ignore` on the CI push trigger: that cannot protect a different workflow, and the translation-bot commit it targeted does not exist here.

Refs NPPM-2752 (Phase 6 cleanup).

A dispatch runs the workflow file from the branch it targets, and GitHub refuses one whose target lacks the trigger. The hatch only works on `release` and `alpha` once a promotion has carried this file to them, so the empty commit stays the fallback until then. Test step 6 reflects that.

### How to test the changes in this Pull Request:

1. Merge this pull request.
2. Open Actions and select the Release workflow.
3. Confirm a "Run workflow" button is present.
4. Select the `main` branch and run the workflow.
5. Confirm the Release job is skipped.
6. Wait for the next `main` to `alpha` promotion.
7. Select the `alpha` branch and run the workflow.
8. Confirm the Release job runs, and releases nothing when there is nothing to release.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

