### PR TITLE
fix(group-subscriptions): keep seat count on switch form when plan max lowered

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -545,8 +545,9 @@ class Subscriptions_Tiers {
 	 * @param bool        $show_variation_attributes Whether the card should render the product variation attributes.
 	 * @param bool        $current                   Whether the product should have the "current" badge.
 	 * @param bool        $selected                  Whether the product should be checked.
+	 * @param int         $seats_ceiling             Seats the current plan already holds, so its radio advertises the same widened maximum as the seats field. 0 for every card but the current one.
 	 */
-	private static function render_product_card( $product, $show_variation_attributes = false, $current = false, $selected = false ) {
+	private static function render_product_card( $product, $show_variation_attributes = false, $current = false, $selected = false, $seats_ceiling = 0 ) {
 		// A name-your-price product has no fixed price to print — get_price() is
 		// empty, so wcs_price_string() would render a bare "/ month" — and the
 		// amount is carried by the form's own input instead.
@@ -586,6 +587,16 @@ class Subscriptions_Tiers {
 		// follow whichever one is checked. A tier with no attributes here sells no
 		// seats, which is what tells the field to hide and stop submitting.
 		$seats = Group_Subscription_Seats::get_field_args( $product );
+
+		// The plan the reader already holds carries the same widened ceiling the seats
+		// field uses: a group that outgrew a since-lowered maximum keeps the seats it
+		// pays for. The client clamp reads this radio, not the field, so without the
+		// match it would pull those seats back down to the plan's raw maximum on load.
+		// Only the current plan has a ceiling (render_form() sets it only when staying
+		// on plan), and only a per-seat, bounded tier has a maximum to raise.
+		if ( $seats && $current && $seats_ceiling > 0 && $seats['max'] > 0 ) {
+			$seats['max'] = max( $seats['max'], $seats_ceiling );
+		}
 
 		?>
 		<label class="newspack-ui__input-card <?php echo $current ? esc_attr( 'current' ) : ''; ?>">
@@ -867,7 +878,7 @@ class Subscriptions_Tiers {
 									self::render_nyp_product_card( $products[0], $products[0] === $current_product, $switch_data );
 								} else {
 									foreach ( $products as $product ) {
-										self::render_product_card( $product, false, $switch_data && $product === $current_product, $product === $selected_product );
+										self::render_product_card( $product, false, $switch_data && $product === $current_product, $product === $selected_product, $seats_ceiling );
 									}
 								}
 								?>
@@ -880,7 +891,7 @@ class Subscriptions_Tiers {
 			if ( ! $should_render_tabs ) {
 				foreach ( $tiers as $products ) {
 					foreach ( $products as $product ) {
-						self::render_product_card( $product, true, $switch_data && $product === $current_product, $product === $selected_product );
+						self::render_product_card( $product, true, $switch_data && $product === $current_product, $product === $selected_product, $seats_ceiling );
 					}
 				}
 			}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -985,6 +985,27 @@ class Newspack_Test_Subscriptions_Tiers extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The current plan's radio advertises the same widened ceiling as the seats
+	 * field. When a group holds more seats than the plan now sells, the field's
+	 * maximum is raised to what it holds so those seats are kept; the client clamp
+	 * reads the radio rather than the field, so the radio has to carry that same
+	 * raised ceiling or a group that outgrew a lowered maximum is pulled back down
+	 * to it on load -- silently reducing the seats it pays for.
+	 */
+	public function test_switch_current_tier_radio_matches_the_widened_ceiling() {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+		$product     = $this->make_tier_product( 343, $this->per_seat_meta( 2, 5 ) );
+		$switch_data = $this->make_switch_data( $user_id, [ 343 ], 343, 8 );
+
+		$html = $this->render_tier_form( $product, $switch_data );
+
+		// The field is widened to the eight seats held; the radio must agree, not
+		// carry the plan's raw maximum of five.
+		$this->assertStringContainsString( 'value="343" data-per-seat="1" data-seats-min="2" data-seats-max="8" checked', $html );
+	}
+
+	/**
 	 * Each tier publishes its own seat bounds on its radio, so the single seats
 	 * field can follow whichever tier is checked. A flat tier publishes none,
 	 * which is what tells the field to hide and stop submitting.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Follow-up to #955 (per-seat pricing for group subscriptions).

On the plan-switch modal, the seat count was computed in two places that could disagree. When a group already holds more seats than its plan's current maximum — because a publisher lowered the maximum after purchase — the seats field widens its `max` to the seats held, so those seats are kept. But the tier's radio still carried the plan's raw maximum, and the client reads the radio, not the field. On page load it clamped the field value down to the raw maximum and enabled the submit button, so a group paying for six seats could drop to five without the owner changing anything.

This carries the same widened ceiling onto the current plan's radio, so the browser and server agree on one number. No client change: the field value stays put, and a form the reader hasn't touched stays a no-op.

### How to test the changes in this Pull Request:

1. Edit a per-seat group product with an existing subscription, and set its maximum seats below that subscription's seat count (e.g. subscription holds 6, set maximum to 5).
2. As the owner, open My Account → the group → Change seats.
3. The seat field shows the count actually held (6), not the lowered maximum, and the submit button is disabled until you change something.
4. Restore the product's maximum. On a plan whose maximum still exceeds the group, the field and submit behave as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Found in a post-merge review of #955.
