### PR TITLE
fix(audience): fix layout and search in Subscriber Discounts

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php
@@ -392,8 +392,9 @@ class Audience_Subscriptions extends Wizard {
 			// `trash` is included because a trashed product can still have active
 			// subscribers, which makes it a real audience the rule must keep
 			// naming — an id that resolves to nothing renders as a bare number.
-			// Suggestions stay narrow, so this cannot offer a trashed product to
-			// pick.
+			// A trashed product stays undiscoverable regardless: `post__in` bounds
+			// the result to ids the caller already named, so this widens what a
+			// caller can resolve and never what it can find.
 			$args['post_status']    = [ 'publish', 'draft', 'pending', 'private', 'future', 'trash' ];
 			$args['post__in']       = $ids;
 			$args['posts_per_page'] = min( count( $ids ), 100 );

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php
@@ -389,7 +389,12 @@ class Audience_Subscriptions extends Wizard {
 			}
 			// Broader status filter when hydrating saved tokens, so the editor keeps
 			// showing products whose status changed since the rule was saved.
-			$args['post_status']    = [ 'publish', 'draft', 'pending', 'private', 'future' ];
+			// `trash` is included because a trashed product can still have active
+			// subscribers, which makes it a real audience the rule must keep
+			// naming — an id that resolves to nothing renders as a bare number.
+			// Suggestions stay narrow, so this cannot offer a trashed product to
+			// pick.
+			$args['post_status']    = [ 'publish', 'draft', 'pending', 'private', 'future', 'trash' ];
 			$args['post__in']       = $ids;
 			$args['posts_per_page'] = min( count( $ids ), 100 );
 			$args['orderby']        = 'post__in';

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/constants.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/constants.ts
@@ -13,3 +13,12 @@ export const SEARCH_ENDPOINTS = {
 	productCategories: 'product-categories-search',
 	subscriptions: 'subscriptions-search',
 } as const;
+
+/**
+ * How many names a list row shows before collapsing the rest into "+N more".
+ *
+ * A row is one line, so the names have to share it with the count that follows
+ * them. Both tabs cap at the same point; what each one counts in the remainder
+ * is its own business.
+ */
+export const MAX_NAMED_ITEMS = 2;

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/constants.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/constants.ts
@@ -15,15 +15,3 @@ export const DISCOUNT_SETTINGS_ENDPOINT = `${ DISCOUNTS_ENDPOINT }/settings`;
 
 /** How many products the editor previews before summarizing the rest. */
 export const PREVIEW_LIMIT = 8;
-
-/**
- * How many subscriptions the list's Subscription column names before summarizing
- * the rest.
- *
- * The cell is one line and has to keep the trailing count legible beside the
- * names, which is what bounds this rather than any particular column width.
- * Matches `MAX_NAMED_PRODUCTS` in the subscriber-only tab, so the two lists in
- * this wizard summarize at the same point. The editor's drawer has room to list
- * the whole audience and caps nothing.
- */
-export const SUBSCRIPTIONS_LABEL_LIMIT = 2;

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/constants.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/constants.ts
@@ -15,3 +15,15 @@ export const DISCOUNT_SETTINGS_ENDPOINT = `${ DISCOUNTS_ENDPOINT }/settings`;
 
 /** How many products the editor previews before summarizing the rest. */
 export const PREVIEW_LIMIT = 8;
+
+/**
+ * How many subscriptions the list's Subscription column names before summarizing
+ * the rest.
+ *
+ * The cell is one line and has to keep the trailing count legible beside the
+ * names, which is what bounds this rather than any particular column width.
+ * Matches `MAX_NAMED_PRODUCTS` in the subscriber-only tab, so the two lists in
+ * this wizard summarize at the same point. The editor's drawer has room to list
+ * the whole audience and caps nothing.
+ */
+export const SUBSCRIPTIONS_LABEL_LIMIT = 2;

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/discount.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/discount.test.js
@@ -5,7 +5,7 @@
 /**
  * Internal dependencies.
  */
-import { discountLabel, formatCurrency, isValidRule, subscriberPrice, subscriptionsLabel, targetingLabel } from './discount';
+import { discountLabel, formatCurrency, isValidRule, subscriberPrice, subscriptionsSummary, targetingLabel } from './discount';
 
 const GBP = {
 	code: 'GBP',
@@ -59,24 +59,46 @@ describe( 'discountLabel', () => {
 	} );
 } );
 
-describe( 'subscriptionsLabel', () => {
+describe( 'subscriptionsSummary', () => {
 	const options = [
 		{ id: 10, name: 'Digital Monthly' },
 		{ id: 11, name: 'Print &amp; Digital' },
 	];
 
 	it( 'names the subscriptions, decoded, in rule order', () => {
-		expect( subscriptionsLabel( [ 10 ], options ) ).toBe( 'Digital Monthly' );
-		expect( subscriptionsLabel( [ 11, 10 ], options ) ).toBe( 'Print & Digital, Digital Monthly' );
+		expect( subscriptionsSummary( [ 10 ], options ) ).toEqual( { named: 'Digital Monthly', more: '' } );
+		expect( subscriptionsSummary( [ 11, 10 ], options ) ).toEqual( { named: 'Print & Digital, Digital Monthly', more: '' } );
 	} );
 
 	it( 'falls back to a count when no name is known', () => {
-		expect( subscriptionsLabel( [ 99 ], options ) ).toBe( '1 subscription' );
-		expect( subscriptionsLabel( [ 98, 99 ], [] ) ).toBe( '2 subscriptions' );
+		expect( subscriptionsSummary( [ 99 ], options ) ).toEqual( { named: '1 subscription', more: '' } );
+		expect( subscriptionsSummary( [ 98, 99 ], [] ) ).toEqual( { named: '2 subscriptions', more: '' } );
 	} );
 
 	it( 'counts the ids it cannot name alongside the ones it can', () => {
-		expect( subscriptionsLabel( [ 10, 98, 99 ], options ) ).toBe( 'Digital Monthly + 2 more' );
+		expect( subscriptionsSummary( [ 10, 98, 99 ], options ) ).toEqual( { named: 'Digital Monthly', more: '+2 more' } );
+	} );
+
+	it( 'names at most two subscriptions, however many the rule covers', () => {
+		const many = Array.from( { length: 49 }, ( _, index ) => ( { id: index + 1, name: `Subscription ${ index + 1 }` } ) );
+		expect(
+			subscriptionsSummary(
+				many.map( option => option.id ),
+				many
+			)
+		).toEqual( { named: 'Subscription 1, Subscription 2', more: '+47 more' } );
+	} );
+
+	// The count is rendered in its own element, so it has to be one number
+	// covering both causes rather than the sum of two separate claims.
+	it( 'reports one count for the names it withheld and the ids it could not resolve, never two', () => {
+		const known = [
+			{ id: 1, name: 'Digital Monthly' },
+			{ id: 2, name: 'Digital Annual' },
+			{ id: 3, name: 'Print Weekend' },
+			{ id: 4, name: 'Print Daily' },
+		];
+		expect( subscriptionsSummary( [ 1, 2, 3, 4, 98, 99 ], known ) ).toEqual( { named: 'Digital Monthly, Digital Annual', more: '+4 more' } );
 	} );
 } );
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/discount.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/discount.ts
@@ -18,6 +18,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 /**
  * Internal dependencies.
  */
+import { SUBSCRIPTIONS_LABEL_LIMIT } from './constants';
 import type { DiscountCurrency, DiscountRule } from './types';
 
 export const DEFAULT_CURRENCY: DiscountCurrency = {
@@ -97,35 +98,60 @@ export function discountLabel( rule: Pick< DiscountRule, 'discount_type' | 'amou
 }
 
 /**
- * The rule's audience, as shown in the list's Subscription column.
+ * The rule's subscription names, in rule order.
  *
- * Names the subscriptions where the options list can resolve them; ids it
- * cannot resolve (a deleted product, or a site with more subscriptions than
- * one options page) fall back to a count so the cell never goes blank.
+ * Ids the options list cannot resolve (a deleted product, or a site with more
+ * subscriptions than one options page) are skipped, so the result is shorter
+ * than `ids` whenever the tab could not name everything a rule covers.
  *
  * @param ids     The rule's subscription product ids.
  * @param options Known subscription products.
  */
-export function subscriptionsLabel( ids: number[], options: { id: number; name: string }[] ): string {
-	const names = ids.map( id => options.find( option => option.id === id )?.name ).filter( ( name ): name is string => !! name );
+export function subscriptionNames( ids: number[], options: { id: number; name: string }[] ): string[] {
+	return ids
+		.map( id => options.find( option => option.id === id )?.name )
+		.filter( ( name ): name is string => !! name )
+		.map( decodeEntities );
+}
+
+/**
+ * The rule's audience, split for the list's Subscription column.
+ *
+ * A rule can cover dozens of subscriptions, so the cell names a couple and
+ * counts the rest. The parts are separate because the cell is one line: the
+ * names truncate and the count must not.
+ *
+ * `more` counts everything the cell does not name, whether it was capped away
+ * or could not be resolved, so the two are never separate numbers. Where
+ * nothing resolves, `named` carries the count rather than going blank.
+ *
+ * @param ids     The rule's subscription product ids.
+ * @param options Known subscription products.
+ */
+export function subscriptionsSummary( ids: number[], options: { id: number; name: string }[] ): { named: string; more: string } {
+	const names = subscriptionNames( ids, options );
 	if ( ! names.length ) {
-		return sprintf(
-			/* translators: %d: number of subscriptions whose subscribers get the discount. */
-			_n( '%d subscription', '%d subscriptions', ids.length, 'newspack-plugin' ),
-			ids.length
-		);
+		return {
+			named: sprintf(
+				/* translators: %d: number of subscriptions whose subscribers get the discount. */
+				_n( '%d subscription', '%d subscriptions', ids.length, 'newspack-plugin' ),
+				ids.length
+			),
+			more: '',
+		};
 	}
-	const listed = names.map( decodeEntities ).join( ', ' );
-	const unresolved = ids.length - names.length;
-	if ( unresolved > 0 ) {
-		return sprintf(
-			/* translators: %1$s: subscription names, %2$d: number of further subscriptions the rule also covers. */
-			_n( '%1$s + %2$d more', '%1$s + %2$d more', unresolved, 'newspack-plugin' ),
-			listed,
-			unresolved
-		);
-	}
-	return listed;
+	const shown = names.slice( 0, SUBSCRIPTIONS_LABEL_LIMIT );
+	const remaining = ids.length - shown.length;
+	return {
+		named: shown.join( ', ' ),
+		more: remaining
+			? sprintf(
+					/* translators: %d: number of further subscriptions the rule covers beyond the ones named beside this. */
+					_n( '+%d more', '+%d more', remaining, 'newspack-plugin' ),
+					remaining
+			  )
+			: '',
+	};
 }
 
 type TargetingFieldsOnly = Pick< DiscountRule, 'targeting' | 'product_ids' | 'category_ids' | 'excluded_product_ids' >;

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/discount.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/discount.ts
@@ -18,7 +18,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 /**
  * Internal dependencies.
  */
-import { SUBSCRIPTIONS_LABEL_LIMIT } from './constants';
+import { MAX_NAMED_ITEMS } from '../../constants';
 import type { DiscountCurrency, DiscountRule } from './types';
 
 export const DEFAULT_CURRENCY: DiscountCurrency = {
@@ -140,7 +140,7 @@ export function subscriptionsSummary( ids: number[], options: { id: number; name
 			more: '',
 		};
 	}
-	const shown = names.slice( 0, SUBSCRIPTIONS_LABEL_LIMIT );
+	const shown = names.slice( 0, MAX_NAMED_ITEMS );
 	const remaining = ids.length - shown.length;
 	return {
 		named: shown.join( ', ' ),

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/fields.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/fields.test.js
@@ -1,0 +1,73 @@
+/**
+ * Tests what the Subscriber discounts list searches and filters on.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies.
+ */
+import { DEFAULT_CURRENCY } from './discount';
+import { discountFields } from './fields';
+
+// Only the fields' values are under test here, never their rendering, so the
+// component library is stubbed rather than pulled in whole.
+jest.mock( '../../../../../../../packages/components/src', () => ( {
+	StatusIndicator: ( { children } ) => children,
+} ) );
+
+const SUBSCRIPTIONS = [
+	{ id: 10, name: 'Digital Monthly' },
+	{ id: 11, name: 'Print Weekend' },
+	// Two products, one name: a catalogue migrated from another plugin routinely
+	// has these, and they must not collapse into one filter option.
+	{ id: 12, name: 'Founding Member' },
+	{ id: 13, name: 'Founding Member' },
+];
+
+const rule = ( id, subscriptionIds ) => ( {
+	id,
+	subscription_product_ids: subscriptionIds,
+	targeting: 'all',
+	product_ids: [],
+	category_ids: [],
+	excluded_product_ids: [],
+	discount_type: 'percent',
+	amount: 20,
+	active: true,
+	created_at: '2026-01-01',
+} );
+
+const RULES = [ rule( 'a', [ 10 ] ), rule( 'b', [ 11 ] ), rule( 'c', [ 12 ] ), rule( 'd', [ 13 ] ) ];
+
+const fields = discountFields( DEFAULT_CURRENCY, SUBSCRIPTIONS );
+const view = { type: 'table', page: 1, perPage: 25, sort: { field: 'created_at', direction: 'desc' }, search: '', filters: [], fields: [] };
+const idsFor = partialView => filterSortAndPaginate( RULES, { ...view, ...partialView }, fields ).data.map( item => item.id );
+
+describe( 'discountFields', () => {
+	// Search matched nothing at all until a field opted in, and an empty result
+	// looks the same as no matches, so nothing surfaced the failure.
+	it( 'matches a search against subscription names', () => {
+		expect( idsFor( { search: 'Digital' } ) ).toEqual( [ 'a' ] );
+		expect( idsFor( { search: 'Founding' } ) ).toEqual( [ 'c', 'd' ] );
+		expect( idsFor( { search: 'nothing here' } ) ).toEqual( [] );
+	} );
+
+	it( 'matches a search against the other columns a publisher can read', () => {
+		expect( idsFor( { search: '20%' } ) ).toHaveLength( RULES.length );
+		expect( idsFor( { search: 'All products' } ) ).toHaveLength( RULES.length );
+	} );
+
+	// Search and filter have to stay on separate fields. Moving the search onto
+	// the Subscription field would key its filter on names, merging the two
+	// Founding Member products into one option that matches both rules — and the
+	// field carrying the search only stays invisible because it opts out of
+	// hiding, which is what keeps it from becoming a column.
+	it( 'keeps subscriptions sharing a name apart in the filter', () => {
+		expect( idsFor( { filters: [ { field: 'subscription', operator: 'isAny', value: [ 12 ] } ] } ) ).toEqual( [ 'c' ] );
+		expect( fields.find( field => field.id === 'subscription_names' ).enableHiding ).toBe( false );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/fields.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/fields.tsx
@@ -1,0 +1,121 @@
+/**
+ * The Subscriber discounts list's DataViews field definitions.
+ *
+ * Separate from the tab so the list's search and filter behaviour can be
+ * exercised without mounting the wizard.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
+import { decodeEntities } from '@wordpress/html-entities';
+import type { Field } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies.
+ */
+import { StatusIndicator } from '../../../../../../../packages/components/src';
+import { discountLabel, excludedLabel, subscriptionNames, subscriptionsSummary, targetingBaseLabel, targetingLabel } from './discount';
+import type { DiscountCurrency, DiscountRule } from './types';
+
+type Subscription = { id: number; name: string };
+
+/**
+ * The list's columns, its filters and what its search matches.
+ *
+ * @param currency      The store's currency, for the discount amounts.
+ * @param subscriptions Every subscription the list can name, which includes the
+ *                      ones a rule covers but the picker would not offer, such
+ *                      as trashed ones. The filter narrows rules already on
+ *                      screen, so it offers that same set.
+ */
+export function discountFields( currency: DiscountCurrency, subscriptions: Subscription[] ): Field< DiscountRule >[] {
+	return [
+		{
+			id: 'subscription',
+			label: __( 'Subscription', 'newspack-plugin' ),
+			enableHiding: false,
+			elements: subscriptions.map( option => ( { value: option.id, label: decodeEntities( option.name ) } ) ),
+			filterBy: { operators: [ 'isAny' ] },
+			// Ids rather than names, so two subscriptions sharing a name stay
+			// separate options in the filter.
+			getValue: ( { item } ) => item.subscription_product_ids,
+			render: ( { item } ) => {
+				const { named, more } = subscriptionsSummary( item.subscription_product_ids, subscriptions );
+				return (
+					<span className="newspack-subscriber-discounts__subscriptions">
+						{ /* The clipped names stay in the DOM, so a screen reader reads the
+						     whole string and `title` shows it on hover. Neither reaches the
+						     subscriptions the count stands for — the editor drawer lists those. */ }
+						<span className="newspack-subscriber-discounts__subscriptions-named" title={ named }>
+							{ named }
+						</span>
+						{ more && <span className="newspack-subscriber-discounts__subscriptions-more">{ more }</span> }
+					</span>
+				);
+			},
+		},
+		{
+			id: 'subscription_names',
+			// Not user-visible on this version of DataViews — the field is absent
+			// from the view's fields and `enableHiding: false` keeps it out of the
+			// column-toggle menu — but that guarantee lives in the library, so the
+			// label stays translated.
+			label: __( 'Subscription names', 'newspack-plugin' ),
+			// DataViews matches a search only against fields that opt in, and the
+			// Subscription field cannot be the one to opt in because its value has
+			// to stay ids for the filter.
+			enableHiding: false,
+			enableSorting: false,
+			enableGlobalSearch: true,
+			getValue: ( { item } ) => subscriptionNames( item.subscription_product_ids, subscriptions ).join( ' ' ),
+		},
+		{
+			id: 'status',
+			label: __( 'Status', 'newspack-plugin' ),
+			elements: [
+				{ value: 'active', label: __( 'Active', 'newspack-plugin' ) },
+				{ value: 'inactive', label: __( 'Inactive', 'newspack-plugin' ) },
+			],
+			filterBy: { operators: [ 'isAny' ] },
+			getValue: ( { item } ) => ( item.active ? 'active' : 'inactive' ),
+			render: ( { item } ) => (
+				<StatusIndicator status={ item.active ? 'active' : 'draft' }>
+					{ item.active ? __( 'Active', 'newspack-plugin' ) : __( 'Inactive', 'newspack-plugin' ) }
+				</StatusIndicator>
+			),
+		},
+		{
+			id: 'discount',
+			label: __( 'Discount', 'newspack-plugin' ),
+			enableGlobalSearch: true,
+			getValue: ( { item } ) => discountLabel( item, currency ),
+		},
+		{
+			id: 'applies_to',
+			label: __( 'Applies to', 'newspack-plugin' ),
+			enableGlobalSearch: true,
+			getValue: ( { item } ) => targetingLabel( item ),
+			render: ( { item } ) => {
+				const excluded = excludedLabel( item );
+				if ( ! excluded ) {
+					return targetingBaseLabel( item );
+				}
+				return (
+					<span className="newspack-subscriber-discounts__applies-to">
+						{ targetingBaseLabel( item ) }
+						<span className="newspack-subscriber-discounts__applies-to-excluded">{ excluded }</span>
+					</span>
+				);
+			},
+		},
+		{
+			id: 'created_at',
+			label: __( 'Created', 'newspack-plugin' ),
+			getValue: ( { item } ) => item.created_at,
+			render: ( { item } ) => ( item.created_at ? dateI18n( getDateSettings().formats.date, item.created_at ) : '' ),
+		},
+	];
+}

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/index.tsx
@@ -10,11 +10,10 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
-import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { decodeEntities } from '@wordpress/html-entities';
 import { addQueryArgs } from '@wordpress/url';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
-import type { Action, Field, View } from '@wordpress/dataviews';
+import type { Action, View } from '@wordpress/dataviews';
 import { percent } from '@wordpress/icons';
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 import { __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components';
@@ -22,21 +21,15 @@ import { __experimentalHStack as HStack, __experimentalVStack as VStack } from '
 /**
  * Internal dependencies.
  */
-import { Button, DataViews, Grid, Notice, SectionHeader, StatusIndicator, Waiting } from '../../../../../../../packages/components/src';
+import { Button, DataViews, Grid, Notice, SectionHeader, Waiting } from '../../../../../../../packages/components/src';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../../../packages/components/src/wizard/store';
 import Router from '../../../../../../../packages/components/src/proxied-imports/router';
 import { SEARCH_ENDPOINTS, WIZARD_ENDPOINT } from '../../constants';
+import { useNames } from '../../use-names';
 import { registerTab } from '../registry';
 import { DISCOUNTS_ENDPOINT } from './constants';
-import {
-	DEFAULT_CURRENCY,
-	discountLabel,
-	excludedLabel,
-	subscriptionNames,
-	subscriptionsSummary,
-	targetingBaseLabel,
-	targetingLabel,
-} from './discount';
+import { DEFAULT_CURRENCY } from './discount';
+import { discountFields } from './fields';
 import DiscountEditor from './editor';
 import SettingsModal from './settings-modal';
 import type { DiscountRule, DiscountsPayload } from './types';
@@ -94,7 +87,9 @@ function SubscriberDiscounts() {
 		apiFetch< { id: number; name: string }[] >( {
 			path: addQueryArgs( `${ WIZARD_ENDPOINT }/${ SEARCH_ENDPOINTS.subscriptions }`, { per_page: 100 } ),
 		} )
-			.then( items => setSubscriptionOptions( items || [] ) )
+			// Decoded once here, so every name in the merged list below is in the
+			// same encoding.
+			.then( items => setSubscriptionOptions( ( items || [] ).map( item => ( { ...item, name: decodeEntities( item.name ) } ) ) ) )
 			.catch( () => setSubscriptionOptions( [] ) );
 	}, [] );
 
@@ -145,88 +140,23 @@ function SubscriberDiscounts() {
 		}
 	}, [ isLoading, editingId, editingRule, history, baseUrl ] );
 
-	const fields: Field< DiscountRule >[] = useMemo(
-		() => [
-			{
-				id: 'subscription',
-				label: __( 'Subscription', 'newspack-plugin' ),
-				enableHiding: false,
-				elements: subscriptionOptions.map( option => ( { value: option.id, label: decodeEntities( option.name ) } ) ),
-				filterBy: { operators: [ 'isAny' ] },
-				getValue: ( { item } ) => item.subscription_product_ids,
-				render: ( { item } ) => {
-					const { named, more } = subscriptionsSummary( item.subscription_product_ids, subscriptionOptions );
-					return (
-						<span className="newspack-subscriber-discounts__subscriptions">
-							{ /* `title` recovers what the ellipsis clipped; the withheld subscriptions are in the editor drawer. */ }
-							<span className="newspack-subscriber-discounts__subscriptions-named" title={ named }>
-								{ named }
-							</span>
-							{ more && <span className="newspack-subscriber-discounts__subscriptions-more">{ more }</span> }
-						</span>
-					);
-				},
-			},
-			{
-				id: 'subscription_names',
-				label: __( 'Subscription names', 'newspack-plugin' ),
-				// Never rendered: it is absent from the view's fields, and
-				// `enableHiding: false` keeps it out of the column-toggle menu too.
-				// It exists because DataViews matches a search only against fields
-				// that opt in, and the Subscription field cannot be the one to opt
-				// in — its value has to stay ids so that two subscriptions sharing
-				// a name stay separate options in its filter.
-				enableHiding: false,
-				enableSorting: false,
-				enableGlobalSearch: true,
-				getValue: ( { item } ) => subscriptionNames( item.subscription_product_ids, subscriptionOptions ).join( ' ' ),
-			},
-			{
-				id: 'status',
-				label: __( 'Status', 'newspack-plugin' ),
-				elements: [
-					{ value: 'active', label: __( 'Active', 'newspack-plugin' ) },
-					{ value: 'inactive', label: __( 'Inactive', 'newspack-plugin' ) },
-				],
-				filterBy: { operators: [ 'isAny' ] },
-				getValue: ( { item } ) => ( item.active ? 'active' : 'inactive' ),
-				render: ( { item } ) => (
-					<StatusIndicator status={ item.active ? 'active' : 'draft' }>
-						{ item.active ? __( 'Active', 'newspack-plugin' ) : __( 'Inactive', 'newspack-plugin' ) }
-					</StatusIndicator>
-				),
-			},
-			{
-				id: 'discount',
-				label: __( 'Discount', 'newspack-plugin' ),
-				getValue: ( { item } ) => discountLabel( item, currency ),
-			},
-			{
-				id: 'applies_to',
-				label: __( 'Applies to', 'newspack-plugin' ),
-				getValue: ( { item } ) => targetingLabel( item ),
-				render: ( { item } ) => {
-					const excluded = excludedLabel( item );
-					if ( ! excluded ) {
-						return targetingBaseLabel( item );
-					}
-					return (
-						<span className="newspack-subscriber-discounts__applies-to">
-							{ targetingBaseLabel( item ) }
-							<span className="newspack-subscriber-discounts__applies-to-excluded">{ excluded }</span>
-						</span>
-					);
-				},
-			},
-			{
-				id: 'created_at',
-				label: __( 'Created', 'newspack-plugin' ),
-				getValue: ( { item } ) => item.created_at,
-				render: ( { item } ) => ( item.created_at ? dateI18n( getDateSettings().formats.date, item.created_at ) : '' ),
-			},
-		],
-		[ currency, subscriptionOptions ]
+	// The picker's one page of suggestions names most subscriptions, but not a
+	// trashed one and not the overflow on a store with more than a page of
+	// them. Resolving the ids the rules actually hold covers both, and is what
+	// keeps a row from counting a subscription it could have named.
+	const ruleSubscriptionIds = useMemo(
+		() => [ ...new Set( payload.rules.flatMap( rule => rule.subscription_product_ids || [] ) ) ],
+		[ payload.rules ]
 	);
+	const resolvedNames = useNames( SEARCH_ENDPOINTS.subscriptions, ruleSubscriptionIds );
+
+	const namedSubscriptions = useMemo( () => {
+		const byId = new Map< number, string >( subscriptionOptions.map( option => [ option.id, option.name ] ) );
+		Object.entries( resolvedNames ).forEach( ( [ id, name ] ) => byId.set( Number( id ), name ) );
+		return [ ...byId ].map( ( [ id, name ] ) => ( { id, name } ) );
+	}, [ subscriptionOptions, resolvedNames ] );
+
+	const fields = useMemo( () => discountFields( currency, namedSubscriptions ), [ currency, namedSubscriptions ] );
 
 	const actions: Action< DiscountRule >[] = useMemo(
 		() => [

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/index.tsx
@@ -151,13 +151,9 @@ function SubscriberDiscounts() {
 				id: 'subscription',
 				label: __( 'Subscription', 'newspack-plugin' ),
 				enableHiding: false,
-				elements: subscriptionOptions.map( option => ( { value: decodeEntities( option.name ), label: decodeEntities( option.name ) } ) ),
+				elements: subscriptionOptions.map( option => ( { value: option.id, label: decodeEntities( option.name ) } ) ),
 				filterBy: { operators: [ 'isAny' ] },
-				// Search matches nothing at all unless some field opts in, and this
-				// is the only column whose text a publisher would search for. It
-				// doubles as the filter's value, so both read names rather than ids.
-				enableGlobalSearch: true,
-				getValue: ( { item } ) => subscriptionNames( item.subscription_product_ids, subscriptionOptions ),
+				getValue: ( { item } ) => item.subscription_product_ids,
 				render: ( { item } ) => {
 					const { named, more } = subscriptionsSummary( item.subscription_product_ids, subscriptionOptions );
 					return (
@@ -170,6 +166,20 @@ function SubscriberDiscounts() {
 						</span>
 					);
 				},
+			},
+			{
+				id: 'subscription_names',
+				label: __( 'Subscription names', 'newspack-plugin' ),
+				// Never rendered: it is absent from the view's fields, and
+				// `enableHiding: false` keeps it out of the column-toggle menu too.
+				// It exists because DataViews matches a search only against fields
+				// that opt in, and the Subscription field cannot be the one to opt
+				// in — its value has to stay ids so that two subscriptions sharing
+				// a name stay separate options in its filter.
+				enableHiding: false,
+				enableSorting: false,
+				enableGlobalSearch: true,
+				getValue: ( { item } ) => subscriptionNames( item.subscription_product_ids, subscriptionOptions ).join( ' ' ),
 			},
 			{
 				id: 'status',

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/index.tsx
@@ -28,7 +28,15 @@ import Router from '../../../../../../../packages/components/src/proxied-imports
 import { SEARCH_ENDPOINTS, WIZARD_ENDPOINT } from '../../constants';
 import { registerTab } from '../registry';
 import { DISCOUNTS_ENDPOINT } from './constants';
-import { DEFAULT_CURRENCY, discountLabel, excludedLabel, subscriptionsLabel, targetingBaseLabel, targetingLabel } from './discount';
+import {
+	DEFAULT_CURRENCY,
+	discountLabel,
+	excludedLabel,
+	subscriptionNames,
+	subscriptionsSummary,
+	targetingBaseLabel,
+	targetingLabel,
+} from './discount';
 import DiscountEditor from './editor';
 import SettingsModal from './settings-modal';
 import type { DiscountRule, DiscountsPayload } from './types';
@@ -143,10 +151,25 @@ function SubscriberDiscounts() {
 				id: 'subscription',
 				label: __( 'Subscription', 'newspack-plugin' ),
 				enableHiding: false,
-				elements: subscriptionOptions.map( option => ( { value: option.id, label: decodeEntities( option.name ) } ) ),
+				elements: subscriptionOptions.map( option => ( { value: decodeEntities( option.name ), label: decodeEntities( option.name ) } ) ),
 				filterBy: { operators: [ 'isAny' ] },
-				getValue: ( { item } ) => item.subscription_product_ids,
-				render: ( { item } ) => subscriptionsLabel( item.subscription_product_ids, subscriptionOptions ),
+				// Search matches nothing at all unless some field opts in, and this
+				// is the only column whose text a publisher would search for. It
+				// doubles as the filter's value, so both read names rather than ids.
+				enableGlobalSearch: true,
+				getValue: ( { item } ) => subscriptionNames( item.subscription_product_ids, subscriptionOptions ),
+				render: ( { item } ) => {
+					const { named, more } = subscriptionsSummary( item.subscription_product_ids, subscriptionOptions );
+					return (
+						<span className="newspack-subscriber-discounts__subscriptions">
+							{ /* `title` recovers what the ellipsis clipped; the withheld subscriptions are in the editor drawer. */ }
+							<span className="newspack-subscriber-discounts__subscriptions-named" title={ named }>
+								{ named }
+							</span>
+							{ more && <span className="newspack-subscriber-discounts__subscriptions-more">{ more }</span> }
+						</span>
+					);
+				},
 			},
 			{
 				id: 'status',

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/style.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/style.scss
@@ -36,6 +36,27 @@
 		font-weight: normal;
 	}
 
+	&__subscriptions {
+		align-items: baseline;
+		display: flex;
+		gap: wp-vars.$grid-unit-05;
+		min-width: 0;
+	}
+
+	// Only the names give way. The count says how much the cell left out, so it
+	// keeps its width and the names ellipsize into whatever is left.
+	&__subscriptions-named {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&__subscriptions-more {
+		color: wp-colors.$gray-700;
+		flex-shrink: 0;
+	}
+
 	&__preview {
 		border-collapse: collapse;
 		width: 100%;
@@ -62,6 +83,16 @@
 		del {
 			margin-right: 4px;
 		}
+	}
+
+	// An auto-layout table sizes a cell to its content, so without this a rule
+	// naming a long subscription widens this column until the columns after it are
+	// pushed off-screen. `max-width: 0` leaves the column its natural share of the
+	// table rather than collapsing it. The title cell carries no class of its own,
+	// so `:has()` is the only hook DataViews 10.3 offers; the view's own
+	// `layout.styles` widths emit no `col` sizing at all in this version.
+	.dataviews-view-table td:has(.dataviews-title-field) {
+		max-width: 0;
 	}
 
 	.dataviews-title-field--clickable:focus:not(:focus-visible) {

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/style.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/style.scss
@@ -43,8 +43,6 @@
 		min-width: 0;
 	}
 
-	// Only the names give way. The count says how much the cell left out, so it
-	// keeps its width and the names ellipsize into whatever is left.
 	&__subscriptions-named {
 		min-width: 0;
 		overflow: hidden;
@@ -85,14 +83,17 @@
 		}
 	}
 
-	// An auto-layout table sizes a cell to its content, so without this a rule
-	// naming a long subscription widens this column until the columns after it are
-	// pushed off-screen. `max-width: 0` leaves the column its natural share of the
-	// table rather than collapsing it. The title cell carries no class of its own,
-	// so `:has()` is the only hook DataViews 10.3 offers; the view's own
-	// `layout.styles` widths emit no `col` sizing at all in this version.
-	.dataviews-view-table td:has(.dataviews-title-field) {
-		max-width: 0;
+	// An auto-layout table sizes a cell to its content, so a rule naming two long
+	// subscriptions widens this column until the ones after it are pushed
+	// off-screen. DataViews caps this wrapper itself, but at 80ch — wide enough
+	// to still overflow the table — so the cap is tightened here rather than
+	// introduced. It has to be done in CSS: `layout.styles` widths reach every
+	// other column, but the primary column is rendered by a branch that does not
+	// read them, and Subscription is the `titleField` for this view.
+	// The `:not()` repeats the one DataViews uses, so this wins on specificity
+	// rather than on which stylesheet a bundler happens to emit last.
+	.dataviews-view-table__primary-column-content:not(.dataviews-column-primary__media) {
+		max-width: 40ch;
 	}
 
 	.dataviews-title-field--clickable:focus:not(:focus-visible) {

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/index.tsx
@@ -24,7 +24,7 @@ import WizardSection from '../../../../../wizards-section';
 import { registerTab } from '../registry';
 import { SEARCH_ENDPOINTS } from '../../constants';
 import { useRestrictions } from './use-restrictions';
-import { useNames } from './use-names';
+import { useNames } from '../../use-names';
 import { excludedLabel, leadingProductNames, moreProductsLabel, scopeLabel } from './labels';
 import RestrictionEditor from './restriction-editor';
 import type { Restriction, RestrictionSettings } from './types';

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/labels.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/labels.tsx
@@ -14,10 +14,8 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies.
  */
+import { MAX_NAMED_ITEMS } from '../../constants';
 import type { Restriction } from './types';
-
-/** How many product names a row shows before collapsing the rest into "+N more". */
-export const MAX_NAMED_PRODUCTS = 2;
 
 /**
  * The names a row leads with, and how many are left over.
@@ -28,8 +26,8 @@ export const MAX_NAMED_PRODUCTS = 2;
 export function leadingProductNames( restriction: Restriction, nameOf: ( id: number ) => string | undefined ) {
 	const names = ( restriction.product_ids || [] ).map( nameOf ).filter( Boolean ) as string[];
 	return {
-		shown: names.slice( 0, MAX_NAMED_PRODUCTS ),
-		remaining: Math.max( 0, names.length - MAX_NAMED_PRODUCTS ),
+		shown: names.slice( 0, MAX_NAMED_ITEMS ),
+		remaining: Math.max( 0, names.length - MAX_NAMED_ITEMS ),
 	};
 }
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/use-names.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/use-names.ts
@@ -1,6 +1,6 @@
 /**
  * Resolves product, product category and subscription IDs to names for the
- * restriction list, which stores only IDs.
+ * wizard's lists, which store only IDs.
  */
 
 /**
@@ -14,7 +14,7 @@ import { addQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies.
  */
-import { WIZARD_ENDPOINT } from '../../constants';
+import { WIZARD_ENDPOINT } from './constants';
 
 type NameMap = Record< number, string >;
 

--- a/plugins/newspack-plugin/tests/unit-tests/wizards/subscriptions-search-api.php
+++ b/plugins/newspack-plugin/tests/unit-tests/wizards/subscriptions-search-api.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Tests the Subscriptions wizard's product search endpoints.
+ *
+ * @package Newspack\Tests\Wizards
+ */
+
+namespace Newspack\Tests\Wizards;
+
+/**
+ * The search endpoints serve two callers with one query: a picker offering
+ * products to choose, and a hydrator naming ids a saved rule already holds.
+ * The statuses they may see differ, and conflating them either hides a rule's
+ * own audience or offers a product nobody should newly pick.
+ *
+ * @group wizards
+ * @group Audience_Subscriptions_Search
+ */
+class Test_Subscriptions_Search_API extends \WP_UnitTestCase {
+
+	const ROUTE = '/newspack/v1/wizard/newspack-audience-subscriptions/subscriptions-search';
+
+	/**
+	 * Enable the content gates flag and load the WooCommerce mocks, which the
+	 * routes' availability check reads.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+		require_once dirname( __DIR__, 2 ) . '/mocks/wc-mocks.php';
+	}
+
+	/**
+	 * Build a REST server and register the wizard's routes on it directly.
+	 * `Wizards::init()` only constructs this wizard where Memberships or the
+	 * subscriber-commerce admin is available, neither of which holds here, so
+	 * `rest_api_init` alone would leave the routes unregistered.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $wp_rest_server;
+		$wp_rest_server = new \WP_REST_Server(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		do_action( 'rest_api_init', $wp_rest_server );
+		register_post_type( 'product', [ 'public' => true ] );
+		register_post_type( 'product_variation', [ 'public' => true ] );
+		register_taxonomy( 'product_type', 'product' );
+		( new \Newspack\Audience_Subscriptions() )->register_api_endpoints();
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+	}
+
+	/**
+	 * Reset the server.
+	 */
+	public function tear_down() {
+		global $wp_rest_server;
+		$wp_rest_server = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a subscription product post.
+	 *
+	 * @param string $name   Product name.
+	 * @param string $status Post status.
+	 *
+	 * @return int
+	 */
+	private function create_subscription_product( $name, $status = 'publish' ) {
+		$product_id = $this->factory->post->create(
+			[
+				'post_type'   => 'product',
+				'post_title'  => $name,
+				'post_status' => $status,
+			]
+		);
+		wp_set_object_terms( $product_id, 'subscription', 'product_type' );
+		// The endpoint reads each hit back through `wc_get_product()`, which the
+		// mocks answer from their own store rather than from the post.
+		\wc_create_mock_product(
+			[
+				'id'     => $product_id,
+				'type'   => 'subscription',
+				'name'   => $name,
+				'status' => $status,
+			]
+		);
+		return $product_id;
+	}
+
+	/**
+	 * Dispatch the endpoint and return its data.
+	 *
+	 * @param array $params Request parameters.
+	 *
+	 * @return array
+	 */
+	private function search( $params ) {
+		$request = new \WP_REST_Request( 'GET', self::ROUTE );
+		$request->set_param( 'per_page', 100 );
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+		return (array) rest_get_server()->dispatch( $request )->get_data();
+	}
+
+	/**
+	 * A trashed product with live subscribers is still a rule's audience, so
+	 * hydrating a saved id has to name it. Left unresolved, the editor renders
+	 * the bare id and the publisher cannot tell what the rule covers.
+	 */
+	public function test_include_names_a_trashed_product() {
+		$trashed_id = $this->create_subscription_product( 'Retired Annual Plan', 'trash' );
+
+		$names = wp_list_pluck( $this->search( [ 'include' => (string) $trashed_id ] ), 'name', 'id' );
+
+		$this->assertSame( 'Retired Annual Plan', $names[ $trashed_id ] ?? null );
+	}
+
+	/**
+	 * The picker is the other caller of the same query, and it must not offer a
+	 * trashed product — nobody should be able to newly select one.
+	 */
+	public function test_suggestions_exclude_trashed_products() {
+		$this->create_subscription_product( 'Retired Annual Plan', 'trash' );
+		$live_id = $this->create_subscription_product( 'Current Annual Plan' );
+
+		$ids = wp_list_pluck( $this->search( [ 'search' => 'Annual Plan' ] ), 'id' );
+
+		$this->assertSame( [ $live_id ], $ids );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Subscriber Discounts list named every subscription a rule covered, uncapped. A rule covering 49 produced a ~1,400-character line that ran through Status and Discount and pushed Created off-screen. A rule covering dozens is ordinary.

The cell now names two and counts the rest, in one count covering both what it capped away and what it could not resolve. The count sits beside the names, so truncation eats names and never the count. An auto-layout table sizes a cell to its content, so the cell is width-capped in CSS too.

Three related fixes on the same screen:

- Search returned nothing for any query: DataViews matches only fields that opt in, and none did. It now covers subscription names, Discount and Applies to.
- Rows named subscriptions from the product picker, which stops after one page and omits trashed products. They now resolve the ids each rule holds.
- A saved token for a trashed product rendered as a bare id. Suggestions are unchanged, so one still cannot be newly selected.

### How to test the changes in this Pull Request:

1. Enable WooCommerce and WooCommerce Subscriptions.
2. Create about 50 subscription products. Give them long, multi-word names.
3. Go to Audience > Subscriptions > Subscriber Discounts.
4. Add a discount. Select every subscription as its audience.
5. Set the browser width to 1280px.
6. Confirm the Subscription cell shows two names, an ellipsis, and a "+N more" count.
7. Confirm Status, Discount, Applies to and Created are all readable.
8. Type part of a subscription name into the search box.
9. Confirm the list shows the rules covering that subscription.
10. Search for a discount amount, such as "20%".
11. Confirm the list shows the rules with that amount.
12. Open the discount for editing.
13. Confirm the drawer still lists every subscription as its own token.
14. Create two subscription products with the same name.
15. Add a discount for each one.
16. Filter the list by that subscription name.
17. Confirm the filter offers two separate options, one per product.
18. Select one option. Confirm only its own discount is listed.
19. Trash a subscription product that a discount covers.
20. Confirm that discount's row still names the trashed subscription.
21. Confirm the Subscription filter still offers it.
22. Open that discount for editing.
23. Confirm the trashed subscription's token shows its name, not a bare number.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

#### Before, at 1280px

![Subscription column overflowing across the Status, Discount and Created columns](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/02/pxr73br3-step-1-before-1280-overflow.png)

#### After, at 1280px

![Subscription column truncated with a visible plus-N-more count and all columns readable](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/02/uupx2n5x-step-3-after-1280-three-rules.png)

The first row covers 49 subscriptions, the second 4, the third 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFZJMEKZAWiqtAWZo4rxpG
