### PR TITLE
fix(newsletters): scope Mailchimp cache cron to enabled audiences

### DIFF
--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -505,6 +505,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 
 			// Update the cache.
 			self::update_cache( $list_id, $list_data );
+			Newspack_Newsletters_Subscription::clear_lists_cache();
 
 			return $list_data;
 		} catch ( Exception $e ) {

--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -8,6 +8,7 @@
 defined( 'ABSPATH' ) || exit;
 
 use Newspack_Newsletters_Mailchimp_Api as Mailchimp;
+use Newspack\Newsletters\Subscription_Lists;
 
 /**
  * Mailchimp cached class data
@@ -62,6 +63,13 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @var int
 	 */
 	const SURFACE_ERRORS_AFTER = 20 * HOUR_IN_SECONDS;
+
+	/**
+	 * How often the cron refreshes an audience that is not offered for subscription
+	 *
+	 * @var int
+	 */
+	const INACTIVE_REFRESH_INTERVAL = DAY_IN_SECONDS;
 
 	/**
 	 * Memoized data to be served across the same request
@@ -245,6 +253,24 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	private static function is_cache_expired( $list_id = 'lists' ) {
 		$cache_date = get_option( self::get_cache_date_key( $list_id ) );
 		return $cache_date && ( time() - $cache_date ) > 20 * MINUTE_IN_SECONDS;
+	}
+
+	/**
+	 * Checks whether the cached data for a given list is older than a given age
+	 *
+	 * Unlike self::is_cache_expired(), a list that was never cached counts as older
+	 * than any age, so the cron can warm it for the first time.
+	 *
+	 * @param string $list_id The List ID.
+	 * @param int    $max_age The age, in seconds.
+	 * @return boolean
+	 */
+	private static function is_cache_older_than( $list_id, $max_age ) {
+		$cache_date = get_option( self::get_cache_date_key( $list_id ) );
+		if ( ! $cache_date ) {
+			return true;
+		}
+		return ( time() - $cache_date ) > $max_age;
 	}
 
 	/**
@@ -539,10 +565,57 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 			return;
 		}
 
+		$active_audience_ids = self::get_active_audience_ids();
+
 		foreach ( $lists as $list ) {
-			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Dispatching request to refresh cache for list ' . $list['id'] );
-			self::dispatch_refresh( $list['id'] );
+			$list_id = (string) $list['id'];
+
+			// Audiences the site does not offer for subscription are refreshed once a day.
+			if (
+				! in_array( $list_id, $active_audience_ids, true )
+				&& ! self::is_cache_older_than( $list_id, self::INACTIVE_REFRESH_INTERVAL )
+			) {
+				Newspack_Newsletters_Logger::log( 'Mailchimp cache: Skipping refresh for inactive list ' . $list_id );
+				continue;
+			}
+
+			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Dispatching request to refresh cache for list ' . $list_id );
+			self::dispatch_refresh( $list_id );
 		}
+	}
+
+	/**
+	 * Gets the IDs of the audiences the site offers for subscription
+	 *
+	 * An audience counts as active when it is offered for subscription itself, or
+	 * when any of its groups or tags is.
+	 *
+	 * @return string[] The audience IDs.
+	 */
+	private static function get_active_audience_ids() {
+		if ( ! class_exists( 'Newspack\Newsletters\Subscription_Lists' ) ) {
+			return [];
+		}
+
+		$audience_ids = [];
+		foreach ( Subscription_Lists::get_configured_for_provider( 'mailchimp' ) as $list ) {
+			if ( ! $list->is_active() ) {
+				continue;
+			}
+			$audience_id = $list->mailchimp_get_audience_id();
+			if ( $audience_id ) {
+				$audience_ids[] = (string) $audience_id;
+			}
+		}
+
+		/**
+		 * Filters the audiences the cron keeps warm.
+		 *
+		 * @param string[] $audience_ids IDs of the audiences offered for subscription.
+		 */
+		$audience_ids = apply_filters( 'newspack_newsletters_mailchimp_active_audiences', array_values( array_unique( $audience_ids ) ) );
+
+		return array_map( 'strval', $audience_ids );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Hotfix into `release` carrying two commits cherry-picked from #939, so the Mailchimp API-call reduction reaches publishers ahead of the regular release cycle.

Refreshing the cached data for one Mailchimp audience costs about five API calls, and the cron dispatched a refresh for **every audience in the account** every ten minutes, whether or not the site offers it for subscription. The cron now keeps an audience on that cadence only while the site offers it: the audience itself is enabled in Newsletters > Settings, or any of its groups or tags is. The rest refresh once a day, and still on demand when someone opens one. The second commit clears the subscription lists cache after an audience refresh, so refreshed data reaches the settings screen.

The third commit on #939, the per-audience refresh lock, is not included here and follows the regular cycle.

Part of NPPM-3070.

### How to test the changes in this Pull Request:

1. Connect a site to a Mailchimp account with several audiences.
2. Set `NEWSPACK_LOG_LEVEL` to `1` in `wp-config.php`. Refresh activity goes to the error log.
3. In Newsletters > Settings, enable one audience and leave the others off.
4. Run `wp cron event run newspack_nl_mailchimp_refresh_cache`. Only the enabled audience is dispatched.
5. Confirm the log reads "Skipping refresh for inactive list" for each audience left off.
6. Disable that audience, then enable a single tag or group inside it.
7. Run the cron again. The parent audience is dispatched, because one of its tags is enabled.
8. Age an unused audience: `wp option update newspack_nl_mailchimp_cache_date_<audience_id> 1`.
9. Run the cron again. That audience refreshes, a day having passed since its last one.
10. After a refresh finishes, open Newsletters > Settings. The refreshed data appears without a further cache flush.
11. Confirm audiences, groups, tags, and segments still list correctly in Newsletters > Settings and the newsletter editor sidebar.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? No new tests: a cherry-pick of reviewed commits from #939.
* [ ] Have you successfully run tests with your changes locally? Not on this branch; both commits passed the `newspack-newsletters` suite on #939, and CI runs it here.

Cherry-picking around the lock commit needed conflict resolution, so these commits are not byte-identical to the originals. The resulting diff is the sum of the two source commits: 76 insertions, 2 deletions, one file.
