### PR TITLE
fix(reader-activation): capture Gravity Forms submissions

### DIFF
--- a/plugins/newspack-plugin/includes/reader-activation/integrations/class-form-capture.php
+++ b/plugins/newspack-plugin/includes/reader-activation/integrations/class-form-capture.php
@@ -13,7 +13,8 @@
  *   submission the vendor's JS or server later rejects may still have
  *   registered the reader.
  * - Programmatic HTMLFormElement.submit() dispatches no submit event and
- *   is not captured.
+ *   is not captured. Gravity Forms — which submits every form this way —
+ *   is captured through its own submission filter bus instead.
  * - Forms that collect somebody else's email address (e.g. "email a
  *   friend") must never be opted in.
  *

--- a/plugins/newspack-plugin/src/reader-activation-form-capture/index.js
+++ b/plugins/newspack-plugin/src/reader-activation-form-capture/index.js
@@ -92,8 +92,7 @@ window.newspackRAS.push( readerActivation => {
 		}
 	};
 
-	const handleSubmit = event => {
-		const form = event.target;
+	const captureForm = form => {
 		if ( form.checkValidity && ! form.checkValidity() ) {
 			return;
 		}
@@ -127,6 +126,8 @@ window.newspackRAS.push( readerActivation => {
 			}
 		} );
 	};
+
+	const handleSubmit = event => captureForm( event.target );
 
 	const attach = () => {
 		getMatchedForms( selectors ).forEach( form => {
@@ -162,4 +163,40 @@ window.newspackRAS.push( readerActivation => {
 		}, 200 );
 	} );
 	observer.observe( document.body, { childList: true, subtree: true } );
+
+	/**
+	 * Gravity Forms (2.9+ theme framework) never yields a native submit event
+	 * to capture: its button intercepts the click and submits via programmatic
+	 * form.submit(), and its own submit listener cancels any native submit
+	 * event as an "unsupported flow". Hook GF's public filter bus instead, at
+	 * the point every GF submission funnels through — whatever the submission
+	 * type (submit, next, save…) or method, matching what the submit listener
+	 * sees from tools that submit natively. The callback must return the
+	 * payload: GF's awaited filter chain hands its return value onward, and
+	 * undefined breaks the vendor submission — which is also why capture
+	 * failures are swallowed here.
+	 */
+	let gformHooked = false;
+	const hookGravityForms = () => {
+		if ( gformHooked || ! window.gform?.utils?.addAsyncFilter ) {
+			return;
+		}
+		gformHooked = true;
+		window.gform.utils.addAsyncFilter( 'gform/submission/pre_submission', data => {
+			try {
+				if ( data?.form && getMatchedForms( selectors ).includes( data.form ) ) {
+					captureForm( data.form );
+				}
+			} catch ( err ) {
+				// Capture must never break the vendor's submission.
+			}
+			return data;
+		} );
+	};
+	hookGravityForms();
+	// gform.utils can land after this deferred script (order follows DOM
+	// position). Every deferred script has run by DOMContentLoaded; load
+	// covers async stragglers.
+	document.addEventListener( 'DOMContentLoaded', hookGravityForms, { once: true } );
+	window.addEventListener( 'load', hookGravityForms, { once: true } );
 } );

--- a/plugins/newspack-plugin/src/reader-activation-form-capture/index.js
+++ b/plugins/newspack-plugin/src/reader-activation-form-capture/index.js
@@ -202,7 +202,16 @@ window.newspackRAS.push( readerActivation => {
 						// signed in. Bounded: past GF_CAPTURE_WAIT the
 						// submission proceeds with the request still in
 						// flight, which keepalive lets survive navigation.
-						await Promise.race( [ pending, new Promise( resolve => setTimeout( resolve, GF_CAPTURE_WAIT ) ) ] );
+						// Settling clears the timer, so no timer outlives the
+						// hold it bounds.
+						await new Promise( resolve => {
+							const timer = setTimeout( resolve, GF_CAPTURE_WAIT );
+							const settle = () => {
+								clearTimeout( timer );
+								resolve();
+							};
+							pending.then( settle, settle );
+						} );
 					}
 				}
 			} catch ( err ) {

--- a/plugins/newspack-plugin/src/reader-activation-form-capture/index.js
+++ b/plugins/newspack-plugin/src/reader-activation-form-capture/index.js
@@ -7,6 +7,15 @@ import { getMatchedForms, getEmailValue, getNameValues } from './utils';
 // v3 tokens expire at 120s; refresh with margin.
 const CAPTCHA_TOKEN_TTL = 100 * 1000;
 
+// Longest a Gravity Forms submission is held for the registration response
+// (ms). The hold ends when the response lands, so this is a ceiling, not a
+// delay — but it must clear the endpoint's slow path (account creation:
+// user insert plus registration hooks, observed above 1.5s), or the auth
+// cookies lose the race and the page GF navigates to renders signed out.
+// GF shows its spinner throughout, so the worst case reads as submit
+// latency rather than a stuck form.
+const GF_CAPTURE_WAIT = 3000;
+
 window.newspackRAS = window.newspackRAS || [];
 window.newspackRAS.push( readerActivation => {
 	const config = window.newspack_form_capture || {};
@@ -110,7 +119,7 @@ window.newspackRAS.push( readerActivation => {
 			// v3 tokens are single-use.
 			warmToken = null;
 		}
-		readerActivation.register( email, 'form-capture', getNameValues( form ), options ).catch( error => {
+		return readerActivation.register( email, 'form-capture', getNameValues( form ), options ).catch( error => {
 			// Only failures that can succeed on a retry within this pageview
 			// release the dedupe: a network error (the response never parsed,
 			// so no code) or a server-side registration failure. Everything
@@ -182,10 +191,19 @@ window.newspackRAS.push( readerActivation => {
 			return;
 		}
 		gformHooked = true;
-		window.gform.utils.addAsyncFilter( 'gform/submission/pre_submission', data => {
+		window.gform.utils.addAsyncFilter( 'gform/submission/pre_submission', async data => {
 			try {
 				if ( data?.form && getMatchedForms( selectors ).includes( data.form ) ) {
-					captureForm( data.form );
+					const pending = captureForm( data.form );
+					if ( pending ) {
+						// GF awaits this filter, so hold the submission until
+						// the registration response lands its auth cookies —
+						// the page GF navigates to then renders the reader as
+						// signed in. Bounded: past GF_CAPTURE_WAIT the
+						// submission proceeds with the request still in
+						// flight, which keepalive lets survive navigation.
+						await Promise.race( [ pending, new Promise( resolve => setTimeout( resolve, GF_CAPTURE_WAIT ) ) ] );
+					}
 				}
 			} catch ( err ) {
 				// Capture must never break the vendor's submission.

--- a/plugins/newspack-plugin/src/reader-activation-form-capture/index.test.js
+++ b/plugins/newspack-plugin/src/reader-activation-form-capture/index.test.js
@@ -440,6 +440,36 @@ describe( 'form-capture client', () => {
 				}
 			} );
 
+			it( 'clears the bounding timer once the registration settles', async () => {
+				// A resolved race does not cancel the losing timer on its own;
+				// left pending, one fires per submission and holds Jest's
+				// teardown open.
+				jest.useFakeTimers();
+				try {
+					const { submitViaGform } = installFakeGform();
+					const ras = loadCaptureClient( GF_FORM );
+					let resolveRegister;
+					ras.register.mockImplementation(
+						() =>
+							new Promise( resolve => {
+								resolveRegister = resolve;
+							} )
+					);
+					// Baseline absorbs unrelated timers (stale mutation-observer
+					// debounces from earlier client loads on the shared document).
+					await drain();
+					const baseline = jest.getTimerCount();
+					const chain = submitViaGform( document.querySelector( 'form' ) );
+					await drain();
+					expect( jest.getTimerCount() ).toBe( baseline + 1 );
+					resolveRegister( {} );
+					await chain;
+					expect( jest.getTimerCount() ).toBe( baseline );
+				} finally {
+					jest.useRealTimers();
+				}
+			} );
+
 			it( 'does not delay the submission when nothing is captured', async () => {
 				// Guards the implementation shape: the wait must be on the
 				// pending registration, not an unconditional timer.

--- a/plugins/newspack-plugin/src/reader-activation-form-capture/index.test.js
+++ b/plugins/newspack-plugin/src/reader-activation-form-capture/index.test.js
@@ -383,5 +383,82 @@ describe( 'form-capture client', () => {
 			await submitViaGform( form );
 			expect( ras.register.mock.calls[ 0 ][ 3 ].captchaToken ).toBe( 'gf-warm-token' );
 		} );
+
+		/**
+		 * GF awaits the pre_submission filter chain, so the adapter can hold
+		 * the submission until the registration response sets the reader's
+		 * auth cookies — the page GF navigates to then renders already
+		 * authenticated. The hold is bounded: registration must never hold
+		 * the reader's submission hostage.
+		 */
+		describe( 'bounded await of the registration', () => {
+			// Settle pending microtask chains without running timers.
+			const drain = async ( rounds = 20 ) => {
+				for ( let i = 0; i < rounds; i++ ) {
+					await Promise.resolve();
+				}
+			};
+
+			it( 'holds the GF submission until the registration settles', async () => {
+				const { submitViaGform } = installFakeGform();
+				const ras = loadCaptureClient( GF_FORM );
+				let resolveRegister;
+				ras.register.mockImplementation(
+					() =>
+						new Promise( resolve => {
+							resolveRegister = resolve;
+						} )
+				);
+				let settled = false;
+				submitViaGform( document.querySelector( 'form' ) ).then( () => {
+					settled = true;
+				} );
+				await flush();
+				expect( settled ).toBe( false );
+				resolveRegister( {} );
+				await flush();
+				expect( settled ).toBe( true );
+			} );
+
+			it( 'releases the submission after the bounded wait when the registration hangs', async () => {
+				jest.useFakeTimers();
+				try {
+					const { submitViaGform } = installFakeGform();
+					const ras = loadCaptureClient( GF_FORM );
+					ras.register.mockImplementation( () => new Promise( () => {} ) );
+					let settled = false;
+					submitViaGform( document.querySelector( 'form' ) ).then( () => {
+						settled = true;
+					} );
+					await drain();
+					expect( settled ).toBe( false );
+					jest.advanceTimersByTime( 3000 );
+					await drain();
+					expect( settled ).toBe( true );
+				} finally {
+					jest.useRealTimers();
+				}
+			} );
+
+			it( 'does not delay the submission when nothing is captured', async () => {
+				// Guards the implementation shape: the wait must be on the
+				// pending registration, not an unconditional timer.
+				jest.useFakeTimers();
+				try {
+					const { submitViaGform } = installFakeGform();
+					const ras = loadCaptureClient( GF_FORM );
+					ras.getReader.mockReturnValue( { email: 'gf-reader@example.com' } );
+					let settled = false;
+					submitViaGform( document.querySelector( 'form' ) ).then( () => {
+						settled = true;
+					} );
+					await drain();
+					expect( settled ).toBe( true );
+					expect( ras.register ).not.toHaveBeenCalled();
+				} finally {
+					jest.useRealTimers();
+				}
+			} );
+		} );
 	} );
 } );

--- a/plugins/newspack-plugin/src/reader-activation-form-capture/index.test.js
+++ b/plugins/newspack-plugin/src/reader-activation-form-capture/index.test.js
@@ -37,6 +37,13 @@ const V3_CONFIG = { captcha_version: 'v3', captcha_site_key: 'site-key' };
 describe( 'form-capture client', () => {
 	afterEach( () => {
 		document.body.innerHTML = '';
+		// Every client load leaves once-listeners on the shared jsdom document
+		// for the GF late-hook retry (a real page runs one bootstrap, so they
+		// can't accumulate there). Drain them while window.gform is absent —
+		// the retry is inert then — so they can't fire into a later test's
+		// fakes. Runs after the nested describe's afterEach deletes the fake.
+		document.dispatchEvent( new Event( 'DOMContentLoaded', { bubbles: true } ) );
+		window.dispatchEvent( new Event( 'load' ) );
 		delete window.newspackRAS;
 		delete window.newspack_form_capture;
 		delete window.newspack_ras_config;
@@ -249,5 +256,132 @@ describe( 'form-capture client', () => {
 	it( 'getMatchedForms resolves an over-broad selector to every form (why bare selectors are rejected server-side)', () => {
 		document.body.innerHTML = `<form id="a"></form><form id="b"></form>`;
 		expect( getMatchedForms( [ 'form' ] ).map( f => f.id ) ).toEqual( [ 'a', 'b' ] );
+	} );
+
+	/**
+	 * Gravity Forms (2.9+ theme framework) submits via programmatic
+	 * form.submit(), which dispatches no submit event — and its own submit
+	 * listener cancels any native submit event as an "unsupported flow" — so
+	 * the generic submit listener can never fire on a GF form. Capture hooks
+	 * GF's public async-filter bus instead.
+	 */
+	describe( 'gravity forms adapter', () => {
+		/**
+		 * Minimal stand-in for GF's gform.utils filter bus. submitViaGform
+		 * replays what gform.submission.submitForm does: run the
+		 * pre_submission filter chain, feeding each callback the previous
+		 * one's return value — a callback that fails to return the payload
+		 * hands undefined to GF and breaks the vendor's submission.
+		 *
+		 * @return {Object} { submitViaGform, addAsyncFilter } — the chain runner and the registration spy.
+		 */
+		const installFakeGform = () => {
+			const filters = {};
+			const addAsyncFilter = jest.fn( ( event, callback ) => {
+				filters[ event ] = filters[ event ] || [];
+				filters[ event ].push( callback );
+			} );
+			window.gform = { utils: { addAsyncFilter } };
+			const submitViaGform = async ( form, data = {} ) => {
+				let payload = { form, submissionType: 'submit', submissionMethod: 'postback', displayConfirmation: true, abort: false, ...data };
+				for ( const callback of filters[ 'gform/submission/pre_submission' ] || [] ) {
+					payload = await callback( payload );
+				}
+				return payload;
+			};
+			return { submitViaGform, addAsyncFilter };
+		};
+
+		afterEach( () => {
+			delete window.gform;
+		} );
+
+		const GF_FORM = `<form id="gform_1" class="newspack-form-capture" novalidate><input type="email" name="input_2" value="gf-reader@example.com"></form>`;
+
+		it( 'captures a matched form through the pre_submission filter and returns the payload to the chain', async () => {
+			const { submitViaGform } = installFakeGform();
+			const ras = loadCaptureClient( GF_FORM );
+			const form = document.querySelector( 'form' );
+			const payload = await submitViaGform( form );
+			expect( ras.register ).toHaveBeenCalledTimes( 1 );
+			expect( ras.register ).toHaveBeenCalledWith( 'gf-reader@example.com', 'form-capture', expect.any( Object ), expect.any( Object ) );
+			// The chain must receive the payload back intact or GF aborts.
+			expect( payload ).toEqual( expect.objectContaining( { form, abort: false } ) );
+		} );
+
+		it( 'ignores submissions from GF forms that are not opted in', async () => {
+			const { submitViaGform } = installFakeGform();
+			const ras = loadCaptureClient( `${ GF_FORM }<form id="gform_2" novalidate><input type="email" value="other@example.com"></form>` );
+			await submitViaGform( document.querySelector( '#gform_2' ) );
+			expect( ras.register ).not.toHaveBeenCalled();
+			// Positive control — the adapter is live, it just skipped the
+			// un-opted-in form.
+			await submitViaGform( document.querySelector( '#gform_1' ) );
+			expect( ras.register ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'returns the payload and keeps GF submitting even when capture throws', async () => {
+			const { submitViaGform } = installFakeGform();
+			const ras = loadCaptureClient( GF_FORM );
+			ras.register.mockImplementation( () => {
+				throw new Error( 'capture exploded' );
+			} );
+			const form = document.querySelector( 'form' );
+			const payload = await submitViaGform( form );
+			// The throw happened inside the filter…
+			expect( ras.register ).toHaveBeenCalledTimes( 1 );
+			// …and the chain still got its payload back.
+			expect( payload ).toEqual( expect.objectContaining( { form, abort: false } ) );
+		} );
+
+		it( 'hooks GF when its scripts land after the capture client, without double-registering', async () => {
+			const ras = loadCaptureClient( GF_FORM );
+			// GF's deferred scripts execute after ours; all are done by DOMContentLoaded.
+			const { submitViaGform, addAsyncFilter } = installFakeGform();
+			document.dispatchEvent( new Event( 'DOMContentLoaded', { bubbles: true } ) );
+			window.dispatchEvent( new Event( 'load' ) );
+			expect( addAsyncFilter ).toHaveBeenCalledTimes( 1 );
+			await submitViaGform( document.querySelector( 'form' ) );
+			expect( ras.register ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'does not double-register when GF was present at bootstrap and lifecycle events still fire', () => {
+			const { addAsyncFilter } = installFakeGform();
+			loadCaptureClient( GF_FORM );
+			document.dispatchEvent( new Event( 'DOMContentLoaded', { bubbles: true } ) );
+			window.dispatchEvent( new Event( 'load' ) );
+			expect( addAsyncFilter ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'dedupes an email across the GF path and the generic submit path', async () => {
+			const { submitViaGform } = installFakeGform();
+			const ras = loadCaptureClient( GF_FORM );
+			const form = document.querySelector( 'form' );
+			await submitViaGform( form );
+			expect( ras.register ).toHaveBeenCalledTimes( 1 );
+			submit( form );
+			expect( ras.register ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'captures on any submission type — a multi-page "next" is a submission, as it is on native-submitting tools', async () => {
+			const { submitViaGform } = installFakeGform();
+			const ras = loadCaptureClient( GF_FORM );
+			await submitViaGform( document.querySelector( 'form' ), { submissionType: 'next' } );
+			expect( ras.register ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'passes the warm captcha token on the GF path', async () => {
+			window.grecaptcha = {
+				ready: callback => callback(),
+				execute: jest.fn( () => Promise.resolve( 'gf-warm-token' ) ),
+			};
+			const { submitViaGform } = installFakeGform();
+			const ras = loadCaptureClient( GF_FORM, V3_CONFIG );
+			const form = document.querySelector( 'form' );
+			focusin( form );
+			await flush();
+			await submitViaGform( form );
+			expect( ras.register.mock.calls[ 0 ][ 3 ].captchaToken ).toBe( 'gf-warm-token' );
+		} );
 	} );
 } );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Since Gravity Forms 2.9, its theme framework submits every form programmatically: the submit button's click handler ends in `HTMLFormElement.submit()`, which dispatches no `submit` event, and GF cancels any native submit event as an unsupported flow. Inbound Form Capture listens for the `submit` event, so opted-in GF forms captured nothing, silently.

The capture client now also hooks `gform/submission/pre_submission` on GF's public filter bus, the point every GF submission passes through, and runs the same capture for matched forms: shared per-pageview dedupe, warm reCAPTCHA token, and name harvesting. The filter always returns its payload and swallows capture failures, so capture can never block the vendor's submission. Registration retries on `DOMContentLoaded`/`load`, since GF's scripts can load after the capture script.

Because GF awaits the filter, the adapter also holds the submission until the registration response lands its auth cookies (3s ceiling; the hold ends when the response arrives), so a new reader lands on the confirmation page already signed in — without it, the postback navigation outruns the response and the next page renders signed out until a refresh. A slow or failed registration releases the submission at the ceiling, and `keepalive` lets the request survive the navigation. Existing readers still see the signed-out header after submitting: a repeat capture never authenticates the session (no silent login by typing someone else's email), by design.

Verified end-to-end against GF 3.1 on a local site: submitting an opted-in form fires the registration request, creates the reader, renders the next page signed in, and the GF entry records as usual.

Related to NPPD-1894.

### How to test the changes in this Pull Request:

1. Activate Gravity Forms and create a form with Name and Email fields.
2. Enable Reader Activation and the Inbound Form Capture integration, and add the form's selector (e.g. `#gform_1`) to its form selectors.
3. Add the form to a page and open it logged out.
4. Submit the form with a new email address. A `POST` to `/wp-json/newspack/v1/reader-activation/register` fires and a reader account is created.
5. Check the page GF lands on after submitting. The header already shows the signed-in account state, with no refresh needed.
6. Confirm the Gravity Forms entry is recorded as usual.
7. Submit the form again with the same email address. No new registration request is sent.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
