### PR TITLE
fix(memberships): keep content restriction on archive feeds

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php
+++ b/plugins/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php
@@ -753,15 +753,23 @@ class Memberships {
 	/**
 	 * Remove content restriction on the front page and archives, to increase performance.
 	 * The only thing Memberships would really do on these pages is add a "You need a membership"-type message in excerpts.
+	 *
+	 * A feed is the exception: an archive requested as a feed is still an archive,
+	 * but its items carry whole post bodies, so the two callbacks that blank a
+	 * restricted body stay registered there. The taxonomy term notice goes either
+	 * way — it echoes markup a feed would emit between the channel head and the
+	 * first item.
 	 */
 	public static function remove_unnecessary_content_restriction() {
 		if ( ( is_front_page() || is_archive() ) && function_exists( 'wc_memberships' ) ) {
 			$memberships = wc_memberships();
 			$restrictions_instance = $memberships->get_restrictions_instance();
 			$posts_restrictions_instance = $restrictions_instance->get_posts_restrictions_instance();
-			remove_action( 'the_post', [ $posts_restrictions_instance, 'restrict_post' ], 0 );
-			remove_filter( 'the_content', [ $posts_restrictions_instance, 'handle_restricted_post_content_filtering' ], 999 );
 			remove_action( 'loop_start', [ $posts_restrictions_instance, 'display_restricted_taxonomy_term_notice' ], 1 );
+			if ( ! is_feed() ) {
+				remove_action( 'the_post', [ $posts_restrictions_instance, 'restrict_post' ], 0 );
+				remove_filter( 'the_content', [ $posts_restrictions_instance, 'handle_restricted_post_content_filtering' ], 999 );
+			}
 		}
 	}
 

--- a/plugins/newspack-plugin/tests/mocks/wc-memberships-restrictions-mock.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-memberships-restrictions-mock.php
@@ -1,0 +1,88 @@
+<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.VariableComment.Missing, Generic.Files.OneObjectStructurePerFile.MultipleFound, WordPress.NamingConventions.PrefixAllGlobals, Universal.Files.SeparateFunctionsFromOO.Mixed
+/**
+ * Stand-in for an active WooCommerce Memberships install that also exposes the
+ * handler chain Newspack walks to reach the content restriction callbacks:
+ * wc_memberships()->get_restrictions_instance()->get_posts_restrictions_instance().
+ *
+ * Both handlers are returned as the same instance every call. Code under test
+ * resolves them again on each call and hands them to remove_action(), which
+ * matches callbacks by object identity — a fresh instance per call would never
+ * match what was registered, and a removal test would pass for the wrong reason.
+ *
+ * Require this only from isolated (separate-process) tests: declaring
+ * wc_memberships() for the whole suite would flip
+ * Newspack\Memberships::is_active() true everywhere and break every test that
+ * assumes Memberships is inactive.
+ *
+ * @package Newspack\Tests
+ */
+
+if ( ! class_exists( 'Newspack_Test_WC_Memberships_Posts_Restrictions' ) ) {
+	/**
+	 * The three callbacks Memberships registers and Newspack may remove. The
+	 * bodies are irrelevant — the tests assert on hook registration, not output.
+	 */
+	class Newspack_Test_WC_Memberships_Posts_Restrictions {
+		public function restrict_post( $post ) {} // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+
+		public function handle_restricted_post_content_filtering( $content ) {
+			return $content;
+		}
+
+		public function display_restricted_taxonomy_term_notice() {}
+	}
+}
+
+if ( ! class_exists( 'Newspack_Test_WC_Memberships_Restrictions' ) ) {
+	class Newspack_Test_WC_Memberships_Restrictions {
+		private $posts_restrictions;
+
+		public function get_posts_restrictions_instance() {
+			if ( ! $this->posts_restrictions instanceof Newspack_Test_WC_Memberships_Posts_Restrictions ) {
+				$this->posts_restrictions = new Newspack_Test_WC_Memberships_Posts_Restrictions();
+			}
+			return $this->posts_restrictions;
+		}
+	}
+}
+
+if ( ! class_exists( 'Newspack_Test_WC_Memberships_Plugin' ) ) {
+	class Newspack_Test_WC_Memberships_Plugin {
+		private $restrictions;
+
+		public function get_restrictions_instance() {
+			if ( ! $this->restrictions instanceof Newspack_Test_WC_Memberships_Restrictions ) {
+				$this->restrictions = new Newspack_Test_WC_Memberships_Restrictions();
+			}
+			return $this->restrictions;
+		}
+	}
+}
+
+if ( ! function_exists( 'wc_memberships' ) ) {
+	function wc_memberships() {
+		static $instance = null;
+		if ( null === $instance ) {
+			$instance = new Newspack_Test_WC_Memberships_Plugin();
+		}
+		return $instance;
+	}
+}
+
+// Last, and load-bearing: the active mock supplies the `WC_Memberships` class
+// that Memberships::is_active() checks for. Requiring it after the declaration
+// above leaves its own function_exists() guard satisfied, so it contributes the
+// class and skips its bare wc_memberships(), which returns no handler chain.
+// Declaring WC_Memberships here instead would be a duplicate class name across
+// mock files, which PHPCS fails.
+require_once __DIR__ . '/wc-memberships-active-mock.php';
+
+// A test that loaded another wc_memberships() double first gets that one, and
+// the handler chain this file exists to provide is silently absent. Say so here
+// rather than letting it surface as an undefined-method fatal several frames
+// away, inside the code under test.
+if ( ! method_exists( wc_memberships(), 'get_restrictions_instance' ) ) {
+	throw new \RuntimeException(
+		'wc_memberships() was already declared by another mock and returns no restrictions handler. Require wc-memberships-restrictions-mock.php before any other WC Memberships mock, in an isolated (separate-process) test.'
+	);
+}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/wc-memberships/archive-restriction-hooks.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/wc-memberships/archive-restriction-hooks.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Tests for Newspack\Memberships::remove_unnecessary_content_restriction().
+ *
+ * @package Newspack\Tests
+ */
+
+/**
+ * The handler drops Woo Memberships' content restriction callbacks on the front
+ * page and on archives. An archive requested as a feed is still an archive, so
+ * those callbacks came off there too and feed items carried whole restricted
+ * post bodies.
+ *
+ * Every test runs in its own process: the mock declares wc_memberships(), which
+ * would otherwise make Memberships::is_active() true for the rest of the suite.
+ *
+ * @group wc-memberships
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class Test_Memberships_Archive_Restriction_Hooks extends WP_UnitTestCase {
+
+	/**
+	 * The memoized restrictions handler whose callbacks are under test.
+	 *
+	 * @var object
+	 */
+	private $restrictions_handler;
+
+	/**
+	 * Category the archive requests resolve to.
+	 *
+	 * @var int
+	 */
+	private $category_id;
+
+	/**
+	 * Stand in for an active Memberships install and publish one categorized post.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		require_once dirname( __DIR__, 3 ) . '/mocks/wc-memberships-restrictions-mock.php';
+
+		$this->restrictions_handler = wc_memberships()->get_restrictions_instance()->get_posts_restrictions_instance();
+		$this->category_id          = $this->factory->category->create( [ 'slug' => 'members-only' ] );
+
+		// The category needs a post: an empty term archive 404s in
+		// WP::handle_404(), which would leave is_archive() false and make the
+		// assertions below pass without exercising the branch under test.
+		$this->factory->post->create(
+			[
+				'post_status'   => 'publish',
+				'post_category' => [ $this->category_id ],
+			]
+		);
+	}
+
+	/**
+	 * Register the three callbacks Woo Memberships adds on `wp` at priority 9,
+	 * at the priorities it uses, so the handler under test can find them.
+	 */
+	private function register_memberships_restriction_hooks() {
+		add_action( 'the_post', [ $this->restrictions_handler, 'restrict_post' ], 0 );
+		add_filter( 'the_content', [ $this->restrictions_handler, 'handle_restricted_post_content_filtering' ], 999 );
+		add_action( 'loop_start', [ $this->restrictions_handler, 'display_restricted_taxonomy_term_notice' ], 1 );
+	}
+
+	/**
+	 * Assert the registered priority of each content restriction callback.
+	 *
+	 * Asserting the priority pins the three numbers the production removals
+	 * hard-code against the ones this test registers with — the two have to agree
+	 * or a remove_action() is a silent no-op. They come from Memberships'
+	 * handle_restriction_modes(), src/Restrictions/Posts.php:107-123.
+	 *
+	 * `restrict_post` sits at priority 0, so the value is compared, never treated
+	 * as a boolean: has_action() returns the priority, and 0 is falsy.
+	 *
+	 * @param int|false $the_post    Expected priority of the_post/restrict_post.
+	 * @param int|false $the_content Expected priority of the_content/handle_restricted_post_content_filtering.
+	 * @param int|false $loop_start  Expected priority of loop_start/display_restricted_taxonomy_term_notice.
+	 */
+	private function assert_hook_priorities( $the_post, $the_content, $loop_start ) {
+		$this->assertSame(
+			$the_post,
+			has_action( 'the_post', [ $this->restrictions_handler, 'restrict_post' ] ),
+			'the_post/restrict_post'
+		);
+		$this->assertSame(
+			$the_content,
+			has_filter( 'the_content', [ $this->restrictions_handler, 'handle_restricted_post_content_filtering' ] ),
+			'the_content/handle_restricted_post_content_filtering'
+		);
+		$this->assertSame(
+			$loop_start,
+			has_action( 'loop_start', [ $this->restrictions_handler, 'display_restricted_taxonomy_term_notice' ] ),
+			'loop_start/display_restricted_taxonomy_term_notice'
+		);
+	}
+
+	/**
+	 * A category feed is an archive, and its items carry full post bodies. The two
+	 * callbacks that blank a restricted body are the only thing standing between a
+	 * restricted post and its whole content going out over RSS, so they survive.
+	 * The term notice does not: it echoes markup the feed would emit between the
+	 * channel head and the first item.
+	 */
+	public function test_archive_feed_keeps_the_content_restriction_hooks() {
+		$this->register_memberships_restriction_hooks();
+
+		// get_term_feed_link() escapes the URL it returns, and go_to() would read
+		// the resulting `&amp;` as part of the query var name and drop the term.
+		$this->go_to( html_entity_decode( get_term_feed_link( $this->category_id, 'category' ) ) );
+
+		$this->assertTrue( is_feed(), 'Expected a feed request.' );
+		$this->assertTrue( is_archive(), 'Expected the category feed to be an archive.' );
+		$this->assert_hook_priorities( 0, 999, false );
+	}
+
+	/**
+	 * The HTML archive keeps the optimization the handler exists for: there the
+	 * callbacks only rewrite excerpts, and dropping them saves the per-post rule
+	 * lookups.
+	 */
+	public function test_html_archive_still_drops_restriction_hooks() {
+		$this->register_memberships_restriction_hooks();
+
+		$this->go_to( get_term_link( $this->category_id, 'category' ) );
+
+		$this->assertFalse( is_feed(), 'Expected a page request, not a feed.' );
+		$this->assertTrue( is_archive(), 'Expected a category archive.' );
+		$this->assert_hook_priorities( false, false, false );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`Memberships::remove_unnecessary_content_restriction()` removes WooCommerce Memberships' three content restriction callbacks on the front page and on archives, on the reasoning that those pages only ever show excerpts.

An archive requested as a feed still satisfies `is_archive()`, and feed items carry whole post bodies in `<content:encoded>` rather than excerpts. Restricted articles were therefore published in full over RSS. On an affected site, a members-only category feed served every gated article while the same posts stayed gated in the site's main feed and on their singular pages. Date, author and custom post type archive feeds leak the same way.

Under the hide-content restriction mode Newspack sites run, Memberships' own `is_feed_restricted()` stands down, so these callbacks are the only guard.

The two callbacks that blank a restricted body now stay registered on feeds. The taxonomy term notice does not: it echoes markup a feed would emit between the channel head and the first item.

### How to test the changes in this Pull Request:

1. Install WooCommerce and WooCommerce Memberships on a test site.
2. Set the Memberships restriction mode to "Hide content only".
3. Create a category. Publish a post in it.
4. Create a membership plan. Restrict that category to the plan.
5. Open the category feed at `/category/<slug>/feed/` while logged out.
6. Confirm the item shows the members-only message, not the article body.
7. Open the site feed at `/feed/`. Confirm it is unchanged.
8. Open the category archive page. Confirm it is unchanged.
9. Open the restricted post while logged out. Confirm it is still gated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Verified on a disposable env: before the fix the category feed carried both body paragraphs and no restriction message; after it carries neither body paragraph, two restriction messages, and parses as well-formed XML. `n test-php --group wc-memberships` passes (4 tests, 14 assertions) and fails on the intended assertion when the fix is reverted. Root PHPCS is clean.

Deliberate omissions worth naming:

* The guard is request-shaped while the assumption it defends is output-shaped. An archive template calling `the_content()` directly would still be unprotected. No first-party path does — `newspack-theme`'s `archive.php` renders excerpts only.
* Publishers using "Skip content restriction in RSS feeds" keep full-text feeds; that option routes through `wc_memberships_is_post_public`, which this change does not touch.
* Pugpig feeds in `newspack-manager` are unaffected. They are `is_home`, not archives, so this code never removed anything on them.
