### PR TITLE
fix(homepage-articles): reset dedup state per render pass (NPLAUNC-242)

### DIFF
--- a/plugins/newspack-blocks/includes/class-newspack-blocks.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks.php
@@ -688,11 +688,15 @@ class Newspack_Blocks {
 	/**
 	 * Forget which posts have been rendered so far, so the next Content Loop or
 	 * Carousel block starts deduplicating from scratch.
+	 *
+	 * The list of posts picked by specific-posts blocks is left alone: it is
+	 * derived from the current post, which `wp_reset_postdata()` cannot restore
+	 * inside a REST request once a block's loop has moved it, so recomputing it
+	 * per pass would give each pass a different exclusion list.
 	 */
 	public static function reset_deduplication() {
-		global $newspack_blocks_post_id, $newspack_blocks_all_specific_posts_ids;
-		$newspack_blocks_post_id                = [];
-		$newspack_blocks_all_specific_posts_ids = null;
+		global $newspack_blocks_post_id;
+		$newspack_blocks_post_id = [];
 
 		/**
 		 * Fires after deduplication state has been reset.

--- a/plugins/newspack-blocks/includes/class-newspack-blocks.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks.php
@@ -21,6 +21,14 @@ class Newspack_Blocks {
 	];
 
 	/**
+	 * Nesting depth of `the_content` filter applications. A depth of zero marks
+	 * the start of a top-level render pass, where deduplication state is reset.
+	 *
+	 * @var int
+	 */
+	private static $content_render_depth = 0;
+
+	/**
 	 * Add hooks and filters.
 	 */
 	public static function init() {
@@ -30,6 +38,8 @@ class Newspack_Blocks {
 		add_post_type_support( 'page', 'newspack_blocks' );
 		add_action( 'jetpack_register_gutenberg_extensions', [ __CLASS__, 'disable_jetpack_donate' ], 99 );
 		add_filter( 'the_content', [ __CLASS__, 'hide_post_content_when_iframe_block_is_fullscreen' ] );
+		add_filter( 'the_content', [ __CLASS__, 'start_content_render_pass' ], PHP_INT_MIN );
+		add_filter( 'the_content', [ __CLASS__, 'end_content_render_pass' ], PHP_INT_MAX );
 		add_filter( 'body_class', [ __CLASS__, 'add_body_classes' ] );
 		add_filter( 'admin_body_class', [ __CLASS__, 'add_body_classes' ] );
 
@@ -614,6 +624,80 @@ class Newspack_Blocks {
 			return class_exists( 'Jetpack' ) && \Jetpack::is_module_active( 'photon' );
 		}
 		return false;
+	}
+
+	/**
+	 * Mark the start of a `the_content` render pass.
+	 *
+	 * Deduplication state accumulates in globals for the life of the request,
+	 * which is right for a front-end page but wrong wherever one request renders
+	 * the same content more than once (a REST save renders it up to three times)
+	 * or renders several posts (a REST collection). There, every top-level pass
+	 * starts from a clean slate so each returns the same posts. Nested passes
+	 * (a Query Loop rendering Post Content, a synced pattern) keep the state of
+	 * the pass they belong to.
+	 *
+	 * @param string $content Post content.
+	 * @return string Unmodified post content.
+	 */
+	public static function start_content_render_pass( $content ) {
+		if ( 0 === self::$content_render_depth && self::should_reset_deduplication_per_render_pass() ) {
+			self::reset_deduplication();
+		}
+		self::$content_render_depth++;
+		return $content;
+	}
+
+	/**
+	 * Mark the end of a `the_content` render pass.
+	 *
+	 * @param string $content Post content.
+	 * @return string Unmodified post content.
+	 */
+	public static function end_content_render_pass( $content ) {
+		self::$content_render_depth = max( 0, self::$content_render_depth - 1 );
+		return $content;
+	}
+
+	/**
+	 * Whether deduplication state should be reset at the start of each top-level
+	 * `the_content` pass.
+	 *
+	 * On the front end the state is kept for the whole request, because a block
+	 * theme can render Content Loop blocks in the template before the post
+	 * content, and those have to be excluded from the blocks inside it.
+	 *
+	 * @return bool
+	 */
+	public static function should_reset_deduplication_per_render_pass() {
+		$is_front_end = ! is_admin()
+			&& ! wp_doing_ajax()
+			&& ! wp_doing_cron()
+			&& ! ( defined( 'REST_REQUEST' ) && REST_REQUEST )
+			&& ! ( defined( 'WP_CLI' ) && WP_CLI );
+
+		/**
+		 * Filters whether deduplication state is reset at the start of each
+		 * top-level `the_content` pass.
+		 *
+		 * @param bool $reset Whether to reset. Default true outside front-end requests.
+		 */
+		return (bool) apply_filters( 'newspack_blocks_reset_deduplication_per_render_pass', ! $is_front_end );
+	}
+
+	/**
+	 * Forget which posts have been rendered so far, so the next Content Loop or
+	 * Carousel block starts deduplicating from scratch.
+	 */
+	public static function reset_deduplication() {
+		global $newspack_blocks_post_id, $newspack_blocks_all_specific_posts_ids;
+		$newspack_blocks_post_id                = [];
+		$newspack_blocks_all_specific_posts_ids = null;
+
+		/**
+		 * Fires after deduplication state has been reset.
+		 */
+		do_action( 'newspack_blocks_deduplication_reset' );
 	}
 
 	/**

--- a/plugins/newspack-blocks/includes/class-newspack-blocks.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks.php
@@ -796,6 +796,8 @@ class Newspack_Blocks {
 			'has_password'        => false,
 			'is_newspack_query'   => true,
 			'tax_query'           => [], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+			// The total is only needed to decide whether a More button has a next page.
+			'no_found_rows'       => empty( $attributes['moreButton'] ),
 		);
 		if ( $specific_mode && $specific_posts ) {
 			$args['posts_per_page'] = count( $specific_posts );

--- a/plugins/newspack-blocks/includes/class-newspack-blocks.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks.php
@@ -676,13 +676,7 @@ class Newspack_Blocks {
 			&& ! ( defined( 'REST_REQUEST' ) && REST_REQUEST )
 			&& ! ( defined( 'WP_CLI' ) && WP_CLI );
 
-		/**
-		 * Filters whether deduplication state is reset at the start of each
-		 * top-level `the_content` pass.
-		 *
-		 * @param bool $reset Whether to reset. Default true outside front-end requests.
-		 */
-		return (bool) apply_filters( 'newspack_blocks_reset_deduplication_per_render_pass', ! $is_front_end );
+		return ! $is_front_end;
 	}
 
 	/**
@@ -697,11 +691,6 @@ class Newspack_Blocks {
 	public static function reset_deduplication() {
 		global $newspack_blocks_post_id;
 		$newspack_blocks_post_id = [];
-
-		/**
-		 * Fires after deduplication state has been reset.
-		 */
-		do_action( 'newspack_blocks_deduplication_reset' );
 	}
 
 	/**

--- a/plugins/newspack-blocks/tests/test-homepage-posts-block.php
+++ b/plugins/newspack-blocks/tests/test-homepage-posts-block.php
@@ -27,6 +27,8 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 			}
 		}
 		$this->registered_post_types = [];
+		self::reset_dedup_globals();
+		wp_reset_postdata();
 		parent::tear_down();
 	}
 
@@ -66,6 +68,135 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 		);
 		$this->registered_post_types[] = $name;
 		return $name;
+	}
+
+	/**
+	 * Clear the request-scoped deduplication globals between tests.
+	 */
+	private static function reset_dedup_globals() {
+		unset( $GLOBALS['newspack_blocks_post_id'], $GLOBALS['newspack_blocks_all_specific_posts_ids'], $GLOBALS['newspack_blocks_hpb_all_blocks'] );
+	}
+
+	/**
+	 * Create published posts and a page holding two Content Loop blocks of one
+	 * post each, and make that page the current post.
+	 *
+	 * @param int $posts_count How many posts to create.
+	 * @return WP_Post The page.
+	 */
+	private function create_dedup_page( $posts_count = 3 ) {
+		self::reset_dedup_globals();
+		for ( $i = 0; $i < $posts_count; $i++ ) {
+			self::factory()->post->create(
+				[
+					'post_status' => 'publish',
+					'post_date'   => gmdate( 'Y-m-d H:i:s', time() - ( $i + 1 ) * HOUR_IN_SECONDS ),
+				]
+			);
+		}
+		$block   = '<!-- wp:newspack-blocks/homepage-articles {"postsToShow":1} /-->';
+		$page_id = self::factory()->post->create(
+			[
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_content' => $block . "\n" . $block,
+			]
+		);
+		$GLOBALS['post'] = get_post( $page_id );
+		setup_postdata( $GLOBALS['post'] );
+		return $GLOBALS['post'];
+	}
+
+	/**
+	 * Apply `the_content` to a post and return the IDs the pass has marked as rendered.
+	 *
+	 * @param WP_Post $post The post.
+	 * @return int[] Deduplicated post IDs after the pass.
+	 */
+	private function render_pass( $post ) {
+		apply_filters( 'the_content', $post->post_content );
+		return array_keys( (array) ( $GLOBALS['newspack_blocks_post_id'] ?? [] ) );
+	}
+
+	/**
+	 * Make the request look like wp-admin, where `is_admin()` is true.
+	 */
+	private function enter_admin() {
+		if ( ! function_exists( 'set_current_screen' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-screen.php';
+			require_once ABSPATH . 'wp-admin/includes/screen.php';
+		}
+		set_current_screen( 'edit-page' );
+		self::assertTrue( is_admin(), 'The request is treated as an admin request.' );
+	}
+
+	/**
+	 * On the front end, deduplication accumulates for the whole request, so a
+	 * second pass over the same content excludes what the first one rendered.
+	 */
+	public function test_dedup_state_is_kept_across_render_passes_on_front_end() {
+		$page = $this->create_dedup_page();
+		self::assertFalse( Newspack_Blocks::should_reset_deduplication_per_render_pass() );
+
+		$first = $this->render_pass( $page );
+		self::assertCount( 2, $first, 'Two blocks of one post each render two distinct posts.' );
+
+		$second = $this->render_pass( $page );
+		self::assertCount( 3, $second, 'The second pass keeps excluding the posts the first pass rendered.' );
+	}
+
+	/**
+	 * Outside the front end (admin, REST, cron, CLI) every top-level pass starts
+	 * from scratch, so re-rendering the same content returns the same posts.
+	 */
+	public function test_dedup_state_resets_per_render_pass_outside_front_end() {
+		$this->enter_admin();
+		$page = $this->create_dedup_page();
+		self::assertTrue( Newspack_Blocks::should_reset_deduplication_per_render_pass() );
+
+		$first = $this->render_pass( $page );
+		self::assertCount( 2, $first, 'Two blocks of one post each render two distinct posts.' );
+
+		$second = $this->render_pass( $page );
+		self::assertSame( $first, $second, 'A second pass over the same content renders the same posts.' );
+	}
+
+	/**
+	 * A `the_content` application nested inside a pass (a Query Loop rendering
+	 * Post Content, for instance) must not wipe the state of the outer pass.
+	 */
+	public function test_nested_content_render_does_not_reset_dedup_state() {
+		$this->enter_admin();
+		$page = $this->create_dedup_page();
+
+		$nested_calls = 0;
+		$nested       = function ( $content ) use ( &$nested_calls ) {
+			if ( 0 === $nested_calls++ ) {
+				apply_filters( 'the_content', '<p>nested</p>' );
+			}
+			return $content;
+		};
+		// After do_blocks (9), so the outer pass has already rendered its blocks.
+		add_filter( 'the_content', $nested, 10 );
+		$ids = $this->render_pass( $page );
+		remove_filter( 'the_content', $nested, 10 );
+
+		self::assertSame( 2, $nested_calls, 'The filter ran for the outer pass and once more for the nested one.' );
+		self::assertCount( 2, $ids, 'The outer pass keeps the posts it rendered before the nested pass.' );
+	}
+
+	/**
+	 * The reset can be forced on or off through the filter.
+	 */
+	public function test_dedup_reset_is_filterable() {
+		add_filter( 'newspack_blocks_reset_deduplication_per_render_pass', '__return_true' );
+		$page   = $this->create_dedup_page();
+		$first  = $this->render_pass( $page );
+		$second = $this->render_pass( $page );
+		remove_filter( 'newspack_blocks_reset_deduplication_per_render_pass', '__return_true' );
+
+		self::assertCount( 2, $first );
+		self::assertSame( $first, $second, 'With the filter on, the front end resets per pass too.' );
 	}
 
 	/**

--- a/plugins/newspack-blocks/tests/test-homepage-posts-block.php
+++ b/plugins/newspack-blocks/tests/test-homepage-posts-block.php
@@ -230,6 +230,20 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 				'description'             => 'With custom post type and author',
 				'ignore_tax_query'        => true,
 			],
+			[
+				'block_attributes'        => [
+					'postsToShow' => 3,
+					'moreButton'  => true,
+				],
+				'resulting_query_partial' => [
+					'posts_per_page' => 3,
+					'post_status'    => [ 'publish' ],
+					'post_type'      => [ 'post' ],
+					'tax_query'      => [],
+					'no_found_rows'  => false,
+				],
+				'description'             => 'A More button needs the total to know whether there is a next page',
+			],
 		];
 
 		foreach ( $cases as $case ) {

--- a/plugins/newspack-blocks/tests/test-homepage-posts-block.php
+++ b/plugins/newspack-blocks/tests/test-homepage-posts-block.php
@@ -186,20 +186,6 @@ class HomepagePostsBlockTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	}
 
 	/**
-	 * The reset can be forced on or off through the filter.
-	 */
-	public function test_dedup_reset_is_filterable() {
-		add_filter( 'newspack_blocks_reset_deduplication_per_render_pass', '__return_true' );
-		$page   = $this->create_dedup_page();
-		$first  = $this->render_pass( $page );
-		$second = $this->render_pass( $page );
-		remove_filter( 'newspack_blocks_reset_deduplication_per_render_pass', '__return_true' );
-
-		self::assertCount( 2, $first );
-		self::assertSame( $first, $second, 'With the filter on, the front end resets per pass too.' );
-	}
-
-	/**
 	 * HPB query from attributes.
 	 */
 	public function test_hpb_build_articles_query() {

--- a/plugins/newspack-blocks/tests/wp-unittestcase-blocks.php
+++ b/plugins/newspack-blocks/tests/wp-unittestcase-blocks.php
@@ -105,15 +105,16 @@ class WP_UnitTestCase_Blocks extends WP_UnitTestCase { // phpcs:ignore
 	 */
 	protected function get_args_with_defaults( $args ) {
 		return array_merge(
-			$args,
 			[
 				'post_status'         => [ 'publish' ],
 				'suppress_filters'    => false,
 				'ignore_sticky_posts' => true,
 				'has_password'        => false,
 				'is_newspack_query'   => true,
+				'no_found_rows'       => true,
 				'post__not_in'        => [],
-			]
+			],
+			$args
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Saving or opening a page in the editor applies `the_content` to it more than once in the same request. WordPress renders `content.rendered`, renders it again after applying Block Hooks, and Yoast SEO renders it a third time on save to count links. Content Loop and Carousel blocks remember which posts they showed in a request-wide global that was never cleared, so each pass excluded everything the earlier passes showed. On a homepage with 28 blocks, one save fetched 185 posts to display 62, and the content handed back to the editor could not match the live page.

Two changes:

- **Deduplication restarts on every top-level `the_content` pass** outside front-end requests (admin, REST, cron, CLI). Each pass now returns the same posts, and the repeated queries are served by WP_Query's result cache. Nested passes, such as a Query Loop rendering Post Content, keep the state of the pass they belong to. Front-end rendering is unchanged, so a block theme with Content Loop blocks in the template above the post content keeps excluding those posts.
- **Article queries skip the `SQL_CALC_FOUND_ROWS` total unless the block shows a More button.** The total is only read to decide whether a next page exists. Profiled on the affected site, the count was 91 percent of each query's time. This is the `no_found_rows` change from NEWS-51.

Part of NPLAUNC-242.

### How to test the changes in this Pull Request:

1. Publish at least six posts. Create a page with three Content Loop blocks, each set to show one post, and publish it.
2. Open the page on the front end. The three blocks show three different posts.
3. Open the page in the editor and save it, with the browser's Network tab open. In the response to the `POST /wp-json/wp/v2/pages/<id>` request, `content.rendered` lists the same three posts as the front end.
4. Repeat step 3 on `release` without this branch. `content.rendered` lists three different posts, none of them shown on the front end.
5. With a block theme, add a Content Loop block to the front page template above the Post Content block. On the front end, the blocks inside the page do not repeat the template block's post.
6. Add a Content Loop block with the More button enabled and fewer posts per page than exist. The More button shows and loads the next page.
7. With Query Monitor active, view a page whose Content Loop blocks have no More button. Their `wp_posts` queries carry no `SQL_CALC_FOUND_ROWS`.
8. From `plugins/newspack-blocks`, run `n test-php --filter HomepagePostsBlockTest`. All tests pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally? Full newspack-blocks suite passes in an isolated env.

Targets `release` as a hotfix. Yoast's save-time render still runs; it is handled by turning off the text link counter in Yoast's site settings rather than in code. Not yet verified against the El Sol clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7GEKCoC1f2rvH5SHFeHA4

