### PR TITLE
fix(homepage-articles): neutralize editor author links (NPPM-3165)

### DIFF
--- a/plugins/newspack-blocks/includes/class-newspack-blocks-api.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks-api.php
@@ -180,22 +180,26 @@ class Newspack_Blocks_API {
 	}
 
 	/**
-	 * Point every link in a rendered payload fragment at '#'.
+	 * Point every anchor in a rendered payload fragment at '#'.
 	 *
 	 * The editor canvas renders the byline and avatar fields verbatim, so a
 	 * live URL navigates the canvas iframe away from the post being edited.
 	 * Runs on the finished markup — after the newspack_blocks_post_byline
 	 * filter — so links injected by filters (e.g. custom bylines) are covered
 	 * too, matching the category-link convention used elsewhere in this
-	 * payload. Prefixed variants such as xlink:href and data-href are matched
-	 * deliberately: xlink:href navigates like href, and over-neutralizing a
-	 * non-navigating attribute is harmless in a payload only the editor sees.
+	 * payload. Only real anchor href attributes are rewritten: "href=" text
+	 * inside another attribute's value (avatar proxy URLs), xlink:href sprite
+	 * references, and plain text all pass through untouched.
 	 *
 	 * @param string $html Rendered markup destined for the editor payload.
-	 * @return string Markup with every href pointing at '#'.
+	 * @return string Markup with every anchor href pointing at '#'.
 	 */
 	private static function neutralize_editor_links( $html ) {
-		return preg_replace( '/\bhref\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', 'href="#"', (string) $html );
+		$processor = new \WP_HTML_Tag_Processor( (string) $html );
+		while ( $processor->next_tag( 'A' ) ) {
+			$processor->set_attribute( 'href', '#' );
+		}
+		return $processor->get_updated_html();
 	}
 
 	/**

--- a/plugins/newspack-blocks/includes/class-newspack-blocks-api.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks-api.php
@@ -187,7 +187,9 @@ class Newspack_Blocks_API {
 	 * Runs on the finished markup — after the newspack_blocks_post_byline
 	 * filter — so links injected by filters (e.g. custom bylines) are covered
 	 * too, matching the category-link convention used elsewhere in this
-	 * payload.
+	 * payload. Prefixed variants such as xlink:href and data-href are matched
+	 * deliberately: xlink:href navigates like href, and over-neutralizing a
+	 * non-navigating attribute is harmless in a payload only the editor sees.
 	 *
 	 * @param string $html Rendered markup destined for the editor payload.
 	 * @return string Markup with every href pointing at '#'.

--- a/plugins/newspack-blocks/includes/class-newspack-blocks-api.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks-api.php
@@ -180,6 +180,23 @@ class Newspack_Blocks_API {
 	}
 
 	/**
+	 * Point every link in a rendered payload fragment at '#'.
+	 *
+	 * The editor canvas renders the byline and avatar fields verbatim, so a
+	 * live URL navigates the canvas iframe away from the post being edited.
+	 * Runs on the finished markup — after the newspack_blocks_post_byline
+	 * filter — so links injected by filters (e.g. custom bylines) are covered
+	 * too, matching the category-link convention used elsewhere in this
+	 * payload.
+	 *
+	 * @param string $html Rendered markup destined for the editor payload.
+	 * @return string Markup with every href pointing at '#'.
+	 */
+	private static function neutralize_editor_links( $html ) {
+		return preg_replace( '/\bhref=("[^"]*"|\'[^\']*\')/', 'href="#"', (string) $html );
+	}
+
+	/**
 	 * Register the video-playlist endpoint.
 	 */
 	public static function register_video_playlist_endpoint() {
@@ -281,8 +298,8 @@ class Newspack_Blocks_API {
 				'newspack_sponsors_show_author'     => Newspack_Blocks::newspack_display_sponsors_and_authors( $sponsors ),
 				'newspack_sponsors_show_categories' => Newspack_Blocks::newspack_display_sponsors_and_categories( $sponsors ),
 				'newspack_tag_labels'               => self::newspack_blocks_get_tag_labels( $data ),
-				'newspack_post_avatars'             => \newspack_blocks_format_avatars( $author_info ),
-				'newspack_post_byline'              => \newspack_blocks_format_byline( $author_info ),
+				'newspack_post_avatars'             => self::neutralize_editor_links( \newspack_blocks_format_avatars( $author_info ) ),
+				'newspack_post_byline'              => self::neutralize_editor_links( \newspack_blocks_format_byline( $author_info ) ),
 				'post_status'                       => $post->post_status,
 				'post_type'                         => $post->post_type,
 				'post_link'                         => Newspack_Blocks::get_post_link( $post->ID ),

--- a/plugins/newspack-blocks/includes/class-newspack-blocks-api.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks-api.php
@@ -193,7 +193,7 @@ class Newspack_Blocks_API {
 	 * @return string Markup with every href pointing at '#'.
 	 */
 	private static function neutralize_editor_links( $html ) {
-		return preg_replace( '/\bhref=("[^"]*"|\'[^\']*\')/', 'href="#"', (string) $html );
+		return preg_replace( '/\bhref\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', 'href="#"', (string) $html );
 	}
 
 	/**

--- a/plugins/newspack-blocks/src/shared/js/utils.js
+++ b/plugins/newspack-blocks/src/shared/js/utils.js
@@ -17,7 +17,11 @@ export const formatSponsorLogos = sponsorInfo => (
 		{ sponsorInfo.map( sponsor => (
 			<Fragment key={ sponsor.id }>
 				{ sponsor.src && (
-					<a href={ sponsor.sponsor_url }>
+					// A live sponsor URL would navigate the editor-canvas iframe away from
+					// the post being edited; the sponsor slot replaces the byline when
+					// newspack_sponsors_show_author is off, so it needs the same inert
+					// href="#" the other editor anchors use.
+					<a href="#">
 						<img src={ sponsor.src } width={ sponsor.img_width } height={ sponsor.img_height } alt={ sponsor.sponsor_name } />
 					</a>
 				) }
@@ -33,7 +37,8 @@ export const formatSponsorByline = sponsorInfo => (
 			return [
 				...accumulator,
 				<span className="author" key={ sponsor.id }>
-					<a href={ sponsor.author_link }>{ sponsor.sponsor_name }</a>
+					{ /* author_link is never populated in the editor payload; href="#" makes the inertness explicit. */ }
+					<a href="#">{ sponsor.sponsor_name }</a>
 				</span>,
 				index < sponsorInfo.length - 2 && ', ',
 				sponsorInfo.length > 1 && index === sponsorInfo.length - 2 && _x( 'and', 'post author', 'newspack-blocks' ),

--- a/plugins/newspack-blocks/src/shared/js/utils.js
+++ b/plugins/newspack-blocks/src/shared/js/utils.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 /**
  * WordPress dependencies
  */

--- a/plugins/newspack-blocks/src/shared/js/utils.test.js
+++ b/plugins/newspack-blocks/src/shared/js/utils.test.js
@@ -1,0 +1,49 @@
+import { formatSponsorLogos, formatSponsorByline } from './utils';
+
+/**
+ * Collect every anchor element in a React element tree.
+ *
+ * The formatters return element trees rendered inside the editor canvas,
+ * where a live href navigates the canvas iframe away from the post being
+ * edited (NPPM-3165). Walking the tree keeps these assertions valid across
+ * structural changes to the markup.
+ *
+ * @param {*} node React element, array, or primitive.
+ * @return {Array} All elements whose type is 'a'.
+ */
+const collectAnchors = node => {
+	if ( Array.isArray( node ) ) {
+		return node.flatMap( collectAnchors );
+	}
+	if ( ! node || typeof node !== 'object' ) {
+		return [];
+	}
+	const anchors = node.type === 'a' ? [ node ] : [];
+	return anchors.concat( collectAnchors( node.props?.children ?? [] ) );
+};
+
+const sponsors = [
+	{
+		id: 1,
+		src: 'https://sponsor.example.test/logo.png',
+		img_width: 100,
+		img_height: 50,
+		sponsor_name: 'Acme Example Supporters',
+		sponsor_url: 'https://sponsor.example.test/supporters/',
+		byline_prefix: 'Sponsored by',
+	},
+];
+
+describe( 'sponsor markup in the editor preview', () => {
+	it( 'renders the sponsor logo anchor inert', () => {
+		const anchors = collectAnchors( formatSponsorLogos( sponsors ) );
+		expect( anchors.length ).toBeGreaterThan( 0 );
+		anchors.forEach( anchor => expect( anchor.props.href ).toBe( '#' ) );
+	} );
+
+	it( 'renders the sponsor byline anchor inert', () => {
+		const anchors = collectAnchors( formatSponsorByline( sponsors ) );
+		expect( anchors.length ).toBeGreaterThan( 0 );
+		anchors.forEach( anchor => expect( anchor.props.href ).toBe( '#' ) );
+	} );
+} );

--- a/plugins/newspack-blocks/tests/test-homepage-posts-block.php
+++ b/plugins/newspack-blocks/tests/test-homepage-posts-block.php
@@ -356,16 +356,16 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 		self::factory()->post->create( [ 'post_status' => 'publish' ] );
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
-		add_filter(
-			'newspack_blocks_post_byline',
-			function () {
-				return '<span class="author vcard"><a class="url fn n" href="https://example.test/author/custom">Custom Byline</a></span>';
-			}
-		);
+		$live_link_byline_filter = function () {
+			return '<span class="author vcard"><a class="url fn n" href="https://example.test/author/custom">Custom Byline</a></span>';
+		};
+		add_filter( 'newspack_blocks_post_byline', $live_link_byline_filter );
 
 		$request = new WP_REST_Request( 'GET', '/newspack-blocks/v1/newspack-blocks-posts' );
 		$request->set_param( 'postsToShow', 10 );
 		$posts = rest_do_request( $request )->get_data();
+
+		remove_filter( 'newspack_blocks_post_byline', $live_link_byline_filter );
 
 		self::assertNotEmpty( $posts, 'The editor posts endpoint returns the published post.' );
 		foreach ( $posts as $post_data ) {
@@ -422,7 +422,7 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 		);
 		self::assertStringContainsString( 'Frank Fixture', $byline, 'The author name renders in the front-end byline.' );
 
-		unset( $GLOBALS['post'] );
+		wp_reset_postdata();
 	}
 
 	/**

--- a/plugins/newspack-blocks/tests/test-homepage-posts-block.php
+++ b/plugins/newspack-blocks/tests/test-homepage-posts-block.php
@@ -393,6 +393,59 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	}
 
 	/**
+	 * Avatar markup whose URL carries an href query parameter must come
+	 * through intact — neutralization touches only real anchor href
+	 * attributes, never "href=" text inside another attribute's value
+	 * (the shape produced by URL-rewriting avatar proxies).
+	 */
+	public function test_editor_posts_endpoint_preserves_avatar_markup() {
+		$author_id = self::factory()->user->create(
+			[
+				'role'          => 'author',
+				'display_name'  => 'Ada Fixture',
+				'user_nicename' => 'ada-fixture',
+			]
+		);
+		self::factory()->post->create(
+			[
+				'post_status' => 'publish',
+				'post_author' => $author_id,
+			]
+		);
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$proxied_avatar_filter = function () {
+			return '<img src="https://cdn.example.test/proxy?url=a&amp;href=x" srcset="https://cdn.example.test/proxy?url=b&amp;href=y 2x" class="avatar" alt="" width="48" height="48" />';
+		};
+		add_filter( 'pre_get_avatar', $proxied_avatar_filter );
+
+		$request = new WP_REST_Request( 'GET', '/newspack-blocks/v1/newspack-blocks-posts' );
+		$request->set_param( 'postsToShow', 10 );
+		$posts = rest_do_request( $request )->get_data();
+
+		remove_filter( 'pre_get_avatar', $proxied_avatar_filter );
+
+		self::assertNotEmpty( $posts, 'The editor posts endpoint returns the published post.' );
+		foreach ( $posts as $post_data ) {
+			self::assertStringContainsString(
+				'src="https://cdn.example.test/proxy?url=a&amp;href=x"',
+				$post_data['newspack_post_avatars'],
+				'The avatar src survives neutralization byte-identical.'
+			);
+			self::assertStringContainsString(
+				'srcset="https://cdn.example.test/proxy?url=b&amp;href=y 2x"',
+				$post_data['newspack_post_avatars'],
+				'The avatar srcset survives neutralization byte-identical.'
+			);
+			self::assertStringContainsString(
+				'href="#"',
+				$post_data['newspack_post_avatars'],
+				'The avatar anchor is still neutralized.'
+			);
+		}
+	}
+
+	/**
 	 * The front-end byline formatter keeps live author-archive links.
 	 *
 	 * The discriminating mirror of the editor tests above: neutralization

--- a/plugins/newspack-blocks/tests/test-homepage-posts-block.php
+++ b/plugins/newspack-blocks/tests/test-homepage-posts-block.php
@@ -282,6 +282,150 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	}
 
 	/**
+	 * The editor posts endpoint must not expose live author-archive links.
+	 *
+	 * The editor canvas renders newspack_post_byline and newspack_post_avatars
+	 * verbatim, so a real href navigates the canvas iframe away from the post
+	 * being edited. Author anchors must be neutralized to href="#", matching
+	 * the category link convention in the same payload.
+	 */
+	public function test_editor_posts_endpoint_neutralizes_author_archive_links() {
+		$author_id = self::factory()->user->create(
+			[
+				'role'          => 'author',
+				'display_name'  => 'Jane Example',
+				'user_nicename' => 'jane-example',
+			]
+		);
+		$authored_post_id = self::factory()->post->create(
+			[
+				'post_status' => 'publish',
+				'post_author' => $author_id,
+			]
+		);
+		// A post whose author no longer exists still renders a byline anchor
+		// ("by" with no name, empty author lookup) and must be neutralized too.
+		$orphan_post_id = self::factory()->post->create(
+			[
+				'post_status' => 'publish',
+				'post_author' => 99999,
+			]
+		);
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$request = new WP_REST_Request( 'GET', '/newspack-blocks/v1/newspack-blocks-posts' );
+		$request->set_param( 'postsToShow', 10 );
+		$posts = rest_do_request( $request )->get_data();
+
+		$posts_by_id = array_column( $posts, null, 'id' );
+		self::assertArrayHasKey( $authored_post_id, $posts_by_id, 'The endpoint returns the authored post.' );
+		self::assertArrayHasKey( $orphan_post_id, $posts_by_id, 'The endpoint returns the orphaned-author post.' );
+
+		self::assertStringContainsString(
+			'Jane Example',
+			$posts_by_id[ $authored_post_id ]['newspack_post_byline'],
+			'The author name still renders in the editor byline.'
+		);
+
+		foreach ( [ $authored_post_id, $orphan_post_id ] as $post_id ) {
+			self::assertStringContainsString(
+				'href="#"',
+				$posts_by_id[ $post_id ]['newspack_post_byline'],
+				'The editor byline anchor is neutralized, not removed.'
+			);
+			self::assertStringNotContainsString(
+				'href="http',
+				$posts_by_id[ $post_id ]['newspack_post_byline'],
+				'The editor byline must not carry a live link.'
+			);
+			self::assertStringNotContainsString(
+				'href="http',
+				$posts_by_id[ $post_id ]['newspack_post_avatars'],
+				'The editor avatar link must not carry a live link.'
+			);
+		}
+	}
+
+	/**
+	 * Byline HTML injected via the newspack_blocks_post_byline filter (the
+	 * newspack-plugin custom-bylines feature hooks it and replaces the byline
+	 * wholesale) must be neutralized too — neutralization runs on the finished
+	 * payload, after the filter.
+	 */
+	public function test_editor_posts_endpoint_neutralizes_filtered_byline_links() {
+		self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		add_filter(
+			'newspack_blocks_post_byline',
+			function () {
+				return '<span class="author vcard"><a class="url fn n" href="https://example.test/author/custom">Custom Byline</a></span>';
+			}
+		);
+
+		$request = new WP_REST_Request( 'GET', '/newspack-blocks/v1/newspack-blocks-posts' );
+		$request->set_param( 'postsToShow', 10 );
+		$posts = rest_do_request( $request )->get_data();
+
+		self::assertNotEmpty( $posts, 'The editor posts endpoint returns the published post.' );
+		foreach ( $posts as $post_data ) {
+			self::assertStringContainsString(
+				'Custom Byline',
+				$post_data['newspack_post_byline'],
+				'The filtered byline content is preserved.'
+			);
+			self::assertStringNotContainsString(
+				'https://example.test/author/custom',
+				$post_data['newspack_post_byline'],
+				'A live link supplied by the byline filter must be neutralized in the editor payload.'
+			);
+			self::assertStringContainsString(
+				'href="#"',
+				$post_data['newspack_post_byline'],
+				'The filtered byline anchor is neutralized, not removed.'
+			);
+		}
+	}
+
+	/**
+	 * The front-end byline formatter keeps live author-archive links.
+	 *
+	 * The discriminating mirror of the editor tests above: neutralization
+	 * belongs to the editor payload only, and moving it into the shared
+	 * formatter would break every reader-facing author link while the editor
+	 * tests stayed green.
+	 */
+	public function test_front_end_byline_formatter_keeps_live_author_links() {
+		$author_id = self::factory()->user->create(
+			[
+				'role'          => 'author',
+				'display_name'  => 'Frank Fixture',
+				'user_nicename' => 'frank-fixture',
+			]
+		);
+		$post_id   = self::factory()->post->create(
+			[
+				'post_status' => 'publish',
+				'post_author' => $author_id,
+			]
+		);
+
+		$GLOBALS['post'] = get_post( $post_id );
+		setup_postdata( $GLOBALS['post'] );
+
+		$byline = newspack_blocks_format_byline( Newspack_Blocks::prepare_authors() );
+
+		self::assertStringContainsString(
+			get_author_posts_url( $author_id, 'frank-fixture' ),
+			$byline,
+			'The front-end byline keeps the live author-archive link.'
+		);
+		self::assertStringContainsString( 'Frank Fixture', $byline, 'The author name renders in the front-end byline.' );
+
+		unset( $GLOBALS['post'] );
+	}
+
+	/**
 	 * The newspack_tag_labels REST field exposes the { flag, link } shape
 	 * returned by \Newspack\Tag_Labels, normalized to a 0-indexed list.
 	 *

--- a/plugins/newspack-blocks/tests/test-homepage-posts-block.php
+++ b/plugins/newspack-blocks/tests/test-homepage-posts-block.php
@@ -338,6 +338,11 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 				$posts_by_id[ $post_id ]['newspack_post_byline'],
 				'The editor byline must not carry a live link.'
 			);
+			self::assertStringContainsString(
+				'href="#"',
+				$posts_by_id[ $post_id ]['newspack_post_avatars'],
+				'The editor avatar anchor is neutralized, not removed.'
+			);
 			self::assertStringNotContainsString(
 				'href="http',
 				$posts_by_id[ $post_id ]['newspack_post_avatars'],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Clicking an author name or avatar in a Content Loop or Content Carousel block could navigate the editor away from the post and load the author archive in the editing area. Other links in the preview, such as headlines, categories, and read-more links, are already disabled while editing.

This change makes author names and avatars inert in the editor preview as well. It also covers custom bylines and posts whose author no longer exists.

Front-end bylines are unchanged and continue linking to author archive pages. A test now covers that behavior.

Ref NPPM-3165.

### How to test the changes in this Pull Request:

1. On `release`, edit a page containing a Content Loop block with author bylines visible.
2. Click an author name twice (the first click selects the block). The editor content area navigates to the author archive.
3. Check out this branch and reload the editor.
4. Click an author name and avatar again. The editor should remain on the post with the block selected.
5. View the page on the front end and confirm that author names still link to their archive pages.

### Release risk: Medium

| Signal | Score | Evidence |
|--------|-------|----------|
| Contract surface | Low | no cross-repo contract paths touched; all symbol consumers inside newspack-blocks |
| Surface type | Medium | editor-only REST endpoint handler output; no schema/auth/payment |
| Publisher exposure | Medium | the everyday editing surface for most publishers; no front-end reader path executes the change |
| Change shape | Low | ~23 production LOC in 1 file; tests added at >1.5x production LOC |

Driven by surface type and publisher exposure (both Medium); contract surface and change shape Low. Pre-push review (multi-reviewer + Codex) came back with 5 findings, all addressed before the PR opened; Copilot review (two Lite rounds + one Balanced round) ended clean.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

