### PR TITLE
fix(subscribers): use core Notice for load-failure states

### DIFF
--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -92,8 +92,7 @@ const ResetHeaderData = () => {
 	const location = useLocation();
 	const { resetHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 
-	// Before paint, so the reset always lands before the incoming section publishes
-	// its own header. A passive effect here would run after any section that
+	// Must stay before paint: a passive effect here would run after a section that
 	// publishes from a layout effect, wiping the header it just set.
 	useLayoutEffect( () => {
 		resetHeaderData();

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -177,6 +177,7 @@ const Wizard = (
 		actions,
 		backNav,
 		badges,
+		fullWidth: headerFullWidth,
 		sectionDescription,
 		sectionMenu,
 		sectionName,
@@ -303,7 +304,7 @@ const Wizard = (
 								render={ routerProps => (
 									<div
 										className={ classnames( 'newspack-wizard__content', className, {
-											'newspack-wizard__content--full-width': section.fullWidth,
+											'newspack-wizard__content--full-width': headerFullWidth ?? section.fullWidth,
 										} ) }
 									>
 										{ 'function' === typeof renderAboveSections ? renderAboveSections() : null }

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -18,7 +18,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { cloneElement, createInterpolateElement, isValidElement, useEffect, useRef, useState, forwardRef } from '@wordpress/element';
+import { cloneElement, createInterpolateElement, isValidElement, useLayoutEffect, useRef, useState, forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { category, chevronLeft, moreVertical } from '@wordpress/icons';
 
@@ -92,7 +92,10 @@ const ResetHeaderData = () => {
 	const location = useLocation();
 	const { resetHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 
-	useEffect( () => {
+	// Before paint, so the reset always lands before the incoming section publishes
+	// its own header. A passive effect here would run after any section that
+	// publishes from a layout effect, wiping the header it just set.
+	useLayoutEffect( () => {
 		resetHeaderData();
 		window.scrollTo( 0, 0 );
 	}, [ location.pathname, resetHeaderData ] );

--- a/packages/components/src/wizard/index.test.js
+++ b/packages/components/src/wizard/index.test.js
@@ -23,6 +23,8 @@ jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 // ExternalLink needs a string href, and the debug Notice reads aux data.
 window.newspack_aux_data = { is_debug_mode: false };
 window.newspack_urls = { support: 'https://help.newspack.com/' };
+// ResetHeaderData scrolls to the top on every route change; jsdom has no scrolling.
+window.scrollTo = jest.fn();
 
 const SETTINGS = { minimumDonation: '5' };
 
@@ -241,7 +243,7 @@ describe( 'Wizard content width', () => {
 		await waitFor( () => expect( container.querySelector( '.newspack-wizard__content' ) ).toHaveClass( 'newspack-wizard__content--full-width' ) );
 	} );
 
-	it( 'keeps a section header published from a layout effect through the route reset', async () => {
+	it( 'keeps a section header published from a layout effect through the mount reset', async () => {
 		render(
 			<Wizard
 				headerText="Test wizard"

--- a/packages/components/src/wizard/index.test.js
+++ b/packages/components/src/wizard/index.test.js
@@ -7,8 +7,8 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
  * WordPress dependencies.
  */
 import apiFetch from '@wordpress/api-fetch';
-import { dispatch, useDispatch } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { dispatch, select, useDispatch } from '@wordpress/data';
+import { useLayoutEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies.
@@ -158,37 +158,100 @@ describe( 'Wizard', () => {
 	} );
 } );
 
+// Publishes its width override before paint, the way the list screens do so the
+// notice never paints full-bleed first.
 const NarrowingSection = () => {
 	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
-	useEffect( () => {
+	useLayoutEffect( () => {
 		setHeaderData( { fullWidth: false } );
 	}, [ setHeaderData ] );
 	return <div>Narrowing section</div>;
 };
 
+// Narrows while it is failing, then clears the override the way a list screen
+// does once a retry succeeds.
+const RecoveringSection = () => {
+	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const [ failed, setFailed ] = useState( true );
+	useLayoutEffect( () => {
+		setHeaderData( { fullWidth: failed ? false : undefined } );
+	}, [ setHeaderData, failed ] );
+	return <button onClick={ () => setFailed( false ) }>Retry</button>;
+};
+
+// Every shipping wizard has more than one section, which is the only arrangement
+// that renders ResetHeaderData. A single-section wizard would never exercise the
+// reset these overrides have to survive.
+const widthSections = renderSection => [
+	{ label: 'List', path: '/', exact: true, fullWidth: true, render: renderSection },
+	{ label: 'Other', path: '/other', render: () => <div>Other section</div> },
+];
+
 describe( 'Wizard content width', () => {
 	beforeEach( () => {
 		apiFetch.mockReset();
-		// A single-section wizard never renders ResetHeaderData, so without this
-		// the previous test's override is still in the store and decides this one.
+		// The store is module-level, so an override left by the previous test would
+		// otherwise decide this one.
 		dispatch( WIZARD_STORE_NAMESPACE ).resetHeaderData();
 	} );
 
 	it( 'renders full-width when the section declares it and nothing overrides it', async () => {
 		const { container } = render(
-			<Wizard headerText="Test wizard" sections={ [ { label: 'List', path: '/', fullWidth: true, render: () => <div>List</div> } ] } />
+			<Wizard
+				headerText="Test wizard"
+				sections={ widthSections( () => (
+					<div>List content</div>
+				) ) }
+			/>
 		);
 
-		expect( await screen.findByText( 'List' ) ).toBeInTheDocument();
+		expect( await screen.findByText( 'List content' ) ).toBeInTheDocument();
 		expect( container.querySelector( '.newspack-wizard__content' ) ).toHaveClass( 'newspack-wizard__content--full-width' );
 	} );
 
-	it( 'falls back to the standard width when the section overrides fullWidth via header data', async () => {
+	it( 'falls back to the standard width when a section overrides fullWidth before paint', async () => {
 		const { container } = render(
-			<Wizard headerText="Test wizard" sections={ [ { label: 'List', path: '/', fullWidth: true, render: () => <NarrowingSection /> } ] } />
+			<Wizard
+				headerText="Test wizard"
+				sections={ widthSections( () => (
+					<NarrowingSection />
+				) ) }
+			/>
 		);
 
 		expect( await screen.findByText( 'Narrowing section' ) ).toBeInTheDocument();
 		expect( container.querySelector( '.newspack-wizard__content' ) ).not.toHaveClass( 'newspack-wizard__content--full-width' );
+	} );
+
+	it( 'restores the declared width when the section clears its override', async () => {
+		const { container } = render(
+			<Wizard
+				headerText="Test wizard"
+				sections={ widthSections( () => (
+					<RecoveringSection />
+				) ) }
+			/>
+		);
+
+		const retry = await screen.findByRole( 'button', { name: 'Retry' } );
+		expect( container.querySelector( '.newspack-wizard__content' ) ).not.toHaveClass( 'newspack-wizard__content--full-width' );
+
+		fireEvent.click( retry );
+
+		await waitFor( () => expect( container.querySelector( '.newspack-wizard__content' ) ).toHaveClass( 'newspack-wizard__content--full-width' ) );
+	} );
+
+	it( 'keeps a section header published from a layout effect through the route reset', async () => {
+		render(
+			<Wizard
+				headerText="Test wizard"
+				sections={ widthSections( () => (
+					<NarrowingSection />
+				) ) }
+			/>
+		);
+
+		expect( await screen.findByText( 'Narrowing section' ) ).toBeInTheDocument();
+		expect( select( WIZARD_STORE_NAMESPACE ).getHeaderData().fullWidth ).toBe( false );
 	} );
 } );

--- a/packages/components/src/wizard/index.test.js
+++ b/packages/components/src/wizard/index.test.js
@@ -7,7 +7,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
  * WordPress dependencies.
  */
 import apiFetch from '@wordpress/api-fetch';
-import { useDispatch } from '@wordpress/data';
+import { dispatch, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 
 /**
@@ -167,6 +167,13 @@ const NarrowingSection = () => {
 };
 
 describe( 'Wizard content width', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+		// A single-section wizard never renders ResetHeaderData, so without this
+		// the previous test's override is still in the store and decides this one.
+		dispatch( WIZARD_STORE_NAMESPACE ).resetHeaderData();
+	} );
+
 	it( 'renders full-width when the section declares it and nothing overrides it', async () => {
 		const { container } = render(
 			<Wizard headerText="Test wizard" sections={ [ { label: 'List', path: '/', fullWidth: true, render: () => <div>List</div> } ] } />

--- a/packages/components/src/wizard/index.test.js
+++ b/packages/components/src/wizard/index.test.js
@@ -7,7 +7,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
  * WordPress dependencies.
  */
 import apiFetch from '@wordpress/api-fetch';
-import { dispatch, select, useDispatch } from '@wordpress/data';
+import { select, useDispatch } from '@wordpress/data';
 import { useLayoutEffect, useState } from '@wordpress/element';
 
 /**
@@ -23,7 +23,6 @@ jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 // ExternalLink needs a string href, and the debug Notice reads aux data.
 window.newspack_aux_data = { is_debug_mode: false };
 window.newspack_urls = { support: 'https://help.newspack.com/' };
-// ResetHeaderData scrolls to the top on every route change; jsdom has no scrolling.
 window.scrollTo = jest.fn();
 
 const SETTINGS = { minimumDonation: '5' };
@@ -160,8 +159,6 @@ describe( 'Wizard', () => {
 	} );
 } );
 
-// Publishes its width override before paint, the way the list screens do so the
-// notice never paints full-bleed first.
 const NarrowingSection = () => {
 	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 	useLayoutEffect( () => {
@@ -170,8 +167,6 @@ const NarrowingSection = () => {
 	return <div>Narrowing section</div>;
 };
 
-// Narrows while it is failing, then clears the override the way a list screen
-// does once a retry succeeds.
 const RecoveringSection = () => {
 	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ failed, setFailed ] = useState( true );
@@ -181,9 +176,8 @@ const RecoveringSection = () => {
 	return <button onClick={ () => setFailed( false ) }>Retry</button>;
 };
 
-// Every shipping wizard has more than one section, which is the only arrangement
-// that renders ResetHeaderData. A single-section wizard would never exercise the
-// reset these overrides have to survive.
+// Two sections, because that is what mounts ResetHeaderData: a single-section
+// wizard never exercises the reset these overrides have to survive.
 const widthSections = renderSection => [
 	{ label: 'List', path: '/', exact: true, fullWidth: true, render: renderSection },
 	{ label: 'Other', path: '/other', render: () => <div>Other section</div> },
@@ -192,9 +186,6 @@ const widthSections = renderSection => [
 describe( 'Wizard content width', () => {
 	beforeEach( () => {
 		apiFetch.mockReset();
-		// The store is module-level, so an override left by the previous test would
-		// otherwise decide this one.
-		dispatch( WIZARD_STORE_NAMESPACE ).resetHeaderData();
 	} );
 
 	it( 'renders full-width when the section declares it and nothing overrides it', async () => {

--- a/packages/components/src/wizard/index.test.js
+++ b/packages/components/src/wizard/index.test.js
@@ -7,12 +7,15 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
  * WordPress dependencies.
  */
 import apiFetch from '@wordpress/api-fetch';
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies.
  */
 import Wizard from './';
 import { useWizardData } from './store/utils';
+import { WIZARD_STORE_NAMESPACE } from './store';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
@@ -152,5 +155,35 @@ describe( 'Wizard', () => {
 		expect( await screen.findByText( 'Static section' ) ).toBeInTheDocument();
 		await flushPending();
 		expect( counts.wizard ).toBe( 0 );
+	} );
+} );
+
+// A section that immediately overrides the wizard's static `fullWidth` config
+// for its own render, the way an error state stands down from a full-width table.
+const NarrowingSection = () => {
+	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
+	useEffect( () => {
+		setHeaderData( { fullWidth: false } );
+	}, [ setHeaderData ] );
+	return <div>Narrowing section</div>;
+};
+
+describe( 'Wizard content width', () => {
+	it( 'renders full-width when the section declares it and nothing overrides it', async () => {
+		const { container } = render(
+			<Wizard headerText="Test wizard" sections={ [ { label: 'List', path: '/', fullWidth: true, render: () => <div>List</div> } ] } />
+		);
+
+		expect( await screen.findByText( 'List' ) ).toBeInTheDocument();
+		expect( container.querySelector( '.newspack-wizard__content' ) ).toHaveClass( 'newspack-wizard__content--full-width' );
+	} );
+
+	it( 'falls back to the standard width when the section overrides fullWidth via header data', async () => {
+		const { container } = render(
+			<Wizard headerText="Test wizard" sections={ [ { label: 'List', path: '/', fullWidth: true, render: () => <NarrowingSection /> } ] } />
+		);
+
+		expect( await screen.findByText( 'Narrowing section' ) ).toBeInTheDocument();
+		expect( container.querySelector( '.newspack-wizard__content' ) ).not.toHaveClass( 'newspack-wizard__content--full-width' );
 	} );
 } );

--- a/packages/components/src/wizard/index.test.js
+++ b/packages/components/src/wizard/index.test.js
@@ -158,8 +158,6 @@ describe( 'Wizard', () => {
 	} );
 } );
 
-// A section that immediately overrides the wizard's static `fullWidth` config
-// for its own render, the way an error state stands down from a full-width table.
 const NarrowingSection = () => {
 	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 	useEffect( () => {

--- a/packages/components/src/wizard/store/index.js
+++ b/packages/components/src/wizard/store/index.js
@@ -16,9 +16,8 @@ import { createAction } from './utils.js';
 export const WIZARD_STORE_NAMESPACE = 'newspack/wizards';
 
 const DEFAULT_STATE = {
-	// `fullWidth` is deliberately absent: Wizard falls back to the section's own
-	// config only when this key is unset, so adding a default here would silently
-	// narrow every full-width section on reset.
+	// `fullWidth` is deliberately absent: a default here would narrow every
+	// full-width section on reset, since Wizard only falls back when it is unset.
 	headerData: {
 		actions: [],
 		backNav: '',

--- a/packages/components/src/wizard/store/index.js
+++ b/packages/components/src/wizard/store/index.js
@@ -16,6 +16,9 @@ import { createAction } from './utils.js';
 export const WIZARD_STORE_NAMESPACE = 'newspack/wizards';
 
 const DEFAULT_STATE = {
+	// `fullWidth` is deliberately absent: Wizard falls back to the section's own
+	// config only when this key is unset, so adding a default here would silently
+	// narrow every full-width section on reset.
 	headerData: {
 		actions: [],
 		backNav: '',

--- a/plugins/newspack-plugin/src/wizards/subscribers/components/LoadFailureNotice.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/components/LoadFailureNotice.jsx
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies.
+ */
+import { Notice } from '@wordpress/components';
+
+/**
+ * A read that failed, stated plainly and announced to assistive tech.
+ *
+ * @param {Object}      props
+ * @param {string}      props.message What went wrong, as a complete sentence.
+ * @param {JSX.Element} props.action  The affordance that follows it: a retry, or a way back.
+ * @return {JSX.Element} The notice.
+ */
+export default function LoadFailureNotice( { message, action } ) {
+	return (
+		// spokenMessage is load-bearing, not redundant: core defaults it to children
+		// and runs non-string children through renderToString mid-render, which
+		// corrupts hook state.
+		<Notice status="error" isDismissible={ false } spokenMessage={ message }>
+			{ message } { action }
+		</Notice>
+	);
+}

--- a/plugins/newspack-plugin/src/wizards/subscribers/components/LoadFailureNotice.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/components/LoadFailureNotice.jsx
@@ -13,9 +13,8 @@ import { Notice } from '@wordpress/components';
  */
 export default function LoadFailureNotice( { message, action } ) {
 	return (
-		// spokenMessage is load-bearing, not redundant: core defaults it to children
-		// and runs non-string children through renderToString mid-render, which
-		// corrupts hook state.
+		// spokenMessage is load-bearing: without it core stringifies these children
+		// mid-render, which corrupts hook state.
 		<Notice status="error" isDismissible={ false } spokenMessage={ message }>
 			{ message } { action }
 		</Notice>

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList-labels.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList-labels.test.jsx
@@ -24,7 +24,6 @@ jest.mock( '../../../../packages/components/src/wizard/store', () => ( { WIZARD_
 jest.mock( '../../../../packages/components/src', () => ( {
 	DataViews: () => null,
 	Button: () => null,
-	Notice: () => null,
 	Waiting: () => null,
 } ) );
 

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList-labels.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList-labels.test.jsx
@@ -23,7 +23,6 @@ jest.mock( '../../../../packages/components/src/wizard/store', () => ( { WIZARD_
 
 jest.mock( '../../../../packages/components/src', () => ( {
 	DataViews: () => null,
-	// forwardRef: the load-failure notice puts a ref on Retry to restore focus.
 	Button: require( 'react' ).forwardRef( () => null ),
 	Waiting: () => null,
 } ) );

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList-labels.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList-labels.test.jsx
@@ -23,7 +23,8 @@ jest.mock( '../../../../packages/components/src/wizard/store', () => ( { WIZARD_
 
 jest.mock( '../../../../packages/components/src', () => ( {
 	DataViews: () => null,
-	Button: () => null,
+	// forwardRef: the load-failure notice puts a ref on Retry to restore focus.
+	Button: require( 'react' ).forwardRef( () => null ),
 	Waiting: () => null,
 } ) );
 

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
@@ -216,14 +216,12 @@ export default function GroupList() {
 	const total = paginationInfo?.totalItems ?? 0;
 
 	// Surface the group count in the header breadcrumb, e.g. "/ Groups (14)".
-	// Before paint, not after: this also carries the width override, and an error
-	// arrives outside a React event, so a passive effect would paint full-bleed once
-	// and then snap into the content column.
+	// Before paint: this carries the width override, and an error arrives outside a
+	// React event, so a passive effect would paint full-bleed for one frame first.
 	useLayoutEffect( () => {
 		setHeaderData( {
 			// Header data is merged, so the explicit `undefined` is what clears a
-			// previous `false`. Dropping the key would strand the screen narrow for
-			// the rest of the visit, because a retry does not change the route.
+			// previous `false`; a retry never changes the route, so nothing else would.
 			fullWidth: error ? false : undefined,
 			sectionName: [
 				{

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
@@ -14,11 +14,11 @@
 /**
  * WordPress dependencies.
  */
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { useLayoutEffect, useMemo, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
-import { __experimentalHStack as HStack, Notice } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { Badge } from '@wordpress/ui';
 
 /**
@@ -27,6 +27,8 @@ import { Badge } from '@wordpress/ui';
 import { Button, DataViews, StatusIndicator, Waiting } from '../../../../packages/components/src';
 import { fmtDate } from '../format';
 import './style.scss';
+import LoadFailureNotice from '../components/LoadFailureNotice';
+import { useRetryFocus } from '../use-retry-focus';
 import { SHOW_AVATARS, useAvatars } from '../data/use-avatars';
 import { useGroups } from '../data/use-groups';
 import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
@@ -233,20 +235,7 @@ export default function GroupList() {
 		} );
 	}, [ setHeaderData, total, groupsLoading, error ] );
 
-	// A retry unmounts this notice while the request is in flight. Without this the
-	// remounted Retry button is a fresh node and a keyboard user is dropped back on
-	// the document body, with no way to reach the retry they just asked for.
-	const retryRef = useRef( null );
-	const hasRetried = useRef( false );
-	const retry = () => {
-		hasRetried.current = true;
-		reload();
-	};
-	useEffect( () => {
-		if ( ! groupsLoading && error && hasRetried.current ) {
-			retryRef.current?.focus();
-		}
-	}, [ groupsLoading, error ] );
+	const { retryRef, retry } = useRetryFocus( { settled: ! groupsLoading, failed: Boolean( error ), reload } );
 
 	if ( groupsLoading ) {
 		return (
@@ -261,15 +250,14 @@ export default function GroupList() {
 	if ( error ) {
 		const message = groupLoadFailedLabel( error );
 		return (
-			// spokenMessage is load-bearing, not redundant: core defaults it to children
-			// and runs non-string children through renderToString mid-render, which
-			// corrupts hook state.
-			<Notice status="error" isDismissible={ false } spokenMessage={ message }>
-				{ message }{ ' ' }
-				<Button variant="link" ref={ retryRef } onClick={ retry }>
-					{ __( 'Retry', 'newspack-plugin' ) }
-				</Button>
-			</Notice>
+			<LoadFailureNotice
+				message={ message }
+				action={
+					<Button variant="link" ref={ retryRef } onClick={ retry }>
+						{ __( 'Retry', 'newspack-plugin' ) }
+					</Button>
+				}
+			/>
 		);
 	}
 

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
@@ -18,13 +18,13 @@ import { useEffect, useMemo, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
-import { __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { __experimentalHStack as HStack, Notice } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { Badge } from '@wordpress/ui';
 
 /**
  * Internal dependencies.
  */
-import { Button, DataViews, Notice, StatusIndicator, Waiting } from '../../../../packages/components/src';
+import { Button, DataViews, StatusIndicator, Waiting } from '../../../../packages/components/src';
 import { fmtDate } from '../format';
 import './style.scss';
 import { SHOW_AVATARS, useAvatars } from '../data/use-avatars';
@@ -216,6 +216,7 @@ export default function GroupList() {
 	// Surface the group count in the header breadcrumb, e.g. "/ Groups (14)".
 	useEffect( () => {
 		setHeaderData( {
+			fullWidth: ! error,
 			sectionName: [
 				{
 					label: GROUP_LABEL_PLURAL,
@@ -238,7 +239,8 @@ export default function GroupList() {
 	// a retry.
 	if ( error ) {
 		return (
-			<Notice isError noticeText={ groupLoadFailedLabel( error ) }>
+			<Notice status="error" isDismissible={ false }>
+				{ groupLoadFailedLabel( error ) }{ ' ' }
 				<Button variant="link" onClick={ reload }>
 					{ __( 'Retry', 'newspack-plugin' ) }
 				</Button>

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
@@ -14,7 +14,7 @@
 /**
  * WordPress dependencies.
  */
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useLayoutEffect, useMemo, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
@@ -214,7 +214,10 @@ export default function GroupList() {
 	const total = paginationInfo?.totalItems ?? 0;
 
 	// Surface the group count in the header breadcrumb, e.g. "/ Groups (14)".
-	useEffect( () => {
+	// Before paint, not after: this also carries the width override, and an error
+	// arrives outside a React event, so a passive effect would paint full-bleed once
+	// and then snap into the content column.
+	useLayoutEffect( () => {
 		setHeaderData( {
 			fullWidth: error ? false : undefined,
 			sectionName: [
@@ -240,6 +243,9 @@ export default function GroupList() {
 	if ( error ) {
 		const message = groupLoadFailedLabel( error );
 		return (
+			// spokenMessage is load-bearing, not redundant: core defaults it to children
+			// and runs non-string children through renderToString mid-render, which
+			// corrupts hook state.
 			<Notice status="error" isDismissible={ false } spokenMessage={ message }>
 				{ message }{ ' ' }
 				<Button variant="link" onClick={ reload }>

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
@@ -14,7 +14,7 @@
 /**
  * WordPress dependencies.
  */
-import { useLayoutEffect, useMemo, useState } from '@wordpress/element';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
@@ -219,6 +219,9 @@ export default function GroupList() {
 	// and then snap into the content column.
 	useLayoutEffect( () => {
 		setHeaderData( {
+			// Header data is merged, so the explicit `undefined` is what clears a
+			// previous `false`. Dropping the key would strand the screen narrow for
+			// the rest of the visit, because a retry does not change the route.
 			fullWidth: error ? false : undefined,
 			sectionName: [
 				{
@@ -229,6 +232,21 @@ export default function GroupList() {
 			],
 		} );
 	}, [ setHeaderData, total, groupsLoading, error ] );
+
+	// A retry unmounts this notice while the request is in flight. Without this the
+	// remounted Retry button is a fresh node and a keyboard user is dropped back on
+	// the document body, with no way to reach the retry they just asked for.
+	const retryRef = useRef( null );
+	const hasRetried = useRef( false );
+	const retry = () => {
+		hasRetried.current = true;
+		reload();
+	};
+	useEffect( () => {
+		if ( ! groupsLoading && error && hasRetried.current ) {
+			retryRef.current?.focus();
+		}
+	}, [ groupsLoading, error ] );
 
 	if ( groupsLoading ) {
 		return (
@@ -248,7 +266,7 @@ export default function GroupList() {
 			// corrupts hook state.
 			<Notice status="error" isDismissible={ false } spokenMessage={ message }>
 				{ message }{ ' ' }
-				<Button variant="link" onClick={ reload }>
+				<Button variant="link" ref={ retryRef } onClick={ retry }>
 					{ __( 'Retry', 'newspack-plugin' ) }
 				</Button>
 			</Notice>

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.jsx
@@ -216,7 +216,7 @@ export default function GroupList() {
 	// Surface the group count in the header breadcrumb, e.g. "/ Groups (14)".
 	useEffect( () => {
 		setHeaderData( {
-			fullWidth: ! error,
+			fullWidth: error ? false : undefined,
 			sectionName: [
 				{
 					label: GROUP_LABEL_PLURAL,
@@ -238,9 +238,10 @@ export default function GroupList() {
 	// A failed read must not read as "this site has no groups": say so, and offer
 	// a retry.
 	if ( error ) {
+		const message = groupLoadFailedLabel( error );
 		return (
-			<Notice status="error" isDismissible={ false }>
-				{ groupLoadFailedLabel( error ) }{ ' ' }
+			<Notice status="error" isDismissible={ false } spokenMessage={ message }>
+				{ message }{ ' ' }
 				<Button variant="link" onClick={ reload }>
 					{ __( 'Retry', 'newspack-plugin' ) }
 				</Button>

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.test.jsx
@@ -148,6 +148,9 @@ describe( 'the group list width override', () => {
 			render( <GroupList /> );
 		} );
 
+		// Presence is the load-bearing part: header data is merged, so only an
+		// explicit `undefined` clears a `false` left by an earlier failure.
+		expect( 'fullWidth' in lastHeaderCall() ).toBe( true );
 		expect( lastHeaderCall().fullWidth ).toBeUndefined();
 	} );
 

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.test.jsx
@@ -7,20 +7,24 @@
 /**
  * External dependencies
  */
-import { render, act } from '@testing-library/react';
+import { render, act, screen, fireEvent } from '@testing-library/react';
 
 /**
  * WordPress dependencies
  */
 import { createReduxStore, register } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
  */
 import GroupList from './GroupList';
+import { groupLoadFailedLabel } from '../labels';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
 
 jest.mock( '../../../../packages/components/src/wizard/store', () => ( { WIZARD_STORE_NAMESPACE: 'test/group-list' } ) );
 
@@ -28,7 +32,11 @@ jest.mock( '../../../../packages/components/src/wizard/store', () => ( { WIZARD_
 // itself comes from filterSortAndPaginate, which stays real.
 jest.mock( '../../../../packages/components/src', () => ( {
 	DataViews: () => null,
-	Button: () => null,
+	// Renders a real button: the load-failure notice puts a ref on Retry to restore
+	// focus, which needs a host node to land on.
+	Button: require( 'react' ).forwardRef( ( { children, ...props }, ref ) =>
+		require( 'react' ).createElement( 'button', { ...props, ref }, children )
+	),
 	Waiting: () => null,
 } ) );
 
@@ -150,5 +158,60 @@ describe( 'the group list width override', () => {
 		} );
 
 		expect( lastHeaderCall().fullWidth ).toBe( false );
+	} );
+} );
+
+describe( 'the GroupList load-failure announcement', () => {
+	beforeEach( () => {
+		headerCalls = [];
+		apiFetch.mockReset();
+		speak.mockClear();
+	} );
+
+	it( 'announces the failure assertively', async () => {
+		apiFetch.mockRejectedValue( new Error( 'nope' ) );
+		await act( async () => {
+			render( <GroupList /> );
+		} );
+
+		expect( speak ).toHaveBeenCalledWith( groupLoadFailedLabel( 'nope' ), 'assertive' );
+	} );
+
+	it( 'says nothing when the read succeeds', async () => {
+		apiFetch.mockResolvedValue( { items: [ group( 1 ) ] } );
+		await act( async () => {
+			render( <GroupList /> );
+		} );
+
+		expect( speak ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'the GroupList retry affordance', () => {
+	beforeEach( () => {
+		headerCalls = [];
+		apiFetch.mockReset();
+	} );
+
+	it( 'returns focus to Retry when a retry fails again', async () => {
+		apiFetch.mockRejectedValue( new Error( 'nope' ) );
+		await act( async () => {
+			render( <GroupList /> );
+		} );
+
+		await act( async () => {
+			fireEvent.click( screen.getByRole( 'button', { name: 'Retry' } ) );
+		} );
+
+		expect( screen.getByRole( 'button', { name: 'Retry' } ) ).toHaveFocus();
+	} );
+
+	it( 'leaves focus alone on the first failure', async () => {
+		apiFetch.mockRejectedValue( new Error( 'nope' ) );
+		await act( async () => {
+			render( <GroupList /> );
+		} );
+
+		expect( screen.getByRole( 'button', { name: 'Retry' } ) ).not.toHaveFocus();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.test.jsx
@@ -29,7 +29,6 @@ jest.mock( '../../../../packages/components/src/wizard/store', () => ( { WIZARD_
 jest.mock( '../../../../packages/components/src', () => ( {
 	DataViews: () => null,
 	Button: () => null,
-	Notice: () => null,
 	Waiting: () => null,
 } ) );
 
@@ -65,6 +64,8 @@ const publishedSection = () => {
 	const named = headerCalls.filter( data => data.sectionName );
 	return named[ named.length - 1 ].sectionName[ 0 ];
 };
+
+const lastHeaderCall = () => headerCalls[ headerCalls.length - 1 ];
 
 describe( 'the group list header count', () => {
 	beforeEach( () => {
@@ -124,5 +125,30 @@ describe( 'the group list header count', () => {
 			render( <GroupList /> );
 		} );
 		expect( publishedSection().countLabel ).toBe( '2 Groups' );
+	} );
+} );
+
+describe( 'the group list width override', () => {
+	beforeEach( () => {
+		headerCalls = [];
+		apiFetch.mockReset();
+	} );
+
+	it( 'leaves the section width alone once the groups land', async () => {
+		apiFetch.mockResolvedValue( { items: [ group( 1 ) ] } );
+		await act( async () => {
+			render( <GroupList /> );
+		} );
+
+		expect( lastHeaderCall().fullWidth ).toBeUndefined();
+	} );
+
+	it( 'narrows the width when the read fails', async () => {
+		apiFetch.mockRejectedValue( new Error( 'nope' ) );
+		await act( async () => {
+			render( <GroupList /> );
+		} );
+
+		expect( lastHeaderCall().fullWidth ).toBe( false );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/GroupList.test.jsx
@@ -32,8 +32,7 @@ jest.mock( '../../../../packages/components/src/wizard/store', () => ( { WIZARD_
 // itself comes from filterSortAndPaginate, which stays real.
 jest.mock( '../../../../packages/components/src', () => ( {
 	DataViews: () => null,
-	// Renders a real button: the load-failure notice puts a ref on Retry to restore
-	// focus, which needs a host node to land on.
+	// A real button, because the focus restoration needs a host node to land on.
 	Button: require( 'react' ).forwardRef( ( { children, ...props }, ref ) =>
 		require( 'react' ).createElement( 'button', { ...props, ref }, children )
 	),
@@ -148,8 +147,7 @@ describe( 'the group list width override', () => {
 			render( <GroupList /> );
 		} );
 
-		// Presence is the load-bearing part: header data is merged, so only an
-		// explicit `undefined` clears a `false` left by an earlier failure.
+		// Presence, not just the value: only an explicit `undefined` clears a `false`.
 		expect( 'fullWidth' in lastHeaderCall() ).toBe( true );
 		expect( lastHeaderCall().fullWidth ).toBeUndefined();
 	} );

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/PersonProfile.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/PersonProfile.jsx
@@ -25,13 +25,12 @@
 /**
  * WordPress dependencies.
  */
-import { createPortal, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { createPortal, useEffect, useMemo, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import {
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	Notice,
 } from '@wordpress/components';
 
 /**
@@ -39,6 +38,8 @@ import {
  */
 import { Button, Card, Divider, Grid, Router, SectionHeader, Waiting } from '../../../../packages/components/src';
 import './style.scss';
+import LoadFailureNotice from '../components/LoadFailureNotice';
+import { useRetryFocus } from '../use-retry-focus';
 import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
 import SubscriptionCard from '../components/SubscriptionCard';
 import { useSubscriber } from '../data/use-subscriber';
@@ -125,20 +126,10 @@ export default function PersonProfile() {
 
 	const { subscriber, loading, error, notFound, reload } = useSubscriber( id );
 
-	// A retry unmounts this notice while the request is in flight. Without this the
-	// remounted Retry button is a fresh node and a keyboard user is dropped back on
-	// the document body, with no way to reach the retry they just asked for.
-	const retryRef = useRef( null );
-	const hasRetried = useRef( false );
-	const retry = () => {
-		hasRetried.current = true;
-		reload();
-	};
-	useEffect( () => {
-		if ( ! loading && ( error || ! subscriber ) && hasRetried.current ) {
-			retryRef.current?.focus();
-		}
-	}, [ loading, error, subscriber ] );
+	// A retry can land on either failure branch, so the ref goes on both affordances
+	// and focus follows whichever one renders. A missing person is covered too: that
+	// read nulls the subscriber.
+	const { retryRef, retry } = useRetryFocus( { settled: ! loading, failed: Boolean( error || ! subscriber ), reload } );
 
 	// A 128px source feeds the 64px header avatar (2x for high-DPR displays),
 	// resolved through the same endpoint the lists use.
@@ -299,15 +290,14 @@ export default function PersonProfile() {
 	if ( notFound ) {
 		const message = __( 'This subscriber could not be found. They may have been deleted.', 'newspack-plugin' );
 		return (
-			// spokenMessage is load-bearing, not redundant: core defaults it to children
-			// and runs non-string children through renderToString mid-render, which
-			// corrupts hook state.
-			<Notice status="error" isDismissible={ false } spokenMessage={ message }>
-				{ message }{ ' ' }
-				<Button variant="link" href={ backNav }>
-					{ __( 'Back to the list', 'newspack-plugin' ) }
-				</Button>
-			</Notice>
+			<LoadFailureNotice
+				message={ message }
+				action={
+					<Button variant="link" ref={ retryRef } href={ backNav }>
+						{ __( 'Back to the list', 'newspack-plugin' ) }
+					</Button>
+				}
+			/>
 		);
 	}
 
@@ -325,15 +315,14 @@ export default function PersonProfile() {
 			);
 		}
 		return (
-			// spokenMessage is load-bearing, not redundant: core defaults it to children
-			// and runs non-string children through renderToString mid-render, which
-			// corrupts hook state.
-			<Notice status="error" isDismissible={ false } spokenMessage={ message }>
-				{ message }{ ' ' }
-				<Button variant="link" ref={ retryRef } onClick={ retry }>
-					{ __( 'Retry', 'newspack-plugin' ) }
-				</Button>
-			</Notice>
+			<LoadFailureNotice
+				message={ message }
+				action={
+					<Button variant="link" ref={ retryRef } onClick={ retry }>
+						{ __( 'Retry', 'newspack-plugin' ) }
+					</Button>
+				}
+			/>
 		);
 	}
 

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/PersonProfile.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/PersonProfile.jsx
@@ -25,7 +25,7 @@
 /**
  * WordPress dependencies.
  */
-import { createPortal, useEffect, useMemo, useState } from '@wordpress/element';
+import { createPortal, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import {
@@ -124,6 +124,21 @@ export default function PersonProfile() {
 	const backNav = isInternalHashPath( rawFrom ) ? rawFrom : '#/';
 
 	const { subscriber, loading, error, notFound, reload } = useSubscriber( id );
+
+	// A retry unmounts this notice while the request is in flight. Without this the
+	// remounted Retry button is a fresh node and a keyboard user is dropped back on
+	// the document body, with no way to reach the retry they just asked for.
+	const retryRef = useRef( null );
+	const hasRetried = useRef( false );
+	const retry = () => {
+		hasRetried.current = true;
+		reload();
+	};
+	useEffect( () => {
+		if ( ! loading && ( error || ! subscriber ) && hasRetried.current ) {
+			retryRef.current?.focus();
+		}
+	}, [ loading, error, subscriber ] );
 
 	// A 128px source feeds the 64px header avatar (2x for high-DPR displays),
 	// resolved through the same endpoint the lists use.
@@ -298,17 +313,24 @@ export default function PersonProfile() {
 
 	// A failed read must not read as "this person has no subscriptions".
 	if ( error || ! subscriber ) {
-		const message = sprintf(
-			/* translators: %s is an error message. */
-			__( 'Could not load this subscriber: %s', 'newspack-plugin' ),
-			// A read can also come back empty without reporting an error, which would
-			// otherwise leave the sentence hanging after the colon.
-			error || __( 'Something went wrong.', 'newspack-plugin' )
-		);
+		// A read can also come back empty without reporting an error. That branch has
+		// no server detail to quote, so it gets its own sentence rather than a filler
+		// clause after the colon.
+		let message = __( 'This subscriber could not be loaded.', 'newspack-plugin' );
+		if ( error ) {
+			message = sprintf(
+				/* translators: %s is an error message. */
+				__( 'Could not load this subscriber: %s', 'newspack-plugin' ),
+				error
+			);
+		}
 		return (
+			// spokenMessage is load-bearing, not redundant: core defaults it to children
+			// and runs non-string children through renderToString mid-render, which
+			// corrupts hook state.
 			<Notice status="error" isDismissible={ false } spokenMessage={ message }>
 				{ message }{ ' ' }
-				<Button variant="link" onClick={ reload }>
+				<Button variant="link" ref={ retryRef } onClick={ retry }>
 					{ __( 'Retry', 'newspack-plugin' ) }
 				</Button>
 			</Notice>

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/PersonProfile.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/PersonProfile.jsx
@@ -31,12 +31,13 @@ import { useDispatch } from '@wordpress/data';
 import {
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	Notice,
 } from '@wordpress/components';
 
 /**
  * Internal dependencies.
  */
-import { Button, Card, Divider, Grid, Notice, Router, SectionHeader, Waiting } from '../../../../packages/components/src';
+import { Button, Card, Divider, Grid, Router, SectionHeader, Waiting } from '../../../../packages/components/src';
 import './style.scss';
 import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
 import SubscriptionCard from '../components/SubscriptionCard';
@@ -282,7 +283,8 @@ export default function PersonProfile() {
 	// a way back — not a Retry button that can never succeed.
 	if ( notFound ) {
 		return (
-			<Notice isError noticeText={ __( 'This subscriber could not be found. They may have been deleted.', 'newspack-plugin' ) }>
+			<Notice status="error" isDismissible={ false }>
+				{ __( 'This subscriber could not be found. They may have been deleted.', 'newspack-plugin' ) }{ ' ' }
 				<Button variant="link" href={ backNav }>
 					{ __( 'Back to the list', 'newspack-plugin' ) }
 				</Button>
@@ -293,8 +295,12 @@ export default function PersonProfile() {
 	// A failed read must not read as "this person has no subscriptions".
 	if ( error || ! subscriber ) {
 		return (
-			// translators: %s is an error message.
-			<Notice isError noticeText={ sprintf( __( 'Could not load this subscriber: %s', 'newspack-plugin' ), error ) }>
+			<Notice status="error" isDismissible={ false }>
+				{ sprintf(
+					/* translators: %s is an error message. */
+					__( 'Could not load this subscriber: %s', 'newspack-plugin' ),
+					error
+				) }{ ' ' }
 				<Button variant="link" onClick={ reload }>
 					{ __( 'Retry', 'newspack-plugin' ) }
 				</Button>

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/PersonProfile.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/PersonProfile.jsx
@@ -282,9 +282,10 @@ export default function PersonProfile() {
 	// A person who does not exist is a dead end, so it gets a plain statement and
 	// a way back — not a Retry button that can never succeed.
 	if ( notFound ) {
+		const message = __( 'This subscriber could not be found. They may have been deleted.', 'newspack-plugin' );
 		return (
-			<Notice status="error" isDismissible={ false }>
-				{ __( 'This subscriber could not be found. They may have been deleted.', 'newspack-plugin' ) }{ ' ' }
+			<Notice status="error" isDismissible={ false } spokenMessage={ message }>
+				{ message }{ ' ' }
 				<Button variant="link" href={ backNav }>
 					{ __( 'Back to the list', 'newspack-plugin' ) }
 				</Button>
@@ -294,13 +295,14 @@ export default function PersonProfile() {
 
 	// A failed read must not read as "this person has no subscriptions".
 	if ( error || ! subscriber ) {
+		const message = sprintf(
+			/* translators: %s is an error message. */
+			__( 'Could not load this subscriber: %s', 'newspack-plugin' ),
+			error
+		);
 		return (
-			<Notice status="error" isDismissible={ false }>
-				{ sprintf(
-					/* translators: %s is an error message. */
-					__( 'Could not load this subscriber: %s', 'newspack-plugin' ),
-					error
-				) }{ ' ' }
+			<Notice status="error" isDismissible={ false } spokenMessage={ message }>
+				{ message }{ ' ' }
 				<Button variant="link" onClick={ reload }>
 					{ __( 'Retry', 'newspack-plugin' ) }
 				</Button>

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/PersonProfile.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/PersonProfile.jsx
@@ -284,6 +284,9 @@ export default function PersonProfile() {
 	if ( notFound ) {
 		const message = __( 'This subscriber could not be found. They may have been deleted.', 'newspack-plugin' );
 		return (
+			// spokenMessage is load-bearing, not redundant: core defaults it to children
+			// and runs non-string children through renderToString mid-render, which
+			// corrupts hook state.
 			<Notice status="error" isDismissible={ false } spokenMessage={ message }>
 				{ message }{ ' ' }
 				<Button variant="link" href={ backNav }>
@@ -298,7 +301,9 @@ export default function PersonProfile() {
 		const message = sprintf(
 			/* translators: %s is an error message. */
 			__( 'Could not load this subscriber: %s', 'newspack-plugin' ),
-			error
+			// A read can also come back empty without reporting an error, which would
+			// otherwise leave the sentence hanging after the colon.
+			error || __( 'Something went wrong.', 'newspack-plugin' )
 		);
 		return (
 			<Notice status="error" isDismissible={ false } spokenMessage={ message }>

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/PersonProfile.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/PersonProfile.jsx
@@ -126,9 +126,7 @@ export default function PersonProfile() {
 
 	const { subscriber, loading, error, notFound, reload } = useSubscriber( id );
 
-	// A retry can land on either failure branch, so the ref goes on both affordances
-	// and focus follows whichever one renders. A missing person is covered too: that
-	// read nulls the subscriber.
+	// A missing person counts as failed here too: that read nulls the subscriber.
 	const { retryRef, retry } = useRetryFocus( { settled: ! loading, failed: Boolean( error || ! subscriber ), reload } );
 
 	// A 128px source feeds the 64px header avatar (2x for high-DPR displays),
@@ -303,9 +301,7 @@ export default function PersonProfile() {
 
 	// A failed read must not read as "this person has no subscriptions".
 	if ( error || ! subscriber ) {
-		// A read can also come back empty without reporting an error. That branch has
-		// no server detail to quote, so it gets its own sentence rather than a filler
-		// clause after the colon.
+		// An empty read reports no error, so there is no server detail to quote.
 		let message = __( 'This subscriber could not be loaded.', 'newspack-plugin' );
 		if ( error ) {
 			message = sprintf(

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/PersonProfile.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/PersonProfile.test.jsx
@@ -1,8 +1,6 @@
 /**
- * A profile read has three ways to fail, and each needs to say which one it was:
- * a person who does not exist, a request that errored, and a request that came
- * back empty without saying why. Each failure also has to leave the keyboard
- * somewhere useful.
+ * A profile read fails three ways, and each has to say which one it was: a person
+ * who does not exist, a request that errored, and one that came back empty.
  */
 
 /**
@@ -27,8 +25,7 @@ jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
 
 jest.mock( '../../../../packages/components/src/wizard/store', () => ( { WIZARD_STORE_NAMESPACE: 'test/person-profile' } ) );
 
-// Only the failure branches are under test, so the profile's layout components
-// render nothing. Button is real enough to take a ref and a focus call.
+// Only the failure branches are under test. Button is real enough to take a ref.
 jest.mock( '../../../../packages/components/src', () => ( {
 	Button: require( 'react' ).forwardRef( ( { children, ...props }, ref ) =>
 		require( 'react' ).createElement( 'button', { ...props, ref }, children )
@@ -75,8 +72,6 @@ describe( 'the person profile failure states', () => {
 	} );
 
 	it( 'gives a read that came back empty its own sentence', async () => {
-		// Resolves, but with nothing: no server message to quote, so the composed
-		// "Could not load this subscriber: …" sentence would hang after the colon.
 		apiFetch.mockResolvedValue( null );
 		await renderProfile();
 

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/PersonProfile.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/PersonProfile.test.jsx
@@ -1,0 +1,125 @@
+/**
+ * A profile read has three ways to fail, and each needs to say which one it was:
+ * a person who does not exist, a request that errored, and a request that came
+ * back empty without saying why. Each failure also has to leave the keyboard
+ * somewhere useful.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, act, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { createReduxStore, register } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
+import { speak } from '@wordpress/a11y';
+
+/**
+ * Internal dependencies
+ */
+import PersonProfile from './PersonProfile';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
+
+jest.mock( '../../../../packages/components/src/wizard/store', () => ( { WIZARD_STORE_NAMESPACE: 'test/person-profile' } ) );
+
+// Only the failure branches are under test, so the profile's layout components
+// render nothing. Button is real enough to take a ref and a focus call.
+jest.mock( '../../../../packages/components/src', () => ( {
+	Button: require( 'react' ).forwardRef( ( { children, ...props }, ref ) =>
+		require( 'react' ).createElement( 'button', { ...props, ref }, children )
+	),
+	Card: () => null,
+	Divider: () => null,
+	Grid: () => null,
+	SectionHeader: () => null,
+	Waiting: () => null,
+	Router: { useParams: () => ( { id: '1' } ), useLocation: () => ( { search: '', pathname: '/subscribers/1' } ) },
+} ) );
+
+jest.mock( '../data/use-avatars', () => ( { SHOW_AVATARS: false, useAvatars: () => ( { avatars: {}, loading: false } ) } ) );
+jest.mock( '../use-portals', () => ( { useWizardNode: () => null } ) );
+jest.mock( '../components/SubscriptionCard', () => () => null );
+
+register(
+	createReduxStore( 'test/person-profile', {
+		reducer: ( state = {} ) => state,
+		actions: { setHeaderData: () => ( { type: 'NOOP' } ) },
+	} )
+);
+
+const renderProfile = async () => {
+	await act( async () => {
+		render( <PersonProfile /> );
+	} );
+};
+
+const notFoundError = () => Object.assign( new Error( 'Not found.' ), { code: 'newspack_subscriber_not_found' } );
+
+describe( 'the person profile failure states', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+		speak.mockClear();
+	} );
+
+	it( 'names a read that failed, quoting the server', async () => {
+		apiFetch.mockRejectedValue( new Error( 'nope' ) );
+		await renderProfile();
+
+		expect( screen.getByText( /Could not load this subscriber: nope/ ) ).toBeInTheDocument();
+		expect( speak ).toHaveBeenCalledWith( 'Could not load this subscriber: nope', 'assertive' );
+	} );
+
+	it( 'gives a read that came back empty its own sentence', async () => {
+		// Resolves, but with nothing: no server message to quote, so the composed
+		// "Could not load this subscriber: …" sentence would hang after the colon.
+		apiFetch.mockResolvedValue( null );
+		await renderProfile();
+
+		expect( screen.getByText( /This subscriber could not be loaded\./ ) ).toBeInTheDocument();
+		expect( speak ).toHaveBeenCalledWith( 'This subscriber could not be loaded.', 'assertive' );
+	} );
+
+	it( 'tells a missing person apart from a failed read, and offers a way back', async () => {
+		apiFetch.mockRejectedValue( notFoundError() );
+		await renderProfile();
+
+		expect( screen.getByText( /could not be found/ ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Back to the list' } ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Retry' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'returns focus to Retry when a retry fails again', async () => {
+		apiFetch.mockRejectedValue( new Error( 'nope' ) );
+		await renderProfile();
+
+		await act( async () => {
+			fireEvent.click( screen.getByRole( 'button', { name: 'Retry' } ) );
+		} );
+
+		expect( screen.getByRole( 'button', { name: 'Retry' } ) ).toHaveFocus();
+	} );
+
+	it( 'returns focus to the way back when a retry turns up a missing person', async () => {
+		apiFetch.mockRejectedValue( new Error( 'nope' ) );
+		await renderProfile();
+
+		apiFetch.mockRejectedValue( notFoundError() );
+		await act( async () => {
+			fireEvent.click( screen.getByRole( 'button', { name: 'Retry' } ) );
+		} );
+
+		expect( screen.getByRole( 'button', { name: 'Back to the list' } ) ).toHaveFocus();
+	} );
+
+	it( 'leaves focus alone on the first failure', async () => {
+		apiFetch.mockRejectedValue( new Error( 'nope' ) );
+		await renderProfile();
+
+		expect( screen.getByRole( 'button', { name: 'Retry' } ) ).not.toHaveFocus();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
@@ -19,13 +19,13 @@
 import { useEffect, useMemo, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
-import { __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { __experimentalHStack as HStack, __experimentalVStack as VStack, Notice } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { Badge, Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies.
  */
-import { Button, DataViews, Notice, Router, StatusIndicator, Waiting } from '../../../../packages/components/src';
+import { Button, DataViews, Router, StatusIndicator, Waiting } from '../../../../packages/components/src';
 import { formatCount } from '../../../../packages/components/src/breadcrumbs/format-count';
 import './style.scss';
 import { fmtRelative, fmtDate } from '../format';
@@ -325,6 +325,7 @@ export default function SubscriberList() {
 	// Surface the subscriber count in the header breadcrumb, e.g. "/ Subscribers (85)".
 	useEffect( () => {
 		setHeaderData( {
+			fullWidth: ! error,
 			sectionName: [
 				{
 					label: __( 'Subscribers', 'newspack-plugin' ),
@@ -351,7 +352,8 @@ export default function SubscriberList() {
 	// offer a retry.
 	if ( error ) {
 		return (
-			<Notice isError noticeText={ sprintf( __( 'Could not load subscribers: %s', 'newspack-plugin' ), error ) }>
+			<Notice status="error" isDismissible={ false }>
+				{ sprintf( __( 'Could not load subscribers: %s', 'newspack-plugin' ), error ) }{ ' ' }
 				<Button variant="link" onClick={ reload }>
 					{ __( 'Retry', 'newspack-plugin' ) }
 				</Button>

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
@@ -325,7 +325,7 @@ export default function SubscriberList() {
 	// Surface the subscriber count in the header breadcrumb, e.g. "/ Subscribers (85)".
 	useEffect( () => {
 		setHeaderData( {
-			fullWidth: ! error,
+			fullWidth: error ? false : undefined,
 			sectionName: [
 				{
 					label: __( 'Subscribers', 'newspack-plugin' ),
@@ -351,9 +351,10 @@ export default function SubscriberList() {
 	// A failed read must not read as "this site has no subscribers": say so, and
 	// offer a retry.
 	if ( error ) {
+		const message = sprintf( __( 'Could not load subscribers: %s', 'newspack-plugin' ), error );
 		return (
-			<Notice status="error" isDismissible={ false }>
-				{ sprintf( __( 'Could not load subscribers: %s', 'newspack-plugin' ), error ) }{ ' ' }
+			<Notice status="error" isDismissible={ false } spokenMessage={ message }>
+				{ message }{ ' ' }
 				<Button variant="link" onClick={ reload }>
 					{ __( 'Retry', 'newspack-plugin' ) }
 				</Button>

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
@@ -16,7 +16,7 @@
 /**
  * WordPress dependencies.
  */
-import { useLayoutEffect, useMemo, useState } from '@wordpress/element';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { __experimentalHStack as HStack, __experimentalVStack as VStack, Notice } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -328,6 +328,9 @@ export default function SubscriberList() {
 	// and then snap into the content column.
 	useLayoutEffect( () => {
 		setHeaderData( {
+			// Header data is merged, so the explicit `undefined` is what clears a
+			// previous `false`. Dropping the key would strand the screen narrow for
+			// the rest of the visit, because a retry does not change the route.
 			fullWidth: error ? false : undefined,
 			sectionName: [
 				{
@@ -342,6 +345,21 @@ export default function SubscriberList() {
 			],
 		} );
 	}, [ setHeaderData, total, subscribersLoading, error ] );
+
+	// A retry unmounts this notice while the request is in flight. Without this the
+	// remounted Retry button is a fresh node and a keyboard user is dropped back on
+	// the document body, with no way to reach the retry they just asked for.
+	const retryRef = useRef( null );
+	const hasRetried = useRef( false );
+	const retry = () => {
+		hasRetried.current = true;
+		reload();
+	};
+	useEffect( () => {
+		if ( ! subscribersLoading && error && hasRetried.current ) {
+			retryRef.current?.focus();
+		}
+	}, [ subscribersLoading, error ] );
 
 	if ( subscribersLoading ) {
 		return (
@@ -365,7 +383,7 @@ export default function SubscriberList() {
 			// corrupts hook state.
 			<Notice status="error" isDismissible={ false } spokenMessage={ message }>
 				{ message }{ ' ' }
-				<Button variant="link" onClick={ reload }>
+				<Button variant="link" ref={ retryRef } onClick={ retry }>
 					{ __( 'Retry', 'newspack-plugin' ) }
 				</Button>
 			</Notice>

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
@@ -16,10 +16,10 @@
 /**
  * WordPress dependencies.
  */
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { useLayoutEffect, useMemo, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
-import { __experimentalHStack as HStack, __experimentalVStack as VStack, Notice } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { Badge, Stack } from '@wordpress/ui';
 
 /**
@@ -28,6 +28,8 @@ import { Badge, Stack } from '@wordpress/ui';
 import { Button, DataViews, Router, StatusIndicator, Waiting } from '../../../../packages/components/src';
 import { formatCount } from '../../../../packages/components/src/breadcrumbs/format-count';
 import './style.scss';
+import LoadFailureNotice from '../components/LoadFailureNotice';
+import { useRetryFocus } from '../use-retry-focus';
 import { fmtRelative, fmtDate } from '../format';
 import { SHOW_AVATARS, useAvatars } from '../data/use-avatars';
 import { useSubscribers } from '../data/use-subscribers';
@@ -346,20 +348,7 @@ export default function SubscriberList() {
 		} );
 	}, [ setHeaderData, total, subscribersLoading, error ] );
 
-	// A retry unmounts this notice while the request is in flight. Without this the
-	// remounted Retry button is a fresh node and a keyboard user is dropped back on
-	// the document body, with no way to reach the retry they just asked for.
-	const retryRef = useRef( null );
-	const hasRetried = useRef( false );
-	const retry = () => {
-		hasRetried.current = true;
-		reload();
-	};
-	useEffect( () => {
-		if ( ! subscribersLoading && error && hasRetried.current ) {
-			retryRef.current?.focus();
-		}
-	}, [ subscribersLoading, error ] );
+	const { retryRef, retry } = useRetryFocus( { settled: ! subscribersLoading, failed: Boolean( error ), reload } );
 
 	if ( subscribersLoading ) {
 		return (
@@ -378,15 +367,14 @@ export default function SubscriberList() {
 			error
 		);
 		return (
-			// spokenMessage is load-bearing, not redundant: core defaults it to children
-			// and runs non-string children through renderToString mid-render, which
-			// corrupts hook state.
-			<Notice status="error" isDismissible={ false } spokenMessage={ message }>
-				{ message }{ ' ' }
-				<Button variant="link" ref={ retryRef } onClick={ retry }>
-					{ __( 'Retry', 'newspack-plugin' ) }
-				</Button>
-			</Notice>
+			<LoadFailureNotice
+				message={ message }
+				action={
+					<Button variant="link" ref={ retryRef } onClick={ retry }>
+						{ __( 'Retry', 'newspack-plugin' ) }
+					</Button>
+				}
+			/>
 		);
 	}
 

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
@@ -325,14 +325,12 @@ export default function SubscriberList() {
 	};
 
 	// Surface the subscriber count in the header breadcrumb, e.g. "/ Subscribers (85)".
-	// Before paint, not after: this also carries the width override, and an error
-	// arrives outside a React event, so a passive effect would paint full-bleed once
-	// and then snap into the content column.
+	// Before paint: this carries the width override, and an error arrives outside a
+	// React event, so a passive effect would paint full-bleed for one frame first.
 	useLayoutEffect( () => {
 		setHeaderData( {
 			// Header data is merged, so the explicit `undefined` is what clears a
-			// previous `false`. Dropping the key would strand the screen narrow for
-			// the rest of the visit, because a retry does not change the route.
+			// previous `false`; a retry never changes the route, so nothing else would.
 			fullWidth: error ? false : undefined,
 			sectionName: [
 				{

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.jsx
@@ -16,7 +16,7 @@
 /**
  * WordPress dependencies.
  */
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useLayoutEffect, useMemo, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { __experimentalHStack as HStack, __experimentalVStack as VStack, Notice } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -323,7 +323,10 @@ export default function SubscriberList() {
 	};
 
 	// Surface the subscriber count in the header breadcrumb, e.g. "/ Subscribers (85)".
-	useEffect( () => {
+	// Before paint, not after: this also carries the width override, and an error
+	// arrives outside a React event, so a passive effect would paint full-bleed once
+	// and then snap into the content column.
+	useLayoutEffect( () => {
 		setHeaderData( {
 			fullWidth: error ? false : undefined,
 			sectionName: [
@@ -351,8 +354,15 @@ export default function SubscriberList() {
 	// A failed read must not read as "this site has no subscribers": say so, and
 	// offer a retry.
 	if ( error ) {
-		const message = sprintf( __( 'Could not load subscribers: %s', 'newspack-plugin' ), error );
+		const message = sprintf(
+			/* translators: %s: the error message returned by the server. */
+			__( 'Could not load subscribers: %s', 'newspack-plugin' ),
+			error
+		);
 		return (
+			// spokenMessage is load-bearing, not redundant: core defaults it to children
+			// and runs non-string children through renderToString mid-render, which
+			// corrupts hook state.
 			<Notice status="error" isDismissible={ false } spokenMessage={ message }>
 				{ message }{ ' ' }
 				<Button variant="link" onClick={ reload }>

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.test.jsx
@@ -29,7 +29,6 @@ jest.mock( '../../../../packages/components/src/wizard/store', () => ( { WIZARD_
 jest.mock( '../../../../packages/components/src', () => ( {
 	DataViews: () => null,
 	Button: () => null,
-	Notice: () => null,
 	Waiting: () => null,
 	Router: { useHistory: () => ( { push: jest.fn() } ), useLocation: () => ( { pathname: '/' } ) },
 } ) );
@@ -68,6 +67,8 @@ const publishedSection = () => {
 	const named = headerCalls.filter( data => data.sectionName );
 	return named[ named.length - 1 ].sectionName[ 0 ];
 };
+
+const lastHeaderCall = () => headerCalls[ headerCalls.length - 1 ];
 
 describe( 'the subscriber list header count', () => {
 	beforeEach( () => {
@@ -127,5 +128,30 @@ describe( 'the subscriber list header count', () => {
 			render( <SubscriberList /> );
 		} );
 		expect( publishedSection().countLabel ).toBe( '2 subscribers' );
+	} );
+} );
+
+describe( 'the subscriber list width override', () => {
+	beforeEach( () => {
+		headerCalls = [];
+		apiFetch.mockReset();
+	} );
+
+	it( 'leaves the section width alone once the subscribers land', async () => {
+		apiFetch.mockResolvedValue( page( 1 ) );
+		await act( async () => {
+			render( <SubscriberList /> );
+		} );
+
+		expect( lastHeaderCall().fullWidth ).toBeUndefined();
+	} );
+
+	it( 'narrows the width when the read fails', async () => {
+		apiFetch.mockRejectedValue( new Error( 'nope' ) );
+		await act( async () => {
+			render( <SubscriberList /> );
+		} );
+
+		expect( lastHeaderCall().fullWidth ).toBe( false );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.test.jsx
@@ -31,8 +31,7 @@ jest.mock( '../../../../packages/components/src/wizard/store', () => ( { WIZARD_
 // reads the router at module scope, so the proxy has to answer here too.
 jest.mock( '../../../../packages/components/src', () => ( {
 	DataViews: () => null,
-	// Renders a real button: the load-failure notice puts a ref on Retry to restore
-	// focus, which needs a host node to land on.
+	// A real button, because the focus restoration needs a host node to land on.
 	Button: require( 'react' ).forwardRef( ( { children, ...props }, ref ) =>
 		require( 'react' ).createElement( 'button', { ...props, ref }, children )
 	),
@@ -150,8 +149,7 @@ describe( 'the subscriber list width override', () => {
 			render( <SubscriberList /> );
 		} );
 
-		// Presence is the load-bearing part: header data is merged, so only an
-		// explicit `undefined` clears a `false` left by an earlier failure.
+		// Presence, not just the value: only an explicit `undefined` clears a `false`.
 		expect( 'fullWidth' in lastHeaderCall() ).toBe( true );
 		expect( lastHeaderCall().fullWidth ).toBeUndefined();
 	} );

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.test.jsx
@@ -7,13 +7,14 @@
 /**
  * External dependencies
  */
-import { render, act } from '@testing-library/react';
+import { render, act, screen, fireEvent } from '@testing-library/react';
 
 /**
  * WordPress dependencies
  */
 import { createReduxStore, register } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -22,13 +23,19 @@ import SubscriberList from './SubscriberList';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
+jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
+
 jest.mock( '../../../../packages/components/src/wizard/store', () => ( { WIZARD_STORE_NAMESPACE: 'test/subscriber-list' } ) );
 
 // Only the header count is under test, so DataViews renders nothing. The list
 // reads the router at module scope, so the proxy has to answer here too.
 jest.mock( '../../../../packages/components/src', () => ( {
 	DataViews: () => null,
-	Button: () => null,
+	// Renders a real button: the load-failure notice puts a ref on Retry to restore
+	// focus, which needs a host node to land on.
+	Button: require( 'react' ).forwardRef( ( { children, ...props }, ref ) =>
+		require( 'react' ).createElement( 'button', { ...props, ref }, children )
+	),
 	Waiting: () => null,
 	Router: { useHistory: () => ( { push: jest.fn() } ), useLocation: () => ( { pathname: '/' } ) },
 } ) );
@@ -153,5 +160,60 @@ describe( 'the subscriber list width override', () => {
 		} );
 
 		expect( lastHeaderCall().fullWidth ).toBe( false );
+	} );
+} );
+
+describe( 'the SubscriberList load-failure announcement', () => {
+	beforeEach( () => {
+		headerCalls = [];
+		apiFetch.mockReset();
+		speak.mockClear();
+	} );
+
+	it( 'announces the failure assertively', async () => {
+		apiFetch.mockRejectedValue( new Error( 'nope' ) );
+		await act( async () => {
+			render( <SubscriberList /> );
+		} );
+
+		expect( speak ).toHaveBeenCalledWith( 'Could not load subscribers: nope', 'assertive' );
+	} );
+
+	it( 'says nothing when the read succeeds', async () => {
+		apiFetch.mockResolvedValue( page( 1 ) );
+		await act( async () => {
+			render( <SubscriberList /> );
+		} );
+
+		expect( speak ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'the SubscriberList retry affordance', () => {
+	beforeEach( () => {
+		headerCalls = [];
+		apiFetch.mockReset();
+	} );
+
+	it( 'returns focus to Retry when a retry fails again', async () => {
+		apiFetch.mockRejectedValue( new Error( 'nope' ) );
+		await act( async () => {
+			render( <SubscriberList /> );
+		} );
+
+		await act( async () => {
+			fireEvent.click( screen.getByRole( 'button', { name: 'Retry' } ) );
+		} );
+
+		expect( screen.getByRole( 'button', { name: 'Retry' } ) ).toHaveFocus();
+	} );
+
+	it( 'leaves focus alone on the first failure', async () => {
+		apiFetch.mockRejectedValue( new Error( 'nope' ) );
+		await act( async () => {
+			render( <SubscriberList /> );
+		} );
+
+		expect( screen.getByRole( 'button', { name: 'Retry' } ) ).not.toHaveFocus();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/SubscriberList.test.jsx
@@ -150,6 +150,9 @@ describe( 'the subscriber list width override', () => {
 			render( <SubscriberList /> );
 		} );
 
+		// Presence is the load-bearing part: header data is merged, so only an
+		// explicit `undefined` clears a `false` left by an earlier failure.
+		expect( 'fullWidth' in lastHeaderCall() ).toBe( true );
 		expect( lastHeaderCall().fullWidth ).toBeUndefined();
 	} );
 
@@ -206,6 +209,24 @@ describe( 'the SubscriberList retry affordance', () => {
 		} );
 
 		expect( screen.getByRole( 'button', { name: 'Retry' } ) ).toHaveFocus();
+	} );
+
+	it( 'leaves focus where the reader moved it while the retry was in flight', async () => {
+		apiFetch.mockRejectedValue( new Error( 'nope' ) );
+		await act( async () => {
+			render( <SubscriberList /> );
+		} );
+
+		const elsewhere = document.createElement( 'button' );
+		document.body.appendChild( elsewhere );
+
+		await act( async () => {
+			fireEvent.click( screen.getByRole( 'button', { name: 'Retry' } ) );
+			elsewhere.focus();
+		} );
+
+		expect( elsewhere ).toHaveFocus();
+		elsewhere.remove();
 	} );
 
 	it( 'leaves focus alone on the first failure', async () => {

--- a/plugins/newspack-plugin/src/wizards/subscribers/screens/style.scss
+++ b/plugins/newspack-plugin/src/wizards/subscribers/screens/style.scss
@@ -258,20 +258,6 @@
 }
 
 .newspack-subscribers__profile {
-	// The "could not load" / "not found" notices carry their retry and back links
-	// as notice actions; give them room and a consistent button metric.
-	.components-notice__actions {
-		margin-top: wp-vars.$grid-unit-15;
-
-		.components-button {
-			height: wp-vars.$grid-unit-40;
-			line-height: 1;
-			margin-left: 0;
-			margin-right: 0;
-			padding: 0 wp-vars.$grid-unit-15;
-		}
-	}
-
 	// Inline (non-full-width) DataViews inherit a -48px horizontal bleed from the
 	// wizard content style; cancel it so the member/invitation tables align with
 	// the rest of the section.

--- a/plugins/newspack-plugin/src/wizards/subscribers/use-retry-focus.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/use-retry-focus.js
@@ -1,0 +1,37 @@
+/**
+ * WordPress dependencies.
+ */
+import { useEffect, useRef } from '@wordpress/element';
+
+/**
+ * Keep a failed read's retry affordance reachable from the keyboard.
+ *
+ * Retrying unmounts the notice while the request is in flight, so the affordance
+ * that comes back is a fresh node and focus has already fallen to the document
+ * body. Focus is restored only when it actually landed there, so a reader who
+ * tabbed away while the request was running is not pulled back.
+ *
+ * @param {Object}   options
+ * @param {boolean}  options.settled Whether the read has finished.
+ * @param {boolean}  options.failed  Whether the finished read failed.
+ * @param {Function} options.reload  Starts the read again.
+ * @return {{retryRef: Object, retry: Function}} Ref for the affordance, and the handler that starts a retry.
+ */
+export function useRetryFocus( { settled, failed, reload } ) {
+	const retryRef = useRef( null );
+	const hasRetried = useRef( false );
+
+	const retry = () => {
+		hasRetried.current = true;
+		reload();
+	};
+
+	useEffect( () => {
+		const node = retryRef.current;
+		if ( settled && failed && hasRetried.current && node && node.ownerDocument.activeElement === node.ownerDocument.body ) {
+			node.focus();
+		}
+	}, [ settled, failed ] );
+
+	return { retryRef, retry };
+}

--- a/plugins/newspack-plugin/src/wizards/subscribers/use-retry-focus.js
+++ b/plugins/newspack-plugin/src/wizards/subscribers/use-retry-focus.js
@@ -6,10 +6,9 @@ import { useEffect, useRef } from '@wordpress/element';
 /**
  * Keep a failed read's retry affordance reachable from the keyboard.
  *
- * Retrying unmounts the notice while the request is in flight, so the affordance
- * that comes back is a fresh node and focus has already fallen to the document
- * body. Focus is restored only when it actually landed there, so a reader who
- * tabbed away while the request was running is not pulled back.
+ * Retrying unmounts the notice, so the affordance that comes back is a fresh node
+ * and focus has fallen to the body. It is restored only when it actually landed
+ * there, so a reader who tabbed away mid-request is not pulled back.
  *
  * @param {Object}   options
  * @param {boolean}  options.settled Whether the read has finished.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Newspack's own `Notice` component never announces to screen readers: it renders a plain `<div>` with no live region and no `speak()` call. This moves the four load-failure notices in the Subscribers wizard (subscriber list, group list, and both person-profile failure states) onto core's `Notice`, which announces through `wp-a11y` and adds a visually hidden "Error notice" label. `status="error"` announces assertively by default, which is what we want for a failed read.

Each notice passes an explicit string `spokenMessage`. That keeps core on its string branch: left to default, `spokenMessage` falls back to `children`, and non-string children get run through `renderToString` during render, which corrupts hook state.

The two list screens were also rendering their error banner full-bleed, because the wizard's layout tracked a static full-width flag per section rather than per render. The shared `Wizard` now accepts a per-render `fullWidth` override via `setHeaderData`, so those screens can drop back to the standard content column while they show a notice instead of their table. The override is written before paint, so the notice never appears full-bleed for a frame on the way in.

Two smaller things in the same area. The person profile completes its sentence when a read comes back empty without any error text. A block of styles for notice actions that these notices never used is gone.

![Subscribers list load-failure notice, now core's Notice component, constrained to the content column](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/03/7vn6e882-Newspack%20Shot%202026-09-03%20at%2016.46.12.png)

### How to test the changes in this Pull Request:

1. Make the subscribers read fail, for example with a `rest_pre_dispatch` filter returning a `WP_Error` for `/newspack/v1/wizard/newspack-subscribers/subscribers`. Open Audience > Subscribers. The error notice sits in the standard content column rather than full-bleed, and does not flash wider on the way in.
2. Do the same for the `/groups` route and open the Groups tab. The notice behaves the same way there.
3. Click Retry on either screen. The read runs again and the table returns to full width once it succeeds.
4. Visit a subscriber profile URL for an ID that does not exist. The notice reads "This subscriber could not be found. They may have been deleted." and the "Back to the list" link returns to the list.
5. With a screen reader running, trigger any of the above. The message is announced as soon as the notice renders.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

`packages/components`' `Wizard` gained an optional `fullWidth` override read from header data. It falls back to the section's own configuration when unset, so existing consumers keep their current behaviour, and nothing outside this plugin's wizards reads or writes the flag today.
