### PR TITLE
chore(lint): correct why duplicate class names are skipped in tests

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -37,11 +37,13 @@
 		</properties>
 	</rule>
 
-	<!-- Each plugin is a separate deliverable, so a test double in one may
-	     legitimately declare a class another plugin ships. This sniff compares
-	     across every file in the run, so it fires only on a whole-tree
-	     `composer phpcs` and never in CI, which lints one directory at a time.
-	     Confining it to non-test code makes the two agree. -->
+	<!-- Test doubles duplicate class names on purpose: a stand-in for a class
+	     another plugin ships, or a second stub of the same thing for an
+	     isolated case. The sniff cannot tell either from a genuine duplicate.
+	     It also sees a pair only when both files land in the same forked batch,
+	     and that boundary moves whenever a PHP file is added anywhere, so it
+	     reports against whichever pull request shifted it rather than the one
+	     that introduced the duplicate. -->
 	<rule ref="Generic.Classes.DuplicateClassName">
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Comment only; the exclusion and lint results are unchanged.

The comment added in #989 says `Generic.Classes.DuplicateClassName` fires "never in CI, which lints one directory at a time". One directory, but that directory is a whole package, so two duplicate declarations inside one package's tests land in the same run and do report. #977 is the worked example: `PHPCS / newspack` went red on `main` for two `WC_Memberships` stubs in `newspack-plugin/tests/mocks/`. Only a cross-plugin pair is whole-tree-only, since no job scans two packages together.

The replacement gives the reason the exclusion actually stands on. The sniff cannot separate a deliberate test double from a genuine duplicate, and it sees a pair only when both files land in the same forked batch of `ceil(files / 8)`. That boundary moves whenever any PHP file is added, so it reports against whichever pull request shifted it rather than the one that introduced the duplicate.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Run `composer phpcs` from the repository root.
3. Confirm the run reports no errors and no warnings, as it does on `main`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
