### PR TITLE
refactor(components): ActionCard notices use core Notice (DSGNEWS-215)

### DIFF
--- a/packages/components/DEVELOPMENT.md
+++ b/packages/components/DEVELOPMENT.md
@@ -176,7 +176,7 @@ import {
 	ActionCard,
 	Button,
 	Card,
-	Notice,
+	SectionHeader,
 	TextControl,
 } from '../../../../../packages/components/src';
 ```
@@ -187,21 +187,21 @@ import {
 
 ```jsx
 // ✅ CORRECT - Within newspack-plugin monorepo
-import { Button, Card, Notice } from '../../../../../packages/components/src';
+import { Button, Card, SectionHeader } from '../../../../../packages/components/src';
 ```
 
 **As an npm package:** If `newspack-components` is installed as a dependency in another plugin, import from the package name:
 
 ```jsx
 // ✅ CORRECT - When installed as npm package
-import { Button, Card, Notice } from 'newspack-components';
+import { Button, Card, SectionHeader } from 'newspack-components';
 ```
 
 **Import individual components** – Import only what you need; do not import the whole namespace. List named imports **alphabetically** (e.g. from `@wordpress/components` or `newspack-components`):
 
 ```jsx
 // ✅ CORRECT – alphabetical
-import { Button, Card, Notice } from '../../../../../packages/components/src';
+import { Button, Card, SectionHeader } from '../../../../../packages/components/src';
 
 // ❌ WRONG – Don't import all
 import * as Components from '../../../../../packages/components/src';
@@ -253,7 +253,7 @@ This section shows how to use components **by context** (backend, blocks, fronte
 /**
  * WordPress dependencies
  */
-import { CheckboxControl, ExternalLink, RangeControl } from '@wordpress/components';
+import { CheckboxControl, ExternalLink, Notice, RangeControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -262,9 +262,8 @@ import {
 	ActionCard,
 	Button,
 	Card,
-	Grid,
-	Notice,
 	Divider,
+	Grid,
 	SectionHeader,
 	TextControl,
 	Waiting,
@@ -273,14 +272,13 @@ import {
 
 **Example – Audience Setup Wizard (real reference):**
 ```jsx
-import { CheckboxControl, ExternalLink, RangeControl } from '@wordpress/components';
+import { CheckboxControl, ExternalLink, Notice, RangeControl } from '@wordpress/components';
 import {
 	ActionCard,
 	Button,
 	Card,
-	Grid,
-	Notice,
 	Divider,
+	Grid,
 	PluginInstaller,
 	SectionHeader,
 	TextControl,
@@ -291,7 +289,9 @@ import {
 export default withWizardScreen( ( { config, updateConfig } ) => {
 	return (
 		<>
-			<Notice noticeText={ __( 'Audience Management is enabled.', 'newspack-plugin' ) } isSuccess />
+			<Notice status="success" isDismissible={ false }>
+				{ __( 'Audience Management is enabled.', 'newspack-plugin' ) }
+			</Notice>
 			<Card noBorder>
 				<ActionCard
 					title={ __( 'Present newsletter signup after checkout', 'newspack-plugin' ) }
@@ -374,7 +374,7 @@ import { Fragment } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { GlobalNotices, Notice, Wizard } from '../../../../../packages/components/src';
+import { GlobalNotices, Wizard } from '../../../../../packages/components/src';
 import sections from './sections';
 
 function Dashboard() {
@@ -622,7 +622,7 @@ Spacing is based on an **8px unit**. Use these values so new styles match existi
 | **8px** | Tight gaps, badge padding, small padding (e.g. ActionCard is-small) | Inline or dense UI |
 | **16px** | Gaps between related controls, buttons card gap, margins inside ActionCard region-children for Card/Grid/TextControl | Related items, form rows |
 | **24px** | Default ActionCard region padding, toggle/region gaps, expandable content padding and sibling spacing | Default internal padding and gaps within a card |
-| **32px** | Card vertical margin, Grid default gap and margin, SectionHeader first-child top, Notice margin, Divider margin | Section rhythm, between blocks |
+| **32px** | Card vertical margin, Grid default gap and margin, SectionHeader first-child top, Newspack Notice margin, Divider margin | Section rhythm, between blocks |
 | **48px** | SectionHeader container margin-top, Card horizontal padding (small screens) | Section separation |
 | **64px** | SectionHeader top margin, Divider margins (large breakpoint), buttons card margin, Card horizontal padding (large screens) | Major section separation |
 
@@ -693,7 +693,7 @@ Components rely on WordPress design system states where applicable; a few Newspa
 - **ActionCard (clickable)** – Hover: `box-shadow: 0 4px 8px rgba(black, 0.08)`; transition 125ms ease-in-out. Use for cards that navigate or open.
 - **Button** – Primary, secondary, disabled, and link variants follow `@wordpress/components` Button; focus and hover come from WordPress base styles.
 - **Toggle (inside ActionCard)** – Checked/unchecked and focus states from WordPress ToggleControl; label is visually hidden but available for accessibility.
-- **Notice** – Success (green), error (red), warning (yellow), info (gray) variants; use for feedback only and one primary message per area when possible.
+- **Notice** – Core's `Notice` carries the status in a tinted, bordered box (info, success, warning, error) and announces itself. The Newspack one, still in place on the screens that have not moved, tints the background and adds an icon. Either way, use notices for feedback only, and one primary message per area when possible.
 
 When adding new interactive components, preserve focus visibility and use the same state patterns (hover shadow, transition) so the UI feels consistent.
 
@@ -724,7 +724,7 @@ When adding new interactive components, preserve focus visibility and use the sa
 - **[@wordpress/components](https://www.npmjs.com/package/@wordpress/components)** – WordPress component library (fallback when Newspack components don’t exist)
 - **[@wordpress/base-styles](https://www.npmjs.com/package/@wordpress/base-styles)** – WordPress Design System styles and colors
 
-**Design resources:** For layout, components, and spacing, refer to the [WordPress Figma Library](https://www.figma.com/community/file/1149596986784498103/wordpress-design-library) and the [Block Editor Handbook](https://developer.wordpress.org/block-editor/reference-guides/components/). The **Components Demo** (`/wp-admin/admin.php?page=newspack-components-demo`) is the live reference for how Newspack components look and behave; use it to confirm spacing and hierarchy when building new screens.
+**Design resources:** For layout, components, and spacing, refer to the [WordPress Figma Library](https://www.figma.com/community/file/1149596986784498103/wordpress-design-library) and the [Block Editor Handbook](https://developer.wordpress.org/block-editor/reference-guides/components/). The **Components Demo** (`/wp-admin/admin.php?page=newspack-components-demo`) is the live reference for how Newspack components look and behave; use it to confirm spacing and hierarchy when building new screens. It no longer catalogues `Notice`; the Action Card examples are the place to see one rendered.
 
 ## Component Patterns
 

--- a/packages/components/DEVELOPMENT.md
+++ b/packages/components/DEVELOPMENT.md
@@ -100,7 +100,7 @@ When building a screen, use the **spacing scale** (8px unit: 16, 24, 32, 48, 64)
 
 - **`ActionCard`** – Use when one concept (e.g. a feature or setting) can be toggled on/off and may have extra content below. Internal padding (24px default; 16px/8px for isMedium/isSmall) and 24px between regions keep hierarchy clear; expandable content uses 24px top padding and 24px between siblings.
 - **`CollapsibleGroup`** / **`CollapsibleGroup.Item`** – A stack of independently collapsible items, separated by dividers and flush with the surrounding column. Not a W3C accordion: the items do not coordinate.
-- **`Notice`** – Use for outcome feedback (success/error/warning) or short contextual messages. Vertical margin is 32px so notices don’t collide with cards; keep one primary message per area when possible.
+- **`Notice`** – Being retired in favour of core’s `Notice` from `@wordpress/components`, which announces itself to assistive technology. Reach for core’s in new work; ours stays for the screens still on it. Where ours is used, vertical margin is 32px so notices don’t collide with cards, and one primary message per area reads best.
 - **`ProgressBar`** – Progress indicator.
 - **`StepsList`** / **`StepsListItem`** – Step-by-step list components.
 - **`StyleCard`** – Style preview card.
@@ -541,7 +541,7 @@ When Newspack components don't provide what you need, use these WordPress compon
 ### Feedback and overlays
 
 - **`Spinner`** – Loading spinner
-- **`Notice`** – Inline notice (success/error/warning); prefer Newspack `Notice` in wizards when it fits
+- **`Notice`** – Inline notice (success/error/warning); prefer this over the Newspack `Notice`, which is being retired
 - **`Placeholder`** – Empty state in blocks
 - **`Modal`** – Modal dialog
 - **`Popover`** – Popover (e.g. webhooks endpoint actions, corrections modal)

--- a/packages/components/src/action-card/action-card.d.ts
+++ b/packages/components/src/action-card/action-card.d.ts
@@ -10,8 +10,9 @@ export interface ActionCardProps {
 	badges?: CardBadge[];
 	className?: string;
 	indent?: string;
-	notification?: string | Error | null;
-	notificationLevel?: 'error' | 'warning' | 'info';
+	notification?: React.ReactNode | Error | null;
+	notificationLevel?: 'error' | 'warning' | 'info' | 'success';
+	notificationHTML?: boolean;
 	isMedium?: boolean;
 	disabled?: boolean | string;
 	hasGreyHeader?: boolean;

--- a/packages/components/src/action-card/index.js
+++ b/packages/components/src/action-card/index.js
@@ -26,29 +26,41 @@ import classnames from 'classnames';
 const NOTIFICATION_LEVELS = [ 'error', 'info', 'success', 'warning' ];
 
 /**
+ * Collect a notification's text, including text nested inside React elements.
+ *
+ * @param {*} value Notification content.
+ * @return {string} The collected text.
+ */
+const getNotificationText = value => {
+	if ( typeof value === 'string' ) {
+		return value;
+	}
+	if ( typeof value === 'number' ) {
+		return String( value );
+	}
+	if ( value instanceof Error ) {
+		return value.message;
+	}
+	if ( Array.isArray( value ) ) {
+		return value.map( getNotificationText ).join( '' );
+	}
+	return value?.props?.children === undefined ? '' : getNotificationText( value.props.children );
+};
+
+/**
  * Derive a plain-text announcement from a notification.
  *
  * Notice defaults spokenMessage to its children and runs renderToString over them
  * during render, which corrupts the hook dispatcher when those children are
  * components. A notification can be any element, so the announcement is always
- * built from its text parts instead of letting that default apply.
+ * built from its text instead of letting that default apply. Tags in an HTML
+ * notification are left in, because speak() strips them itself and does so with a
+ * space rather than welding together the words either side.
  *
- * @param {*}       notification Notification content.
- * @param {boolean} isHTML       Whether the content is an HTML string.
+ * @param {*} notification Notification content.
  * @return {string} Message to announce.
  */
-const getSpokenNotification = ( notification, isHTML ) => {
-	const parts = Array.isArray( notification ) ? notification : [ notification ];
-	const text = parts
-		.map( part => {
-			if ( typeof part === 'string' ) {
-				return part;
-			}
-			return part instanceof Error ? part.message : '';
-		} )
-		.join( '' );
-	return ( isHTML ? text.replace( /<[^>]*>/g, '' ) : text ).trim();
-};
+const getSpokenNotification = notification => getNotificationText( notification ).trim();
 
 /**
  * ActionCard component
@@ -135,6 +147,7 @@ const ActionCard = ( {
 	}, [ collapse ] );
 
 	const hasChildren = notification || children;
+	const notificationContent = notification instanceof Error ? notification.message : notification;
 	const classes = classnames(
 		'newspack-action-card',
 		simple && 'newspack-card--is-clickable',
@@ -273,12 +286,12 @@ const ActionCard = ( {
 			</div>
 			{ notification && NOTIFICATION_LEVELS.includes( notificationLevel ) && (
 				<div className="newspack-action-card__notification newspack-action-card__region-children">
-					<Notice
-						status={ notificationLevel }
-						isDismissible={ false }
-						spokenMessage={ getSpokenNotification( notification, notificationHTML ) }
-					>
-						{ notificationHTML ? <RawHTML>{ notification }</RawHTML> : notification }
+					<Notice status={ notificationLevel } isDismissible={ false } spokenMessage={ getSpokenNotification( notification ) }>
+						{ notificationHTML && typeof notificationContent === 'string' ? (
+							<RawHTML>{ notificationContent }</RawHTML>
+						) : (
+							notificationContent
+						) }
 					</Notice>
 				</div>
 			) }

--- a/packages/components/src/action-card/index.js
+++ b/packages/components/src/action-card/index.js
@@ -5,8 +5,8 @@
 /**
  * WordPress dependencies
  */
-import { Draggable, ExternalLink, ToggleControl } from '@wordpress/components';
-import { useEffect, useState } from '@wordpress/element';
+import { Draggable, ExternalLink, Notice, ToggleControl } from '@wordpress/components';
+import { RawHTML, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, check, chevronDown, chevronUp, dragHandle } from '@wordpress/icons';
 import { Badge } from '@wordpress/ui';
@@ -14,7 +14,7 @@ import { Badge } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
-import { Button, Card, Grid, Handoff, Notice, Waiting } from '../';
+import { Button, Card, Grid, Handoff, Waiting } from '../';
 import { ActionCardProps } from './action-card.d.ts';
 import './style.scss';
 
@@ -23,8 +23,36 @@ import './style.scss';
  */
 import classnames from 'classnames';
 
+const NOTIFICATION_LEVELS = [ 'error', 'info', 'success', 'warning' ];
+
+/**
+ * Derive a plain-text announcement from a notification.
+ *
+ * Notice defaults spokenMessage to its children and runs renderToString over them
+ * during render, which corrupts the hook dispatcher when those children are
+ * components. A notification can be any element, so the announcement is always
+ * built from its text parts instead of letting that default apply.
+ *
+ * @param {*}       notification Notification content.
+ * @param {boolean} isHTML       Whether the content is an HTML string.
+ * @return {string} Message to announce.
+ */
+const getSpokenNotification = ( notification, isHTML ) => {
+	const parts = Array.isArray( notification ) ? notification : [ notification ];
+	const text = parts
+		.map( part => {
+			if ( typeof part === 'string' ) {
+				return part;
+			}
+			return part instanceof Error ? part.message : '';
+		} )
+		.join( '' );
+	return ( isHTML ? text.replace( /<[^>]*>/g, '' ) : text ).trim();
+};
+
 /**
  * ActionCard component
+ *
  * @param {ActionCardProps} props Component props.
  * @return {JSX.Element} ActionCard component.
  */
@@ -243,12 +271,15 @@ const ActionCard = ( {
 					</Button>
 				) }
 			</div>
-			{ notification && (
+			{ notification && NOTIFICATION_LEVELS.includes( notificationLevel ) && (
 				<div className="newspack-action-card__notification newspack-action-card__region-children">
-					{ 'error' === notificationLevel && <Notice noticeText={ notification } isError rawHTML={ notificationHTML } /> }
-					{ 'info' === notificationLevel && <Notice noticeText={ notification } rawHTML={ notificationHTML } /> }
-					{ 'success' === notificationLevel && <Notice noticeText={ notification } isSuccess rawHTML={ notificationHTML } /> }
-					{ 'warning' === notificationLevel && <Notice noticeText={ notification } isWarning rawHTML={ notificationHTML } /> }
+					<Notice
+						status={ notificationLevel }
+						isDismissible={ false }
+						spokenMessage={ getSpokenNotification( notification, notificationHTML ) }
+					>
+						{ notificationHTML ? <RawHTML>{ notification }</RawHTML> : notification }
+					</Notice>
 				</div>
 			) }
 			{ children && ( ( expandable && expanded ) || ! expandable ) ? (

--- a/packages/components/src/action-card/index.js
+++ b/packages/components/src/action-card/index.js
@@ -7,6 +7,7 @@
  */
 import { Draggable, ExternalLink, Notice, ToggleControl } from '@wordpress/components';
 import { RawHTML, useEffect, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { Icon, check, chevronDown, chevronUp, dragHandle } from '@wordpress/icons';
 import { Badge } from '@wordpress/ui';
@@ -28,6 +29,9 @@ const NOTIFICATION_LEVELS = [ 'error', 'info', 'success', 'warning' ];
 /**
  * Collect a notification's text, including text nested inside React elements.
  *
+ * Segments join with a space so that adjacent elements do not weld together: by the
+ * time speak() sees this string the markup that separated them is already gone.
+ *
  * @param {*} value Notification content.
  * @return {string} The collected text.
  */
@@ -42,7 +46,7 @@ const getNotificationText = value => {
 		return value.message;
 	}
 	if ( Array.isArray( value ) ) {
-		return value.map( getNotificationText ).join( '' );
+		return value.map( getNotificationText ).join( ' ' );
 	}
 	return value?.props?.children === undefined ? '' : getNotificationText( value.props.children );
 };
@@ -54,13 +58,13 @@ const getNotificationText = value => {
  * during render, which corrupts the hook dispatcher when those children are
  * components. A notification can be any element, so the announcement is always
  * built from its text instead of letting that default apply. Tags in an HTML
- * notification are left in, because speak() strips them itself and does so with a
- * space rather than welding together the words either side.
+ * notification stay in, since speak() strips them itself. Entities do not survive
+ * that, so they are decoded here to match what the notice shows.
  *
  * @param {*} notification Notification content.
  * @return {string} Message to announce.
  */
-const getSpokenNotification = notification => getNotificationText( notification ).trim();
+const getSpokenNotification = notification => decodeEntities( getNotificationText( notification ) ).replace( /\s+/g, ' ' ).trim();
 
 /**
  * ActionCard component
@@ -287,8 +291,8 @@ const ActionCard = ( {
 			{ notification && NOTIFICATION_LEVELS.includes( notificationLevel ) && (
 				<div className="newspack-action-card__notification newspack-action-card__region-children">
 					<Notice status={ notificationLevel } isDismissible={ false } spokenMessage={ getSpokenNotification( notification ) }>
-						{ notificationHTML && typeof notificationContent === 'string' ? (
-							<RawHTML>{ notificationContent }</RawHTML>
+						{ notificationHTML && typeof notification === 'string' ? (
+							<RawHTML className="newspack-action-card__notification-html">{ notification }</RawHTML>
 						) : (
 							notificationContent
 						) }

--- a/packages/components/src/action-card/index.js
+++ b/packages/components/src/action-card/index.js
@@ -58,13 +58,38 @@ const getNotificationText = value => {
  * during render, which corrupts the hook dispatcher when those children are
  * components. A notification can be any element, so the announcement is always
  * built from its text instead of letting that default apply. Tags in an HTML
- * notification stay in, since speak() strips them itself. Entities do not survive
- * that, so they are decoded here to match what the notice shows.
+ * notification stay in, since speak() strips them itself. Entities are decoded so
+ * the announcement matches the text on screen, which getNotificationContent decodes
+ * for the same reason.
  *
  * @param {*} notification Notification content.
  * @return {string} Message to announce.
  */
 const getSpokenNotification = notification => decodeEntities( getNotificationText( notification ) ).replace( /\s+/g, ' ' ).trim();
+
+/**
+ * Decode a notification's own text for display.
+ *
+ * React does not decode entities in text children, and notification text is often
+ * server-sourced, so a message carrying `&#8217;` would otherwise show the entity
+ * and announce the character. The HTML branch is left alone: there the browser's
+ * parser decodes as it renders.
+ *
+ * @param {*} value Notification content.
+ * @return {*} The content, with its own strings decoded.
+ */
+const getNotificationContent = value => {
+	if ( value instanceof Error ) {
+		return decodeEntities( value.message );
+	}
+	if ( typeof value === 'string' ) {
+		return decodeEntities( value );
+	}
+	if ( Array.isArray( value ) ) {
+		return value.map( getNotificationContent );
+	}
+	return value;
+};
 
 /**
  * ActionCard component
@@ -151,7 +176,7 @@ const ActionCard = ( {
 	}, [ collapse ] );
 
 	const hasChildren = notification || children;
-	const notificationContent = notification instanceof Error ? notification.message : notification;
+	const notificationContent = getNotificationContent( notification );
 	const classes = classnames(
 		'newspack-action-card',
 		simple && 'newspack-card--is-clickable',

--- a/packages/components/src/action-card/index.test.js
+++ b/packages/components/src/action-card/index.test.js
@@ -2,6 +2,10 @@
  * External dependencies.
  */
 import { render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies.
+ */
 import { speak } from '@wordpress/a11y';
 import { useState } from '@wordpress/element';
 
@@ -10,7 +14,10 @@ import { useState } from '@wordpress/element';
  */
 import ActionCard from './index';
 
-jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
+jest.mock( '@wordpress/a11y', () => ( {
+	...jest.requireActual( '@wordpress/a11y' ),
+	speak: jest.fn(),
+} ) );
 
 /**
  * The library Badge styles its wrapper rather than its text, so a badge with no label
@@ -123,11 +130,55 @@ describe( 'ActionCard notifications', () => {
 		expect( spoken() ).toContain( 'Network unreachable' );
 	} );
 
-	it( 'announces HTML notifications without welding words together', () => {
-		render( <ActionCard title="Ad Manager" notificationLevel="error" notification="<p>Install failed.</p><p>Try again.</p>" notificationHTML /> );
+	it( 'hands HTML notifications to speak() with their tags intact, for speak() to strip', () => {
+		const { container } = render(
+			<ActionCard title="Ad Manager" notificationLevel="error" notification="<p>Install failed.</p><p>Try again.</p>" notificationHTML />
+		);
 
-		expect( spoken()[ 0 ] ).toContain( 'Install failed.' );
-		expect( spoken()[ 0 ] ).not.toContain( 'failed.Try' );
+		expect( container.querySelectorAll( '.newspack-action-card__notification-html > p' ) ).toHaveLength( 2 );
+		expect( spoken()[ 0 ] ).toContain( '<p>Install failed.</p>' );
+	} );
+
+	it( 'decodes entities so the announcement matches the visible text', () => {
+		render(
+			<ActionCard
+				title="Ad Manager"
+				notificationLevel="error"
+				notification="Plugin &#8220;Foo&#8221; could not be activated"
+				notificationHTML
+			/>
+		);
+
+		expect( spoken()[ 0 ] ).toContain( '“Foo”' );
+	} );
+
+	it( 'renders a non-string notification as children even when notificationHTML is set', () => {
+		const { container } = render(
+			<ActionCard title="Ad Manager" notificationLevel="error" notification={ <span>Network unreachable</span> } notificationHTML />
+		);
+
+		expect( screen.getByText( 'Network unreachable' ) ).toBeInTheDocument();
+		expect( container.querySelector( '.newspack-action-card__notification-html' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps adjacent element texts apart in the announcement', () => {
+		render(
+			<ActionCard
+				title="Ad Manager"
+				notificationLevel="error"
+				notification={ [
+					// eslint-disable-next-line react/jsx-indent
+					<a key="dashboard" href="https://example.org">
+						Visit your GAM dashboard
+					</a>,
+					<button key="connect" type="button">
+						Click here to connect your account.
+					</button>,
+				] }
+			/>
+		);
+
+		expect( spoken()[ 0 ] ).toBe( 'Visit your GAM dashboard Click here to connect your account.' );
 	} );
 
 	it( 'survives a re-render that changes how many hooked components the notification holds', () => {

--- a/packages/components/src/action-card/index.test.js
+++ b/packages/components/src/action-card/index.test.js
@@ -130,26 +130,43 @@ describe( 'ActionCard notifications', () => {
 		expect( spoken() ).toContain( 'Network unreachable' );
 	} );
 
-	it( 'hands HTML notifications to speak() with their tags intact, for speak() to strip', () => {
+	it( 'renders HTML notifications in their own wrapper and hands speak() the tags to strip', () => {
 		const { container } = render(
-			<ActionCard title="Ad Manager" notificationLevel="error" notification="<p>Install failed.</p><p>Try again.</p>" notificationHTML />
+			<ActionCard title="Ad Manager" notificationLevel="error" notification={ '<p>Install failed.</p><p>Try again.</p>' } notificationHTML />
 		);
 
 		expect( container.querySelectorAll( '.newspack-action-card__notification-html > p' ) ).toHaveLength( 2 );
 		expect( spoken()[ 0 ] ).toContain( '<p>Install failed.</p>' );
 	} );
 
-	it( 'decodes entities so the announcement matches the visible text', () => {
+	it( 'decodes entities in both the announcement and the visible text', () => {
+		render( <ActionCard title="Ad Manager" notificationLevel="error" notification={ 'Plugin &#8220;Foo&#8221; could not be activated' } /> );
+
+		expect( screen.getByText( 'Plugin “Foo” could not be activated' ) ).toBeInTheDocument();
+		expect( spoken()[ 0 ] ).toContain( '“Foo”' );
+	} );
+
+	it( 'decodes entities inside an array of notification parts', () => {
 		render(
+			<ActionCard title="Ad Manager" notificationLevel="error" notification={ [ 'Could not reach the publisher&#8217;s network.', ' ' ] } />
+		);
+
+		expect( screen.getByText( /Could not reach the publisher’s network\./ ) ).toBeInTheDocument();
+		expect( spoken()[ 0 ] ).toContain( 'publisher’s' );
+	} );
+
+	it( 'leaves entity decoding to the browser on the HTML branch', () => {
+		const { container } = render(
 			<ActionCard
 				title="Ad Manager"
 				notificationLevel="error"
-				notification="Plugin &#8220;Foo&#8221; could not be activated"
+				notification={ 'Get it from <a href="https://example.org">the plugin&#8217;s site</a>' }
 				notificationHTML
 			/>
 		);
 
-		expect( spoken()[ 0 ] ).toContain( '“Foo”' );
+		expect( container.querySelector( '.newspack-action-card__notification-html a' ).textContent ).toBe( 'the plugin’s site' );
+		expect( spoken()[ 0 ] ).toContain( 'plugin’s site' );
 	} );
 
 	it( 'renders a non-string notification as children even when notificationHTML is set', () => {

--- a/packages/components/src/action-card/index.test.js
+++ b/packages/components/src/action-card/index.test.js
@@ -2,11 +2,15 @@
  * External dependencies.
  */
 import { render, screen } from '@testing-library/react';
+import { speak } from '@wordpress/a11y';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies.
  */
 import ActionCard from './index';
+
+jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
 
 /**
  * The library Badge styles its wrapper rather than its text, so a badge with no label
@@ -52,5 +56,92 @@ describe( 'ActionCard badges', () => {
 		expect( withEmptyArray.querySelectorAll( '[class*="__badge"]' ) ).toHaveLength( 0 );
 		// An empty array used to fall through as a literal `0` in the heading.
 		expect( withEmptyArray.textContent ).not.toContain( '0' );
+	} );
+} );
+
+/**
+ * ActionCard derives the notice's spoken message rather than letting core default it to
+ * the children. Core runs `renderToString` over that default during render, which corrupts
+ * the hook dispatcher when the children are components — so the derivation is what keeps a
+ * notification carrying a `<Button>` from crashing the card on a later re-render.
+ */
+describe( 'ActionCard notifications', () => {
+	beforeEach( () => {
+		speak.mockClear();
+	} );
+
+	const spoken = () => speak.mock.calls.map( call => call[ 0 ] );
+
+	it( 'renders a notice for a recognised level', () => {
+		const { container } = render( <ActionCard title="Ad Manager" notification="Plugin cannot be installed" notificationLevel="error" /> );
+
+		expect( container.querySelector( '.components-notice.is-error' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders no notice for an unrecognised or absent level', () => {
+		const { container: unknown } = render( <ActionCard title="Ad Manager" notification="Something happened" notificationLevel="critical" /> );
+		expect( unknown.querySelector( '.components-notice' ) ).not.toBeInTheDocument();
+
+		const { container: absent } = render( <ActionCard title="Ad Manager" notification="Something happened" /> );
+		expect( absent.querySelector( '.components-notice' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'announces the text inside an element-only notification', () => {
+		render(
+			<ActionCard
+				title="Ad Manager"
+				notificationLevel="error"
+				notification={ [ <button key="connect">Click here to connect your account.</button> ] }
+			/>
+		);
+
+		expect( spoken() ).toContain( 'Click here to connect your account.' );
+	} );
+
+	it( 'announces strings and element text together', () => {
+		render(
+			<ActionCard
+				title="Ad Manager"
+				notificationLevel="success"
+				notification={ [
+					'Created custom targeting keys: ',
+					// eslint-disable-next-line react/jsx-indent
+					<a key="dashboard" href="https://example.org">
+						Visit your GAM dashboard
+					</a>,
+				] }
+			/>
+		);
+
+		expect( spoken() ).toContain( 'Created custom targeting keys: Visit your GAM dashboard' );
+	} );
+
+	it( 'announces an Error and renders its message rather than throwing', () => {
+		render( <ActionCard title="Ad Manager" notificationLevel="error" notification={ new Error( 'Network unreachable' ) } /> );
+
+		expect( screen.getByText( 'Network unreachable' ) ).toBeInTheDocument();
+		expect( spoken() ).toContain( 'Network unreachable' );
+	} );
+
+	it( 'announces HTML notifications without welding words together', () => {
+		render( <ActionCard title="Ad Manager" notificationLevel="error" notification="<p>Install failed.</p><p>Try again.</p>" notificationHTML /> );
+
+		expect( spoken()[ 0 ] ).toContain( 'Install failed.' );
+		expect( spoken()[ 0 ] ).not.toContain( 'failed.Try' );
+	} );
+
+	it( 'survives a re-render that changes how many hooked components the notification holds', () => {
+		const HookedAction = ( { children } ) => {
+			const [ label ] = useState( children );
+			return <button type="button">{ label }</button>;
+		};
+		const card = notification => <ActionCard title="Ad Manager" notificationLevel="error" notification={ notification } />;
+
+		const { rerender, container } = render(
+			card( [ <HookedAction key="retry">Retry</HookedAction>, <HookedAction key="docs">Documentation</HookedAction> ] )
+		);
+
+		expect( () => rerender( card( [ <HookedAction key="retry">Retry</HookedAction> ] ) ) ).not.toThrow();
+		expect( container.querySelector( '.components-notice.is-error' ) ).toBeInTheDocument();
 	} );
 } );

--- a/packages/components/src/action-card/style.scss
+++ b/packages/components/src/action-card/style.scss
@@ -343,14 +343,8 @@
 			margin: 0;
 		}
 
-		&.newspack-action-card__region-children {
-			.components-notice {
-				margin-top: 32px;
-
-				&:first-child {
-					margin-top: 0;
-				}
-			}
+		.components-notice__content > div > * {
+			margin: 0;
 		}
 	}
 

--- a/packages/components/src/action-card/style.scss
+++ b/packages/components/src/action-card/style.scss
@@ -339,17 +339,17 @@
 
 	/* Notifications */
 	.newspack-action-card__notification {
-		.newspack-notice {
+		.components-notice {
 			margin: 0;
-
-			&__heading {
-				margin-top: 0;
-			}
 		}
 
 		&.newspack-action-card__region-children {
-			.newspack-notice {
+			.components-notice {
 				margin-top: 32px;
+
+				&:first-child {
+					margin-top: 0;
+				}
 			}
 		}
 	}

--- a/packages/components/src/action-card/style.scss
+++ b/packages/components/src/action-card/style.scss
@@ -343,7 +343,7 @@
 			margin: 0;
 		}
 
-		.components-notice__content > div > * {
+		.newspack-action-card__notification-html > * {
 			margin: 0;
 		}
 	}

--- a/packages/components/src/plugin-toggle/index.js
+++ b/packages/components/src/plugin-toggle/index.js
@@ -99,7 +99,7 @@ class PluginToggle extends Component {
 					toggleChecked={ this.isPluginInstalledAndActive( plugin ) }
 					toggleOnChange={ value => this.managePlugin( slug, value ) }
 					notification={ error }
-					notificationHTML={ error }
+					notificationHTML={ !! error }
 					notificationLevel="error"
 				/>
 			);

--- a/packages/components/src/plugin-toggle/index.js
+++ b/packages/components/src/plugin-toggle/index.js
@@ -99,7 +99,7 @@ class PluginToggle extends Component {
 					toggleChecked={ this.isPluginInstalledAndActive( plugin ) }
 					toggleOnChange={ value => this.managePlugin( slug, value ) }
 					notification={ error }
-					notificationHTML={ !! error }
+					notificationHTML
 					notificationLevel="error"
 				/>
 			);

--- a/plugins/newspack-plugin/src/admin/style.scss
+++ b/plugins/newspack-plugin/src/admin/style.scss
@@ -347,14 +347,6 @@ h1 {
 	}
 
 	&.newspack-action-card {
-		.newspack-action-card__notification {
-			&.newspack-action-card__region-children {
-				.newspack-notice {
-					margin-top: 1rem;
-				}
-			}
-		}
-
 		.newspack-action-card__region-children:not(:last-child) {
 			padding-bottom: 0;
 			padding-top: 2rem;

--- a/plugins/newspack-plugin/src/wizards/audience/views/setup/style.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/setup/style.scss
@@ -108,9 +108,6 @@ span.is-skipped {
 
 .newspack-ras-wizard {
 	&__prerequisite.newspack-card.newspack-action-card {
-		.newspack-action-card__notification.newspack-action-card__region-children .newspack-notice {
-			margin-top: 0;
-		}
 		.button-group button {
 			margin-right: 8px;
 		}

--- a/plugins/newspack-plugin/src/wizards/componentsDemo/index.js
+++ b/plugins/newspack-plugin/src/wizards/componentsDemo/index.js
@@ -556,14 +556,6 @@ class ComponentsDemo extends Component {
 							</EmptyState.Root>
 						</Card>
 						<Card>
-							<h2>{ __( 'Notice', 'newspack-plugin' ) }</h2>
-							<Notice noticeText={ __( 'This is an info notice.', 'newspack-plugin' ) } />
-							<Notice noticeText={ __( 'This is an error notice.', 'newspack-plugin' ) } isError />
-							<Notice noticeText={ __( 'This is a help notice.', 'newspack-plugin' ) } isHelp />
-							<Notice noticeText={ __( 'This is a success notice.', 'newspack-plugin' ) } isSuccess />
-							<Notice noticeText={ __( 'This is a warning notice.', 'newspack-plugin' ) } isWarning />
-						</Card>
-						<Card>
 							<h2>{ __( 'Plugin installer', 'newspack-plugin' ) }</h2>
 							<PluginInstaller
 								plugins={ [ 'woocommerce', 'wordpress-seo' ] }
@@ -878,16 +870,10 @@ class ComponentsDemo extends Component {
 									] }
 									onChange={ selectValues => this.setState( { selectValues } ) }
 								/>
-								<Notice
-									noticeText={
-										<>
-											{ __( 'Selected:', 'newspack-plugin' ) }{ ' ' }
-											{ this.state.selectValues.length > 0
-												? this.state.selectValues.join( ', ' )
-												: __( 'none', 'newspack-plugin' ) }
-										</>
-									}
-								/>
+								<p>
+									{ __( 'Selected:', 'newspack-plugin' ) }{ ' ' }
+									{ this.state.selectValues.length > 0 ? this.state.selectValues.join( ', ' ) : __( 'none', 'newspack-plugin' ) }
+								</p>
 							</Grid>
 						</Card>
 						<Card>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`ActionCard` rendered its notifications through Newspack's own `Notice`, which announces nothing to assistive technology and takes a separate boolean per level. It now renders core's `Notice`, with `notificationLevel` mapping straight onto `status`.

The announcement is derived from the notification's text rather than left to default. Core's `Notice` runs `renderToString` over its children during render, and several call sites pass React elements, which corrupts the hook dispatcher on a later re-render. The derivation walks nested elements, so a notification built from links and buttons announces its text instead of nothing.

`ActionCardProps` has caught up with what the component accepts: `notification` takes any node, `notificationLevel` includes `success`, and `notificationHTML` is declared. An `Error` used to throw when it reached `Notice` as children, so it is normalised to its message first.

The Components Demo no longer showcases `Notice`, and the spacing overrides that targeted the old `.newspack-notice` class have gone with it.

The chrome changes, because core owns it now: a bordered, rounded, tinted box with no icon.

![ActionCard error and warning notifications rendered with core Notice on the Components Demo](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/03/h3vah7w1-action-card-core-notice-v2.png)

### How to test the changes in this Pull Request:

1. Build the branch and open Newspack > Components Demo.
2. Scroll to the Action Card section. Expect Example Four to show a red error notice and Example Five a yellow warning notice, both with working links.
3. Confirm no Notice section sits between Empty state and Plugin installer.
4. Scroll to Select dropdowns and pick a few Multi-select options. Expect "Selected: …" as plain text, not a notice.
5. Open Advertising > Providers with Google Ad Manager connected but erroring. Expect the notice to render its message and its GAM dashboard link.
6. On the same screen, disable a plugin so a Plugin toggle reports a failure. Expect the error to render as formatted text, not escaped markup.
7. With VoiceOver running, reload a screen from step 5 or 6. Expect the message announced once, assertively for errors.
8. Put Google Ad Manager in the enabled-and-available-but-not-connected state, where the only notification is the "connect your account" button. Expect VoiceOver to announce that text rather than silence.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

`plugin-installer` still pipes a server error message through `RawHTML`, which this PR leaves alone; it belongs with the same treatment for `GlobalNotices`, which takes its content from a URL parameter.

Part of the `@wordpress/ui` audit in DSGNEWS-215, which stays open. `@wordpress/ui`'s own `Notice` carries the same `renderToString` hazard, so it was not a way around it; the choice between the two libraries is still open for the wrapper work.
