### PR TITLE
fix(analytics): restore GA4 custom-dimension registry lookup

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
@@ -439,6 +439,61 @@ final class GA4_Custom_Dimensions {
 	}
 
 	/**
+	 * List the parameter names of every EVENT-scoped custom dimension currently
+	 * registered on the connected GA4 property.
+	 *
+	 * Scoped to EVENT dimensions specifically because the Data API references
+	 * those as `customEvent:<param>` (USER-scoped dimensions are `customUser:`),
+	 * so callers checking a `customEvent:` reference must not be satisfied by a
+	 * same-named USER-scoped dimension.
+	 *
+	 * Unlike status(), this returns the full event-scoped set actually present
+	 * on the property — not just the intersection with Newspack's standard set —
+	 * so callers can authoritatively check whether an arbitrary `customEvent:`
+	 * dimension (e.g. `post_id`) is available before querying the Data API.
+	 *
+	 * Reuses the same Newspack-OAuth-then-Site-Kit auth fallback as the rest of
+	 * this class.
+	 *
+	 * @param string|null $property_id GA4 property ID to list dimensions for. When
+	 *                                 null (default), resolves Site Kit's configured
+	 *                                 property. Pass an explicit ID so the Admin API
+	 *                                 lookup matches the Data API property being
+	 *                                 queried (the lists can differ per property).
+	 *
+	 * @return string[]|\WP_Error Registered event-scoped parameter names, or
+	 *                            WP_Error if the property or Admin API can't be reached.
+	 */
+	public static function get_registered_parameter_names( ?string $property_id = null ) {
+		$property_id = $property_id ?? self::get_property_id();
+		if ( ! $property_id ) {
+			return new \WP_Error( 'newspack_ga4_dimensions', 'No GA4 property ID configured in Site Kit.' );
+		}
+
+		$existing = self::with_admin_client(
+			function ( $client, $source ) use ( $property_id ) {
+				try {
+					return $client->list_custom_dimensions( $property_id );
+				} catch ( \Throwable $e ) {
+					return new \WP_Error( 'newspack_ga4_dimensions', 'Failed listing custom dimensions: ' . $e->getMessage() );
+				}
+			}
+		);
+		if ( is_wp_error( $existing ) ) {
+			return $existing;
+		}
+
+		$event_scoped = array_filter(
+			$existing,
+			function ( $dimension ) {
+				return isset( $dimension['scope'] ) && 'EVENT' === $dimension['scope'];
+			}
+		);
+
+		return array_values( array_filter( array_column( $event_scoped, 'parameterName' ) ) );
+	}
+
+	/**
 	 * Provision Newspack's standard GA4 custom dimensions.
 	 *
 	 * Idempotent: existing dimensions on the property are detected by


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Insights App tab pre-checks which custom dimensions a GA4 property has registered before querying the Data API, through `GA4_Custom_Dimensions::get_registered_parameter_names()`. That method shipped with the Insights work (NPPD-1647) and left `main` with the rest of the Insights code when #313 parked the epic. The Insights GA4 client has since re-landed in newspack-manager, but only feature-detects the method: while it is absent, the pre-check blocks nothing, an unregistered `customEvent:KG*` dimension reaches GA4, and the rejected `batchRunReports` call zeroes out every standard metric batched with it. The App tab then renders empty for any property missing one KG dimension.

This restores the method exactly as it stood before the revert, with no other changes.

Part of NPPM-3245.

### How to test the changes in this Pull Request:

1. On a site with this branch and Google connected, run `wp eval 'print_r( \Newspack\GA4_Custom_Dimensions::get_registered_parameter_names() );'`. It prints the event-scoped parameter names registered on the Site Kit property.
2. Run it again passing an app property id. The list reflects that property, not Site Kit's.
3. With newspack-manager active, open Insights → App for a property missing a KG dimension (e.g. only `KGPageName` registered). Reach and Engagement show real numbers; only the cards needing the missing dimension render empty.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? — n/a: re-lands code merged and reviewed in NPPD-1647; the guard around the caller is covered in newspack-manager (`tests/insights/class-test-ga4-client-dimension-guard.php`).
* [ ] Have you successfully run tests with your changes locally? — not run: `php -l` passes; the restored hunk applied cleanly and is byte-identical to the pre-#313 version.

Based on `release` as a hotfix; the newspack-manager side of NPPM-3245 (fail-closed pre-check, batch isolation) lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UdPeeG7T95yg8poLARrCN