### PR TITLE
fix(content-loop): keep editor preview links from navigating away

### DIFF
--- a/plugins/newspack-blocks/includes/class-newspack-blocks-api.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks-api.php
@@ -180,29 +180,6 @@ class Newspack_Blocks_API {
 	}
 
 	/**
-	 * Point every anchor in a rendered payload fragment at '#'.
-	 *
-	 * The editor canvas renders the byline and avatar fields verbatim, so a
-	 * live URL navigates the canvas iframe away from the post being edited.
-	 * Runs on the finished markup — after the newspack_blocks_post_byline
-	 * filter — so links injected by filters (e.g. custom bylines) are covered
-	 * too, matching the category-link convention used elsewhere in this
-	 * payload. Only real anchor href attributes are rewritten: "href=" text
-	 * inside another attribute's value (avatar proxy URLs), xlink:href sprite
-	 * references, and plain text all pass through untouched.
-	 *
-	 * @param string $html Rendered markup destined for the editor payload.
-	 * @return string Markup with every anchor href pointing at '#'.
-	 */
-	private static function neutralize_editor_links( $html ) {
-		$processor = new \WP_HTML_Tag_Processor( (string) $html );
-		while ( $processor->next_tag( 'A' ) ) {
-			$processor->set_attribute( 'href', '#' );
-		}
-		return $processor->get_updated_html();
-	}
-
-	/**
 	 * Register the video-playlist endpoint.
 	 */
 	public static function register_video_playlist_endpoint() {
@@ -304,8 +281,8 @@ class Newspack_Blocks_API {
 				'newspack_sponsors_show_author'     => Newspack_Blocks::newspack_display_sponsors_and_authors( $sponsors ),
 				'newspack_sponsors_show_categories' => Newspack_Blocks::newspack_display_sponsors_and_categories( $sponsors ),
 				'newspack_tag_labels'               => self::newspack_blocks_get_tag_labels( $data ),
-				'newspack_post_avatars'             => self::neutralize_editor_links( \newspack_blocks_format_avatars( $author_info ) ),
-				'newspack_post_byline'              => self::neutralize_editor_links( \newspack_blocks_format_byline( $author_info ) ),
+				'newspack_post_avatars'             => \newspack_blocks_format_avatars( $author_info ),
+				'newspack_post_byline'              => \newspack_blocks_format_byline( $author_info ),
 				'post_status'                       => $post->post_status,
 				'post_type'                         => $post->post_type,
 				'post_link'                         => Newspack_Blocks::get_post_link( $post->ID ),

--- a/plugins/newspack-blocks/includes/class-newspack-blocks-api.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks-api.php
@@ -102,7 +102,12 @@ class Newspack_Blocks_API {
 			return '';
 		}
 
-		$linked_category = '<a href="' . esc_url( get_category_link( $category->term_id ) ) . '">' . $category->name . '</a>';
+		$category_link = get_category_link( $category->term_id );
+		// newspack_blocks_format_categories() links the name only when the term
+		// resolves to a URL; match it so the preview and the front end agree.
+		$linked_category = $category_link
+			? '<a href="' . esc_url( $category_link ) . '">' . $category->name . '</a>'
+			: $category->name;
 
 		return apply_filters( 'newspack_blocks_categories', $linked_category );
 	}

--- a/plugins/newspack-blocks/includes/class-newspack-blocks-api.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks-api.php
@@ -144,7 +144,7 @@ class Newspack_Blocks_API {
 				$sponsor_info_item = [
 					'flag'          => $sponsor['sponsor_flag'],
 					'sponsor_name'  => $sponsor['sponsor_name'],
-					'sponsor_url'   => $sponsor['sponsor_url'],
+					'sponsor_url'   => sanitize_url( (string) $sponsor['sponsor_url'] ),
 					'byline_prefix' => $sponsor['sponsor_byline'],
 					'id'            => $sponsor['sponsor_id'],
 					'scope'         => $sponsor['sponsor_scope'],
@@ -290,7 +290,7 @@ class Newspack_Blocks_API {
 				'newspack_post_byline'              => \newspack_blocks_format_byline( $author_info ),
 				'post_status'                       => $post->post_status,
 				'post_type'                         => $post->post_type,
-				'post_link'                         => Newspack_Blocks::get_post_link( $post->ID ),
+				'post_link'                         => sanitize_url( (string) Newspack_Blocks::get_post_link( $post->ID ) ),
 			];
 
 			// Support Newspack Listings hide author/publish date options.

--- a/plugins/newspack-blocks/includes/class-newspack-blocks-api.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks-api.php
@@ -102,7 +102,7 @@ class Newspack_Blocks_API {
 			return '';
 		}
 
-		$linked_category = '<a href="#">' . $category->name . '</a>';
+		$linked_category = '<a href="' . esc_url( get_category_link( $category->term_id ) ) . '">' . $category->name . '</a>';
 
 		return apply_filters( 'newspack_blocks_categories', $linked_category );
 	}

--- a/plugins/newspack-blocks/src/blocks/carousel/edit.js
+++ b/plugins/newspack-blocks/src/blocks/carousel/edit.js
@@ -1,4 +1,4 @@
-/* eslint-disable jsx-a11y/anchor-is-valid, jsx-a11y/anchor-has-content, jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus */
+/* eslint-disable jsx-a11y/anchor-has-content, jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus */
 
 /**
  * External dependencies
@@ -36,6 +36,7 @@ import QueryControls from '../../components/query-controls';
 import { PostTypesPanel, PostStatusesPanel } from '../../components/editor-panels';
 import createSwiper from './create-swiper';
 import { getBylineHTML, formatSponsorLogos, formatSponsorByline, getPostStatusLabel } from '../../shared/js/utils';
+import { preventPreviewNavigation } from '../../shared/js/inert-preview';
 // Use same posts store as Homepage Posts block.
 import { postsBlockSelector, postsBlockDispatch, shouldReflow } from '../homepage-articles/utils';
 
@@ -355,7 +356,7 @@ class Edit extends Component {
 					<PostTypesPanel attributes={ attributes } setAttributes={ setAttributes } />
 					<PostStatusesPanel attributes={ attributes } setAttributes={ setAttributes } />
 				</InspectorControls>
-				<div { ...blockProps } className={ classes }>
+				<div { ...blockProps } className={ classes } onClickCapture={ preventPreviewNavigation }>
 					{ hasNoPosts && (
 						<Placeholder className="component-placeholder__align-center">
 							<div style={ { margin: 'auto' } }>{ __( 'Sorry, no posts were found.' ) }</div>
@@ -380,7 +381,7 @@ class Edit extends Component {
 									>
 										{ getPostStatusLabel( post ) }
 										<figure className="post-thumbnail">
-											<a href="#" rel="bookmark">
+											<a href={ post.post_link } rel="bookmark">
 												{ post.newspack_featured_image_src ? (
 													<img
 														className={ `image-fit-${ imageFit }` }
@@ -416,7 +417,7 @@ class Edit extends Component {
 													<div className="cat-links tag-labels">
 														{ post.newspack_tag_labels.map( ( newspack_tag_label, index ) => {
 															return newspack_tag_label.link ? (
-																<a key={ index } href="#" className="tag-label flag">
+																<a key={ index } href={ newspack_tag_label.link } className="tag-label flag">
 																	{ newspack_tag_label.flag }
 																</a>
 															) : (
@@ -429,7 +430,7 @@ class Edit extends Component {
 												) }
 												{ showTitle && (
 													<h3 className="entry-title">
-														<a href="#">{ decodeEntities( post.title.rendered.trim() ) }</a>
+														<a href={ post.post_link }>{ decodeEntities( post.title.rendered.trim() ) }</a>
 													</h3>
 												) }
 												<div className="entry-meta">

--- a/plugins/newspack-blocks/src/blocks/carousel/edit.js
+++ b/plugins/newspack-blocks/src/blocks/carousel/edit.js
@@ -381,7 +381,11 @@ class Edit extends Component {
 									>
 										{ getPostStatusLabel( post ) }
 										<figure className="post-thumbnail">
-											<a href={ post.post_link } rel="bookmark">
+											{ /* get_post_link() returns false when a post type is not public and has
+											     no external URL. Coerce to undefined so React omits the attribute
+											     instead of warning; carousel/view.php leaves this anchor unguarded
+											     on the front end too, so the preview matches it. */ }
+											<a href={ post.post_link || undefined } rel="bookmark">
 												{ post.newspack_featured_image_src ? (
 													<img
 														className={ `image-fit-${ imageFit }` }
@@ -430,7 +434,11 @@ class Edit extends Component {
 												) }
 												{ showTitle && (
 													<h3 className="entry-title">
-														<a href={ post.post_link }>{ decodeEntities( post.title.rendered.trim() ) }</a>
+														{ post.post_link ? (
+															<a href={ post.post_link }>{ decodeEntities( post.title.rendered.trim() ) }</a>
+														) : (
+															decodeEntities( post.title.rendered.trim() )
+														) }
 													</h3>
 												) }
 												<div className="entry-meta">

--- a/plugins/newspack-blocks/src/blocks/homepage-articles/edit.tsx
+++ b/plugins/newspack-blocks/src/blocks/homepage-articles/edit.tsx
@@ -6,6 +6,7 @@
 import QueryControls from '../../components/query-controls';
 import { postsBlockSelector, postsBlockDispatch, isBlogPrivate, shouldReflow } from './utils';
 import { getBylineHTML, formatSponsorLogos, formatSponsorByline, getPostStatusLabel } from '../../shared/js/utils';
+import { preventPreviewNavigation } from '../../shared/js/inert-preview';
 import { PostTypesPanel, PostStatusesPanel } from '../../components/editor-panels';
 
 /**
@@ -694,6 +695,7 @@ class Edit extends Component< HomepageArticlesProps > {
 				<div
 					{ ...blockProps }
 					className={ classes }
+					onClickCapture={ preventPreviewNavigation }
 					style={ {
 						color: textColor.color,
 					} }

--- a/plugins/newspack-blocks/src/blocks/homepage-articles/edit.tsx
+++ b/plugins/newspack-blocks/src/blocks/homepage-articles/edit.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable jsx-a11y/anchor-is-valid, @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 /**
  * Internal dependencies
@@ -90,7 +90,7 @@ class Edit extends Component< HomepageArticlesProps > {
 				{ getPostStatusLabel( post ) }
 				{ showImage && post.newspack_featured_image_src && (
 					<figure className="post-thumbnail" key="thumbnail">
-						<a href="#">
+						<a href={ post.post_link }>
 							{ imageShape === 'landscape' && <img src={ post.newspack_featured_image_src.landscape } alt="" /> }
 							{ imageShape === 'portrait' && <img src={ post.newspack_featured_image_src.portrait } alt="" /> }
 							{ imageShape === 'square' && <img src={ post.newspack_featured_image_src.square } alt="" /> }
@@ -119,7 +119,7 @@ class Edit extends Component< HomepageArticlesProps > {
 						<div className="cat-links tag-labels">
 							{ post.newspack_tag_labels.map( ( newspack_tag_label, index ) => {
 								return newspack_tag_label.link ? (
-									<a key={ index } href="#" className="tag-label flag">
+									<a key={ index } href={ newspack_tag_label.link } className="tag-label flag">
 										{ newspack_tag_label.flag }
 									</a>
 								) : (
@@ -132,11 +132,11 @@ class Edit extends Component< HomepageArticlesProps > {
 					) }
 					{ RichText.isEmpty( sectionHeader ) ? (
 						<h2 className="entry-title" key="title">
-							<a href="#">{ postTitle }</a>
+							<a href={ post.post_link }>{ postTitle }</a>
 						</h2>
 					) : (
 						<h3 className="entry-title" key="title">
-							<a href="#">{ postTitle }</a>
+							<a href={ post.post_link }>{ postTitle }</a>
 						</h3>
 					) }
 					{ IS_SUBTITLE_SUPPORTED_IN_THEME && showSubtitle && (
@@ -155,7 +155,7 @@ class Edit extends Component< HomepageArticlesProps > {
 						</RawHTML>
 					) }
 					{ showReadMore && post.post_link && (
-						<a href="#" key="readmore" className="more-link">
+						<a href={ post.post_link } key="readmore" className="more-link">
 							{ readMoreLabel }
 						</a>
 					) }

--- a/plugins/newspack-blocks/src/blocks/homepage-articles/edit.tsx
+++ b/plugins/newspack-blocks/src/blocks/homepage-articles/edit.tsx
@@ -85,17 +85,24 @@ class Edit extends Component< HomepageArticlesProps > {
 		);
 
 		const postTitle = this.titleForPost( post );
+		// Newspack_Blocks::get_post_link() returns false for a post type that is not
+		// public and carries no external URL, so the front end renders the title and
+		// thumbnail unlinked in that case (templates/article.php). Mirror it here
+		// rather than emitting an anchor with no destination.
+		const featuredImage = post.newspack_featured_image_src ? (
+			<Fragment>
+				{ imageShape === 'landscape' && <img src={ post.newspack_featured_image_src.landscape } alt="" /> }
+				{ imageShape === 'portrait' && <img src={ post.newspack_featured_image_src.portrait } alt="" /> }
+				{ imageShape === 'square' && <img src={ post.newspack_featured_image_src.square } alt="" /> }
+				{ imageShape === 'uncropped' && <img src={ post.newspack_featured_image_src.uncropped } alt="" /> }
+			</Fragment>
+		) : null;
 		return (
 			<article className={ postClasses } key={ post.id } style={ styles }>
 				{ getPostStatusLabel( post ) }
 				{ showImage && post.newspack_featured_image_src && (
 					<figure className="post-thumbnail" key="thumbnail">
-						<a href={ post.post_link }>
-							{ imageShape === 'landscape' && <img src={ post.newspack_featured_image_src.landscape } alt="" /> }
-							{ imageShape === 'portrait' && <img src={ post.newspack_featured_image_src.portrait } alt="" /> }
-							{ imageShape === 'square' && <img src={ post.newspack_featured_image_src.square } alt="" /> }
-							{ imageShape === 'uncropped' && <img src={ post.newspack_featured_image_src.uncropped } alt="" /> }
-						</a>
+						{ post.post_link ? <a href={ post.post_link }>{ featuredImage }</a> : featuredImage }
 						{ ( showCaption || showCredit ) && (
 							<div
 								dangerouslySetInnerHTML={ {
@@ -132,11 +139,11 @@ class Edit extends Component< HomepageArticlesProps > {
 					) }
 					{ RichText.isEmpty( sectionHeader ) ? (
 						<h2 className="entry-title" key="title">
-							<a href={ post.post_link }>{ postTitle }</a>
+							{ post.post_link ? <a href={ post.post_link }>{ postTitle }</a> : postTitle }
 						</h2>
 					) : (
 						<h3 className="entry-title" key="title">
-							<a href={ post.post_link }>{ postTitle }</a>
+							{ post.post_link ? <a href={ post.post_link }>{ postTitle }</a> : postTitle }
 						</h3>
 					) }
 					{ IS_SUBTITLE_SUPPORTED_IN_THEME && showSubtitle && (

--- a/plugins/newspack-blocks/src/shared/js/inert-preview.js
+++ b/plugins/newspack-blocks/src/shared/js/inert-preview.js
@@ -1,0 +1,16 @@
+/**
+ * Cancel any click that lands on or inside an anchor.
+ *
+ * Attached with onClickCapture to a block's editor-preview wrapper so no link
+ * in the preview — JSX-authored, server-built, or filter-injected — navigates
+ * the editor-canvas iframe away from the post being edited, while links keep
+ * rendering with their real destinations. Ctrl/middle-click open-in-new-tab
+ * still works: those don't dispatch a plain click through this path.
+ *
+ * @param {Event} event Click event from the capture phase.
+ */
+export const preventPreviewNavigation = event => {
+	if ( event.target.closest( 'a' ) ) {
+		event.preventDefault();
+	}
+};

--- a/plugins/newspack-blocks/src/shared/js/inert-preview.js
+++ b/plugins/newspack-blocks/src/shared/js/inert-preview.js
@@ -1,15 +1,25 @@
 /**
- * Cancel any click that lands on or inside an anchor.
+ * Cancel any unmodified click that lands on or inside an anchor.
  *
  * Attached with onClickCapture to a block's editor-preview wrapper so no link
  * in the preview — JSX-authored, server-built, or filter-injected — navigates
  * the editor-canvas iframe away from the post being edited, while links keep
- * rendering with their real destinations. Ctrl/middle-click open-in-new-tab
- * still works: those don't dispatch a plain click through this path.
+ * rendering with their real destinations.
+ *
+ * Modified clicks are left alone so an editor can still open a previewed post
+ * in a new tab or window: ctrl/cmd+click dispatches an ordinary click whose
+ * default action is open-in-new-tab, so cancelling it would take that away.
+ * Guarding on the four modifiers is the same test link-intercepting routers
+ * use (React Router's isModifiedEvent). None of them navigate the canvas, so
+ * the no-navigation guarantee holds. Middle-click needs no guard: it fires
+ * auxclick, which never reaches this handler.
  *
  * @param {Event} event Click event from the capture phase.
  */
 export const preventPreviewNavigation = event => {
+	if ( event.metaKey || event.ctrlKey || event.shiftKey || event.altKey ) {
+		return;
+	}
 	if ( event.target.closest( 'a' ) ) {
 		event.preventDefault();
 	}

--- a/plugins/newspack-blocks/src/shared/js/inert-preview.js
+++ b/plugins/newspack-blocks/src/shared/js/inert-preview.js
@@ -17,10 +17,17 @@
  * practice. Two gestures never reach this handler at all: middle-click fires
  * auxclick, and on macOS ctrl+click is a secondary click that fires contextmenu.
  *
+ * A target that cannot be asked for an ancestor anchor is ignored rather than
+ * throwing: an exception raised here runs in the capture phase and would stop
+ * every later click in the preview from being handled at all.
+ *
  * @param {MouseEvent | import('react').MouseEvent} event Click event from the capture phase.
  */
 export const preventPreviewNavigation = event => {
 	if ( event.metaKey || event.ctrlKey || event.shiftKey || event.altKey ) {
+		return;
+	}
+	if ( typeof event.target?.closest !== 'function' ) {
 		return;
 	}
 	if ( event.target.closest( 'a' ) ) {

--- a/plugins/newspack-blocks/src/shared/js/inert-preview.js
+++ b/plugins/newspack-blocks/src/shared/js/inert-preview.js
@@ -7,14 +7,17 @@
  * rendering with their real destinations.
  *
  * Modified clicks are left alone so an editor can still open a previewed post
- * in a new tab or window: ctrl/cmd+click dispatches an ordinary click whose
- * default action is open-in-new-tab, so cancelling it would take that away.
- * Guarding on the four modifiers is the same test link-intercepting routers
- * use (React Router's isModifiedEvent). None of them navigate the canvas, so
- * the no-navigation guarantee holds. Middle-click needs no guard: it fires
- * auxclick, which never reaches this handler.
+ * in a new tab or window: cmd+click on macOS, ctrl+click elsewhere, dispatches
+ * an ordinary click whose default action is open-in-new-tab, and cancelling it
+ * would take that away. Guarding on all four modifiers is the same test
+ * link-intercepting routers use (React Router's isModifiedEvent), and is
+ * deliberately wider than the gestures that open a tab. The gap it leaves is
+ * the Super key on Windows and Linux, which sets metaKey while carrying no link
+ * behaviour of its own; the OS claims that chord before the page sees it in
+ * practice. Two gestures never reach this handler at all: middle-click fires
+ * auxclick, and on macOS ctrl+click is a secondary click that fires contextmenu.
  *
- * @param {Event} event Click event from the capture phase.
+ * @param {MouseEvent | import('react').MouseEvent} event Click event from the capture phase.
  */
 export const preventPreviewNavigation = event => {
 	if ( event.metaKey || event.ctrlKey || event.shiftKey || event.altKey ) {

--- a/plugins/newspack-blocks/src/shared/js/inert-preview.test.js
+++ b/plugins/newspack-blocks/src/shared/js/inert-preview.test.js
@@ -46,6 +46,12 @@ describe( 'preventPreviewNavigation', () => {
 		} );
 	} );
 
+	it( 'ignores a target that cannot be asked for an ancestor anchor', () => {
+		const event = { target: {}, preventDefault: jest.fn() };
+		expect( () => preventPreviewNavigation( event ) ).not.toThrow();
+		expect( event.preventDefault ).not.toHaveBeenCalled();
+	} );
+
 	it( 'leaves non-anchor clicks alone', () => {
 		const container = document.createElement( 'div' );
 		container.innerHTML = '<article><h2 class="entry-title">Headline</h2></article>';

--- a/plugins/newspack-blocks/src/shared/js/inert-preview.test.js
+++ b/plugins/newspack-blocks/src/shared/js/inert-preview.test.js
@@ -1,0 +1,39 @@
+/**
+ * The editor preview must never navigate the canvas: any click that lands on
+ * or inside an anchor is cancelled at the container, whatever markup produced
+ * the anchor (JSX, server HTML, filter-injected HTML).
+ */
+import { preventPreviewNavigation } from './inert-preview';
+
+describe( 'preventPreviewNavigation', () => {
+	const dispatchClick = ( container, target ) => {
+		container.addEventListener( 'click', preventPreviewNavigation, true );
+		const event = new MouseEvent( 'click', { bubbles: true, cancelable: true } );
+		target.dispatchEvent( event );
+		return event;
+	};
+
+	it( 'cancels a click on an anchor inside the container', () => {
+		const container = document.createElement( 'div' );
+		container.innerHTML = '<article><span class="byline"><a href="https://example.test/author/jane/">Jane</a></span></article>';
+		document.body.appendChild( container );
+		const event = dispatchClick( container, container.querySelector( 'a' ) );
+		expect( event.defaultPrevented ).toBe( true );
+	} );
+
+	it( 'cancels a click on an element nested inside an anchor', () => {
+		const container = document.createElement( 'div' );
+		container.innerHTML = '<a href="https://example.test/"><img alt="" /></a>';
+		document.body.appendChild( container );
+		const event = dispatchClick( container, container.querySelector( 'img' ) );
+		expect( event.defaultPrevented ).toBe( true );
+	} );
+
+	it( 'leaves non-anchor clicks alone', () => {
+		const container = document.createElement( 'div' );
+		container.innerHTML = '<article><h2 class="entry-title">Headline</h2></article>';
+		document.body.appendChild( container );
+		const event = dispatchClick( container, container.querySelector( 'h2' ) );
+		expect( event.defaultPrevented ).toBe( false );
+	} );
+} );

--- a/plugins/newspack-blocks/src/shared/js/inert-preview.test.js
+++ b/plugins/newspack-blocks/src/shared/js/inert-preview.test.js
@@ -1,7 +1,8 @@
 /**
- * The editor preview must never navigate the canvas: any click that lands on
- * or inside an anchor is cancelled at the container, whatever markup produced
- * the anchor (JSX, server HTML, filter-injected HTML).
+ * The handler cancels any unmodified click that lands on or inside an anchor,
+ * and leaves modified clicks alone so open-in-new-tab still works. These cases
+ * exercise that predicate against plain DOM. Whether it covers every anchor in
+ * a preview depends on where the blocks attach it, which is not decided here.
  */
 import { preventPreviewNavigation } from './inert-preview';
 

--- a/plugins/newspack-blocks/src/shared/js/inert-preview.test.js
+++ b/plugins/newspack-blocks/src/shared/js/inert-preview.test.js
@@ -29,6 +29,22 @@ describe( 'preventPreviewNavigation', () => {
 		expect( event.defaultPrevented ).toBe( true );
 	} );
 
+	it( 'leaves a modified click alone so open-in-new-tab still works', () => {
+		[ 'ctrlKey', 'metaKey', 'shiftKey', 'altKey' ].forEach( modifier => {
+			const container = document.createElement( 'div' );
+			container.innerHTML = '<a href="https://example.test/">Headline</a>';
+			document.body.appendChild( container );
+			container.addEventListener( 'click', preventPreviewNavigation, true );
+			const event = new MouseEvent( 'click', {
+				bubbles: true,
+				cancelable: true,
+				[ modifier ]: true,
+			} );
+			container.querySelector( 'a' ).dispatchEvent( event );
+			expect( event.defaultPrevented ).toBe( false );
+		} );
+	} );
+
 	it( 'leaves non-anchor clicks alone', () => {
 		const container = document.createElement( 'div' );
 		container.innerHTML = '<article><h2 class="entry-title">Headline</h2></article>';

--- a/plugins/newspack-blocks/src/shared/js/utils.js
+++ b/plugins/newspack-blocks/src/shared/js/utils.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
 /**
  * WordPress dependencies
  */
@@ -15,15 +14,16 @@ export const getBylineHTML = ( post, showAvatar = false ) => {
 
 export const formatSponsorLogos = sponsorInfo => (
 	<span className="sponsor-logos">
-		{ sponsorInfo.map( sponsor => (
-			<Fragment key={ sponsor.id }>
-				{ sponsor.src && (
-					<a href={ sponsor.sponsor_url }>
-						<img src={ sponsor.src } width={ sponsor.img_width } height={ sponsor.img_height } alt={ sponsor.sponsor_name } />
-					</a>
-				) }
-			</Fragment>
-		) ) }
+		{ sponsorInfo.map( sponsor => {
+			if ( ! sponsor.src ) {
+				return <Fragment key={ sponsor.id } />;
+			}
+			const logo = <img src={ sponsor.src } width={ sponsor.img_width } height={ sponsor.img_height } alt={ sponsor.sponsor_name } />;
+			// sponsor_url is empty whenever the sponsor has no link set, and an
+			// empty href resolves to the document itself — so the front end wraps
+			// the logo only when there is a URL (templates/article.php).
+			return <Fragment key={ sponsor.id }>{ sponsor.sponsor_url ? <a href={ sponsor.sponsor_url }>{ logo }</a> : logo }</Fragment>;
+		} ) }
 	</span>
 );
 
@@ -34,8 +34,7 @@ export const formatSponsorByline = sponsorInfo => (
 			return [
 				...accumulator,
 				<span className="author" key={ sponsor.id }>
-					{ /* author_link is never populated in the payload; '#' keeps the anchor inert-by-content, and the container handler covers it regardless. */ }
-					<a href="#">{ sponsor.sponsor_name }</a>
+					{ sponsor.sponsor_url ? <a href={ sponsor.sponsor_url }>{ sponsor.sponsor_name }</a> : sponsor.sponsor_name }
 				</span>,
 				index < sponsorInfo.length - 2 && ', ',
 				sponsorInfo.length > 1 && index === sponsorInfo.length - 2 && _x( 'and', 'post author', 'newspack-blocks' ),

--- a/plugins/newspack-blocks/src/shared/js/utils.js
+++ b/plugins/newspack-blocks/src/shared/js/utils.js
@@ -18,11 +18,7 @@ export const formatSponsorLogos = sponsorInfo => (
 		{ sponsorInfo.map( sponsor => (
 			<Fragment key={ sponsor.id }>
 				{ sponsor.src && (
-					// A live sponsor URL would navigate the editor-canvas iframe away from
-					// the post being edited; the sponsor slot replaces the byline when
-					// newspack_sponsors_show_author is off, so it needs the same inert
-					// href="#" the other editor anchors use.
-					<a href="#">
+					<a href={ sponsor.sponsor_url }>
 						<img src={ sponsor.src } width={ sponsor.img_width } height={ sponsor.img_height } alt={ sponsor.sponsor_name } />
 					</a>
 				) }
@@ -38,7 +34,7 @@ export const formatSponsorByline = sponsorInfo => (
 			return [
 				...accumulator,
 				<span className="author" key={ sponsor.id }>
-					{ /* author_link is never populated in the editor payload; href="#" makes the inertness explicit. */ }
+					{ /* author_link is never populated in the payload; '#' keeps the anchor inert-by-content, and the container handler covers it regardless. */ }
 					<a href="#">{ sponsor.sponsor_name }</a>
 				</span>,
 				index < sponsorInfo.length - 2 && ', ',

--- a/plugins/newspack-blocks/src/shared/js/utils.test.js
+++ b/plugins/newspack-blocks/src/shared/js/utils.test.js
@@ -3,10 +3,10 @@ import { formatSponsorLogos, formatSponsorByline } from './utils';
 /**
  * Collect every anchor element in a React element tree.
  *
- * The formatters return element trees rendered inside the editor canvas,
- * where a live href navigates the canvas iframe away from the post being
- * edited (NPPM-3165). Walking the tree keeps these assertions valid across
- * structural changes to the markup.
+ * The formatters return element trees rendered inside the editor canvas, where
+ * anchors carry the same destinations the front end renders; navigation is
+ * prevented at the preview container instead. Walking the tree keeps these
+ * assertions valid across structural changes to the markup.
  *
  * @param {*} node React element, array, or primitive.
  * @return {Array} All elements whose type is 'a'.
@@ -41,9 +41,15 @@ describe( 'sponsor markup in the editor preview', () => {
 		anchors.forEach( anchor => expect( anchor.props.href ).toBe( 'https://sponsor.example.test/supporters/' ) );
 	} );
 
-	it( 'renders the sponsor byline anchor inert', () => {
+	it( 'renders the sponsor byline anchor with its real URL', () => {
 		const anchors = collectAnchors( formatSponsorByline( sponsors ) );
 		expect( anchors.length ).toBeGreaterThan( 0 );
-		anchors.forEach( anchor => expect( anchor.props.href ).toBe( '#' ) );
+		anchors.forEach( anchor => expect( anchor.props.href ).toBe( 'https://sponsor.example.test/supporters/' ) );
+	} );
+
+	it( 'renders the sponsor name unlinked when the sponsor has no URL', () => {
+		const withoutUrl = [ { ...sponsors[ 0 ], sponsor_url: '' } ];
+		expect( collectAnchors( formatSponsorByline( withoutUrl ) ) ).toHaveLength( 0 );
+		expect( collectAnchors( formatSponsorLogos( withoutUrl ) ) ).toHaveLength( 0 );
 	} );
 } );

--- a/plugins/newspack-blocks/src/shared/js/utils.test.js
+++ b/plugins/newspack-blocks/src/shared/js/utils.test.js
@@ -35,10 +35,10 @@ const sponsors = [
 ];
 
 describe( 'sponsor markup in the editor preview', () => {
-	it( 'renders the sponsor logo anchor inert', () => {
+	it( 'renders the sponsor logo anchor with its real URL', () => {
 		const anchors = collectAnchors( formatSponsorLogos( sponsors ) );
 		expect( anchors.length ).toBeGreaterThan( 0 );
-		anchors.forEach( anchor => expect( anchor.props.href ).toBe( '#' ) );
+		anchors.forEach( anchor => expect( anchor.props.href ).toBe( 'https://sponsor.example.test/supporters/' ) );
 	} );
 
 	it( 'renders the sponsor byline anchor inert', () => {

--- a/plugins/newspack-blocks/tests/test-homepage-posts-block.php
+++ b/plugins/newspack-blocks/tests/test-homepage-posts-block.php
@@ -299,7 +299,7 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 				'user_nicename' => 'nia-fixture',
 			]
 		);
-		self::factory()->post->create(
+		$authored_post_id = self::factory()->post->create(
 			[
 				'post_status' => 'publish',
 				'post_author' => $author_id,
@@ -311,10 +311,11 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 		$request->set_param( 'postsToShow', 10 );
 		$posts = rest_do_request( $request )->get_data();
 
-		self::assertNotEmpty( $posts, 'The editor posts endpoint returns the published post.' );
+		$posts_by_id = array_column( $posts, null, 'id' );
+		self::assertArrayHasKey( $authored_post_id, $posts_by_id, 'The editor posts endpoint returns the authored post.' );
 		self::assertStringContainsString(
 			get_author_posts_url( $author_id, 'nia-fixture' ),
-			$posts[0]['newspack_post_byline'],
+			$posts_by_id[ $authored_post_id ]['newspack_post_byline'],
 			'The editor byline carries the live author-archive link; the preview container is what prevents navigation.'
 		);
 	}
@@ -324,9 +325,8 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	 *
 	 * newspack_blocks_format_byline() is shared by the front end and the editor
 	 * payload, so it must stay free of editor-only concerns. This pins that:
-	 * reintroducing link rewriting here would break every reader-facing author
-	 * link, and the editor no longer needs it — the preview container blocks
-	 * navigation instead.
+	 * link rewriting here would break every reader-facing author link, and the
+	 * editor does not need it — the preview container blocks navigation.
 	 */
 	public function test_front_end_byline_formatter_keeps_live_author_links() {
 		$author_id = self::factory()->user->create(

--- a/plugins/newspack-blocks/tests/test-homepage-posts-block.php
+++ b/plugins/newspack-blocks/tests/test-homepage-posts-block.php
@@ -284,6 +284,33 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	}
 
 	/**
+	 * The editor posts payload never carries an unsafe URL scheme.
+	 *
+	 * post_link resolves from the newspack_sponsor_url / newspack_supporter_url
+	 * meta, which is stored through sanitize_text_field and so can hold any
+	 * string. The editor renders it as an href, and a modified click follows it,
+	 * so the payload applies the same protocol allowlist the front end gets from
+	 * esc_url() in templates/article.php.
+	 */
+	public function test_editor_posts_endpoint_strips_unsafe_link_schemes() {
+		$post_id = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		update_post_meta( $post_id, 'newspack_sponsor_url', 'javascript:alert(1)' );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$request = new WP_REST_Request( 'GET', '/newspack-blocks/v1/newspack-blocks-posts' );
+		$request->set_param( 'postsToShow', 10 );
+		$posts = rest_do_request( $request )->get_data();
+
+		$posts_by_id = array_column( $posts, null, 'id' );
+		self::assertArrayHasKey( $post_id, $posts_by_id, 'The editor posts endpoint returns the post.' );
+		self::assertStringNotContainsString(
+			'javascript:',
+			(string) $posts_by_id[ $post_id ]['post_link'],
+			'The editor payload does not carry a javascript: URL for the preview to render as an href.'
+		);
+	}
+
+	/**
 	 * The editor posts payload carries real author-archive links.
 	 *
 	 * Navigation is prevented at the preview container (see

--- a/plugins/newspack-blocks/tests/test-homepage-posts-block.php
+++ b/plugins/newspack-blocks/tests/test-homepage-posts-block.php
@@ -284,128 +284,19 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	}
 
 	/**
-	 * The editor posts endpoint must not expose live author-archive links.
+	 * The editor posts payload carries real author-archive links.
 	 *
-	 * The editor canvas renders newspack_post_byline and newspack_post_avatars
-	 * verbatim, so a real href navigates the canvas iframe away from the post
-	 * being edited. Author anchors must be neutralized to href="#", matching
-	 * the category link convention in the same payload.
+	 * Navigation is prevented at the preview container (see
+	 * shared/js/inert-preview.js), so the payload keeps the same URLs the front
+	 * end renders — which is what lets an editor ctrl/middle-click a previewed
+	 * post open in a new tab.
 	 */
-	public function test_editor_posts_endpoint_neutralizes_author_archive_links() {
+	public function test_editor_posts_endpoint_carries_live_author_links() {
 		$author_id = self::factory()->user->create(
 			[
 				'role'          => 'author',
-				'display_name'  => 'Jane Example',
-				'user_nicename' => 'jane-example',
-			]
-		);
-		$authored_post_id = self::factory()->post->create(
-			[
-				'post_status' => 'publish',
-				'post_author' => $author_id,
-			]
-		);
-		// A post whose author no longer exists still renders a byline anchor
-		// ("by" with no name, empty author lookup) and must be neutralized too.
-		$orphan_post_id = self::factory()->post->create(
-			[
-				'post_status' => 'publish',
-				'post_author' => 99999,
-			]
-		);
-		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
-
-		$request = new WP_REST_Request( 'GET', '/newspack-blocks/v1/newspack-blocks-posts' );
-		$request->set_param( 'postsToShow', 10 );
-		$posts = rest_do_request( $request )->get_data();
-
-		$posts_by_id = array_column( $posts, null, 'id' );
-		self::assertArrayHasKey( $authored_post_id, $posts_by_id, 'The endpoint returns the authored post.' );
-		self::assertArrayHasKey( $orphan_post_id, $posts_by_id, 'The endpoint returns the orphaned-author post.' );
-
-		self::assertStringContainsString(
-			'Jane Example',
-			$posts_by_id[ $authored_post_id ]['newspack_post_byline'],
-			'The author name still renders in the editor byline.'
-		);
-
-		foreach ( [ $authored_post_id, $orphan_post_id ] as $post_id ) {
-			self::assertStringContainsString(
-				'href="#"',
-				$posts_by_id[ $post_id ]['newspack_post_byline'],
-				'The editor byline anchor is neutralized, not removed.'
-			);
-			self::assertStringNotContainsString(
-				'href="http',
-				$posts_by_id[ $post_id ]['newspack_post_byline'],
-				'The editor byline must not carry a live link.'
-			);
-			self::assertStringContainsString(
-				'href="#"',
-				$posts_by_id[ $post_id ]['newspack_post_avatars'],
-				'The editor avatar anchor is neutralized, not removed.'
-			);
-			self::assertStringNotContainsString(
-				'href="http',
-				$posts_by_id[ $post_id ]['newspack_post_avatars'],
-				'The editor avatar link must not carry a live link.'
-			);
-		}
-	}
-
-	/**
-	 * Byline HTML injected via the newspack_blocks_post_byline filter (the
-	 * newspack-plugin custom-bylines feature hooks it and replaces the byline
-	 * wholesale) must be neutralized too — neutralization runs on the finished
-	 * payload, after the filter.
-	 */
-	public function test_editor_posts_endpoint_neutralizes_filtered_byline_links() {
-		self::factory()->post->create( [ 'post_status' => 'publish' ] );
-		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
-
-		$live_link_byline_filter = function () {
-			return '<span class="author vcard"><a class="url fn n" href="https://example.test/author/custom">Custom Byline</a></span>';
-		};
-		add_filter( 'newspack_blocks_post_byline', $live_link_byline_filter );
-
-		$request = new WP_REST_Request( 'GET', '/newspack-blocks/v1/newspack-blocks-posts' );
-		$request->set_param( 'postsToShow', 10 );
-		$posts = rest_do_request( $request )->get_data();
-
-		remove_filter( 'newspack_blocks_post_byline', $live_link_byline_filter );
-
-		self::assertNotEmpty( $posts, 'The editor posts endpoint returns the published post.' );
-		foreach ( $posts as $post_data ) {
-			self::assertStringContainsString(
-				'Custom Byline',
-				$post_data['newspack_post_byline'],
-				'The filtered byline content is preserved.'
-			);
-			self::assertStringNotContainsString(
-				'https://example.test/author/custom',
-				$post_data['newspack_post_byline'],
-				'A live link supplied by the byline filter must be neutralized in the editor payload.'
-			);
-			self::assertStringContainsString(
-				'href="#"',
-				$post_data['newspack_post_byline'],
-				'The filtered byline anchor is neutralized, not removed.'
-			);
-		}
-	}
-
-	/**
-	 * Avatar markup whose URL carries an href query parameter must come
-	 * through intact — neutralization touches only real anchor href
-	 * attributes, never "href=" text inside another attribute's value
-	 * (the shape produced by URL-rewriting avatar proxies).
-	 */
-	public function test_editor_posts_endpoint_preserves_avatar_markup() {
-		$author_id = self::factory()->user->create(
-			[
-				'role'          => 'author',
-				'display_name'  => 'Ada Fixture',
-				'user_nicename' => 'ada-fixture',
+				'display_name'  => 'Nia Fixture',
+				'user_nicename' => 'nia-fixture',
 			]
 		);
 		self::factory()->post->create(
@@ -416,44 +307,26 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 		);
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
-		$proxied_avatar_filter = function () {
-			return '<img src="https://cdn.example.test/proxy?url=a&amp;href=x" srcset="https://cdn.example.test/proxy?url=b&amp;href=y 2x" class="avatar" alt="" width="48" height="48" />';
-		};
-		add_filter( 'pre_get_avatar', $proxied_avatar_filter );
-
 		$request = new WP_REST_Request( 'GET', '/newspack-blocks/v1/newspack-blocks-posts' );
 		$request->set_param( 'postsToShow', 10 );
 		$posts = rest_do_request( $request )->get_data();
 
-		remove_filter( 'pre_get_avatar', $proxied_avatar_filter );
-
 		self::assertNotEmpty( $posts, 'The editor posts endpoint returns the published post.' );
-		foreach ( $posts as $post_data ) {
-			self::assertStringContainsString(
-				'src="https://cdn.example.test/proxy?url=a&amp;href=x"',
-				$post_data['newspack_post_avatars'],
-				'The avatar src survives neutralization byte-identical.'
-			);
-			self::assertStringContainsString(
-				'srcset="https://cdn.example.test/proxy?url=b&amp;href=y 2x"',
-				$post_data['newspack_post_avatars'],
-				'The avatar srcset survives neutralization byte-identical.'
-			);
-			self::assertStringContainsString(
-				'href="#"',
-				$post_data['newspack_post_avatars'],
-				'The avatar anchor is still neutralized.'
-			);
-		}
+		self::assertStringContainsString(
+			get_author_posts_url( $author_id, 'nia-fixture' ),
+			$posts[0]['newspack_post_byline'],
+			'The editor byline carries the live author-archive link; the preview container is what prevents navigation.'
+		);
 	}
 
 	/**
 	 * The front-end byline formatter keeps live author-archive links.
 	 *
-	 * The discriminating mirror of the editor tests above: neutralization
-	 * belongs to the editor payload only, and moving it into the shared
-	 * formatter would break every reader-facing author link while the editor
-	 * tests stayed green.
+	 * newspack_blocks_format_byline() is shared by the front end and the editor
+	 * payload, so it must stay free of editor-only concerns. This pins that:
+	 * reintroducing link rewriting here would break every reader-facing author
+	 * link, and the editor no longer needs it — the preview container blocks
+	 * navigation instead.
 	 */
 	public function test_front_end_byline_formatter_keeps_live_author_links() {
 		$author_id = self::factory()->user->create(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

#### The problem

Some links in Content Loop and Content Carousel previews could still navigate the editor away from the post being edited:

* Image captions and credits.
* Links in excerpt and full-content previews.
* The article meta footer.
* Links added by filters or site-specific code.

This could leave the front-end page loaded inside the editing canvas, with the admin bar across the top. Clicking **Edit** there opens a second editor inside the first.

#### The fix

A single handler on each block preview now prevents normal link clicks from navigating the editor, regardless of where the link came from. Because navigation is handled at the preview level, links can keep their real destinations instead of using placeholders.

This now covers:

* Headlines, thumbnails, categories, tag labels, and read-more links.
* Author names and avatars, including custom bylines.
* Sponsor logos and bylines.
* Image captions and credits.
* Links in excerpt and full-content previews.
* The article meta footer.
* Anything added by a filter.

With this change:

* Cmd-click, Ctrl-click, and middle-click open a link in a new tab and leave the editor where it is.
* Hovering a link shows its real destination.
* Links with no destination render as plain text, matching the front end.

Content Carousel already prevents mouse clicks from reaching links inside slides; this change also covers keyboard activation there.

One browser-controlled path remains: right-clicking a link and choosing **Open Link** still navigates the editor, because that action does not trigger a page click event.

Ref NPPM-3241. Follows NPPM-3165 (#992).

### How to test the changes in this Pull Request:

Set up the fixtures on `main`:

1. Publish post A. Publish post B with a link to post A in its body. The link must be in the body, not the excerpt.
2. Give post B a featured image. Fill in both Credit and Credit URL in the Attachment Details sidebar, alongside the image you just picked. The credit URL is what puts a link inside the caption.
3. Publish a page containing this block, pasted in through **Options → Code editor**. Full content is required: it is what puts post B's body link in the preview.

```
<!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"showFullContent":true,"postsToShow":3,"showImage":true,"showCaption":true,"showCredit":true,"showCategory":true,"showAuthor":true,"showAvatar":true,"showDate":true,"showReadMore":true} /-->
```

Reproduce the problem on `main`. Skip this half if you only have the branch checked out; verification starts at step 8.

4. Edit the page. Click the block once to select it.
5. Click the link to post A in the preview. The canvas loads the front end of post A, with the admin bar across the top.
6. Click **Edit** in that admin bar. A second editor loads inside the canvas.
7. View the page on the front end and note how the article previews look. This is the baseline for step 15.

Verify the fix on this branch:

8. Edit the page, select the block, and click the link to post A. The canvas stays on the page being edited.
9. Click the credit link in an image caption. Nothing navigates.
10. Tab to a post title in the preview and press Enter. Nothing navigates.
11. Hover that title. The status bar shows the post's permalink, not `#`.
12. Cmd-click that title (Ctrl-click on Windows and Linux). The post opens in a new browser tab, and the tab holding the editor is unchanged.
13. Middle-click the same title. The post opens in a new tab the same way.
14. Add a Content Carousel block to the page. Click a slide title, then tab to a slide title and press Enter. Neither navigates, and the slider still responds to its arrow buttons.
15. If the site already has sponsored posts or posts with tag labels, click those in the preview too. Neither navigates.
16. View the page on the front end. It looks as it did in step 7, and each link opens its own destination.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? A Jest suite covers the handler, and a PHP test covers the payload contract it relies on. End-to-end coverage is described under **Technical details**.
* [x] Have you successfully run tests with your changes locally? Jest, PHPUnit, `typescript:check`, PHPCS, and ESLint all pass.

<details>
<summary><strong>Technical details</strong> — implementation, prior art, and deferred coverage</summary>

### Why the wrapper, not each link

The preview renders anchors this block does not author: `RawHTML` for byline, avatars, categories, excerpt, full content, and the article meta footer, plus whatever the `newspack_blocks_post_byline` and `newspack_blocks_categories` filters inject. Handlers attached to the anchors this block builds cannot reach those, and neither could the per-field rewriting. A site-specific plugin that hooks `newspack_blocks_categories` and appends an anchor with a live URL is enough to defeat it, since `neutralize_editor_links()` ran on two payload fields and not that one.

WordPress core takes the same approach in its Latest Posts block: keep a real `href`, cancel the click. Core attaches the handler to each anchor, which works because its preview is entirely JSX. Ours also renders server-built and filter-injected markup, so the handler goes one level up.

### Removed

`Newspack_Blocks::neutralize_editor_links()` and both call sites, and ten hardcoded `href="#"` anchors across `edit.tsx`, `carousel/edit.js`, `shared/js/utils.js`, and the primary-category builder in `class-newspack-blocks-api.php`. The `jsx-a11y/anchor-is-valid` disable came out of the three JavaScript files, since no placeholder anchors remain. `.swiper-wrapper { pointer-events: none }` is deliberately untouched: it exists to quiet Swiper drag, and as a side effect no mouse click reaches a link inside a slide, which is why the modifier passthrough applies to the Content Loop only and the carousel relies on the handler for keyboard activation.

### Modifier guard

The handler returns early on `metaKey`, `ctrlKey`, `shiftKey`, and `altKey`, the same check link-intercepting routers use. One gap: the Super key on Windows and Linux sets `metaKey` while carrying no link behavior of its own, so in principle that chord navigates. In practice the operating system claims it before the click reaches the page, and React Router's `isModifiedEvent` carries the same edge case.

### Unlinked items

`Newspack_Blocks::get_post_link()` returns `false` for a post type that is not public and has no external URL, and `sponsor_url` is empty whenever a sponsor has no link set. Both now render without an anchor in the preview, as they already do on the front end.

### Front-end output is unchanged

`newspack_blocks_format_byline()`, `newspack_blocks_format_avatars()`, `templates/article.php`, and `carousel/view.php` are untouched. `newspack_blocks_get_primary_category()` runs only in `posts_endpoint()`; the front end builds its category markup through `newspack_blocks_format_categories()`.

### Deferred end-to-end coverage

Three payload tests asserting `href="#"` are gone. One test replaces them, asserting the payload carries the live author-archive URL, the contract the editor now relies on.

An end-to-end spec covering the canvas is written and verified: it passes against this fix and fails against a build with the handler removed. It is not in this PR. The nightly suite runs specs from `main` against a site on the stable release channel, so a spec expecting this fix would fail there every night until the fix reaches stable. The spec ships in a follow-up PR once the release carrying this change reaches that site.

Until then, one claim is unpinned: nothing in the shipping suite proves the handler is attached to the wrapper. Removing `onClickCapture` leaves every Jest and PHPUnit test green.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

