### PR TITLE
chore(ci): cherry-pick #975 and #1000 to alpha

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -37,11 +37,13 @@
 		</properties>
 	</rule>
 
-	<!-- Each plugin is a separate deliverable, so a test double in one may
-	     legitimately declare a class another plugin ships. This sniff compares
-	     across every file in the run, so it fires only on a whole-tree
-	     `composer phpcs` and never in CI, which lints one directory at a time.
-	     Confining it to non-test code makes the two agree. -->
+	<!-- Test doubles duplicate class names on purpose: a stand-in for a class
+	     another plugin ships, or a second stub of the same thing for an
+	     isolated case. The sniff cannot tell either from a genuine duplicate.
+	     It also sees a pair only when both files land in the same forked batch,
+	     and that boundary moves whenever a PHP file is added anywhere, so it
+	     reports against whichever pull request shifted it rather than the one
+	     that introduced the duplicate. -->
 	<rule ref="Generic.Classes.DuplicateClassName">
 		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -15,7 +15,6 @@
 	<!-- Project-wide exclusions. AGENTS.md: short array syntax is allowed,
 	     Yoda conditions not required. -->
 	<rule ref="WordPress">
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>
 		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found"/>
 		<exclude name="Universal.Operators.DisallowStandalonePostIncrementDecrement.PostIncrementFound"/>
 		<exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction"/>
@@ -36,6 +35,15 @@
 				<element value="manage_woocommerce"/>
 			</property>
 		</properties>
+	</rule>
+
+	<!-- Each plugin is a separate deliverable, so a test double in one may
+	     legitimately declare a class another plugin ships. This sniff compares
+	     across every file in the run, so it fires only on a whole-tree
+	     `composer phpcs` and never in CI, which lints one directory at a time.
+	     Confining it to non-test code makes the two agree. -->
+	<rule ref="Generic.Classes.DuplicateClassName">
+		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
 	<!-- republication-tracker-tool's main file is named without the standard
@@ -70,16 +78,7 @@
 	<rule ref="Squiz.Commenting.InlineComment.InvalidEndChar">
 		<exclude-pattern>*/themes/newspack-theme/*</exclude-pattern>
 	</rule>
-	<rule ref="Squiz.Commenting.InlineComment.NotCapital">
-		<exclude-pattern>*/themes/newspack-theme/*</exclude-pattern>
-	</rule>
 	<rule ref="Generic.WhiteSpace.ScopeIndent.Incorrect">
-		<exclude-pattern>*/themes/newspack-theme/*</exclude-pattern>
-	</rule>
-	<rule ref="Generic.WhiteSpace.ScopeIndent.IncorrectExact">
-		<exclude-pattern>*/themes/newspack-theme/*</exclude-pattern>
-	</rule>
-	<rule ref="PEAR.Functions.FunctionCallSignature.Indent">
 		<exclude-pattern>*/themes/newspack-theme/*</exclude-pattern>
 	</rule>
 
@@ -125,7 +124,10 @@
 	<exclude-pattern>*/*.asset.php</exclude-pattern>
 	<exclude-pattern>*/tests/fixtures/*</exclude-pattern>
 
-	<!-- Skipped in legacy per-package configs; tests had laxer norms. -->
+	<!-- These two suites break WordPress runtime rules deliberately: stub
+	     classes, several object structures per file, direct filesystem calls,
+	     assignment to $GLOBALS['post']. Linting them would mean ~50
+	     suppressions asserting "this is a test double" against no real fix. -->
 	<exclude-pattern>*/plugins/newspack-blocks/tests/*</exclude-pattern>
 	<exclude-pattern>*/themes/newspack-theme/tests/*</exclude-pattern>
 </ruleset>

--- a/plugins/newspack-blocks/tests/bootstrap.php
+++ b/plugins/newspack-blocks/tests/bootstrap.php
@@ -59,6 +59,7 @@ if ( ! $autoloader_loaded ) {
  */
 require_once __DIR__ . '/class-newspack-tag-labels-stub.php';
 require_once __DIR__ . '/class-newspack-block-visibility-stub.php';
+require_once __DIR__ . '/class-wc-order-stub.php';
 
 // Start up the WP testing environment.
 require $newspack_blocks_tests_dir . '/includes/bootstrap.php';

--- a/plugins/newspack-blocks/tests/class-wc-order-stub.php
+++ b/plugins/newspack-blocks/tests/class-wc-order-stub.php
@@ -3,9 +3,15 @@
  * Test stub for WooCommerce's WC_Order.
  *
  * The newspack-blocks test suite runs without WooCommerce loaded, so the real
- * WC_Order class is absent. This stub carries the two accessors the modal
- * checkout return-URL and tracking callbacks read, and satisfies both the
+ * WC_Order class is absent. This stub carries the accessors the modal checkout
+ * return-URL, tracking and cart-data paths read, and satisfies both the
  * is_a( $order, 'WC_Order' ) and instanceof checks those paths use.
+ *
+ * It is the suite's only definition of the class, loaded from bootstrap.php so
+ * it is in place before any test file runs. A second, partial definition in a
+ * test file would not merely duplicate this one: both guard on class_exists(),
+ * so whichever the suite happened to load first would win and silently take the
+ * other's methods away from every test.
  *
  * @package Newspack_Blocks
  */
@@ -21,7 +27,7 @@ if ( ! class_exists( 'WC_Order' ) ) {
 		 *
 		 * @var int
 		 */
-		private $id;
+		protected $id;
 
 		/**
 		 * Order key.
@@ -31,14 +37,23 @@ if ( ! class_exists( 'WC_Order' ) ) {
 		private $order_key;
 
 		/**
+		 * Line items.
+		 *
+		 * @var array
+		 */
+		protected $items = [];
+
+		/**
 		 * Constructor.
 		 *
 		 * @param int    $id        Order ID.
 		 * @param string $order_key Order key.
+		 * @param array  $items     Line items.
 		 */
-		public function __construct( $id = 0, $order_key = '' ) {
+		public function __construct( $id = 0, $order_key = '', $items = [] ) {
 			$this->id        = $id;
 			$this->order_key = $order_key;
+			$this->items     = $items;
 		}
 
 		/**
@@ -57,6 +72,27 @@ if ( ! class_exists( 'WC_Order' ) ) {
 		 */
 		public function get_order_key() {
 			return $this->order_key;
+		}
+
+		/**
+		 * Get the line items.
+		 *
+		 * @return array
+		 */
+		public function get_items() {
+			return $this->items;
+		}
+
+		/**
+		 * Get an order meta value.
+		 *
+		 * @param string $key Meta key.
+		 *
+		 * @return string
+		 */
+		public function get_meta( $key ) {
+			unset( $key );
+			return '';
 		}
 	}
 }

--- a/plugins/newspack-blocks/tests/test-modal-checkout-data.php
+++ b/plugins/newspack-blocks/tests/test-modal-checkout-data.php
@@ -193,51 +193,6 @@ if ( ! class_exists( 'WC_Order_Item_Product' ) ) {
 	}
 }
 
-if ( ! class_exists( 'WC_Order' ) ) {
-	/**
-	 * Minimal WooCommerce order stub.
-	 */
-	class WC_Order {
-		/**
-		 * Line items.
-		 *
-		 * @var array
-		 */
-		protected $items = [];
-
-		/**
-		 * Order ID.
-		 *
-		 * @var int
-		 */
-		protected $id;
-
-		/**
-		 * Constructor.
-		 *
-		 * @param array $items Line items.
-		 * @param int   $id    Order ID.
-		 */
-		public function __construct( $items = [], $id = 900 ) {
-			$this->items = $items;
-			$this->id    = $id;
-		}
-
-		public function get_id() {
-			return $this->id;
-		}
-
-		public function get_items() {
-			return $this->items;
-		}
-
-		public function get_meta( $key ) {
-			unset( $key );
-			return '';
-		}
-	}
-}
-
 if ( ! class_exists( 'WC_Subscription' ) ) {
 	/**
 	 * Minimal subscription stub. A subscription created by hand in wp-admin has
@@ -259,7 +214,7 @@ if ( ! class_exists( 'WC_Subscription' ) ) {
 		 * @param int            $id     Subscription ID.
 		 */
 		public function __construct( $items = [], $parent = false, $id = 901 ) {
-			parent::__construct( $items, $id );
+			parent::__construct( $id, '', $items );
 			$this->parent = $parent;
 		}
 
@@ -351,7 +306,7 @@ class Newspack_Blocks_Modal_Checkout_Data_Test extends WP_UnitTestCase_Blocks {
 			2171 => new WC_Product( 2171, 'subscription', [], '99', 'Annual Supporter' ),
 		];
 
-		$parent       = new WC_Order( [ new WC_Order_Item_Product( 2171, '99' ) ], 900 );
+		$parent       = new WC_Order( 900, '', [ new WC_Order_Item_Product( 2171, '99' ) ] );
 		$subscription = new WC_Subscription( [ new WC_Order_Item_Product( 2170, '25' ) ], $parent, 901 );
 
 		$data = Checkout_Data::get_checkout_data( $subscription );
@@ -374,7 +329,7 @@ class Newspack_Blocks_Modal_Checkout_Data_Test extends WP_UnitTestCase_Blocks {
 			2172 => new WC_Product( 2172, 'simple', [], '15', 'Monthly Donation' ),
 		];
 
-		$parent       = new WC_Order( [ new WC_Order_Item_Product( 2172, '15' ) ], 902 );
+		$parent       = new WC_Order( 902, '', [ new WC_Order_Item_Product( 2172, '15' ) ] );
 		$subscription = new WC_Subscription( [ new WC_Order_Item_Product( 2172, '15' ) ], $parent, 903 );
 
 		$data = Checkout_Data::get_checkout_data( $subscription );

--- a/plugins/newspack-blocks/tests/test-modal-checkout.php
+++ b/plugins/newspack-blocks/tests/test-modal-checkout.php
@@ -44,7 +44,6 @@ if ( ! function_exists( 'wcs_get_product_limitation' ) ) {
 }
 
 require_once __DIR__ . '/mocks/newspack-plugin-mocks.php';
-require_once __DIR__ . '/class-wc-order-stub.php';
 
 if ( ! function_exists( 'WC' ) ) {
 	/**

--- a/plugins/newspack-blocks/tests/test-tracking-data-events.php
+++ b/plugins/newspack-blocks/tests/test-tracking-data-events.php
@@ -7,7 +7,6 @@
 
 require_once __DIR__ . '/mocks/newspack-plugin-mocks.php';
 require_once __DIR__ . '/mocks/newspack-plugin-data-events-utils-mock.php';
-require_once __DIR__ . '/class-wc-order-stub.php';
 
 /**
  * Tests for the modal checkout Data Events tracking integration.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

CI on `alpha` has been failing since 2026-08-25, which blocks the stable release PR #1004. Two unrelated breakages:

- `PHPUnit / @automattic/newspack-blocks` errors with `Call to undefined method WC_Order::get_order_key()`. `alpha` carries two `WC_Order` stubs behind existence guards; whichever is declared first wins, and the shorter one has no `get_order_key()`.
- `PHPCS / newspack` reports a duplicate `WC_Memberships` mock class. PHPCS exits non-zero on warnings, so one warning fails the job.

Both were already fixed on `main`, five days apart, and `alpha` has not taken `main` since 2026-08-20. This carries the three responsible commits across with `git cherry-pick -x`: #975, #989 and #1000. None of it is new work.

#989 is included to allow #1000 to merge cleanly: it drops four PHPCS exemptions it describes as dead. They are dead on `alpha` too: `newspack-theme` lints clean across 81 files under the new ruleset.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] New tests n/a: this restores existing tests rather than adding any.
* [x] Have you successfully run tests with your changes locally?
