### PR TITLE
fix(content-gate): empty institution rule grants nobody (NPPD-2217)

### DIFF
--- a/plugins/newspack-plugin/includes/cli/class-premium-newsletters-verify.php
+++ b/plugins/newspack-plugin/includes/cli/class-premium-newsletters-verify.php
@@ -1073,12 +1073,14 @@ class Premium_Newsletters_Verify {
 	 *   subscribed while entitled are indistinguishable from the whole reader base.
 	 *
 	 * An unconfigured rule is skipped, because it paywalls nothing:
-	 * is_email_domain_whitelisted(), has_reader_data() and Institution::evaluate()
-	 * each return true on an empty value. Two rules are exceptions, both verified
-	 * against their evaluators:
+	 * is_email_domain_whitelisted() and has_reader_data() both return true on an
+	 * empty value. Three rules are exceptions, all verified against their
+	 * evaluators:
 	 *
 	 * - `one_time_purchase` counts whatever its value: has_one_time_purchase() fails
 	 *   closed on an empty product list, so an unconfigured one restricts everyone.
+	 * - `institution` counts whatever its value, for the same reason:
+	 *   Institution::evaluate() matches nobody when it names no institution.
 	 * - `subscription` counts when it names no product: has_active_subscription()
 	 *   then passes an empty product filter to
 	 *   WooCommerce_Connection::get_active_subscriptions_for_user(), which grants on
@@ -1104,13 +1106,26 @@ class Premium_Newsletters_Verify {
 			// group, so the question is asked per group, not per rule. A group holding
 			// a subscription rule that names products admits nobody who does not also
 			// hold one of those products — whatever else it ANDs on top only narrows
-			// that set further, and the walk already covers it. Asking per rule instead
+			// that set further, down to and including nobody at all. Asking per rule
 			// reports a gate with a single `subscription + institution` group as only
 			// partly checked, and fails a run that in fact checked everyone who could
 			// get in.
+			// A rule that admits nobody makes the whole group admit nobody, whatever
+			// the subscription rule names. Letting the product bound stand for the
+			// group would describe its population as "holders of those products" —
+			// readers this gate in fact denies, and whom check_access() removes from
+			// the list while the run reports them clean.
+			$group_admits_nobody = false;
+			foreach ( $group as $rule ) {
+				if ( 'institution' === (string) ( $rule['slug'] ?? '' ) && empty( $rule['value'] ?? null ) ) {
+					$group_admits_nobody = true;
+					break;
+				}
+			}
+
 			$group_widens = true;
 			foreach ( $group as $rule ) {
-				if ( 'subscription' !== (string) ( $rule['slug'] ?? '' ) ) {
+				if ( $group_admits_nobody || 'subscription' !== (string) ( $rule['slug'] ?? '' ) ) {
 					continue;
 				}
 				if ( ! empty( array_filter( array_map( 'intval', (array) ( $rule['value'] ?? null ) ) ) ) ) {
@@ -1128,7 +1143,9 @@ class Premium_Newsletters_Verify {
 				if ( '' === $slug ) {
 					continue;
 				}
-				if ( 'one_time_purchase' !== $slug && 'subscription' !== $slug && empty( $value ) ) {
+				// The three rules named in the docblock restrict whatever value they
+				// carry; every other rule with no value paywalls nobody.
+				if ( empty( $value ) && ! in_array( $slug, [ 'one_time_purchase', 'subscription', 'institution' ], true ) ) {
 					continue;
 				}
 				$slugs[] = $slug;

--- a/plugins/newspack-plugin/includes/cli/class-premium-newsletters-verify.php
+++ b/plugins/newspack-plugin/includes/cli/class-premium-newsletters-verify.php
@@ -1047,6 +1047,39 @@ class Premium_Newsletters_Verify {
 	}
 
 	/**
+	 * Whether a rule denies every reader as written.
+	 *
+	 * Only the two rules that fail closed on a missing value are detectable here,
+	 * and only from the value's emptiness:
+	 *
+	 * - `institution` names no institution, so Institution::evaluate() matches nobody.
+	 * - `one_time_purchase` names no product, so has_one_time_purchase() never reaches
+	 *   a lookup. Its value is composite, so the emptiness that matters is
+	 *   `product_ids` rather than the value as a whole.
+	 *
+	 * A populated but unsatisfiable value — an institution ID that no longer
+	 * resolves, a product that was deleted — denies every reader just the same and
+	 * reads as configured from here. Detecting it would mean resolving each value
+	 * against the store, which this command does not do; a gate in that state is
+	 * reported as enumerable and its population overstated.
+	 *
+	 * @param array $rule One access rule.
+	 *
+	 * @return bool
+	 */
+	private static function rule_admits_nobody( array $rule ): bool {
+		$slug = (string) ( $rule['slug'] ?? '' );
+		if ( 'institution' === $slug ) {
+			return empty( $rule['value'] ?? null );
+		}
+		if ( 'one_time_purchase' === $slug ) {
+			$value = \Newspack\Access_Rules::sanitize_one_time_purchase_value( $rule['value'] ?? [] );
+			return empty( $value['product_ids'] );
+		}
+		return false;
+	}
+
+	/**
 	 * The slugs of a gate's access rules that paywall it but whose population this
 	 * command cannot enumerate.
 	 *
@@ -1117,7 +1150,7 @@ class Premium_Newsletters_Verify {
 			// the list while the run reports them clean.
 			$group_admits_nobody = false;
 			foreach ( $group as $rule ) {
-				if ( 'institution' === (string) ( $rule['slug'] ?? '' ) && empty( $rule['value'] ?? null ) ) {
+				if ( self::rule_admits_nobody( (array) $rule ) ) {
 					$group_admits_nobody = true;
 					break;
 				}

--- a/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
@@ -107,9 +107,20 @@ class Access_Rules {
 	 *     @type bool     $empty_grants_access
 	 *                                        Optional. Whether the rule's callback reads an empty
 	 *                                        value as "no constraint", so leaving it empty grants
-	 *                                        access to every reader. Defaults to false. A rule
-	 *                                        that declares it is refused a save while the gate is
-	 *                                        active and its value is empty.
+	 *                                        access to every reader. Defaults to false. Decides
+	 *                                        which way the editor and the save error describe an
+	 *                                        empty value, never whether it is allowed.
+	 *     @type bool     $requires_value     Optional. Whether an empty value leaves the rule
+	 *                                        unconfigured rather than expressing a usable
+	 *                                        condition. Defaults to false. A rule that declares
+	 *                                        it is refused a save while the gate is active and
+	 *                                        its value is empty. Independent of which way the
+	 *                                        rule then evaluates: `institution` denies every
+	 *                                        reader and the two free-text rules grant every
+	 *                                        reader, and neither is what the operator meant.
+	 *                                        `subscription` must not declare it — naming no
+	 *                                        product means "any active subscription", which is a
+	 *                                        condition publishers configure deliberately.
 	 *     @type bool     $supports_anonymous Whether the rule's callback can evaluate access for
 	 *                                        a logged-out visitor (`user_id = 0`). Defaults to
 	 *                                        false — `evaluate_rule` short-circuits to false for
@@ -153,11 +164,14 @@ class Access_Rules {
 				'options'             => [],
 				'has_options'         => $has_options,
 				'is_boolean'          => false,
-				// It is a property of the rule's callback, not of the value's shape:
-				// `institution` returns true when it names none, and so do the two
-				// free-text rules when left blank, while `subscription` naming no
-				// product still requires *an* active subscription.
+				// Both are properties of the rule's callback rather than of the
+				// value's shape, and they are not the same question: the two
+				// free-text rules grant every reader when left blank and
+				// `institution` denies every reader, yet all three are unconfigured.
+				// `subscription` naming no product is neither — it still requires
+				// *an* active subscription.
 				'empty_grants_access' => false,
+				'requires_value'      => false,
 			]
 		);
 		self::$rules[ $rule['id'] ] = $rule;
@@ -226,20 +240,22 @@ class Access_Rules {
 				'placeholder'         => __( 'example.com,another.com', 'newspack-plugin' ),
 				'callback'            => [ __CLASS__, 'is_email_domain_whitelisted' ],
 				'empty_grants_access' => true,
+				'requires_value'      => true,
 			],
 			'reader_data'       => [
 				'name'                => __( 'Reader data', 'newspack-plugin' ),
 				'description'         => __( 'Set custom conditions based on reader data key/value pairs.', 'newspack-plugin' ),
 				'callback'            => [ __CLASS__, 'has_reader_data' ],
 				'empty_grants_access' => true,
+				'requires_value'      => true,
 			],
 			'institution'       => [
-				'name'                => __( 'Institutional access', 'newspack-plugin' ),
-				'description'         => __( 'Grant access to readers from selected institutions.', 'newspack-plugin' ),
-				'options'             => [ Institution::class, 'get_options' ],
-				'callback'            => [ Institution::class, 'evaluate' ],
-				'supports_anonymous'  => true,
-				'empty_grants_access' => true,
+				'name'               => __( 'Institutional access', 'newspack-plugin' ),
+				'description'        => __( 'Grant access to readers from selected institutions.', 'newspack-plugin' ),
+				'options'            => [ Institution::class, 'get_options' ],
+				'callback'           => [ Institution::class, 'evaluate' ],
+				'supports_anonymous' => true,
+				'requires_value'     => true,
 			],
 		];
 
@@ -437,6 +453,33 @@ class Access_Rules {
 			return false;
 		}
 		return self::evaluate_rules( $eligible_groups, 0 );
+	}
+
+	/**
+	 * Evaluate a gate's access rules for whoever is asking.
+	 *
+	 * The two evaluators are not interchangeable, and the difference only shows on
+	 * a rule left with no value. `evaluate_rules()` runs every rule against the id
+	 * it is handed, and a logged-out visitor is id 0 — so a rule that reads its
+	 * empty value as "no constraint" reports satisfied, and lets an anonymous
+	 * visitor through a gate that names a condition nobody evaluated.
+	 * `evaluate_anonymous_rules()` drops those groups first.
+	 *
+	 * Every surface gating content for both audiences goes through here, so one
+	 * gate cannot answer differently depending on which surface asked.
+	 *
+	 * @param array $access_rules The gate's access rules.
+	 * @param int   $user_id      Reader to evaluate for; 0 for a logged-out visitor.
+	 * @param array $context      Optional. Evaluation context, applied only to the
+	 *                            logged-in path — the anonymous one reaches no rule
+	 *                            that reads it.
+	 *
+	 * @return bool Whether the visitor passes the rules.
+	 */
+	public static function evaluate_rules_for_visitor( $access_rules, $user_id, $context = [] ) {
+		return $user_id
+			? self::evaluate_rules( $access_rules, $user_id, $context )
+			: self::evaluate_anonymous_rules( $access_rules );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
@@ -458,12 +458,23 @@ class Access_Rules {
 	/**
 	 * Evaluate a gate's access rules for whoever is asking.
 	 *
-	 * The two evaluators are not interchangeable, and the difference only shows on
-	 * a rule left with no value. `evaluate_rules()` runs every rule against the id
-	 * it is handed, and a logged-out visitor is id 0 — so a rule that reads its
-	 * empty value as "no constraint" reports satisfied, and lets an anonymous
-	 * visitor through a gate that names a condition nobody evaluated.
-	 * `evaluate_anonymous_rules()` drops those groups first.
+	 * The two evaluators are not interchangeable. For a registered rule they now
+	 * agree: `evaluate_rule()` denies user 0 before reading the value unless the
+	 * rule is `supports_anonymous`, and the only such rule — `institution` — denies
+	 * on an empty value. What still differs is a rule the site does not register:
+	 * `evaluate_rule()` returns true for a missing callback, and does so ahead of
+	 * the anonymous check, so `evaluate_rules( …, 0 )` admits a logged-out visitor
+	 * to a group whose only rule came from a switched-off integration. The same
+	 * goes for the shapes neither the wizard nor the REST sanitizer produces and
+	 * block attributes are never checked for — an empty group, a rule carrying no
+	 * slug — which have no condition to fail and so read as satisfied.
+	 * `evaluate_anonymous_rules()` drops all of those groups first.
+	 *
+	 * That leaves one deliberate asymmetry: an unregistered rule is skipped for a
+	 * signed-in reader (a gate the publisher cannot see or edit must not deny
+	 * everyone) and denies a logged-out visitor (an unevaluated condition must not
+	 * stand in for registration). Both directions are chosen; neither is a bug to
+	 * reconcile.
 	 *
 	 * Every surface gating content for both audiences goes through here, so one
 	 * gate cannot answer differently depending on which surface asked.

--- a/plugins/newspack-plugin/includes/content-gate/class-block-visibility.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-block-visibility.php
@@ -658,7 +658,7 @@ class Block_Visibility {
 			// payment-recovery toggle, and a reader in the retry window should see
 			// member-only blocks just as they can pass the gate itself.
 			$rule_context  = [ 'payment_recovery_grace' => $custom_access['payment_recovery_grace'] ?? true ];
-			$access_passes = Access_Rules::evaluate_rules( $custom_access['access_rules'], $user_id, $rule_context );
+			$access_passes = Access_Rules::evaluate_rules_for_visitor( $custom_access['access_rules'], $user_id, $rule_context );
 		}
 
 		// AND logic: both must pass when both are configured.

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate-api.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate-api.php
@@ -183,7 +183,7 @@ class Content_Gate_API {
 			$sanitized_custom_access = self::sanitize_custom_access( $gate['custom_access'] );
 			$leaves_rules_unenforced = self::save_leaves_rules_unenforced( $gate, $sanitized, $gate_id );
 			if ( ! is_wp_error( $sanitized_custom_access ) ) {
-				$sanitized_custom_access = self::reject_rules_left_unconstrained( $sanitized_custom_access, $gate_id, $leaves_rules_unenforced );
+				$sanitized_custom_access = self::reject_rules_left_unconfigured( $sanitized_custom_access, $gate_id, $leaves_rules_unenforced );
 			}
 			if ( is_wp_error( $sanitized_custom_access ) ) {
 				// Only a caller who could act on the refusal is told about it. Sanitization
@@ -210,7 +210,7 @@ class Content_Gate_API {
 		} elseif ( ! self::save_leaves_rules_unenforced( $gate, $sanitized, $gate_id ) ) {
 			// A save that publishes the gate without naming its custom access section
 			// still puts the stored rules live, so they are judged as they are.
-			$stored_rules_verdict = self::reject_rules_left_unconstrained( [], $gate_id, false );
+			$stored_rules_verdict = self::reject_rules_left_unconfigured( [], $gate_id, false );
 			if ( is_wp_error( $stored_rules_verdict ) ) {
 				return $stored_rules_verdict;
 			}
@@ -222,13 +222,17 @@ class Content_Gate_API {
 	}
 
 	/**
-	 * Reject an active gate holding a rule that has been left granting everyone.
+	 * Reject an active gate holding a rule the operator has left unconfigured.
 	 *
-	 * Scoped to rules registered with `empty_grants_access`, whose callback reads
-	 * an empty value as "no constraint" and so evaluates true for every reader.
-	 * That state is reachable without typing a character — enabling the rule seeds
-	 * it with its empty default, and on a site with no institutions published the
-	 * picker has nothing else to offer.
+	 * Scoped to rules registered with `requires_value`, whose empty value expresses
+	 * no condition. That state is reachable without typing a character — enabling
+	 * the rule seeds it with its empty default, and on a site with no institutions
+	 * published the picker has nothing else to offer.
+	 *
+	 * Which way such a rule then evaluates does not change the answer here, and the
+	 * rules disagree: `institution` matches nobody, the two free-text rules match
+	 * everybody. Both are the gate doing something other than what the operator
+	 * configured, so both are refused rather than saved and explained.
 	 *
 	 * An empty value is not the same thing on every rule, which is why the
 	 * declaration decides and the value's shape does not: `subscription` naming no
@@ -244,7 +248,7 @@ class Content_Gate_API {
 	 *
 	 * @return array|\WP_Error The settings unchanged, or an error naming the rule.
 	 */
-	private static function reject_rules_left_unconstrained( $sanitized_custom_access, $gate_id, $leaves_rules_unenforced ) {
+	private static function reject_rules_left_unconfigured( $sanitized_custom_access, $gate_id, $leaves_rules_unenforced ) {
 		$access_rules = $sanitized_custom_access['access_rules'] ?? null;
 		if ( null === $access_rules ) {
 			// A partial save carries only what it changes, and the settings it omits
@@ -297,7 +301,7 @@ class Content_Gate_API {
 					continue;
 				}
 				$registered = $registered_rules[ $rule['slug'] ?? '' ] ?? null;
-				if ( empty( $registered['empty_grants_access'] ) || ! self::rule_value_is_empty( $rule['value'] ?? null ) ) {
+				if ( empty( $registered['requires_value'] ) || ! self::rule_value_is_empty( $rule['value'] ?? null ) ) {
 					continue;
 				}
 				return self::empty_access_rule_value_error( $registered );
@@ -324,24 +328,39 @@ class Content_Gate_API {
 	}
 
 	/**
-	 * The error returned when an active gate holds a rule left granting everyone.
+	 * The error returned when an active gate holds a rule left unconfigured.
+	 *
+	 * Names what the empty value actually does, which is the rule's own business
+	 * and differs between them: `institution` matches nobody, the free-text rules
+	 * match everybody. Reporting the wrong one sends the operator looking for the
+	 * wrong symptom on the front end.
 	 *
 	 * @param array $rule The registered rule.
 	 *
 	 * @return \WP_Error
 	 */
 	private static function empty_access_rule_value_error( $rule ) {
-		$message = empty( $rule['has_options'] )
-			/* translators: %s: the access rule's name, e.g. "Whitelisted email domain". */
-			? __( 'Enter a value for the “%s” access rule, or turn the rule off. Left empty, it grants access to everyone.', 'newspack-plugin' )
-			/* translators: %s: the access rule's name, e.g. "Institutional access". */
-			: __( 'Select at least one option for the “%s” access rule, or turn the rule off. Left empty, it grants access to everyone.', 'newspack-plugin' );
+		$grants_access = ! empty( $rule['empty_grants_access'] );
+		if ( empty( $rule['has_options'] ) ) {
+			$message = $grants_access
+				/* translators: %s: the access rule's name, e.g. "Whitelisted email domain". */
+				? __( 'Enter a value for the “%s” access rule, or turn the rule off. Left empty, it grants access to everyone.', 'newspack-plugin' )
+				/* translators: %s: the access rule's name, e.g. "Whitelisted email domain". */
+				: __( 'Enter a value for the “%s” access rule, or turn the rule off. Left empty, it matches no reader.', 'newspack-plugin' );
+		} else {
+			$message = $grants_access
+				/* translators: %s: the access rule's name, e.g. "Institutional access". */
+				? __( 'Select at least one option for the “%s” access rule, or turn the rule off. Left empty, it grants access to everyone.', 'newspack-plugin' )
+				/* translators: %s: the access rule's name, e.g. "Institutional access". */
+				: __( 'Select at least one option for the “%s” access rule, or turn the rule off. Left empty, it matches no reader.', 'newspack-plugin' );
+		}
 		return new \WP_Error(
 			'empty_access_rule_value',
 			sprintf( $message, $rule['name'] ),
 			[
-				'status'    => 400,
-				'rule_name' => $rule['name'],
+				'status'              => 400,
+				'rule_name'           => $rule['name'],
+				'empty_grants_access' => $grants_access,
 			]
 		);
 	}
@@ -363,17 +382,20 @@ class Content_Gate_API {
 		if ( ! $leaves_rules_unenforced || 'empty_access_rule_value' !== $error->get_error_code() ) {
 			return $error;
 		}
-		$rule_name = $error->get_error_data()['rule_name'] ?? '';
+		$error_data = $error->get_error_data();
+		$rule_name  = $error_data['rule_name'] ?? '';
+		$message    = empty( $error_data['empty_grants_access'] )
+			/* translators: %s: the access rule's name, e.g. "Institutional access". */
+			? __( 'The “%s” access rule is empty, so it matches no reader. Give it a value or remove it before this gate is active again.', 'newspack-plugin' )
+			/* translators: %s: the access rule's name, e.g. "Whitelisted email domain". */
+			: __( 'The “%s” access rule is empty, so it grants access to everyone. Give it a value or remove it before this gate is active again.', 'newspack-plugin' );
 		return new \WP_Error(
 			'empty_access_rule_value',
-			sprintf(
-				/* translators: %s: the access rule's name, e.g. "Institutional access". */
-				__( 'The “%s” access rule is empty, so it grants access to everyone. Give it a value or remove it before this gate is active again.', 'newspack-plugin' ),
-				$rule_name
-			),
+			sprintf( $message, $rule_name ),
 			[
-				'status'    => 400,
-				'rule_name' => $rule_name,
+				'status'              => 400,
+				'rule_name'           => $rule_name,
+				'empty_grants_access' => ! empty( $error_data['empty_grants_access'] ),
 			]
 		);
 	}

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate-api.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate-api.php
@@ -315,9 +315,9 @@ class Content_Gate_API {
 	 *
 	 * Both shapes a rule can take carry the same meaning when empty: an
 	 * options-backed rule selects nothing with `[]`, a free-text one with `''`,
-	 * and a stored rule can be missing its value altogether. Every rule that
-	 * declares `empty_grants_access` grants every reader in that state, whichever
-	 * of the two it is.
+	 * and a stored rule can be missing its value altogether. All three say the
+	 * rule names no condition. Which way it then evaluates is the rule's own
+	 * business, and `empty_grants_access` is where each rule states it.
 	 *
 	 * @param mixed $value The rule's value.
 	 *
@@ -335,6 +335,10 @@ class Content_Gate_API {
 	 * match everybody. Reporting the wrong one sends the operator looking for the
 	 * wrong symptom on the front end.
 	 *
+	 * No rule the plugin registers reaches the free-text "matches no reader"
+	 * string today; it is kept for rules other plugins register through
+	 * Access_Rules::register_rule().
+	 *
 	 * @param array $rule The registered rule.
 	 *
 	 * @return \WP_Error
@@ -345,11 +349,11 @@ class Content_Gate_API {
 			$message = $grants_access
 				/* translators: %s: the access rule's name, e.g. "Whitelisted email domain". */
 				? __( 'Enter a value for the “%s” access rule, or turn the rule off. Left empty, it grants access to everyone.', 'newspack-plugin' )
-				/* translators: %s: the access rule's name, e.g. "Whitelisted email domain". */
+				/* translators: %s: the access rule's name. */
 				: __( 'Enter a value for the “%s” access rule, or turn the rule off. Left empty, it matches no reader.', 'newspack-plugin' );
 		} else {
 			$message = $grants_access
-				/* translators: %s: the access rule's name, e.g. "Institutional access". */
+				/* translators: %s: the access rule's name, e.g. a promoted field that excludes a list of values. */
 				? __( 'Select at least one option for the “%s” access rule, or turn the rule off. Left empty, it grants access to everyone.', 'newspack-plugin' )
 				/* translators: %s: the access rule's name, e.g. "Institutional access". */
 				: __( 'Select at least one option for the “%s” access rule, or turn the rule off. Left empty, it matches no reader.', 'newspack-plugin' );

--- a/plugins/newspack-plugin/includes/content-gate/class-content-restriction-control.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-restriction-control.php
@@ -446,9 +446,8 @@ class Content_Restriction_Control {
 				if ( $user_id === 0 ) {
 					// Anonymous visitors can still pass via the gate's custom_access rules if they
 					// match a populated rule with `supports_anonymous` (currently only `institution`).
-					// An unpopulated rule (e.g., institution rule with no institutions selected) must
-					// not grant access — Access_Rules treats an empty value as "no constraint" and
-					// returns true, which would silently bypass registration here.
+					// A rule left with no value names no condition, so it cannot be what lets a
+					// visitor past the registration wall.
 					$anonymous_bypass_passed = ! empty( $gate['custom_access']['active'] )
 						&& Access_Rules::evaluate_anonymous_rules( $gate['custom_access']['access_rules'] ?? [] );
 					$is_restricted  = ! $anonymous_bypass_passed;
@@ -467,7 +466,7 @@ class Content_Restriction_Control {
 			if ( ! $is_restricted && null === $anonymous_bypass_passed && ! empty( $gate['custom_access']['active'] ) ) {
 				$access_rules = $gate['custom_access']['access_rules'] ?? [];
 				$rule_context = [ 'payment_recovery_grace' => $gate['custom_access']['payment_recovery_grace'] ?? true ];
-				if ( ! empty( $access_rules ) && ! Access_Rules::evaluate_rules( $access_rules, $user_id, $rule_context ) ) {
+				if ( ! empty( $access_rules ) && ! Access_Rules::evaluate_rules_for_visitor( $access_rules, $user_id, $rule_context ) ) {
 					$is_restricted  = true;
 					$gate_layout_id = $gate['custom_access']['gate_layout_id'] ?? $gate['id'];
 				}

--- a/plugins/newspack-plugin/includes/content-gate/class-institution.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-institution.php
@@ -275,24 +275,30 @@ class Institution {
 	/**
 	 * Evaluate whether a user matches any of the selected institutions.
 	 *
+	 * Naming no institution matches nobody. The rule's default is `[]`, so reading
+	 * it as "no constraint" would mean switching the rule on — before publishing
+	 * any institution, or after deleting the last one — opened the gate to every
+	 * reader. Denying instead matches the other options-backed rules, where an
+	 * empty value narrows rather than removes the check, and matches
+	 * `Access_Rules::evaluate_anonymous_rules()`, which has always read a rule with
+	 * no value as granting nobody.
+	 *
+	 * The state is refused a save while the gate is active (`requires_value` on the
+	 * rule's registration), so this governs values stored by the paths that never
+	 * reach that check: block attributes, WP-CLI, and rows predating it.
+	 *
 	 * @param int   $user_id         User ID.
 	 * @param mixed $institution_ids Selected institution IDs — an array of post IDs
-	 *                               when well-formed; any other shape is treated as
-	 *                               malformed and fails closed.
+	 *                               when well-formed; any other shape is malformed.
 	 *
 	 * @return bool Whether the user matches any institution.
 	 */
 	public static function evaluate( $user_id, $institution_ids ) {
-		// A value of the wrong shape (e.g. a free-text string saved before values
-		// were validated) is malformed configuration, not the absence of a
-		// constraint — fail closed rather than grant access.
-		if ( Access_Rules::is_malformed_options_backed_value( $institution_ids ) ) {
+		// Nothing selected, or a value of a shape this rule cannot read (e.g. a
+		// free-text string saved before values were validated). Neither expresses a
+		// condition, so neither can be satisfied.
+		if ( empty( $institution_ids ) || ! is_array( $institution_ids ) ) {
 			return false;
-		}
-
-		// An empty value means the rule imposes no constraint.
-		if ( empty( $institution_ids ) ) {
-			return true;
 		}
 
 		$institutions = self::get_cached_institutions();

--- a/plugins/newspack-plugin/includes/content-gate/class-user-gate-access.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-user-gate-access.php
@@ -148,6 +148,13 @@ class User_Gate_Access {
 			return sprintf( __( '%s (invalid duration, grants no access)', 'newspack-plugin' ), $products_label );
 		}
 
+		// Also ahead of the generic branch, for the same reason: an institution rule
+		// naming nothing matches nobody, so "(any)" would contradict the Fail the
+		// reader is looking at.
+		if ( 'institution' === $slug && ( ! is_array( $value ) || empty( $value ) ) ) {
+			return __( '(no institutions selected)', 'newspack-plugin' );
+		}
+
 		if ( empty( $value ) ) {
 			return __( '(any)', 'newspack-plugin' );
 		}

--- a/plugins/newspack-plugin/includes/reader-activation/class-promoted-fields.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-promoted-fields.php
@@ -149,11 +149,14 @@ class Promoted_Fields {
 					// holds the field at all. `list__in`, `date_range` and `default` deny
 					// on an empty value instead.
 					'empty_grants_access' => $empty_grants_access,
-					// Only the granting ones are refused a save, which keeps promoted
-					// fields behaving as they did. A field's options come from the
-					// provider's roster and can arrive after the rule is written, so an
-					// empty deny-on-empty rule is a state an operator can be part-way
-					// through rather than one they have finished getting wrong.
+					// Narrower than the flag's own definition, which counts any empty
+					// value as unconfigured whichever way the rule then evaluates: a
+					// `list__in` field naming nothing denies every reader, saves without
+					// refusal, and reads as a blank condition in the gate summary. Only
+					// the granting ones are refused a save here, so that this change
+					// leaves promoted fields evaluating and saving as they did. Closing
+					// the gap belongs with the rest of the unconfigured-rule warnings, in
+					// NPPD-2227.
 					'requires_value'      => $empty_grants_access,
 					'callback'            => function ( $user_id, $args ) use ( $field ) {
 						return self::evaluate_field( $field, $user_id, $args );

--- a/plugins/newspack-plugin/includes/reader-activation/class-promoted-fields.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-promoted-fields.php
@@ -131,6 +131,7 @@ class Promoted_Fields {
 			if ( ! $field->is_access_rule() ) {
 				continue;
 			}
+			$empty_grants_access = in_array( $field->get_matching_function(), [ 'list__not_in', 'range' ], true );
 			Access_Rules::register_rule(
 				[
 					'id'                  => $key,
@@ -146,9 +147,14 @@ class Promoted_Fields {
 					// `list__not_in` naming nothing excludes nobody, and `range` with no
 					// bounds falls back to 0..PHP_INT_MAX. Either admits every reader who
 					// holds the field at all. `list__in`, `date_range` and `default` deny
-					// on an empty value, so declaring them would refuse a save that is
-					// merely narrow.
-					'empty_grants_access' => in_array( $field->get_matching_function(), [ 'list__not_in', 'range' ], true ),
+					// on an empty value instead.
+					'empty_grants_access' => $empty_grants_access,
+					// Only the granting ones are refused a save, which keeps promoted
+					// fields behaving as they did. A field's options come from the
+					// provider's roster and can arrive after the rule is written, so an
+					// empty deny-on-empty rule is a state an operator can be part-way
+					// through rather than one they have finished getting wrong.
+					'requires_value'      => $empty_grants_access,
 					'callback'            => function ( $user_id, $args ) use ( $field ) {
 						return self::evaluate_field( $field, $user_id, $args );
 					},

--- a/plugins/newspack-plugin/includes/reader-activation/sync/contact-metadata/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/reader-activation/sync/contact-metadata/class-content-gate.php
@@ -239,9 +239,10 @@ class Content_Gate extends Contact_Metadata {
 				return Group_Subscription::get_group_names_for_user( $user_id, $product_filter );
 
 			case 'institution':
-				// An empty institution rule imposes no constraint per Institution::evaluate(),
-				// but there's no specific institution to attribute. A populated non-array
-				// value fails the rule outright, so this resolver is never reached for one.
+				// Defensive: neither shape reaches here, because Institution::evaluate()
+				// fails the rule on both and this resolver runs only for a rule that
+				// passed. Kept so a future caller cannot read an unmatched rule as an
+				// attribution.
 				if ( ! is_array( $value ) || empty( $value ) ) {
 					return [];
 				}

--- a/plugins/newspack-plugin/src/content-gate/editor/block-visibility.test.ts
+++ b/plugins/newspack-plugin/src/content-gate/editor/block-visibility.test.ts
@@ -160,15 +160,11 @@ describe( 'block-visibility access rule value control', () => {
 		expect( controlOf( control ).type ).toBe( TextControl );
 	} );
 
-	it( 'takes the picker out of play when an empty value would grant everyone', () => {
-		// The seeded default is an empty array, which `institution` evaluates as "no
-		// constraint" — so an interactive picker with no options offers exactly one
-		// expressible answer, and it opens the gate.
-		const control = renderControl(
-			'institution',
-			{ name: 'Institutional access', has_options: true, empty_grants_access: true, options: [] },
-			[]
-		);
+	it( 'takes the picker out of play when the rule needs a value it cannot offer', () => {
+		// The seeded default is an empty array, so an interactive picker with no
+		// options offers exactly one expressible answer, and it is the one that leaves
+		// the rule describing nobody.
+		const control = renderControl( 'institution', { name: 'Institutional access', has_options: true, requires_value: true, options: [] }, [] );
 
 		expect( pickerOf( control ).props.disabled ).toBe( true );
 	} );
@@ -190,7 +186,7 @@ describe( 'block-visibility access rule value control', () => {
 			{
 				name: 'Institutional access',
 				has_options: true,
-				empty_grants_access: true,
+				requires_value: true,
 				options: [ { value: 1, label: 'Springfield University' } ],
 			},
 			'Shelbyville University'

--- a/plugins/newspack-plugin/src/content-gate/editor/index.d.ts
+++ b/plugins/newspack-plugin/src/content-gate/editor/index.d.ts
@@ -20,6 +20,7 @@ type AccessRuleConfig = {
 	options?: AccessRuleOption[];
 	has_options: boolean;
 	empty_grants_access?: boolean;
+	requires_value?: boolean;
 };
 type ActiveRule = {
 	slug: string;

--- a/plugins/newspack-plugin/src/content-gate/utils/access-rule-value.ts
+++ b/plugins/newspack-plugin/src/content-gate/utils/access-rule-value.ts
@@ -23,6 +23,7 @@ type AccessRuleShape = {
 	has_options?: boolean;
 	is_boolean?: boolean;
 	empty_grants_access?: boolean;
+	requires_value?: boolean;
 	options?: unknown[];
 };
 
@@ -77,10 +78,24 @@ export const isMalformedAccessRuleValue = ( config: AccessRuleShape | undefined,
 /**
  * Whether a rule imposes no constraint as stored, and so grants access to every
  * reader. Only rules that declare `empty_grants_access` read their empty value
- * that way — `subscription` naming no product still requires an active one.
+ * that way — `subscription` naming no product still requires an active one, and
+ * `institution` naming none matches nobody.
  */
 export const isUnconstrainedAccessRuleValue = ( config: AccessRuleShape | undefined, value: unknown ) =>
 	Boolean( config?.empty_grants_access ) && isEmptyAccessRuleValue( value );
+
+/**
+ * Whether a rule that needs a value has none, so it states no condition at all.
+ *
+ * The superset of the state above, and the one the editor and the save-time
+ * refusal both act on. Every rule granting access on an empty value also
+ * declares `requires_value`; `institution` declares only `requires_value`,
+ * because it matches nobody instead — a different symptom, equally far from
+ * what the operator configured. Only the wording of the caution depends on
+ * which of the two it is.
+ */
+export const isUnconfiguredAccessRuleValue = ( config: AccessRuleShape | undefined, value: unknown ) =>
+	Boolean( config?.requires_value ) && isEmptyAccessRuleValue( value );
 
 /**
  * The caution to show under a rule's picker, or undefined where the stored value
@@ -115,17 +130,28 @@ export const getAccessRuleValueNotice = ( config: AccessRuleShape | undefined, v
 					'newspack-plugin'
 			  );
 	}
-	if ( ! isUnconstrainedAccessRuleValue( config, value ) ) {
+	if ( ! isUnconfiguredAccessRuleValue( config, value ) ) {
 		return undefined;
 	}
-	// Nothing to pick and nothing picked: every answer the picker can express is the
-	// one that lets every reader through, so say where the items come from.
+	// What an empty value does is the rule's own business, and the two answers are
+	// opposites. Naming the wrong one sends an editor looking for the wrong symptom
+	// on the front end: an open paywall reads nothing like a walled-off one.
+	if ( isUnconstrainedAccessRuleValue( config, value ) ) {
+		// Nothing to pick and nothing picked: every answer the picker can express is
+		// the one that lets every reader through, so say where the items come from.
+		return hasOptions
+			? __(
+					'Nothing is selected, so this rule grants access to everyone. Select at least one option, or turn the rule off.',
+					'newspack-plugin'
+			  )
+			: __(
+					'This rule has nothing to select yet, so it grants access to everyone. Add the items it selects, or turn the rule off.',
+					'newspack-plugin'
+			  );
+	}
 	return hasOptions
-		? __( 'Nothing is selected, so this rule grants access to everyone. Select at least one option, or turn the rule off.', 'newspack-plugin' )
-		: __(
-				'This rule has nothing to select yet, so it grants access to everyone. Add the items it selects, or turn the rule off.',
-				'newspack-plugin'
-		  );
+		? __( 'Nothing is selected, so this rule matches no reader. Select at least one option, or turn the rule off.', 'newspack-plugin' )
+		: __( 'This rule has nothing to select yet, so it matches no reader. Add the items it selects, or turn the rule off.', 'newspack-plugin' );
 };
 
 /**
@@ -141,4 +167,4 @@ export const getAccessRuleValueNotice = ( config: AccessRuleShape | undefined, v
  * @param hasOptions Whether the picker has anything to offer.
  */
 export const isAccessRulePickerInert = ( config: AccessRuleShape | undefined, value: unknown, hasOptions: boolean ) =>
-	! hasOptions && isUnconstrainedAccessRuleValue( config, value );
+	! hasOptions && isUnconfiguredAccessRuleValue( config, value );

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/access-rule-control.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/access-rule-control.test.jsx
@@ -222,13 +222,13 @@ describe( 'AccessRuleControl, a rule whose value would let everyone through', ()
 		expect( screen.getByText( /Springfield University/ ) ).toHaveTextContent( 'grants no access' );
 	} );
 
-	it( 'disables the picker and says why when an empty value would grant everyone', async () => {
-		// The seeded default is an empty array, which `institution` evaluates as "no
-		// constraint" — so an interactive picker with no options offers exactly one
-		// expressible answer, and it opens the gate.
-		renderRule( 'institution', { name: 'Institutional access', has_options: true, empty_grants_access: true, options: [] }, [] );
+	it( 'disables the picker and says why when the rule has nothing to select and nothing selected', async () => {
+		// The seeded default is an empty array, so an interactive picker with no options
+		// offers exactly one expressible answer — and it is the one that stops the rule
+		// describing anybody.
+		renderRule( 'institution', { name: 'Institutional access', has_options: true, requires_value: true, options: [] }, [] );
 
-		expect( await screen.findByText( /grants access to everyone/ ) ).toBeInTheDocument();
+		expect( await screen.findByText( /matches no reader/ ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'combobox' ) ).toBeDisabled();
 		// And the reason is tied to the field. A disabled control is out of the tab order,
 		// so an adjacent paragraph the field does not point at reaches nobody arriving by
@@ -236,16 +236,23 @@ describe( 'AccessRuleControl, a rule whose value would let everyone through', ()
 		expect( screen.getByRole( 'group' ) ).toHaveAttribute( 'aria-describedby', screen.getByRole( 'note' ).id );
 	} );
 
-	it( 'says nothing about granting everyone while the rule still names something', async () => {
+	it( 'says nothing about an unconfigured rule while it still names something', async () => {
 		// The institutions a rule names can be deleted after it is saved. The value is
-		// then populated and denies every reader, so the caution for an empty rule is the
-		// opposite of what it does — and disabling the field would leave deleting the
-		// whole rule as the only way to clear the stale tokens.
-		renderRule( 'institution', { name: 'Institutional access', has_options: true, empty_grants_access: true, options: [] }, [ 12 ] );
+		// then populated, and disabling the field would leave deleting the whole rule as
+		// the only way to clear the stale tokens.
+		renderRule( 'institution', { name: 'Institutional access', has_options: true, requires_value: true, options: [] }, [ 12 ] );
 
 		expect( await screen.findByText( '(institution not listed) (#12)' ) ).toBeInTheDocument();
-		expect( screen.queryByText( /grants access to everyone/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /matches no reader/ ) ).not.toBeInTheDocument();
 		expect( screen.getByRole( 'combobox' ) ).not.toBeDisabled();
+	} );
+
+	it( 'tells a free-text rule left blank that it grants everyone, not that it matches nobody', async () => {
+		// The two rules that need a value disagree about what happens without one, and the
+		// caution is where an editor learns which symptom to look for.
+		renderRule( 'email_domain', { name: 'Whitelisted email domain', has_options: false, empty_grants_access: true, requires_value: true }, '' );
+
+		expect( await screen.findByText( /grants access to everyone/ ) ).toBeInTheDocument();
 	} );
 
 	it( 'keeps the picker for a rule that still constrains when empty, and for one with nothing to select', () => {
@@ -256,6 +263,7 @@ describe( 'AccessRuleControl, a rule whose value would let everyone through', ()
 		renderRule( 'subscription', { name: 'Active subscription', has_options: true, options: [] }, [] );
 
 		expect( screen.getByRole( 'combobox' ) ).not.toBeDisabled();
+		expect( screen.queryByText( /matches no reader/ ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( /grants access to everyone/ ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/gate-summary-access-rule-values.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/gate-summary-access-rule-values.test.jsx
@@ -17,6 +17,8 @@ window.newspackAudienceContentGates = {
 			name: 'One-time purchase',
 			options: [ ANNUAL_188250, ANNUAL_205482, { value: 42, label: 'Founder&#8217;s Club' } ],
 		},
+		institution: { name: 'Institutional access', has_options: true, requires_value: true, options: [] },
+		email_domain: { name: 'Whitelisted email domain', has_options: false, empty_grants_access: true, requires_value: true },
 	},
 	available_content_rules: {},
 };
@@ -84,5 +86,16 @@ describe( 'gate summary, Paid access', () => {
 		);
 
 		expect( screen.getByText( '(product not listed) (#999999) (forever)' ) ).toBeInTheDocument();
+	} );
+
+	it( 'says which way an unconfigured rule fails, per rule', () => {
+		// A rule with no value renders as a blank condition, and the summary is the
+		// only place a publisher sees the whole gate at once. The two rules that can
+		// be left empty do opposite things, so one wording for both would be wrong
+		// half the time.
+		renderPaidAccess( gateWith( { slug: 'institution', value: [] }, { slug: 'email_domain', value: '' } ) );
+
+		expect( screen.getByText( 'Not set (matches no reader)' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Not set (grants access to everyone)' ) ).toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/gate-summary.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/gate-summary.tsx
@@ -19,7 +19,7 @@ import {
 	getMissingOptionLabel,
 	type AccessRuleOption,
 } from '../../../../content-gate/access-rule-options';
-import { getMeteringCount, isMalformedAccessRuleValue, isUnconstrainedAccessRuleValue } from './utils';
+import { getMeteringCount, isMalformedAccessRuleValue, isUnconfiguredAccessRuleValue, isUnconstrainedAccessRuleValue } from './utils';
 import { normalizeOneTimePurchaseValue } from '../../../../content-gate/components/one-time-purchase-rule-control';
 
 const availableAccessRules = window.newspackAudienceContentGates.available_access_rules || {};
@@ -94,10 +94,13 @@ const formatAccessRuleValue = ( rule: GateAccessRule, optionsBySlug: Record< str
 			  )
 			: __( 'Invalid value (grants no access)', 'newspack-plugin' );
 	}
-	// A rule left empty renders as a blank condition, which is indistinguishable
-	// from a narrow one — while it is the state that lets every reader through.
-	if ( isUnconstrainedAccessRuleValue( config, rule.value ) ) {
-		return __( 'Not set (grants access to everyone)', 'newspack-plugin' );
+	// A rule left empty renders as a blank condition, indistinguishable from a
+	// narrow one — while it is doing something the summary is the only place to
+	// see. Which of the two it does is the rule's own business.
+	if ( isUnconfiguredAccessRuleValue( config, rule.value ) ) {
+		return isUnconstrainedAccessRuleValue( config, rule.value )
+			? __( 'Not set (grants access to everyone)', 'newspack-plugin' )
+			: __( 'Not set (matches no reader)', 'newspack-plugin' );
 	}
 	if ( Array.isArray( rule.value ) && options ) {
 		return formatAccessRuleOptionValues( rule.value, options, rule.slug );

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/types/index.d.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/types/index.d.ts
@@ -31,6 +31,7 @@ type AccessRule = {
 	options?: { value: string; label: string }[];
 	has_options: boolean;
 	empty_grants_access?: boolean;
+	requires_value?: boolean;
 	placeholder?: string;
 	value: GateAccessRuleValue;
 };

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/utils.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/utils.test.js
@@ -9,6 +9,7 @@ import {
 	hasSharedMeteredPath,
 	isGateMetered,
 	isMalformedAccessRuleValue,
+	isUnconfiguredAccessRuleValue,
 	isUnconstrainedAccessRuleValue,
 	sharesTheSiteMeter,
 } from './utils';
@@ -165,28 +166,37 @@ describe( 'getMeteringCount', () => {
 } );
 
 /**
- * The state the ticket is about: a rule that imposes no constraint lets every
- * reader through, so the wizard has to say so rather than render a blank
- * condition (NPPD-2143).
+ * A rule left with no value is doing something, and the two predicates answer
+ * different questions about it. `isUnconfigured` decides whether the wizard
+ * cautions at all; `isUnconstrained` decides only which way the caution reads.
+ * Keeping them apart is what lets `institution` be refused a save while matching
+ * nobody (NPPD-2217), where the free-text rules match everybody (NPPD-2143).
  */
-describe( 'isUnconstrainedAccessRuleValue', () => {
-	const institution = { name: 'Institutional access', has_options: true, empty_grants_access: true };
-	const emailDomain = { name: 'Whitelisted email domain', has_options: false, empty_grants_access: true };
+describe( 'isUnconstrainedAccessRuleValue and isUnconfiguredAccessRuleValue', () => {
+	const institution = { name: 'Institutional access', has_options: true, requires_value: true };
+	const emailDomain = { name: 'Whitelisted email domain', has_options: false, empty_grants_access: true, requires_value: true };
 	const subscription = { name: 'Active subscription', has_options: true };
 
-	it( 'reads the empty value of a rule that grants everyone when empty', () => {
-		expect( isUnconstrainedAccessRuleValue( institution, [] ) ).toBe( true );
-		expect( isUnconstrainedAccessRuleValue( institution, '' ) ).toBe( true );
+	it( 'reads an empty value as unconfigured whichever way the rule then evaluates', () => {
+		expect( isUnconfiguredAccessRuleValue( institution, [] ) ).toBe( true );
+		expect( isUnconfiguredAccessRuleValue( institution, '' ) ).toBe( true );
+		expect( isUnconfiguredAccessRuleValue( emailDomain, '' ) ).toBe( true );
+	} );
+
+	it( 'calls only the rules that grant everyone unconstrained', () => {
 		expect( isUnconstrainedAccessRuleValue( emailDomain, '' ) ).toBe( true );
+		// An institution rule naming nothing matches nobody, the opposite verdict.
+		expect( isUnconstrainedAccessRuleValue( institution, [] ) ).toBe( false );
 	} );
 
 	it( 'leaves a populated rule alone', () => {
-		expect( isUnconstrainedAccessRuleValue( institution, [ 12 ] ) ).toBe( false );
+		expect( isUnconfiguredAccessRuleValue( institution, [ 12 ] ) ).toBe( false );
 		expect( isUnconstrainedAccessRuleValue( emailDomain, 'example.com' ) ).toBe( false );
 	} );
 
 	it( 'is not about emptiness alone: a rule that still constrains when empty is a configuration', () => {
 		// `subscription` naming no product requires any active subscription.
+		expect( isUnconfiguredAccessRuleValue( subscription, [] ) ).toBe( false );
 		expect( isUnconstrainedAccessRuleValue( subscription, [] ) ).toBe( false );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/utils.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/utils.tsx
@@ -122,6 +122,7 @@ export {
 	getAccessRuleValueNotice,
 	isAccessRulePickerInert,
 	isMalformedAccessRuleValue,
+	isUnconfiguredAccessRuleValue,
 	isUnconstrainedAccessRuleValue,
 } from '../../../../content-gate/utils/access-rule-value';
 

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-access-rules.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-access-rules.php
@@ -1179,19 +1179,36 @@ class Newspack_Test_Access_Rules extends WP_UnitTestCase {
 	/**
 	 * Test that a logged-out visitor is judged by the anonymous evaluator.
 	 *
-	 * The two evaluators agree on every rule a gate can hold today, so what this
-	 * pins is the shape neither the wizard nor the REST sanitizer produces and
-	 * block attributes are never checked for: a group with nothing in it, or a
-	 * rule carrying no slug. `evaluate_rules()` has no condition to fail and reads
-	 * the group as satisfied, which admits every visitor. The anonymous evaluator
-	 * treats both as unconfigured.
+	 * The two evaluators agree on every registered rule a gate can hold today, so
+	 * what this pins is the three shapes where they part. Two are shapes neither
+	 * the wizard nor the REST sanitizer produces and block attributes are never
+	 * checked for: a group with nothing in it, and a rule carrying no slug. The
+	 * third is a rule from an integration the site has switched off, which reaches
+	 * `evaluate_rule()`'s missing-callback branch — and that branch returns true
+	 * ahead of the anonymous check. In all three `evaluate_rules()` has no
+	 * condition to fail and reads the group as satisfied, which admits every
+	 * visitor. The anonymous evaluator treats all three as unconfigured.
+	 *
+	 * The unregistered case is deliberately asymmetric: skipped for a signed-in
+	 * reader (asserted in
+	 * test_an_unregistered_rule_is_skipped_rather_than_failing_its_group), denying
+	 * for a logged-out one. Pinned here so a later reconciliation of the two is a
+	 * decision rather than a tidy-up.
 	 *
 	 * @group Access_Rules
 	 */
 	public function test_evaluate_rules_for_visitor_judges_a_logged_out_visitor_anonymously() {
 		foreach ( [
-			'an empty group'          => [ [] ],
-			'a rule carrying no slug' => [ [ [ 'value' => 'orphan' ] ] ],
+			'an empty group'                         => [ [] ],
+			'a rule carrying no slug'                => [ [ [ 'value' => 'orphan' ] ] ],
+			'a rule from a switched-off integration' => [
+				[
+					[
+						'slug'  => 'field_from_a_disabled_integration',
+						'value' => 'anything',
+					],
+				],
+			],
 		] as $description => $rules ) {
 			$this->assertTrue(
 				Access_Rules::evaluate_rules( $rules, 0 ),

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-access-rules.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-access-rules.php
@@ -1092,4 +1092,132 @@ class Newspack_Test_Access_Rules extends WP_UnitTestCase {
 			'A subscription rule\'s IDs should survive sanitizing whether or not the shop has products.'
 		);
 	}
+
+	/**
+	 * Test that a subscriber loses access when their group also carries an
+	 * institution rule naming nothing.
+	 *
+	 * The one case where reading an unconfigured rule as "matches nobody" takes
+	 * access away from readers who are paying for it. Rules AND within a group, so
+	 * the subscription rule no longer decides on its own. The gate save refuses
+	 * this shape, which leaves rows written before that check — and the block
+	 * attributes and CLI paths that never reach it.
+	 *
+	 * @group Access_Rules
+	 */
+	public function test_a_subscriber_is_denied_when_the_group_also_names_no_institution() {
+		$this->create_subscription();
+
+		$subscription_only = [
+			[
+				[
+					'slug'  => 'subscription',
+					'value' => [ self::$product_id ],
+				],
+			],
+		];
+		$this->assertTrue(
+			Access_Rules::evaluate_rules( $subscription_only, self::$owner_user_id ),
+			'The subscriber passes a group holding only their subscription rule.'
+		);
+
+		$with_unconfigured_institution = [
+			[
+				[
+					'slug'  => 'subscription',
+					'value' => [ self::$product_id ],
+				],
+				[
+					'slug'  => 'institution',
+					'value' => [],
+				],
+			],
+		];
+		$this->assertFalse(
+			Access_Rules::evaluate_rules( $with_unconfigured_institution, self::$owner_user_id ),
+			'ANDing an institution rule that names nothing withholds access from the same subscriber.'
+		);
+	}
+
+	/**
+	 * Test that a rule the site no longer registers is skipped, not denied.
+	 *
+	 * A slug disappears from the registry whenever the integration that supplied
+	 * it is switched off — `Promoted_Fields::register()` adds one rule per enabled
+	 * field of each active integration. Reading such a rule as a failed condition
+	 * would take a gate the publisher cannot see or edit and have it deny every
+	 * reader, so the group is decided by the rules that are still real.
+	 *
+	 * Asserting the group passes is what separates "skipped" from "denied": a test
+	 * expecting false would be satisfied by either.
+	 *
+	 * @group Access_Rules
+	 */
+	public function test_an_unregistered_rule_is_skipped_rather_than_failing_its_group() {
+		$this->create_subscription();
+
+		$this->assertTrue(
+			Access_Rules::evaluate_rules(
+				[
+					[
+						[
+							'slug'  => 'subscription',
+							'value' => [ self::$product_id ],
+						],
+						[
+							'slug'  => 'field_from_a_disabled_integration',
+							'value' => 'anything',
+						],
+					],
+				],
+				self::$owner_user_id
+			),
+			'The registered rule the reader passes decides the group.'
+		);
+	}
+
+	/**
+	 * Test that a logged-out visitor is judged by the anonymous evaluator.
+	 *
+	 * The two evaluators agree on every rule a gate can hold today, so what this
+	 * pins is the shape neither the wizard nor the REST sanitizer produces and
+	 * block attributes are never checked for: a group with nothing in it, or a
+	 * rule carrying no slug. `evaluate_rules()` has no condition to fail and reads
+	 * the group as satisfied, which admits every visitor. The anonymous evaluator
+	 * treats both as unconfigured.
+	 *
+	 * @group Access_Rules
+	 */
+	public function test_evaluate_rules_for_visitor_judges_a_logged_out_visitor_anonymously() {
+		foreach ( [
+			'an empty group'          => [ [] ],
+			'a rule carrying no slug' => [ [ [ 'value' => 'orphan' ] ] ],
+		] as $description => $rules ) {
+			$this->assertTrue(
+				Access_Rules::evaluate_rules( $rules, 0 ),
+				"The direct evaluator reads {$description} as satisfied, which is what this routing keeps off the gating surfaces."
+			);
+			$this->assertFalse(
+				Access_Rules::evaluate_rules_for_visitor( $rules, 0 ),
+				"A logged-out visitor is denied by {$description}."
+			);
+		}
+
+		$institution_rule = [
+			[
+				[
+					'slug'  => 'institution',
+					'value' => [],
+				],
+			],
+		];
+		$this->assertFalse(
+			Access_Rules::evaluate_rules_for_visitor( $institution_rule, 0 ),
+			'An institution rule naming nothing denies a logged-out visitor.'
+		);
+		$this->assertFalse(
+			Access_Rules::evaluate_rules_for_visitor( $institution_rule, self::$owner_user_id ),
+			'And denies a logged-in reader, which is the asymmetry this issue is about.'
+		);
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-block-visibility.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-block-visibility.php
@@ -348,6 +348,61 @@ class Newspack_Test_Block_Visibility extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A block hidden behind an institution rule naming nothing renders for
+	 * everyone.
+	 *
+	 * The one direction in this change that opens content rather than closing it.
+	 * "Hidden" shows the block to whoever fails the rules, and a rule naming no
+	 * institution is now failed by every reader, so a block the publisher kept away
+	 * from the public starts rendering — to signed-in readers and, through the
+	 * excerpt path, into homepage and listing markup cached without a per-reader
+	 * key. Block attributes never pass the gate save's refusal, so nothing upstream
+	 * catches this shape.
+	 */
+	public function test_hidden_mode_publishes_a_block_whose_rule_matches_nobody() {
+		$rules = [
+			'custom_access' => [
+				'active'       => true,
+				'access_rules' => [
+					[
+						[
+							'slug'  => 'institution',
+							'value' => [],
+						],
+					],
+				],
+			],
+		];
+		$block = $this->make_block_with_rules( 'core/group', $rules, 'hidden' );
+
+		foreach ( [
+			'a logged-out visitor' => 0,
+			'a signed-in reader'   => $this->test_user_id,
+		] as $description => $user_id ) {
+			Block_Visibility::reset_cache_for_tests();
+			$this->assertFalse(
+				Block_Visibility::is_hidden_for_user( $block, $user_id ),
+				"The block is withheld from {$description} no longer."
+			);
+		}
+
+		$markup = '<!-- wp:group ' . wp_json_encode(
+			[
+				'newspackAccessControlMode'       => 'custom',
+				'newspackAccessControlRules'      => $rules,
+				'newspackAccessControlVisibility' => 'hidden',
+			]
+		) . ' --><div class="wp-block-group"><!-- wp:paragraph --><p>WITHHELD</p><!-- /wp:paragraph --></div><!-- /wp:group -->';
+
+		Block_Visibility::reset_cache_for_tests();
+		$this->assertStringContainsString(
+			'WITHHELD',
+			Block_Visibility::strip_blocks_hidden_from_public( $markup ),
+			'And survives the excerpt path, whose output is cached without a per-reader key.'
+		);
+	}
+
+	/**
 	 * All three target block types are evaluated.
 	 */
 	public function test_all_target_block_types_evaluated() {

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-content-gate-api.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-content-gate-api.php
@@ -513,6 +513,65 @@ class Newspack_Test_Content_Gate_API extends WP_UnitTestCase {
 		);
 		$this->assertWPError( $sanitized_gate );
 		$this->assertSame( 'empty_access_rule_value', $sanitized_gate->get_error_code() );
+		// The refusal names what the empty value does, and the two rules that reach
+		// it disagree. An operator told the gate is open goes looking for a leak;
+		// this one is walled shut.
+		$this->assertStringContainsString(
+			'matches no reader',
+			$sanitized_gate->get_error_message(),
+			'An institution rule naming nothing must not be reported as granting access to everyone.'
+		);
+	}
+
+	/**
+	 * A rule that needs a value is refused whichever way its empty value then
+	 * evaluates. `email_domain` grants every reader where `institution` grants
+	 * none, and both are the gate doing something other than what was configured.
+	 */
+	public function test_active_custom_access_rejects_a_free_text_rule_left_blank() {
+		$sanitized_gate = Content_Gate_API::sanitize_gate(
+			[
+				'custom_access' => [
+					'active'       => true,
+					'access_rules' => [
+						[
+							[
+								'slug'  => 'email_domain',
+								'value' => '',
+							],
+						],
+					],
+				],
+			]
+		);
+		$this->assertWPError( $sanitized_gate );
+		$this->assertSame( 'empty_access_rule_value', $sanitized_gate->get_error_code() );
+		$this->assertStringContainsString( 'grants access to everyone', $sanitized_gate->get_error_message() );
+	}
+
+	/**
+	 * A subscription rule naming no product is a configuration publishers use: it
+	 * grants on any active subscription, so the gate still keeps non-subscribers
+	 * out. Refusing it would block that, which is why the refusal keys on the
+	 * rule's own declaration rather than on the value being empty.
+	 */
+	public function test_active_custom_access_allows_a_subscription_rule_naming_no_product() {
+		$sanitized_gate = Content_Gate_API::sanitize_gate(
+			[
+				'custom_access' => [
+					'active'       => true,
+					'access_rules' => [
+						[
+							[
+								'slug'  => 'subscription',
+								'value' => [],
+							],
+						],
+					],
+				],
+			]
+		);
+		$this->assertNotWPError( $sanitized_gate );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-content-gate-api.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-content-gate-api.php
@@ -399,8 +399,8 @@ class Newspack_Test_Content_Gate_API extends WP_UnitTestCase {
 
 	/**
 	 * Create a gate holding an institution rule with nothing selected: a
-	 * well-formed value that `Institution::evaluate()` reads as "no constraint",
-	 * so the rule grants access to every reader.
+	 * well-formed value naming no institution, which `Institution::evaluate()`
+	 * reads as a condition no reader satisfies.
 	 *
 	 * @param bool  $active    Whether custom access is switched on.
 	 * @param array $selection The institution IDs the rule names.
@@ -489,11 +489,10 @@ class Newspack_Test_Content_Gate_API extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The other route to a gate that grants everyone: enable an options-backed
+	 * The other route to a gate nobody meant to publish: enable an options-backed
 	 * rule on a site with nothing to select, touch nothing, save. The rule seeds
-	 * with its `[]` default, which is a well-formed "no constraint" value, and
-	 * `Institution::evaluate()` returns true for it. An active gate must not save
-	 * in that state.
+	 * with its `[]` default — well-formed, and naming no condition. An active gate
+	 * must not save in that state, whichever way the rule then evaluates.
 	 */
 	public function test_active_custom_access_rejects_an_options_backed_rule_with_nothing_selected() {
 		$sanitized_gate = Content_Gate_API::sanitize_gate(
@@ -616,9 +615,9 @@ class Newspack_Test_Content_Gate_API extends WP_UnitTestCase {
 	/**
 	 * `[]` is a configuration for some options-backed rules, not the absence of
 	 * one. `subscription` with no product named requires *any* active
-	 * subscription, which still keeps non-subscribers out. Only a rule that
-	 * declares `empty_grants_access` opens the gate when left empty, so only
-	 * that rule may refuse the save.
+	 * subscription, which still keeps non-subscribers out. `requires_value` is
+	 * what marks a rule whose empty value expresses nothing, so only a rule
+	 * declaring it may refuse the save.
 	 */
 	public function test_active_custom_access_accepts_an_empty_value_for_a_rule_that_still_constrains() {
 		$sanitized_gate = Content_Gate_API::sanitize_gate(
@@ -837,9 +836,10 @@ class Newspack_Test_Content_Gate_API extends WP_UnitTestCase {
 	}
 
 	/**
-	 * `empty_grants_access` is a property of the rule's callback, not of its
-	 * value's shape. A free-text rule left blank grants every reader just as an
-	 * options-backed one with nothing selected does.
+	 * The refusal follows the rule's declaration, not the shape of its value. A
+	 * free-text rule left blank is as unconfigured as an options-backed one with
+	 * nothing selected; `empty_grants_access` only decides which way the message
+	 * reads.
 	 */
 	public function test_an_active_gate_may_not_leave_a_free_text_rule_that_grants_everyone_blank() {
 		$refused = Content_Gate_API::sanitize_gate(

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-content-gate-metadata.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-content-gate-metadata.php
@@ -882,19 +882,19 @@ class Newspack_Test_Content_Gate_Metadata extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that an empty institution rule value imposes no constraint and
+	 * Test that an institution rule naming nothing withholds access and
 	 * contributes no group label.
 	 *
-	 * Institution::evaluate() treats an empty $value as "no constraint," so the
-	 * rule passes — but there's no specific institution to attribute, so
-	 * Content_Access_Group must come back empty (and crucially: no TypeError on
-	 * a `foreach` over a non-iterable).
+	 * The synced field is the reason this is worth pinning separately from the
+	 * evaluator: it is what a publisher's ESP segments on, so a rule that matches
+	 * nobody has to read as Content_Access "No" rather than as an unattributed
+	 * pass. The empty group label also covers the `foreach` over a non-iterable.
 	 *
 	 * @dataProvider empty_institution_value_provider
 	 *
 	 * @param mixed $value Empty rule value.
 	 */
-	public function test_group_label_empty_for_empty_institution_rule( $value ) {
+	public function test_no_access_and_no_group_label_for_empty_institution_rule( $value ) {
 		// An institution must exist so the rule evaluation has something to consider.
 		$this->create_institution( 'Test University', [ 'email_domain' => 'example.com' ] );
 
@@ -910,7 +910,7 @@ class Newspack_Test_Content_Gate_Metadata extends WP_UnitTestCase {
 
 		$result = $this->get_metadata_for_user( self::$user_id );
 
-		$this->assertEquals( 'Yes', $result['Content_Access'], 'Empty institution rule imposes no constraint per Institution::evaluate().' );
+		$this->assertEquals( 'No', $result['Content_Access'], 'An institution rule naming nothing matches no reader.' );
 		$this->assertEmpty( $result['Content_Access_Group'], 'Empty institution rule should yield no group label.' );
 	}
 

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-institution.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-institution.php
@@ -457,20 +457,31 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that an empty value keeps its no-constraint semantics while a populated
-	 * value of the wrong shape (e.g. a free-text string saved by a picker that
-	 * degraded to a text box) fails closed instead of granting access to everyone.
+	 * Test that a rule naming no institution matches nobody, whichever way it was
+	 * left empty, and that a value of a shape the rule cannot read does the same.
+	 *
+	 * The empty case is the one that decides whether switching the rule on before
+	 * publishing any institution opens the gate to everyone or closes it to
+	 * everyone. The contrast at the end is what stops a regression here from
+	 * reading as "institutions never match".
 	 */
-	public function test_evaluate_fails_closed_for_populated_non_array_value() {
+	public function test_evaluate_matches_nobody_when_no_institution_is_named() {
 		$reader_id = $this->create_reader( 'reader@fail-closed.edu' );
 
-		$this->assertTrue( Institution::evaluate( $reader_id, [] ), 'An empty array means no constraint.' );
-		$this->assertTrue( Institution::evaluate( $reader_id, null ), 'Null means no constraint.' );
-		$this->assertTrue( Institution::evaluate( $reader_id, '' ), 'An empty string means no constraint.' );
+		$this->assertFalse( Institution::evaluate( $reader_id, [] ), 'An empty array names no institution.' );
+		$this->assertFalse( Institution::evaluate( $reader_id, null ), 'Null names no institution.' );
+		$this->assertFalse( Institution::evaluate( $reader_id, '' ), 'An empty string names no institution.' );
+		$this->assertFalse( Institution::evaluate( 0, [] ), 'An anonymous visitor is denied on the same value.' );
 
 		$this->assertFalse( Institution::evaluate( $reader_id, 'Springfield University' ), 'A populated non-array value must not grant access.' );
 		$this->assertFalse( Institution::evaluate( $reader_id, '0' ), 'A falsy string is still a value someone typed.' );
 		$this->assertFalse( Institution::evaluate( $reader_id, 0 ), 'A falsy number is still a value someone typed.' );
+
+		$inst_id = Institution::create( 'Fail Closed University', '', [ 'email_domain' => 'fail-closed.edu' ] );
+		$this->assertIsInt( $inst_id );
+		$this->post_ids[] = $inst_id;
+		delete_transient( Institution::TRANSIENT_KEY );
+		$this->assertTrue( Institution::evaluate( $reader_id, [ $inst_id ] ), 'A rule naming an institution the reader belongs to still grants.' );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-premium-newsletters-verify.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-premium-newsletters-verify.php
@@ -792,9 +792,13 @@ class Test_Premium_Newsletters_Verify extends \WP_UnitTestCase {
 	 * 42" and those readers are reported entitled — while check_access() removes
 	 * them from the list. The gate has to come back as one this command cannot
 	 * enumerate instead.
+	 *
+	 * A one-time purchase rule naming no product denies every reader for the same
+	 * reason, and hides it better: its value is composite, so the rule is non-empty
+	 * while the `product_ids` that decide it are not.
 	 */
 	public function test_unenumerable_paid_rules_does_not_let_a_product_bound_mask_a_rule_admitting_nobody() {
-		$rules = [
+		$with_institution = [
 			[
 				[
 					'slug'  => 'subscription',
@@ -809,7 +813,30 @@ class Test_Premium_Newsletters_Verify extends \WP_UnitTestCase {
 
 		$this->assertSame(
 			[ 'subscription', 'institution' ],
-			$this->invoke_private_static( 'unenumerable_paid_rules', [ $rules ] )
+			$this->invoke_private_static( 'unenumerable_paid_rules', [ $with_institution ] )
+		);
+
+		$with_one_time_purchase = [
+			[
+				[
+					'slug'  => 'subscription',
+					'value' => [ 42 ],
+				],
+				[
+					'slug'  => 'one_time_purchase',
+					'value' => [
+						'product_ids'    => [],
+						'duration_value' => 30,
+						'duration_unit'  => 'days',
+					],
+				],
+			],
+		];
+
+		$this->assertSame(
+			[ 'subscription', 'one_time_purchase' ],
+			$this->invoke_private_static( 'unenumerable_paid_rules', [ $with_one_time_purchase ] ),
+			'A one-time purchase rule naming no product admits nobody, whatever else the group names.'
 		);
 	}
 

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-premium-newsletters-verify.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-premium-newsletters-verify.php
@@ -695,12 +695,15 @@ class Test_Premium_Newsletters_Verify extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * An unconfigured rule paywalls nobody — is_email_domain_whitelisted() and
-	 * Institution::evaluate() both return true on an empty value — so a gate
-	 * carrying only those is genuinely harmless and must not start failing runs.
+	 * Whether an empty rule is harmless depends on the rule, so the partition has
+	 * to ask per rule rather than treating "no value" as "nothing to check".
+	 * is_email_domain_whitelisted() and has_reader_data() return true on an empty
+	 * value and paywall nobody; Institution::evaluate() matches nobody and
+	 * paywalls everybody. Reading the second as harmless would report a gate that
+	 * excludes the whole reader base as fully verified.
 	 */
-	public function test_partition_gates_treats_unconfigured_rules_as_harmless() {
-		$gate = $this->make_gate(
+	public function test_partition_gates_separates_harmless_rules_from_paywalling_ones() {
+		$harmless = $this->make_gate(
 			15,
 			true,
 			[
@@ -710,6 +713,26 @@ class Test_Premium_Newsletters_Verify extends \WP_UnitTestCase {
 						'value' => '',
 					],
 					[
+						'slug'  => 'reader_data',
+						'value' => '',
+					],
+				],
+			]
+		);
+
+		$partitioned = $this->invoke_private_static( 'partition_gates', [ [ $harmless ] ] );
+
+		$this->assertSame( [], $partitioned['verifiable'] );
+		$this->assertSame( [], $partitioned['unenumerable'] );
+		$this->assertCount( 1, $partitioned['registration_only'] );
+		$this->assertFalse( $this->invoke_private_static( 'verification_failed', [ $this->clean_summary(), $this->complete_coverage() ] ) );
+
+		$paywalling = $this->make_gate(
+			16,
+			true,
+			[
+				[
+					[
 						'slug'  => 'institution',
 						'value' => [],
 					],
@@ -717,25 +740,26 @@ class Test_Premium_Newsletters_Verify extends \WP_UnitTestCase {
 			]
 		);
 
-		$partitioned = $this->invoke_private_static( 'partition_gates', [ [ $gate ] ] );
+		$partitioned = $this->invoke_private_static( 'partition_gates', [ [ $paywalling ] ] );
 
 		$this->assertSame( [], $partitioned['verifiable'] );
-		$this->assertSame( [], $partitioned['unenumerable'] );
-		$this->assertCount( 1, $partitioned['registration_only'] );
-		$this->assertFalse( $this->invoke_private_static( 'verification_failed', [ $this->clean_summary(), $this->complete_coverage() ] ) );
+		$this->assertCount( 1, $partitioned['unenumerable'] );
+		$this->assertSame( [ 'institution' ], $partitioned['unenumerable'][0]['unenumerable_rules'] );
 	}
 
 	/**
-	 * Two rules restrict even with an empty value, so neither may be skipped as
+	 * Three rules restrict even with an empty value, so none may be skipped as
 	 * unconfigured. A subscription rule naming no product grants on any active
 	 * subscription at all — has_active_subscription() passes the empty product
 	 * filter through to WooCommerce_Connection::get_active_subscriptions_for_user(),
 	 * which then accepts any of them — and an empty one-time purchase rule fails
 	 * closed in has_one_time_purchase() rather than granting, so it restricts
-	 * everyone. Both are the opposite of is_email_domain_whitelisted() and
-	 * Institution::evaluate(), which return true on an empty value.
+	 * everyone. Institution::evaluate() is the third: it matches nobody when it
+	 * names no institution. All three are the opposite of
+	 * is_email_domain_whitelisted() and has_reader_data(), which return true on an
+	 * empty value.
 	 */
-	public function test_unenumerable_paid_rules_counts_the_two_rules_that_restrict_while_empty() {
+	public function test_unenumerable_paid_rules_counts_the_three_rules_that_restrict_while_empty() {
 		$rules = [
 			[
 				[
@@ -746,11 +770,45 @@ class Test_Premium_Newsletters_Verify extends \WP_UnitTestCase {
 					'slug'  => 'one_time_purchase',
 					'value' => [],
 				],
+				[
+					'slug'  => 'institution',
+					'value' => [],
+				],
 			],
 		];
 
 		$this->assertSame(
-			[ 'subscription', 'one_time_purchase' ],
+			[ 'subscription', 'one_time_purchase', 'institution' ],
+			$this->invoke_private_static( 'unenumerable_paid_rules', [ $rules ] )
+		);
+	}
+
+	/**
+	 * Test that a product-bound group is not reported as enumerable when another
+	 * rule in it admits nobody.
+	 *
+	 * `subscription [42] AND institution []` denies every reader at runtime. Left
+	 * to the subscription rule alone, the group's population reads as "holders of
+	 * 42" and those readers are reported entitled — while check_access() removes
+	 * them from the list. The gate has to come back as one this command cannot
+	 * enumerate instead.
+	 */
+	public function test_unenumerable_paid_rules_does_not_let_a_product_bound_mask_a_rule_admitting_nobody() {
+		$rules = [
+			[
+				[
+					'slug'  => 'subscription',
+					'value' => [ 42 ],
+				],
+				[
+					'slug'  => 'institution',
+					'value' => [],
+				],
+			],
+		];
+
+		$this->assertSame(
+			[ 'subscription', 'institution' ],
 			$this->invoke_private_static( 'unenumerable_paid_rules', [ $rules ] )
 		);
 	}

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/content-gates.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/content-gates.php
@@ -2078,11 +2078,10 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Blocker: an institution rule saved with no institutions selected
-	 * (`value => []`) must not silently grant anonymous access. Without a
-	 * value, the rule is "not configured" — Institution::evaluate(0, [])
-	 * returns true as the rule's own no-constraint semantics, but for the
-	 * registration bypass we require a populated rule that actually matches.
+	 * An institution rule saved with no institutions selected (`value => []`)
+	 * must not grant anonymous access. The rule names no condition, so
+	 * Institution::evaluate() satisfies nobody with it, and the registration
+	 * bypass requires a populated rule that actually matches.
 	 */
 	public function test_anonymous_with_unpopulated_institution_rule_is_restricted() {
 		$this->configure_published_gate(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

An Institutional access rule with nothing selected granted access to everyone. Its default value is an empty list, so switching the rule on before publishing any institution opened the content instead of restricting it. It now matches nobody.

`empty_grants_access` was answering two questions at once: what an empty value does, and whether the save should be refused. They are split, and the refusal now keys on a new `requires_value`. That keeps an unconfigured institution rule unsavable now that it denies rather than grants, and keeps `subscription` naming no product savable, since that still requires an active subscription. Both pickers and the save error now say which way each rule fails, rather than telling every rule it grants everyone.

Logged-out visitors on both gating surfaces are judged by the anonymous evaluator, so a rule the site cannot evaluate no longer admits them.

Four other readers of the value follow: the premium-newsletter verifier, the reader access panel, the gate summary, and one stale comment.

**Behaviour change.** A gate whose institution rule is on with nothing selected starts restricting. A group such as `subscription (populated) AND institution (empty)` was decided by the subscription rule and now fails for every reader, paying subscribers included. A sweep of the 46 sites in the Access Control project found no gate holding that shape, so nothing changes on those sites on that count. The anonymous routing does reach them: a logged-out visitor is no longer admitted by a rule the site cannot evaluate — a promoted field whose integration has since been disconnected, a rule from a deactivated plugin, a stored group left empty. Logged-in readers are unaffected either way.

One case moves the other way: a block saved as Hidden behind an empty institution rule now renders for every reader instead of being withheld from every reader. Hidden withholds from readers who match, and the rule matches nobody.

Rebuilt on `main` after #775 landed. That PR introduced the per-rule declaration, the save-time refusal and the shared picker notice this change now extends, so the branch was rebased onto it rather than merged.

[NPPD-2227](https://linear.app/a8c/issue/NPPD-2227) covers a standing admin warning for gates that grant nobody; [NPPD-2226](https://linear.app/a8c/issue/NPPD-2226) covers a pre-existing excerpt-cache issue found alongside this.

Closes NPPD-2217.

### How to test the changes in this Pull Request:

1. Add `define( 'NEWSPACK_CONTENT_GATES', true );` to `wp-config.php`.
2. Enable Audience Management. Publish no institutions.
3. Go to Audience > Access Control. Add a gate that restricts all posts.
4. Turn on Paid Access, then turn on Institutional access.
5. Confirm the notice says the rule matches no reader, and the picker is disabled.
6. Click Save. Confirm the save is refused and the message names the rule.
7. Create and publish an institution with an email domain rule.
8. Reload the gate editor. Confirm the notice now says nothing is selected, and the picker is usable.
9. Select the institution. Confirm the notice disappears. Save the gate.
10. Open a post as a logged-in reader whose verified email matches that domain.
11. Confirm the reader sees the full post.
12. Remove the institution from the rule. Save. Confirm the save is refused.
13. Turn on Whitelisted email domain. Leave it blank. Click Save.
14. Confirm the message for that rule says it grants access to everyone.
15. Turn on Active subscription. Leave its picker empty. Click Save.
16. Confirm the gate saves. An empty subscription rule requires any active subscription.

Gate editor, no institutions published:

![Gate editor: institution rule on, no institutions published](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/03/s6vaieaw-nppd2217-wizard-no-institutions-notice.png)

Gate editor, an institution exists but none selected:

![Gate editor: institutions exist, none selected](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/03/ohjdy4fb-nppd2217-wizard-empty-institution-notice.png)

### Other information:

* [x] Have you added unit tests?
* [x] Have you tested this change locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CP3y193tka9sRsVaVH6Ku5

