### PR TITLE
feat(reader-activation): toggle-group control for integration settings

### DIFF
--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
@@ -13,7 +13,7 @@ import { Stack } from '@wordpress/ui';
 import { CollapsibleGroup, Divider, Grid, SectionHeader, useUnsavedChangesDialog } from '../../../../../packages/components/src';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 import WizardsTab from '../../../wizards-tab';
-import { SettingsField, settingsFieldRenders } from './settings-field';
+import { SettingsField, settingsFieldRenders, toBool } from './settings-field';
 
 import './configure-view.scss';
 
@@ -147,11 +147,6 @@ export const reconcileOperators = ( currentMap, options ) => {
 	} );
 	return changed ? next : map;
 };
-
-// Coerce a value to boolean. Values can arrive from WP options as scalar
-// strings (`'1'`/`'0'`/`'true'`/`'false'`/`''`); note `Boolean( '0' )` is `true`
-// in JS, so the falsy string forms are matched explicitly.
-const toBool = value => ( typeof value === 'string' ? ! [ '', '0', 'false' ].includes( value.toLowerCase() ) : Boolean( value ) );
 
 // Push-pipeline settings that render inside the Outbound section: the metadata
 // prefix is only read on push paths (prepare_contact()) and account-deletion

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/settings-field.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/settings-field.js
@@ -27,6 +27,18 @@ import './settings-field.scss';
 export const isEmptyValue = value => value === undefined || value === null || value === '';
 
 /**
+ * Coerce a stored field value to boolean.
+ *
+ * Values can arrive from WP options as scalar strings (`'1'`/`'0'`/`'true'`/
+ * `'false'`/`''`); `Boolean( '0' )` is `true` in JS, so the falsy string forms
+ * are matched explicitly.
+ *
+ * @param {*} value Value to coerce.
+ * @return {boolean} The boolean form.
+ */
+export const toBool = value => ( typeof value === 'string' ? ! [ '', '0', 'false' ].includes( value.toLowerCase() ) : Boolean( value ) );
+
+/**
  * Whether a select field offers an option that can actually be chosen.
  *
  * The ESP list call prepends a `None` entry to every successful response, so a
@@ -147,7 +159,10 @@ export const SettingsField = ( { field, value, onChange } ) => {
 				</div>
 			);
 		}
-		case 'checkbox':
+		case 'checkbox': {
+			// toBool, not truthiness: stored values round-trip through WP options
+			// as scalar strings, and `'0'`/`'false'` must read as off.
+			const checked = toBool( value );
 			// A checkbox field may declare `control: 'toggle_group'` to render as an
 			// Enabled/Disabled toggle group instead — the same stored boolean, but a
 			// presentation suited to feature switches whose label names the feature
@@ -159,7 +174,7 @@ export const SettingsField = ( { field, value, onChange } ) => {
 						key={ key }
 						label={ label }
 						help={ help }
-						value={ value ? 'enabled' : 'disabled' }
+						value={ checked ? 'enabled' : 'disabled' }
 						onChange={ next => onChange( 'enabled' === next ) }
 						isBlock
 						__next40pxDefaultSize
@@ -170,7 +185,8 @@ export const SettingsField = ( { field, value, onChange } ) => {
 					</ToggleGroupControl>
 				);
 			}
-			return <CheckboxControl key={ key } label={ label } help={ help } checked={ !! value } onChange={ onChange } __nextHasNoMarginBottom />;
+			return <CheckboxControl key={ key } label={ label } help={ help } checked={ checked } onChange={ onChange } __nextHasNoMarginBottom />;
+		}
 		case 'select': {
 			const selectable = hasSelectableOption( field );
 			return (

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/settings-field.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/settings-field.js
@@ -2,7 +2,14 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { CheckboxControl, ExternalLink, SelectControl, TextareaControl } from '@wordpress/components';
+import {
+	CheckboxControl,
+	ExternalLink,
+	SelectControl,
+	TextareaControl,
+	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
 
 /**
  * Internal dependencies.
@@ -141,6 +148,28 @@ export const SettingsField = ( { field, value, onChange } ) => {
 			);
 		}
 		case 'checkbox':
+			// A checkbox field may declare `control: 'toggle_group'` to render as an
+			// Enabled/Disabled toggle group instead — the same stored boolean, but a
+			// presentation suited to feature switches whose label names the feature
+			// ("Deals") rather than the action ("Enable deals"). Integrations running
+			// against a plugin without this parameter fall back to the checkbox.
+			if ( 'toggle_group' === field.control ) {
+				return (
+					<ToggleGroupControl
+						key={ key }
+						label={ label }
+						help={ help }
+						value={ value ? 'enabled' : 'disabled' }
+						onChange={ next => onChange( 'enabled' === next ) }
+						isBlock
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					>
+						<ToggleGroupControlOption label={ __( 'Enabled', 'newspack-plugin' ) } value="enabled" />
+						<ToggleGroupControlOption label={ __( 'Disabled', 'newspack-plugin' ) } value="disabled" />
+					</ToggleGroupControl>
+				);
+			}
 			return <CheckboxControl key={ key } label={ label } help={ help } checked={ !! value } onChange={ onChange } __nextHasNoMarginBottom />;
 		case 'select': {
 			const selectable = hasSelectableOption( field );

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/settings-field.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/settings-field.test.js
@@ -170,11 +170,15 @@ describe( 'SettingsField with control: toggle_group', () => {
 		expect( screen.getByRole( 'radio', { name: 'Disabled' } ) ).not.toBeChecked();
 	} );
 
-	// Stored checkbox values round-trip through WP options as '1'/'', so the
-	// falsy string form must land on Disabled.
-	it( 'maps a falsy stored value to Disabled', () => {
-		render( <SettingsField field={ field } value={ '' } onChange={ () => {} } /> );
-		expect( screen.getByRole( 'radio', { name: 'Disabled' } ) ).toBeChecked();
+	// Stored checkbox values round-trip through WP options as scalar strings,
+	// and `Boolean( '0' )` is `true` in JS — every falsy stored form must land
+	// on Disabled.
+	it( 'maps every falsy stored form to Disabled', () => {
+		[ '', '0', 'false', false, undefined ].forEach( stored => {
+			const { unmount } = render( <SettingsField field={ field } value={ stored } onChange={ () => {} } /> );
+			expect( screen.getByRole( 'radio', { name: 'Disabled' } ) ).toBeChecked();
+			unmount();
+		} );
 	} );
 
 	// The stored value stays a boolean — the option strings are presentation
@@ -189,5 +193,10 @@ describe( 'SettingsField with control: toggle_group', () => {
 	it( 'keeps rendering a plain checkbox without the control parameter', () => {
 		render( <SettingsField field={ { ...field, control: undefined } } value={ true } onChange={ () => {} } /> );
 		expect( screen.getByRole( 'checkbox', { name: 'Deals' } ) ).toBeChecked();
+	} );
+
+	it( 'coerces string forms on the plain checkbox path too', () => {
+		render( <SettingsField field={ { ...field, control: undefined } } value={ '0' } onChange={ () => {} } /> );
+		expect( screen.getByRole( 'checkbox', { name: 'Deals' } ) ).not.toBeChecked();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/settings-field.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/settings-field.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -150,5 +150,44 @@ describe( 'SettingsField', () => {
 	it( 'renders nothing for a hidden field', () => {
 		const { container } = renderField( { key: 'secret', type: 'hidden', label: 'Secret' } );
 		expect( container ).toBeEmptyDOMElement();
+	} );
+} );
+
+// The toggle group renders for real from @wordpress/components, so these tests
+// exercise core's own radio-group wiring rather than a stand-in for it.
+describe( 'SettingsField with control: toggle_group', () => {
+	const field = {
+		key: 'deals_enabled',
+		type: 'checkbox',
+		control: 'toggle_group',
+		label: 'Deals',
+		description: 'Push completed orders as deals.',
+	};
+
+	it( 'renders a checkbox field as an Enabled/Disabled toggle group', () => {
+		render( <SettingsField field={ field } value={ true } onChange={ () => {} } /> );
+		expect( screen.getByRole( 'radio', { name: 'Enabled' } ) ).toBeChecked();
+		expect( screen.getByRole( 'radio', { name: 'Disabled' } ) ).not.toBeChecked();
+	} );
+
+	// Stored checkbox values round-trip through WP options as '1'/'', so the
+	// falsy string form must land on Disabled.
+	it( 'maps a falsy stored value to Disabled', () => {
+		render( <SettingsField field={ field } value={ '' } onChange={ () => {} } /> );
+		expect( screen.getByRole( 'radio', { name: 'Disabled' } ) ).toBeChecked();
+	} );
+
+	// The stored value stays a boolean — the option strings are presentation
+	// only, so the save payload matches what a plain checkbox would submit.
+	it( 'emits booleans, not option values', () => {
+		const onChange = jest.fn();
+		render( <SettingsField field={ field } value={ true } onChange={ onChange } /> );
+		fireEvent.click( screen.getByRole( 'radio', { name: 'Disabled' } ) );
+		expect( onChange ).toHaveBeenCalledWith( false );
+	} );
+
+	it( 'keeps rendering a plain checkbox without the control parameter', () => {
+		render( <SettingsField field={ { ...field, control: undefined } } value={ true } onChange={ () => {} } /> );
+		expect( screen.getByRole( 'checkbox', { name: 'Deals' } ) ).toBeChecked();
 	} );
 } );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The integrations settings UI renders every boolean field as a checkbox, which reads as an action ("Enable Deals") rather than a state. A settings field declared with `type: 'checkbox'` can now opt into `control: 'toggle_group'`, rendering as a two-option Enabled/Disabled toggle group — the same control the content-gate metering settings use (#919). The parameter is presentation-only: the field still submits and stores a boolean, and a declaration carrying it renders as a plain checkbox on plugin versions that predate the parameter, so consumers can adopt it without a version gate.

First consumer is the ActiveCampaign Deals switch in newspack-manager (Automattic/newspack-manager#735); either PR can land first.

Part of NPPD-2178.

### How to test the changes in this Pull Request:

1. Check out Automattic/newspack-manager#735, which declares `control: 'toggle_group'` on the ActiveCampaign Deals field, and define `NEWSPACK_ACTIVECAMPAIGN_ENABLED`.
2. Open Newspack → Audience → Integrations → ActiveCampaign. The Deals field renders as an Enabled/Disabled toggle group titled "Deals".
3. Select Enabled and save. Reload the screen: the toggle is still on Enabled, and `wp option get newspack_integration_settings_activecampaign_deals_enabled` holds a boolean value, not an option string.
4. Confirm a checkbox field without the parameter (any other integration toggle) still renders as a checkbox.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

No screenshot: the rendered control is the stock toggle group already on the content-gate metering screen (#919), and exercising this parameter needs the companion manager branch.
