### PR TITLE
test(e2e): serve provisioning's featured image locally

### DIFF
--- a/e2e/site-setup.sh
+++ b/e2e/site-setup.sh
@@ -280,6 +280,52 @@ log_success "Sample Page removed"
 if [ "$POSTS_ENABLED" = true ]; then
     log_info "Step 2: Creating $POSTS_COUNT posts with categories..."
     wp eval '
+        // Answer starter content-s featured-image request from disk.
+        //
+        // Newspack releases up to 6.48.22 download one image per post from
+        // picsum.photos, so provisioning pays a third-party round trip per post
+        // and stalls entirely when that host is down. Newspack 6.49 onwards uses
+        // a bundled image and never makes the request, leaving this filter inert;
+        // it can go once every site this script provisions is past 6.48.22.
+        add_filter(
+            "pre_http_request",
+            function ( $preempt, $args, $url ) {
+                if ( strpos( $url, "picsum.photos" ) === false ) {
+                    return $preempt;
+                }
+                $give_up = new WP_Error( "no_remote_images", "Remote images are disabled during provisioning." );
+                // download_url() streams to a temp file and reads it back, so the
+                // bytes go there rather than into the response body.
+                if ( empty( $args["stream"] ) || empty( $args["filename"] ) || ! function_exists( "imagecreatetruecolor" ) ) {
+                    return $give_up;
+                }
+                static $jpeg = null;
+                if ( $jpeg === null ) {
+                    $image = imagecreatetruecolor( 1200, 800 );
+                    for ( $y = 0; $y < 800; $y++ ) {
+                        $color = imagecolorallocate( $image, (int) ( 30 + $y / 20 ), (int) ( 40 + $y / 13 ), (int) ( 140 + $y / 9 ) );
+                        imageline( $image, 0, $y, 1199, $y, $color );
+                    }
+                    ob_start();
+                    imagejpeg( $image, null, 82 );
+                    $jpeg = ob_get_clean();
+                    imagedestroy( $image );
+                }
+                if ( ! $jpeg || false === file_put_contents( $args["filename"], $jpeg ) ) {
+                    return $give_up;
+                }
+                return [
+                    "headers"  => [],
+                    "body"     => "",
+                    "response" => [ "code" => 200, "message" => "OK" ],
+                    "cookies"  => [],
+                    "filename" => $args["filename"],
+                ];
+            },
+            10,
+            3
+        );
+
         if ( class_exists( "Newspack\Starter_Content_Generated" ) ) {
             Newspack\Starter_Content_Generated::create_categories();
             echo "Categories created\n";


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Provisioning generates the featured image it needs instead of downloading one per post from `picsum.photos`. The filter sits in the same `wp eval` that creates the posts, so it holds whatever Newspack version the site is running.

#1002 already removed the download, but the nightly runs against a site pinned to the stable channel, currently Newspack 6.48.22, which still makes the request. Until a release carrying #1002 reaches that channel, the nightly keeps timing out: picsum has been answering 503, or 522 after 39 seconds, since 2026-08-31, and provisioning does ten posts per phase across two phases. Builds [19238193](https://teamcity.a8c.com/buildConfiguration/Newspack_E2eTests/19238193) and [19243036](https://teamcity.a8c.com/buildConfiguration/Newspack_E2eTests/19243036) both hit TeamCity's 20-minute limit with zero tests run.

The comment on the filter records when it can go: once every site this script provisions is past 6.48.22.

`e2e-plugin.php` looks like the natural home for this and is the wrong one. `e2e-setup.sh` activates that plugin after `site-setup.sh` has already created the posts, so a filter there never fires during provisioning.

### How to test the changes in this Pull Request:

1. Create an env from this branch: `n env create <name> --worktree newspack-plugin:test/e2e-local-provisioning-image --up`.
2. In the env container, check out a Newspack build older than 6.49, so starter content still requests the remote image.
3. Provision: `cd e2e && SITE_URL="https://<name>.test" ADMIN_USER=admin ADMIN_PASSWORD=password USE_SETUP=true npx playwright test --project=setup-vanilla`.
4. The setup project passes in minutes, not tens of minutes.
5. Run `wp cache flush`, then open any starter post. It shows a 1200x800 featured image.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? This is provisioning code for the E2E suite; the setup project exercises it.
* [x] Have you successfully run tests with your changes locally?

Verified against an env pinned to the pre-#1002 plugin, with picsum returning 503/522: 19 starter posts created in about 3 seconds, every one with a 1200x800 thumbnail. The same `create_post` call without the filter took 39.2 seconds and produced no image.
