### PR TITLE
fix(starter-content): restore featured images on generated posts

### DIFF
--- a/plugins/newspack-plugin/includes/starter_content/class-starter-content-generated.php
+++ b/plugins/newspack-plugin/includes/starter_content/class-starter-content-generated.php
@@ -539,14 +539,19 @@ class Starter_Content_Generated extends Starter_Content_Provider {
 			return null;
 		}
 
+		// wp_handle_sideload() takes $file by reference and writes back into it, so the
+		// array has to be a variable. Passing the literal is a fatal on PHP 8, which took
+		// down every non-E2E starter-content post before it could get a featured image.
+		$file = [
+			'name'     => 'automated_upload.jpg',
+			'type'     => mime_content_type( $temp_file ),
+			'tmp_name' => $temp_file,
+			'error'    => 0,
+			'size'     => filesize( $temp_file ),
+		];
+
 		$file_attributes = wp_handle_sideload(
-			[
-				'name'     => 'automated_upload.jpg',
-				'type'     => mime_content_type( $temp_file ),
-				'tmp_name' => $temp_file,
-				'error'    => 0,
-				'size'     => filesize( $temp_file ),
-			],
+			$file,
 			[
 				'test_form'   => false,
 				'test_size'   => true,

--- a/plugins/newspack-plugin/includes/starter_content/class-starter-content-generated.php
+++ b/plugins/newspack-plugin/includes/starter_content/class-starter-content-generated.php
@@ -540,8 +540,7 @@ class Starter_Content_Generated extends Starter_Content_Provider {
 		}
 
 		// wp_handle_sideload() takes $file by reference and writes back into it, so the
-		// array has to be a variable. Passing the literal is a fatal on PHP 8, which took
-		// down every non-E2E starter-content post before it could get a featured image.
+		// array has to be a variable — passing a literal here throws (#1002).
 		$file = [
 			'name'     => 'automated_upload.jpg',
 			'type'     => mime_content_type( $temp_file ),
@@ -560,6 +559,10 @@ class Starter_Content_Generated extends Starter_Content_Provider {
 		);
 
 		if ( is_wp_error( $file_attributes ) || ! empty( $file_attributes['error'] ) ) {
+			// download_url() leaves cleanup to the caller, and _wp_handle_upload() only
+			// unlinks the temp file on a successful move, so every failure above this
+			// point abandons it in the system temp directory.
+			wp_delete_file( $temp_file );
 			return null;
 		}
 

--- a/plugins/newspack-plugin/tests/unit-tests/starter-content-generated.php
+++ b/plugins/newspack-plugin/tests/unit-tests/starter-content-generated.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Tests generated starter content.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Starter_Content_Generated;
+
+/**
+ * Tests generated starter content.
+ */
+class Newspack_Test_Starter_Content_Generated extends WP_UnitTestCase {
+
+	/**
+	 * Files written into the uploads directory by a test, removed afterwards.
+	 *
+	 * @var string[]
+	 */
+	private $written_files = [];
+
+	/**
+	 * Filters this test added, removed individually in tear_down().
+	 *
+	 * Removing them by name rather than clearing the hook: the WordPress test suite
+	 * installs its own pre_http_request handlers, and remove_all_filters() takes those
+	 * with it and breaks every later test that makes a request.
+	 *
+	 * @var callable[]
+	 */
+	private $http_filters = [];
+
+	public function tear_down() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		foreach ( $this->written_files as $file ) {
+			if ( file_exists( $file ) ) {
+				unlink( $file ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
+			}
+		}
+		$this->written_files = [];
+		foreach ( $this->http_filters as $filter ) {
+			remove_filter( 'pre_http_request', $filter, 10 );
+		}
+		$this->http_filters = [];
+		parent::tear_down();
+	}
+
+	/**
+	 * Serve the bundled starter image instead of reaching the image host, writing it to
+	 * the stream target download_url() passes so the sideload sees a real file.
+	 */
+	private function stub_image_download() {
+		$filter = function ( $pre, $args, $url ) {
+			if ( false === strpos( $url, 'picsum.photos' ) ) {
+				return $pre;
+			}
+			if ( ! empty( $args['filename'] ) ) {
+				copy( NEWSPACK_ABSPATH . 'includes/raw_assets/images/starter-content-featured-image.jpg', $args['filename'] );
+			}
+			return [
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'headers'  => [],
+				'body'     => '',
+				'cookies'  => [],
+				'filename' => $args['filename'] ?? null,
+			];
+		};
+
+		$this->http_filters[] = $filter;
+		add_filter( 'pre_http_request', $filter, 10, 3 );
+	}
+
+	/**
+	 * The image sideload lands a file in the uploads directory.
+	 *
+	 * Passing the sideload array inline is a fatal on PHP 8 rather than a failed upload,
+	 * because wp_handle_sideload() takes its first argument by reference. Every
+	 * starter-content post outside E2E died there before it could get a featured image.
+	 */
+	public function test_download_random_image_sideloads_into_uploads() {
+		$this->stub_image_download();
+
+		$method = new ReflectionMethod( Starter_Content_Generated::class, 'download_random_image' );
+		$method->setAccessible( true );
+		$path = $method->invoke( null );
+
+		$this->assertIsString( $path, 'The sideload returns a path rather than failing.' );
+		$this->written_files[] = $path;
+
+		$this->assertFileExists( $path, 'The sideloaded file is on disk.' );
+		$uploads = wp_upload_dir();
+		$this->assertStringStartsWith( $uploads['basedir'], $path, 'The file landed in the uploads directory.' );
+		$this->assertGreaterThan( 0, filesize( $path ), 'The sideloaded file has content.' );
+	}
+
+	/**
+	 * A failed download is reported as no image, not as a fatal.
+	 */
+	public function test_download_random_image_returns_null_when_the_request_fails() {
+		$filter = function () {
+			return new WP_Error( 'http_request_failed', 'Offline.' );
+		};
+		$this->http_filters[] = $filter;
+		add_filter( 'pre_http_request', $filter, 10, 3 );
+
+		$method = new ReflectionMethod( Starter_Content_Generated::class, 'download_random_image' );
+		$method->setAccessible( true );
+
+		$this->assertNull( $method->invoke( null ), 'An unreachable image host yields no image.' );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/starter-content-generated.php
+++ b/plugins/newspack-plugin/tests/unit-tests/starter-content-generated.php
@@ -20,27 +20,26 @@ class Newspack_Test_Starter_Content_Generated extends WP_UnitTestCase {
 	private $written_files = [];
 
 	/**
-	 * Filters this test added, removed individually in tear_down().
+	 * URLs the stub intercepted, asserted so a source URL change cannot reach the network.
 	 *
-	 * Removing them by name rather than clearing the hook: the WordPress test suite
-	 * installs its own pre_http_request handlers, and remove_all_filters() takes those
-	 * with it and breaks every later test that makes a request.
-	 *
-	 * @var callable[]
+	 * @var string[]
 	 */
-	private $http_filters = [];
+	private $stubbed_urls = [];
 
-	public function tear_down() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+	/**
+	 * Remove the uploads this test wrote.
+	 *
+	 * Only the files: WP_UnitTestCase_Base::tear_down() restores $GLOBALS['wp_filter']
+	 * from its own snapshot, so filters added during a test need no bookkeeping here,
+	 * but nothing reverts writes into the uploads directory.
+	 */
+	public function tear_down() {
 		foreach ( $this->written_files as $file ) {
 			if ( file_exists( $file ) ) {
 				unlink( $file ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
 			}
 		}
 		$this->written_files = [];
-		foreach ( $this->http_filters as $filter ) {
-			remove_filter( 'pre_http_request', $filter, 10 );
-		}
-		$this->http_filters = [];
 		parent::tear_down();
 	}
 
@@ -50,9 +49,7 @@ class Newspack_Test_Starter_Content_Generated extends WP_UnitTestCase {
 	 */
 	private function stub_image_download() {
 		$filter = function ( $pre, $args, $url ) {
-			if ( false === strpos( $url, 'picsum.photos' ) ) {
-				return $pre;
-			}
+			$this->stubbed_urls[] = $url;
 			if ( ! empty( $args['filename'] ) ) {
 				copy( NEWSPACK_ABSPATH . 'includes/raw_assets/images/starter-content-featured-image.jpg', $args['filename'] );
 			}
@@ -61,23 +58,24 @@ class Newspack_Test_Starter_Content_Generated extends WP_UnitTestCase {
 					'code'    => 200,
 					'message' => 'OK',
 				],
-				'headers'  => [],
+				// download_url() renames the temp file to a real extension from this
+				// header, which is the shape the image host actually returns.
+				'headers'  => [ 'content-type' => 'image/jpeg' ],
 				'body'     => '',
 				'cookies'  => [],
 				'filename' => $args['filename'] ?? null,
 			];
 		};
 
-		$this->http_filters[] = $filter;
 		add_filter( 'pre_http_request', $filter, 10, 3 );
 	}
 
 	/**
 	 * The image sideload lands a file in the uploads directory.
 	 *
-	 * Passing the sideload array inline is a fatal on PHP 8 rather than a failed upload,
-	 * because wp_handle_sideload() takes its first argument by reference. Every
-	 * starter-content post outside E2E died there before it could get a featured image.
+	 * Guards the by-reference argument to wp_handle_sideload(): passing a literal there
+	 * throws rather than returning an upload error, so this fails as an error, not an
+	 * assertion.
 	 */
 	public function test_download_random_image_sideloads_into_uploads() {
 		$this->stub_image_download();
@@ -85,6 +83,12 @@ class Newspack_Test_Starter_Content_Generated extends WP_UnitTestCase {
 		$method = new ReflectionMethod( Starter_Content_Generated::class, 'download_random_image' );
 		$method->setAccessible( true );
 		$path = $method->invoke( null );
+
+		$this->assertSame(
+			[ 'https://picsum.photos/1200/800' ],
+			$this->stubbed_urls,
+			'The stub intercepted the request. A source URL change would otherwise reach the network.'
+		);
 
 		$this->assertIsString( $path, 'The sideload returns a path rather than failing.' );
 		$this->written_files[] = $path;
@@ -97,13 +101,20 @@ class Newspack_Test_Starter_Content_Generated extends WP_UnitTestCase {
 
 	/**
 	 * A failed download is reported as no image, not as a fatal.
+	 *
+	 * This passes with the sideload fix reverted — the WP_Error returns above that call.
+	 * It is here to pin the null-return contract the one caller branches on, against a
+	 * future reordering of the guards, rather than to cover the fix.
 	 */
 	public function test_download_random_image_returns_null_when_the_request_fails() {
-		$filter = function () {
-			return new WP_Error( 'http_request_failed', 'Offline.' );
-		};
-		$this->http_filters[] = $filter;
-		add_filter( 'pre_http_request', $filter, 10, 3 );
+		add_filter(
+			'pre_http_request',
+			function () {
+				return new WP_Error( 'http_request_failed', 'Offline.' );
+			},
+			10,
+			3
+		);
 
 		$method = new ReflectionMethod( Starter_Content_Generated::class, 'download_random_image' );
 		$method->setAccessible( true );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Generated starter content creates its categories and then no posts at all. `wp_handle_sideload()` takes its first argument by reference, and the call passed an array literal, which PHP 8 rejects outright with `Argument #1 ($file) could not be passed by reference`. The fatal lands on the first post, so `n setup` finishes with categories and an empty site. The setup wizard reaches the same call through `api_starter_content_post`, which is registered on every site.

Two things kept this quiet. The fatal has nothing to do with the network, so it fires whether or not the image host answers, and it presents as one of the image-fetch failures being fixed elsewhere. And the E2E path branches to `copy_bundled_image()`, added when starter-content images moved off the public internet, so nothing running in CI reaches the call.

The break is six days old and has nothing to do with a PHP version. `git log -S wp_handle_sideload` on this file returns two commits: the call arrived in 2021 as `wp_handle_sideload( $file, $overrides )`, passing a variable, and #1002 inlined the array while extracting `download_random_image()` on 2026-08-31. So the code was correct for the whole PHP 5 to 8 era and the regression rode in on an unrelated refactor. It reached `newspack@6.50.0-alpha.1` on `main` and `alpha`; `git branch -r --contains` does not include `release`, so no stable release carried it.

The fix assigns the array to a variable. Two regression tests come with it, stubbing the HTTP layer so the sideload runs for real against the bundled image instead of being asserted around.

We weighed one alternative: pointing the non-E2E path at the bundled image too, dropping the network dependency entirely. We left it out because it changes what publishers get, one repeated image in place of a varied one, and that is a product decision separate from the fatal.

An earlier version of these tests cleared `pre_http_request` wholesale in teardown and turned 142 later tests into errors while still passing under `--filter`. The teardown now removes nothing: `WP_UnitTestCase_Base` restores the filter globals from its own snapshot after every test, so filters added during a test need no bookkeeping, and the full suite confirms nothing leaks. Teardown keeps only the uploads cleanup, which nothing else reverts.

Found while building an environment for unrelated work; no Linear issue.

### How to test the changes in this Pull Request:

1. On a site where `NEWSPACK_IS_E2E` is not defined, run `n setup --yes`. Ten starter posts are created, each with a featured image.
2. Check the PHP error log for that run. It carries no `wp_handle_sideload()` fatal.
3. Run the same setup with `NEWSPACK_IS_E2E` defined. Posts still take the bundled image, unchanged from before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Full newspack-plugin suite green (3899 tests, 11027 assertions, 9 skipped), phpcs clean against the root ruleset. Reverting the fix turns the sideload test into the error above. The failure-path test is not a regression test for it and passes either way; its docblock says so and says what it does pin instead.

