### PR TITLE
fix(author-profile): load a page's authors in one request instead of one per block

### DIFF
--- a/plugins/newspack-blocks/src/blocks/author-list/class-wp-rest-newspack-author-list-controller.php
+++ b/plugins/newspack-blocks/src/blocks/author-list/class-wp-rest-newspack-author-list-controller.php
@@ -173,6 +173,11 @@ class WP_REST_Newspack_Author_List_Controller extends WP_REST_Newspack_Authors_C
 		];
 		$options         = wp_parse_args( $options, $default_options );
 		$fields          = $options['fields'];
+
+		// Only the component's own author roles can be listed. A caller-chosen role outside them
+		// is dropped, and when nothing usable remains the user query is skipped below rather than
+		// run without a role filter, which would match every user on the site.
+		$options['author_roles'] = array_values( array_intersect( (array) $options['author_roles'], Newspack_Blocks\get_authors_roles_slugs() ) );
 		$current_page    = 1;
 
 		// Array to store all authors.
@@ -219,7 +224,7 @@ class WP_REST_Newspack_Author_List_Controller extends WP_REST_Newspack_Authors_C
 			}
 		}
 
-		if ( in_array( $options['author_type'], [ 'all', 'users' ], true ) ) {
+		if ( ! empty( $options['author_roles'] ) && in_array( $options['author_type'], [ 'all', 'users' ], true ) ) {
 			// Reset current page for new query.
 			$current_page         = 1;
 			$exclude_empty        = $options['exclude_empty'] ? true : false;

--- a/plugins/newspack-blocks/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
+++ b/plugins/newspack-blocks/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
@@ -335,6 +335,12 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 			}
 		}
 
+		if ( $author_ids ) {
+			// Two queries for the whole list instead of two per user: get_user_by() reads the user
+			// row and its capabilities from the object cache once both are primed.
+			cache_users( $author_ids );
+		}
+
 		foreach ( $author_ids as $author_id ) {
 			$user_data = self::format_user( get_user_by( 'id', $author_id ), $fields, $avatar_hide_default );
 			if ( $user_data ) {

--- a/plugins/newspack-blocks/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
+++ b/plugins/newspack-blocks/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
@@ -66,6 +66,19 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Whether a WP user holds one of the roles this component treats as an author.
+	 *
+	 * The listing branch has always been narrowed to these roles. The by-id branches have to
+	 * agree with it, or an id becomes a way to read any user's profile fields.
+	 *
+	 * @param WP_User|false $user The user.
+	 * @return bool
+	 */
+	public static function is_author_role_user( $user ) {
+		return $user && ! empty( array_intersect( (array) $user->roles, \Newspack_Blocks\get_authors_roles_slugs() ) );
+	}
+
+	/**
 	 * Turn a comma-separated list (or array) of IDs into unique positive integers.
 	 *
 	 * @param string|array $value Raw request param.
@@ -215,7 +228,7 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 			if ( 0 === $guest_author_total ) {
 				$user = get_user_by( 'id', $author_id ); // Get the WP user.
 
-				if ( $user ) {
+				if ( self::is_author_role_user( $user ) ) {
 					$users = [ $user ];
 				}
 			}
@@ -342,7 +355,11 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 		}
 
 		foreach ( $author_ids as $author_id ) {
-			$user_data = self::format_user( get_user_by( 'id', $author_id ), $fields, $avatar_hide_default );
+			$user = get_user_by( 'id', $author_id );
+			if ( ! self::is_author_role_user( $user ) ) {
+				continue;
+			}
+			$user_data = self::format_user( $user, $fields, $avatar_hide_default );
 			if ( $user_data ) {
 				$authors[] = $user_data;
 			}
@@ -616,7 +633,9 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 	 */
 	protected function get_post_authors( $post_id, $fields, $avatar_hide_default ) {
 		$post = get_post( $post_id );
-		if ( ! $post ) {
+
+		// Who wrote an unpublished post is not the caller's to know unless they can read it.
+		if ( ! $post || ! current_user_can( 'read_post', $post->ID ) ) {
 			return rest_ensure_response( [] );
 		}
 

--- a/plugins/newspack-blocks/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
+++ b/plugins/newspack-blocks/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
@@ -66,15 +66,23 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Most IDs one batched lookup resolves.
+	 *
+	 * A page never needs more than it has blocks, and an unbounded list would recreate the long
+	 * PHP request the batched lookup exists to avoid. The editor splits its batches to match.
+	 */
+	const MAX_BATCH_IDS = 100;
+
+	/**
 	 * Turn a comma-separated list (or array) of IDs into unique positive integers.
 	 *
 	 * @param string|array $value Raw request param.
-	 * @return int[]
+	 * @return int[] At most MAX_BATCH_IDS of them.
 	 */
 	public static function sanitize_id_list( $value ) {
 		$ids = is_array( $value ) ? $value : explode( ',', (string) $value );
 		$ids = array_filter( array_map( 'absint', $ids ) );
-		return array_values( array_unique( $ids ) );
+		return array_slice( array_values( array_unique( $ids ) ), 0, self::MAX_BATCH_IDS );
 	}
 
 	/**
@@ -151,8 +159,9 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 		$author_ids          = ! empty( $request->get_param( 'author_ids' ) ) ? $request->get_param( 'author_ids' ) : []; // Fetch several WP users by ID in one request.
 		$guest_author_ids    = ! empty( $request->get_param( 'guest_author_ids' ) ) ? $request->get_param( 'guest_author_ids' ) : []; // Fetch several guest authors by ID in one request.
 
-		// If a list of IDs is provided, resolve them all in one response.
-		if ( $author_ids || $guest_author_ids ) {
+		// If a list of IDs is provided, resolve them all in one response. A list with no valid ID
+		// is still a list, and gets an empty response rather than the recent-authors listing.
+		if ( $request->has_param( 'author_ids' ) || $request->has_param( 'guest_author_ids' ) ) {
 			return $this->get_authors_by_ids( $author_ids, $guest_author_ids, $fields, $avatar_hide_default );
 		}
 
@@ -306,8 +315,10 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 	 * Return the given users and guest authors in one response.
 	 *
 	 * Backs the editor's batched lookups: a page with many Author Profile blocks resolves every
-	 * author with a single request instead of one per block. Each ID is looked up the way the
-	 * single-ID path does, so a record is identical to what a block received on its own.
+	 * author with a single request instead of one per block. Each ID is formatted the way the
+	 * single-ID path formats it, so a record matches what a block received on its own, including
+	 * the guest-to-user fallback: a guest ID means "not known to be a WP user", because blocks
+	 * saved before the `isGuestAuthor` attribute existed default to it for every author.
 	 *
 	 * @param int[] $author_ids          WP user IDs.
 	 * @param int[] $guest_author_ids    Guest author post IDs.
@@ -327,12 +338,16 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 					'orderby'        => 'post__in',
 				]
 			);
+			$found         = [];
 			foreach ( $guest_authors as $guest_author ) {
+				$found[]           = (int) $guest_author->ID;
 				$guest_author_data = self::format_guest_author( $guest_author, $fields, $avatar_hide_default );
 				if ( $guest_author_data ) {
 					$authors[] = $guest_author_data;
 				}
 			}
+			// Resolve the rest as WP users, the way the single-ID path and the front-end renderer do.
+			$author_ids = array_values( array_unique( array_merge( $author_ids, array_diff( $guest_author_ids, $found ) ) ) );
 		}
 
 		if ( $author_ids ) {
@@ -375,6 +390,9 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 		];
 
 		$guest_author = ( new CoAuthors_Guest_Authors() )->get_guest_author_by( 'id', $guest_author->ID );
+		if ( ! $guest_author ) {
+			return null;
+		}
 
 		if ( in_array( 'avatar', $fields, true ) && function_exists( 'coauthors_get_avatar' ) ) {
 			$avatar = coauthors_get_avatar( $guest_author, 256, $avatar_hide_default ? 'blank' : '' );
@@ -498,7 +516,7 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 			$user_data['url'] = esc_url( get_author_posts_url( $user->data->ID ) );
 		}
 		if ( false === $fields || in_array( 'social', $fields, true ) ) {
-			$user_data['social'] = self::get_social( $user->data->ID );
+			$user_data['social'] = self::get_social( $user->data->ID, false );
 		}
 
 		if ( class_exists( '\Newspack\Authors_Custom_Fields' ) ) {
@@ -564,10 +582,11 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 	/**
 	 * Get social media URLs and SVGs, if available. Only standard WP users have this user meta.
 	 *
-	 * @param int $author_id Author ID.
+	 * @param int     $author_id       Author ID.
+	 * @param boolean $is_guest_author Whether the ID is a CAP guest author, whose website lives in post meta.
 	 * @return array Array of social links and SVGs.
 	 */
-	public static function get_social( $author_id ) {
+	public static function get_social( $author_id, $is_guest_author = true ) {
 		$social_profiles = [
 			'facebook',
 			'twitter',
@@ -585,9 +604,13 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 
 		return array_reduce(
 			$social_profiles,
-			function( $acc, $profile ) use ( $author_id ) {
+			function( $acc, $profile ) use ( $author_id, $is_guest_author ) {
 				$is_website = 'website' === $profile;
-				$handle     = $is_website ? get_post_meta( $author_id, 'cap-website', true ) : get_the_author_meta( $profile, $author_id );
+				if ( $is_website && ! $is_guest_author ) {
+					// A WP user has no post meta to read, and reading it costs a query per user.
+					return $acc;
+				}
+				$handle = $is_website ? get_post_meta( $author_id, 'cap-website', true ) : get_the_author_meta( $profile, $author_id );
 
 				if ( $handle ) {
 					$url             = 'twitter' === $profile ? esc_url( 'https://x.com/' . $handle ) : esc_url( $handle );

--- a/plugins/newspack-blocks/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
+++ b/plugins/newspack-blocks/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
@@ -72,6 +72,8 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 	 * PHP request the batched lookup exists to avoid. The editor splits its batches to match.
 	 */
 	const MAX_BATCH_IDS = 100;
+
+	/**
 	 * Whether a WP user holds one of the roles this component treats as an author.
 	 *
 	 * The listing branch has always been narrowed to these roles. The by-id branches have to

--- a/plugins/newspack-blocks/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
+++ b/plugins/newspack-blocks/src/blocks/author-profile/class-wp-rest-newspack-authors-controller.php
@@ -66,6 +66,18 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Turn a comma-separated list (or array) of IDs into unique positive integers.
+	 *
+	 * @param string|array $value Raw request param.
+	 * @return int[]
+	 */
+	public static function sanitize_id_list( $value ) {
+		$ids = is_array( $value ) ? $value : explode( ',', (string) $value );
+		$ids = array_filter( array_map( 'absint', $ids ) );
+		return array_values( array_unique( $ids ) );
+	}
+
+	/**
 	 * Registers the necessary REST API routes.
 	 *
 	 * @access public
@@ -104,6 +116,12 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 						'post_id'             => [
 							'sanitize_callback' => 'absint',
 						],
+						'author_ids'          => [
+							'sanitize_callback' => [ __CLASS__, 'sanitize_id_list' ],
+						],
+						'guest_author_ids'    => [
+							'sanitize_callback' => [ __CLASS__, 'sanitize_id_list' ],
+						],
 					],
 					'permission_callback' => function() {
 						return current_user_can( 'edit_posts' );
@@ -130,6 +148,13 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 		$fields              = self::restrict_fields( $fields );
 		$include             = ! empty( $request->get_param( 'include' ) ) ? explode( ',', $request->get_param( 'include' ) ) : null; // Fetch authors by multiple IDs.
 		$post_id             = ! empty( $request->get_param( 'post_id' ) ) ? $request->get_param( 'post_id' ) : 0; // Fetch authors for a specific post (contextual mode).
+		$author_ids          = ! empty( $request->get_param( 'author_ids' ) ) ? $request->get_param( 'author_ids' ) : []; // Fetch several WP users by ID in one request.
+		$guest_author_ids    = ! empty( $request->get_param( 'guest_author_ids' ) ) ? $request->get_param( 'guest_author_ids' ) : []; // Fetch several guest authors by ID in one request.
+
+		// If a list of IDs is provided, resolve them all in one response.
+		if ( $author_ids || $guest_author_ids ) {
+			return $this->get_authors_by_ids( $author_ids, $guest_author_ids, $fields, $avatar_hide_default );
+		}
 
 		// If post_id is provided, get authors for that specific post.
 		if ( $post_id ) {
@@ -242,29 +267,9 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 			array_reduce(
 				! empty( $guest_authors ) ? $guest_authors : [],
 				function( $acc, $guest_author ) use ( $fields, $avatar_hide_default ) {
-					if ( $guest_author ) {
-						if ( class_exists( 'CoAuthors_Guest_Authors' ) ) {
-							$guest_author_data = [
-								'id'         => intval( $guest_author->ID ),
-								'registered' => $guest_author->post_date,
-								'is_guest'   => true,
-								'slug'       => $guest_author->post_name,
-							];
-
-							$guest_author = ( new CoAuthors_Guest_Authors() )->get_guest_author_by( 'id', $guest_author->ID );
-
-							if ( in_array( 'avatar', $fields, true ) && function_exists( 'coauthors_get_avatar' ) ) {
-								$avatar = coauthors_get_avatar( $guest_author, 256, $avatar_hide_default ? 'blank' : '' );
-
-								if ( \Newspack_Blocks\is_avatar_displayable( $avatar, $avatar_hide_default ) ) {
-									$guest_author_data['avatar'] = $avatar;
-								}
-							}
-
-							$guest_author_data = self::fill_guest_author_data( $guest_author_data, $guest_author, $fields );
-
-							$acc[] = $guest_author_data;
-						}
+					$guest_author_data = self::format_guest_author( $guest_author, $fields, $avatar_hide_default );
+					if ( $guest_author_data ) {
+						$acc[] = $guest_author_data;
 					}
 					return $acc;
 				},
@@ -273,24 +278,9 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 			array_reduce(
 				$users,
 				function( $acc, $user ) use ( $fields, $avatar_hide_default ) {
-					if ( $user ) {
-						$user_data = [
-							'id'         => intval( $user->data->ID ),
-							'registered' => $user->data->user_registered,
-							'is_guest'   => false,
-							'slug'       => $user->data->user_login,
-						];
-
-						if ( in_array( 'avatar', $fields, true ) ) {
-							$avatar = get_avatar( $user->data->ID, 256, $avatar_hide_default ? 'blank' : '' );
-
-							if ( \Newspack_Blocks\is_avatar_displayable( $avatar, $avatar_hide_default ) ) {
-								$user_data['avatar'] = $avatar;
-							}
-						}
-
-						$user_data = self::fill_user_data( $user_data, $user, $fields );
-						$acc[]     = $user_data;
+					$user_data = self::format_user( $user, $fields, $avatar_hide_default );
+					if ( $user_data ) {
+						$acc[] = $user_data;
 					}
 					return $acc;
 				},
@@ -310,6 +300,116 @@ class WP_REST_Newspack_Authors_Controller extends WP_REST_Controller {
 		$response->header( 'x-wp-total', $user_total + $guest_author_total );
 
 		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Return the given users and guest authors in one response.
+	 *
+	 * Backs the editor's batched lookups: a page with many Author Profile blocks resolves every
+	 * author with a single request instead of one per block. Each ID is looked up the way the
+	 * single-ID path does, so a record is identical to what a block received on its own.
+	 *
+	 * @param int[] $author_ids          WP user IDs.
+	 * @param int[] $guest_author_ids    Guest author post IDs.
+	 * @param array $fields              Fields to include.
+	 * @param bool  $avatar_hide_default Whether to hide the default avatar.
+	 * @return WP_REST_Response
+	 */
+	public function get_authors_by_ids( $author_ids, $guest_author_ids, $fields, $avatar_hide_default ) {
+		$authors = [];
+
+		if ( $guest_author_ids ) {
+			$guest_authors = get_posts(
+				[
+					'post_type'      => 'guest-author',
+					'post__in'       => $guest_author_ids,
+					'posts_per_page' => count( $guest_author_ids ),
+					'orderby'        => 'post__in',
+				]
+			);
+			foreach ( $guest_authors as $guest_author ) {
+				$guest_author_data = self::format_guest_author( $guest_author, $fields, $avatar_hide_default );
+				if ( $guest_author_data ) {
+					$authors[] = $guest_author_data;
+				}
+			}
+		}
+
+		foreach ( $author_ids as $author_id ) {
+			$user_data = self::format_user( get_user_by( 'id', $author_id ), $fields, $avatar_hide_default );
+			if ( $user_data ) {
+				$authors[] = $user_data;
+			}
+		}
+
+		$response = new WP_REST_Response( $authors );
+		$response->header( 'x-wp-total', count( $authors ) );
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Format a guest author post as an endpoint record.
+	 *
+	 * @param WP_Post|false $guest_author        Guest author post.
+	 * @param array         $fields              Fields to include.
+	 * @param bool          $avatar_hide_default Whether to hide the default avatar.
+	 * @return array|null Record, or null when there is nothing to format.
+	 */
+	public static function format_guest_author( $guest_author, $fields, $avatar_hide_default ) {
+		if ( ! $guest_author || ! class_exists( 'CoAuthors_Guest_Authors' ) ) {
+			return null;
+		}
+
+		$guest_author_data = [
+			'id'         => intval( $guest_author->ID ),
+			'registered' => $guest_author->post_date,
+			'is_guest'   => true,
+			'slug'       => $guest_author->post_name,
+		];
+
+		$guest_author = ( new CoAuthors_Guest_Authors() )->get_guest_author_by( 'id', $guest_author->ID );
+
+		if ( in_array( 'avatar', $fields, true ) && function_exists( 'coauthors_get_avatar' ) ) {
+			$avatar = coauthors_get_avatar( $guest_author, 256, $avatar_hide_default ? 'blank' : '' );
+
+			if ( \Newspack_Blocks\is_avatar_displayable( $avatar, $avatar_hide_default ) ) {
+				$guest_author_data['avatar'] = $avatar;
+			}
+		}
+
+		return self::fill_guest_author_data( $guest_author_data, $guest_author, $fields );
+	}
+
+	/**
+	 * Format a WP user as an endpoint record.
+	 *
+	 * @param WP_User|false $user                The user.
+	 * @param array         $fields              Fields to include.
+	 * @param bool          $avatar_hide_default Whether to hide the default avatar.
+	 * @return array|null Record, or null when there is nothing to format.
+	 */
+	public static function format_user( $user, $fields, $avatar_hide_default ) {
+		if ( ! $user ) {
+			return null;
+		}
+
+		$user_data = [
+			'id'         => intval( $user->data->ID ),
+			'registered' => $user->data->user_registered,
+			'is_guest'   => false,
+			'slug'       => $user->data->user_login,
+		];
+
+		if ( in_array( 'avatar', $fields, true ) ) {
+			$avatar = get_avatar( $user->data->ID, 256, $avatar_hide_default ? 'blank' : '' );
+
+			if ( \Newspack_Blocks\is_avatar_displayable( $avatar, $avatar_hide_default ) ) {
+				$user_data['avatar'] = $avatar;
+			}
+		}
+
+		return self::fill_user_data( $user_data, $user, $fields );
 	}
 
 	/**

--- a/plugins/newspack-blocks/src/blocks/author-profile/edit.js
+++ b/plugins/newspack-blocks/src/blocks/author-profile/edit.js
@@ -41,6 +41,11 @@ import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
+ * Internal dependencies
+ */
+import { fetchAuthorById, fetchAuthorList } from '../../shared/js/author-fetch';
+
+/**
  * Register block bindings source for author data in the editor.
  * This enables core blocks to display author data via bindings.
  *
@@ -398,21 +403,14 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 		setError( null );
 		setIsLoading( true );
 		try {
-			const params = {
-				author_id: authorId,
-				is_guest_author: isGuestAuthor ? 1 : 0,
+			// Shared with every other Author Profile block on the page, so a page of profiles
+			// costs one request instead of one per block.
+			const _author = await fetchAuthorById( {
+				authorId,
+				isGuestAuthor,
 				fields: 'id,name,bio,email,social,avatar,url',
-			};
-
-			if ( avatarHideDefault ) {
-				params.avatar_hide_default = 1;
-			}
-
-			const response = await apiFetch( {
-				path: addQueryArgs( '/newspack-blocks/v1/authors', params ),
+				avatarHideDefault,
 			} );
-
-			const _author = response.pop();
 
 			if ( ! _author ) {
 				throw sprintf(
@@ -476,21 +474,16 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 				fields.push( 'email' );
 			}
 			const results = await Promise.all(
-				bylineAuthorIds.map( id => {
-					const params = {
-						author_id: id,
-						is_guest_author: 0,
+				bylineAuthorIds.map( id =>
+					fetchAuthorById( {
+						authorId: id,
+						isGuestAuthor: false,
 						fields: fields.join( ',' ),
-					};
-					if ( avatarHideDefault ) {
-						params.avatar_hide_default = 1;
-					}
-					return apiFetch( {
-						path: addQueryArgs( '/newspack-blocks/v1/authors', params ),
-					} );
-				} )
+						avatarHideDefault,
+					} )
+				)
 			);
-			setContextualAuthors( results.flat().filter( Boolean ) );
+			setContextualAuthors( results.filter( Boolean ) );
 		} catch ( e ) {
 			setError( e.message || e || __( 'Error fetching byline authors.', 'newspack-blocks' ) );
 			setContextualAuthors( [] );
@@ -767,16 +760,7 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 								if ( authorId && ! error ) {
 									return [];
 								}
-								const response = await apiFetch( {
-									parse: false,
-									path: addQueryArgs( '/newspack-blocks/v1/authors', {
-										search,
-										offset,
-										fields: 'id,name',
-									} ),
-								} );
-								const total = parseInt( response.headers.get( 'x-wp-total' ) || 0, 10 );
-								const authors = await response.json();
+								const { authors, total } = await fetchAuthorList( { search, offset, fields: 'id,name' } );
 								if ( ! maxItemsToSuggest && ! search ) {
 									setMaxItemsToSuggest( total );
 								}
@@ -972,17 +956,7 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 								return [];
 							}
 
-							const response = await apiFetch( {
-								parse: false,
-								path: addQueryArgs( '/newspack-blocks/v1/authors', {
-									search,
-									offset,
-									fields: 'id,name',
-								} ),
-							} );
-
-							const total = parseInt( response.headers.get( 'x-wp-total' ) || 0, 10 );
-							const authors = await response.json();
+							const { authors, total } = await fetchAuthorList( { search, offset, fields: 'id,name' } );
 
 							// Set max items for "load more" functionality in suggestions list.
 							if ( ! maxItemsToSuggest && ! search ) {

--- a/plugins/newspack-blocks/src/blocks/author-profile/edit.js
+++ b/plugins/newspack-blocks/src/blocks/author-profile/edit.js
@@ -279,7 +279,6 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 		isGuestAuthor,
 		isContextual,
 		layoutVersion,
-		showSocial,
 		showEmail,
 		textSize,
 		showAvatar,
@@ -527,17 +526,6 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 			delete window.__newspackAuthorsByBlock[ clientId ];
 		};
 	}, [ authorsToRender, previewAuthorIndex, layoutVersion, clientId ] );
-
-	// Combine social links and email, which are shown together.
-	const getSocialLinks = authorData => {
-		const socialLinks = ( showSocial && authorData?.social ) || {};
-		if ( showEmail && authorData?.email ) {
-			socialLinks.email = authorData.email;
-		} else {
-			delete socialLinks.email;
-		}
-		return socialLinks;
-	};
 
 	// Determine if we're in nested layout mode (publisher-controlled composition).
 	// In nested mode, hide field toggles since publishers control display by adding/removing blocks.
@@ -906,11 +894,7 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 				{ inspectorControls }
 				{ blockControls }
 				{ authorsToRender.map( authorData => (
-					<SingleAuthor
-						key={ authorData.id }
-						author={ { ...authorData, social: getSocialLinks( authorData ) } }
-						attributes={ attributes }
-					/>
+					<SingleAuthor key={ authorData.id } author={ authorData } attributes={ attributes } />
 				) ) }
 			</div>
 		);
@@ -922,7 +906,7 @@ const AuthorProfile = ( { attributes, setAttributes, context, clientId } ) => {
 			<div { ...blockProps }>
 				{ inspectorControls }
 				{ blockControls }
-				<SingleAuthor author={ { ...author, social: getSocialLinks( author ) } } attributes={ attributes } />
+				<SingleAuthor author={ author } attributes={ attributes } />
 			</div>
 		);
 	}

--- a/plugins/newspack-blocks/src/blocks/author-profile/single-author.js
+++ b/plugins/newspack-blocks/src/blocks/author-profile/single-author.js
@@ -12,6 +12,11 @@ import { autop } from '@wordpress/autop';
  */
 import classnames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
+import { getSocialLinks } from './social-links';
+
 // Show a link to the author's post archive page, if available.
 const MaybeLink = ( { author, children, showArchiveLink } ) =>
 	showArchiveLink && author && author.url ? (
@@ -25,18 +30,8 @@ const MaybeLink = ( { author, children, showArchiveLink } ) =>
 export const SingleAuthor = ( { author, attributes } ) => {
 	const { showBio, showSocial, showEmail, showArchiveLink, showAvatar, textSize, avatarAlignment, avatarBorderRadius, avatarSize } = attributes;
 
-	// Combine social links and email, which are shown together.
-	const socialLinks = ( showSocial && author && author.social ) || {};
-	if ( showEmail && author && author.email ) {
-		socialLinks.email = author.email;
-	} else {
-		delete socialLinks.email;
-	}
-	if ( attributes.shownewspack_phone_number && author && author.newspack_phone_number ) {
-		socialLinks.newspack_phone_number = author.newspack_phone_number;
-	} else {
-		delete socialLinks.newspack_phone_number;
-	}
+	// Combine social links and contact links, which are shown together.
+	const socialLinks = getSocialLinks( author, { showSocial, showEmail, showPhone: attributes.shownewspack_phone_number } );
 
 	const employment = [ attributes.shownewspack_role && author.newspack_role, attributes.shownewspack_employer && author.newspack_employer ]
 		.filter( Boolean )

--- a/plugins/newspack-blocks/src/blocks/author-profile/social-links.js
+++ b/plugins/newspack-blocks/src/blocks/author-profile/social-links.js
@@ -1,0 +1,25 @@
+/**
+ * Combine an author's social links with the contact links a block chooses to show.
+ *
+ * Returns a new object. Author records are shared between every block on the page that shows
+ * the same author, so a block must not write its own choices into the record it was given.
+ *
+ * @param {Object}  author             Author record from the authors endpoint.
+ * @param {Object}  options
+ * @param {boolean} options.showSocial Whether to include the social links.
+ * @param {boolean} options.showEmail  Whether to include the email link.
+ * @param {boolean} options.showPhone  Whether to include the phone number link.
+ * @return {Object} Links keyed by service.
+ */
+export function getSocialLinks( author, { showSocial, showEmail, showPhone } ) {
+	const links = { ...( ( showSocial && author?.social ) || {} ) };
+	delete links.email;
+	delete links.newspack_phone_number;
+	if ( showEmail && author?.email ) {
+		links.email = author.email;
+	}
+	if ( showPhone && author?.newspack_phone_number ) {
+		links.newspack_phone_number = author.newspack_phone_number;
+	}
+	return links;
+}

--- a/plugins/newspack-blocks/src/blocks/author-profile/social-links.test.js
+++ b/plugins/newspack-blocks/src/blocks/author-profile/social-links.test.js
@@ -1,0 +1,42 @@
+import { getSocialLinks } from './social-links';
+
+const author = () => ( {
+	social: { twitter: { url: 'https://x.com/a' } },
+	email: { url: 'mailto:a@example.test' },
+	newspack_phone_number: { url: 'tel:1' },
+} );
+
+describe( 'getSocialLinks', () => {
+	it( 'adds the email to the social links when it is shown', () => {
+		expect( getSocialLinks( author(), { showSocial: true, showEmail: true } ) ).toEqual( {
+			twitter: { url: 'https://x.com/a' },
+			email: { url: 'mailto:a@example.test' },
+		} );
+	} );
+
+	it( 'returns only the email when social links are hidden', () => {
+		expect( getSocialLinks( author(), { showSocial: false, showEmail: true } ) ).toEqual( { email: { url: 'mailto:a@example.test' } } );
+	} );
+
+	it( 'adds the phone number when it is shown', () => {
+		expect( getSocialLinks( author(), { showSocial: false, showEmail: false, showPhone: true } ) ).toEqual( {
+			newspack_phone_number: { url: 'tel:1' },
+		} );
+	} );
+
+	it( 'leaves the author record untouched', () => {
+		const record = author();
+
+		getSocialLinks( record, { showSocial: true, showEmail: true } );
+		expect( record.social ).toEqual( { twitter: { url: 'https://x.com/a' } } );
+
+		// A record shared between blocks may already carry a link another block added.
+		record.social.email = { url: 'mailto:other@example.test' };
+		expect( getSocialLinks( record, { showSocial: true, showEmail: false } ) ).toEqual( { twitter: { url: 'https://x.com/a' } } );
+		expect( record.social.email ).toEqual( { url: 'mailto:other@example.test' } );
+	} );
+
+	it( 'returns an empty object for a missing author', () => {
+		expect( getSocialLinks( undefined, { showSocial: true, showEmail: true } ) ).toEqual( {} );
+	} );
+} );

--- a/plugins/newspack-blocks/src/shared/js/author-fetch.js
+++ b/plugins/newspack-blocks/src/shared/js/author-fetch.js
@@ -20,6 +20,10 @@ const ENDPOINT = '/newspack-blocks/v1/authors';
 // short enough to be invisible next to the request itself.
 const BATCH_WINDOW_MS = 50;
 
+// Most ids the endpoint resolves in one request. Larger batches are split to match, so a block
+// past the limit is not told its author does not exist.
+const MAX_BATCH_IDS = 100;
+
 // Long enough to cover a page load and block re-mounts, short enough that a profile edited in
 // another tab shows up on the next reload.
 const CACHE_TTL_MS = 60 * 1000;
@@ -45,11 +49,52 @@ const readCache = key => {
 const writeCache = ( key, value ) => cache.set( key, { expires: Date.now() + CACHE_TTL_MS, value } );
 
 /**
- * Send one request for every author queued under a batch key and settle each caller.
+ * Request a set of authors, giving a failed request one more try.
+ *
+ * A request dropped by a busy server is the failure this fetcher exists to soften, and a whole
+ * page of blocks now rides on each one, so a single failure should not blank every block.
+ *
+ * @param {Object} params Query params.
+ * @return {Promise<Array>} The author records.
+ */
+const requestAuthors = async params => {
+	const path = addQueryArgs( ENDPOINT, params );
+	try {
+		return await apiFetch( { path } );
+	} catch {
+		return apiFetch( { path } );
+	}
+};
+
+/**
+ * Resolve every caller covered by one request from its response.
+ *
+ * @param {string}  batchKey Key grouping lookups that share fields and avatar options.
+ * @param {Array}   entries  Queued lookups the request carries.
+ * @param {Promise} request  The request.
+ */
+const settleEntries = async ( batchKey, entries, request ) => {
+	try {
+		const authors = await request;
+		const byKey = new Map( ( authors || [] ).map( author => [ authorKey( author.id, author.is_guest ), author ] ) );
+		entries.forEach( entry => {
+			const key = authorKey( entry.authorId, entry.isGuestAuthor );
+			// A guest id that matched no guest author comes back as the WP user with that id.
+			const author = byKey.get( key ) || ( entry.isGuestAuthor ? byKey.get( authorKey( entry.authorId, false ) ) : undefined );
+			writeCache( `${ batchKey }|${ key }`, author );
+			entry.settlers.forEach( ( { resolve } ) => resolve( author ) );
+		} );
+	} catch ( error ) {
+		entries.forEach( entry => entry.settlers.forEach( ( { reject } ) => reject( error ) ) );
+	}
+};
+
+/**
+ * Send the lookups queued under a batch key, in as many requests as the endpoint's limit needs.
  *
  * @param {string} batchKey Key grouping lookups that share fields and avatar options.
  */
-const flushBatch = async batchKey => {
+const flushBatch = batchKey => {
 	const batch = pendingBatches.get( batchKey );
 	pendingBatches.delete( batchKey );
 	if ( ! batch ) {
@@ -57,30 +102,24 @@ const flushBatch = async batchKey => {
 	}
 
 	const entries = Array.from( batch.entries.values() );
-	const params = { fields: batch.fields };
-	if ( batch.avatarHideDefault ) {
-		params.avatar_hide_default = 1;
-	}
-	const userIds = entries.filter( entry => ! entry.isGuestAuthor ).map( entry => entry.authorId );
-	const guestIds = entries.filter( entry => entry.isGuestAuthor ).map( entry => entry.authorId );
-	if ( userIds.length ) {
-		params.author_ids = userIds.join( ',' );
-	}
-	if ( guestIds.length ) {
-		params.guest_author_ids = guestIds.join( ',' );
-	}
+	const userEntries = entries.filter( entry => ! entry.isGuestAuthor );
+	const guestEntries = entries.filter( entry => entry.isGuestAuthor );
+	const requests = Math.max( Math.ceil( userEntries.length / MAX_BATCH_IDS ), Math.ceil( guestEntries.length / MAX_BATCH_IDS ) );
 
-	try {
-		const authors = await apiFetch( { path: addQueryArgs( ENDPOINT, params ) } );
-		const byKey = new Map( ( authors || [] ).map( author => [ authorKey( author.id, author.is_guest ), author ] ) );
-		entries.forEach( entry => {
-			const key = authorKey( entry.authorId, entry.isGuestAuthor );
-			const author = byKey.get( key );
-			writeCache( `${ batchKey }|${ key }`, author );
-			entry.settlers.forEach( ( { resolve } ) => resolve( author ) );
-		} );
-	} catch ( error ) {
-		entries.forEach( entry => entry.settlers.forEach( ( { reject } ) => reject( error ) ) );
+	for ( let i = 0; i < requests; i++ ) {
+		const users = userEntries.slice( i * MAX_BATCH_IDS, ( i + 1 ) * MAX_BATCH_IDS );
+		const guests = guestEntries.slice( i * MAX_BATCH_IDS, ( i + 1 ) * MAX_BATCH_IDS );
+		const params = { fields: batch.fields };
+		if ( batch.avatarHideDefault ) {
+			params.avatar_hide_default = 1;
+		}
+		if ( users.length ) {
+			params.author_ids = users.map( entry => entry.authorId ).join( ',' );
+		}
+		if ( guests.length ) {
+			params.guest_author_ids = guests.map( entry => entry.authorId ).join( ',' );
+		}
+		settleEntries( batchKey, [ ...users, ...guests ], requestAuthors( params ) );
 	}
 };
 
@@ -136,8 +175,11 @@ export function fetchAuthorById( { authorId, isGuestAuthor = false, fields, avat
 export function fetchAuthorList( { search, offset, fields = 'id,name' } = {} ) {
 	const params = { search: search || '', offset: offset || 0, fields };
 	const key = `list|${ params.search }|${ params.offset }|${ params.fields }`;
+	// Only the initial list is worth keeping: every empty block asks for it at once, while a typed
+	// search should see an author created or renamed a moment ago.
+	const keep = ! params.search && ! params.offset;
 
-	const cached = readCache( key );
+	const cached = keep ? readCache( key ) : null;
 	if ( cached ) {
 		return Promise.resolve( cached.value );
 	}
@@ -145,18 +187,20 @@ export function fetchAuthorList( { search, offset, fields = 'id,name' } = {} ) {
 		return inFlightLists.get( key );
 	}
 
-	const request = ( async () => {
-		try {
-			const response = await apiFetch( { parse: false, path: addQueryArgs( ENDPOINT, params ) } );
+	// The request starts on the next tick, once it is recorded as in flight, so one that fails
+	// before it starts is still cleared instead of being handed to every later caller.
+	const request = Promise.resolve()
+		.then( () => apiFetch( { parse: false, path: addQueryArgs( ENDPOINT, params ) } ) )
+		.then( async response => {
 			const total = parseInt( response.headers.get( 'x-wp-total' ) || 0, 10 );
 			const authors = await response.json();
 			const result = { authors, total };
-			writeCache( key, result );
+			if ( keep ) {
+				writeCache( key, result );
+			}
 			return result;
-		} finally {
-			inFlightLists.delete( key );
-		}
-	} )();
+		} )
+		.finally( () => inFlightLists.delete( key ) );
 	inFlightLists.set( key, request );
 
 	return request;

--- a/plugins/newspack-blocks/src/shared/js/author-fetch.js
+++ b/plugins/newspack-blocks/src/shared/js/author-fetch.js
@@ -1,0 +1,173 @@
+/**
+ * Shared author lookups for the editor.
+ *
+ * Every Author Profile block used to fetch its author with its own request, so a staff page
+ * with thirty blocks fired thirty requests at once and, on a site near its PHP worker limit,
+ * some were dropped. Lookups made within one short window are combined into a single call to
+ * the authors endpoint, results are shared between blocks and kept briefly, and identical
+ * suggestion-list requests are de-duplicated the same way.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+
+const ENDPOINT = '/newspack-blocks/v1/authors';
+
+// Blocks mount in bursts as the editor renders. This is long enough to catch a burst and
+// short enough to be invisible next to the request itself.
+const BATCH_WINDOW_MS = 50;
+
+// Long enough to cover a page load and block re-mounts, short enough that a profile edited in
+// another tab shows up on the next reload.
+const CACHE_TTL_MS = 60 * 1000;
+
+const cache = new Map();
+const pendingBatches = new Map();
+const inFlightLists = new Map();
+
+const authorKey = ( authorId, isGuestAuthor ) => `${ isGuestAuthor ? 'g' : 'u' }:${ authorId }`;
+
+const readCache = key => {
+	const hit = cache.get( key );
+	if ( ! hit ) {
+		return null;
+	}
+	if ( hit.expires < Date.now() ) {
+		cache.delete( key );
+		return null;
+	}
+	return hit;
+};
+
+const writeCache = ( key, value ) => cache.set( key, { expires: Date.now() + CACHE_TTL_MS, value } );
+
+/**
+ * Send one request for every author queued under a batch key and settle each caller.
+ *
+ * @param {string} batchKey Key grouping lookups that share fields and avatar options.
+ */
+const flushBatch = async batchKey => {
+	const batch = pendingBatches.get( batchKey );
+	pendingBatches.delete( batchKey );
+	if ( ! batch ) {
+		return;
+	}
+
+	const entries = Array.from( batch.entries.values() );
+	const params = { fields: batch.fields };
+	if ( batch.avatarHideDefault ) {
+		params.avatar_hide_default = 1;
+	}
+	const userIds = entries.filter( entry => ! entry.isGuestAuthor ).map( entry => entry.authorId );
+	const guestIds = entries.filter( entry => entry.isGuestAuthor ).map( entry => entry.authorId );
+	if ( userIds.length ) {
+		params.author_ids = userIds.join( ',' );
+	}
+	if ( guestIds.length ) {
+		params.guest_author_ids = guestIds.join( ',' );
+	}
+
+	try {
+		const authors = await apiFetch( { path: addQueryArgs( ENDPOINT, params ) } );
+		const byKey = new Map( ( authors || [] ).map( author => [ authorKey( author.id, author.is_guest ), author ] ) );
+		entries.forEach( entry => {
+			const key = authorKey( entry.authorId, entry.isGuestAuthor );
+			const author = byKey.get( key );
+			writeCache( `${ batchKey }|${ key }`, author );
+			entry.settlers.forEach( ( { resolve } ) => resolve( author ) );
+		} );
+	} catch ( error ) {
+		entries.forEach( entry => entry.settlers.forEach( ( { reject } ) => reject( error ) ) );
+	}
+};
+
+/**
+ * Look up one author, sharing the request with every other lookup made in the same window.
+ *
+ * @param {Object}  options
+ * @param {number}  options.authorId          WP user ID, or guest author post ID.
+ * @param {boolean} options.isGuestAuthor     Whether the ID is a guest author.
+ * @param {string}  options.fields            Comma-separated fields to request.
+ * @param {boolean} options.avatarHideDefault Whether to hide the default avatar.
+ * @return {Promise<Object|undefined>} The author record, or undefined when none matched.
+ */
+export function fetchAuthorById( { authorId, isGuestAuthor = false, fields, avatarHideDefault = false } ) {
+	const id = parseInt( authorId, 10 );
+	const batchKey = `${ fields }|${ avatarHideDefault ? 1 : 0 }`;
+	const key = authorKey( id, !! isGuestAuthor );
+
+	const cached = readCache( `${ batchKey }|${ key }` );
+	if ( cached ) {
+		return Promise.resolve( cached.value );
+	}
+
+	let batch = pendingBatches.get( batchKey );
+	if ( ! batch ) {
+		batch = {
+			fields,
+			avatarHideDefault,
+			entries: new Map(),
+			timer: setTimeout( () => flushBatch( batchKey ), BATCH_WINDOW_MS ),
+		};
+		pendingBatches.set( batchKey, batch );
+	}
+
+	let entry = batch.entries.get( key );
+	if ( ! entry ) {
+		entry = { authorId: id, isGuestAuthor: !! isGuestAuthor, settlers: [] };
+		batch.entries.set( key, entry );
+	}
+
+	return new Promise( ( resolve, reject ) => entry.settlers.push( { resolve, reject } ) );
+}
+
+/**
+ * Fetch a page of author suggestions, sharing identical in-flight requests.
+ *
+ * @param {Object} options
+ * @param {string} options.search Search string.
+ * @param {number} options.offset Offset for pagination.
+ * @param {string} options.fields Comma-separated fields to request.
+ * @return {Promise<{authors: Array, total: number}>} Authors and the total reported by the endpoint.
+ */
+export function fetchAuthorList( { search, offset, fields = 'id,name' } = {} ) {
+	const params = { search: search || '', offset: offset || 0, fields };
+	const key = `list|${ params.search }|${ params.offset }|${ params.fields }`;
+
+	const cached = readCache( key );
+	if ( cached ) {
+		return Promise.resolve( cached.value );
+	}
+	if ( inFlightLists.has( key ) ) {
+		return inFlightLists.get( key );
+	}
+
+	const request = ( async () => {
+		try {
+			const response = await apiFetch( { parse: false, path: addQueryArgs( ENDPOINT, params ) } );
+			const total = parseInt( response.headers.get( 'x-wp-total' ) || 0, 10 );
+			const authors = await response.json();
+			const result = { authors, total };
+			writeCache( key, result );
+			return result;
+		} finally {
+			inFlightLists.delete( key );
+		}
+	} )();
+	inFlightLists.set( key, request );
+
+	return request;
+}
+
+/**
+ * Forget cached results and queued lookups. Intended for tests.
+ */
+export function resetAuthorFetchCache() {
+	cache.clear();
+	pendingBatches.forEach( batch => clearTimeout( batch.timer ) );
+	pendingBatches.clear();
+	inFlightLists.clear();
+}

--- a/plugins/newspack-blocks/src/shared/js/author-fetch.test.js
+++ b/plugins/newspack-blocks/src/shared/js/author-fetch.test.js
@@ -1,0 +1,162 @@
+import apiFetch from '@wordpress/api-fetch';
+import { getQueryArgs } from '@wordpress/url';
+
+import { fetchAuthorById, fetchAuthorList, resetAuthorFetchCache } from './author-fetch';
+
+jest.mock( '@wordpress/api-fetch', () => ( { __esModule: true, default: jest.fn() } ) );
+
+const FIELDS = 'id,name,bio';
+
+const user = ( id, name ) => ( { id, is_guest: false, name } );
+const guest = ( id, name ) => ( { id, is_guest: true, name } );
+
+/**
+ * Let the batching window elapse and the resulting promises settle.
+ */
+const flush = async () => {
+	await jest.advanceTimersByTimeAsync( 100 );
+};
+
+const argsOf = call => getQueryArgs( call[ 0 ].path );
+
+beforeEach( () => {
+	jest.useFakeTimers();
+	apiFetch.mockReset();
+	resetAuthorFetchCache();
+} );
+
+afterEach( () => {
+	jest.useRealTimers();
+} );
+
+describe( 'fetchAuthorById', () => {
+	it( 'coalesces lookups made in the same window into one request', async () => {
+		apiFetch.mockResolvedValue( [ user( 1, 'One' ), user( 2, 'Two' ), guest( 5, 'Five' ) ] );
+
+		const lookups = Promise.all( [
+			fetchAuthorById( { authorId: 1, isGuestAuthor: false, fields: FIELDS } ),
+			fetchAuthorById( { authorId: 2, isGuestAuthor: false, fields: FIELDS } ),
+			fetchAuthorById( { authorId: 5, isGuestAuthor: true, fields: FIELDS } ),
+		] );
+		await flush();
+		await lookups;
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( argsOf( apiFetch.mock.calls[ 0 ] ) ).toEqual( {
+			author_ids: '1,2',
+			guest_author_ids: '5',
+			fields: FIELDS,
+		} );
+	} );
+
+	it( 'resolves each caller with its own author', async () => {
+		apiFetch.mockResolvedValue( [ user( 1, 'One' ), guest( 1, 'Guest One' ) ] );
+
+		const lookups = Promise.all( [
+			fetchAuthorById( { authorId: 1, isGuestAuthor: false, fields: FIELDS } ),
+			fetchAuthorById( { authorId: 1, isGuestAuthor: true, fields: FIELDS } ),
+		] );
+		await flush();
+		const [ asUser, asGuest ] = await lookups;
+
+		expect( asUser ).toEqual( user( 1, 'One' ) );
+		expect( asGuest ).toEqual( guest( 1, 'Guest One' ) );
+	} );
+
+	it( 'resolves undefined for an author the endpoint did not return', async () => {
+		apiFetch.mockResolvedValue( [ user( 1, 'One' ) ] );
+
+		const lookup = fetchAuthorById( { authorId: 404, isGuestAuthor: false, fields: FIELDS } );
+		await flush();
+
+		await expect( lookup ).resolves.toBeUndefined();
+	} );
+
+	it( 'keeps lookups with different fields or avatar options in separate requests', async () => {
+		apiFetch.mockResolvedValue( [ user( 1, 'One' ) ] );
+
+		const lookups = Promise.all( [
+			fetchAuthorById( { authorId: 1, isGuestAuthor: false, fields: FIELDS } ),
+			fetchAuthorById( { authorId: 1, isGuestAuthor: false, fields: 'id,name' } ),
+			fetchAuthorById( { authorId: 1, isGuestAuthor: false, fields: FIELDS, avatarHideDefault: true } ),
+		] );
+		await flush();
+		await lookups;
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 3 );
+		expect( argsOf( apiFetch.mock.calls[ 2 ] ) ).toMatchObject( { avatar_hide_default: '1' } );
+	} );
+
+	it( 'serves a repeated lookup from cache without a new request', async () => {
+		apiFetch.mockResolvedValue( [ user( 1, 'One' ) ] );
+
+		const first = fetchAuthorById( { authorId: 1, isGuestAuthor: false, fields: FIELDS } );
+		await flush();
+		await first;
+
+		const second = fetchAuthorById( { authorId: 1, isGuestAuthor: false, fields: FIELDS } );
+		await flush();
+
+		await expect( second ).resolves.toEqual( user( 1, 'One' ) );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'rejects every caller when the request fails and retries on the next lookup', async () => {
+		apiFetch.mockRejectedValueOnce( new Error( 'The response is not a valid JSON response.' ) );
+
+		const first = fetchAuthorById( { authorId: 1, isGuestAuthor: false, fields: FIELDS } );
+		const second = fetchAuthorById( { authorId: 2, isGuestAuthor: false, fields: FIELDS } );
+		first.catch( () => {} );
+		second.catch( () => {} );
+		await flush();
+
+		await expect( first ).rejects.toThrow( 'not a valid JSON response' );
+		await expect( second ).rejects.toThrow( 'not a valid JSON response' );
+
+		apiFetch.mockResolvedValue( [ user( 1, 'One' ) ] );
+		const retry = fetchAuthorById( { authorId: 1, isGuestAuthor: false, fields: FIELDS } );
+		await flush();
+
+		await expect( retry ).resolves.toEqual( user( 1, 'One' ) );
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+	} );
+} );
+
+describe( 'fetchAuthorList', () => {
+	const response = ( authors, total ) => ( {
+		headers: { get: header => ( header === 'x-wp-total' ? String( total ) : null ) },
+		json: async () => authors,
+	} );
+
+	it( 'returns the authors and the total from the response headers', async () => {
+		apiFetch.mockResolvedValue( response( [ user( 1, 'One' ) ], 42 ) );
+
+		await expect( fetchAuthorList( { search: '', offset: 0, fields: 'id,name' } ) ).resolves.toEqual( {
+			authors: [ user( 1, 'One' ) ],
+			total: 42,
+		} );
+		expect( apiFetch.mock.calls[ 0 ][ 0 ] ).toMatchObject( { parse: false } );
+		expect( argsOf( apiFetch.mock.calls[ 0 ] ) ).toEqual( { search: '', offset: '0', fields: 'id,name' } );
+	} );
+
+	it( 'shares one request between identical concurrent lookups', async () => {
+		apiFetch.mockResolvedValue( response( [ user( 1, 'One' ) ], 1 ) );
+
+		const [ a, b ] = await Promise.all( [
+			fetchAuthorList( { search: '', offset: 0, fields: 'id,name' } ),
+			fetchAuthorList( { search: '', offset: 0, fields: 'id,name' } ),
+		] );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( a ).toEqual( b );
+	} );
+
+	it( 'requests again when the search differs', async () => {
+		apiFetch.mockResolvedValue( response( [], 0 ) );
+
+		await fetchAuthorList( { search: '', offset: 0, fields: 'id,name' } );
+		await fetchAuthorList( { search: 'jo', offset: 0, fields: 'id,name' } );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+	} );
+} );

--- a/plugins/newspack-blocks/src/shared/js/author-fetch.test.js
+++ b/plugins/newspack-blocks/src/shared/js/author-fetch.test.js
@@ -101,8 +101,42 @@ describe( 'fetchAuthorById', () => {
 		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'rejects every caller when the request fails and retries on the next lookup', async () => {
-		apiFetch.mockRejectedValueOnce( new Error( 'The response is not a valid JSON response.' ) );
+	it( 'resolves a guest lookup with the WP user the endpoint fell back to', async () => {
+		apiFetch.mockResolvedValue( [ user( 7, 'Legacy' ) ] );
+
+		const lookup = fetchAuthorById( { authorId: 7, isGuestAuthor: true, fields: FIELDS } );
+		await flush();
+
+		await expect( lookup ).resolves.toEqual( user( 7, 'Legacy' ) );
+		expect( argsOf( apiFetch.mock.calls[ 0 ] ) ).toEqual( { guest_author_ids: '7', fields: FIELDS } );
+	} );
+
+	it( 'splits a batch larger than the endpoint limit into several requests', async () => {
+		apiFetch.mockResolvedValue( [] );
+
+		const lookups = Promise.all(
+			Array.from( { length: 101 }, ( _, i ) => fetchAuthorById( { authorId: i + 1, isGuestAuthor: false, fields: FIELDS } ) )
+		);
+		await flush();
+		await lookups;
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+		expect( argsOf( apiFetch.mock.calls[ 0 ] ).author_ids.split( ',' ) ).toHaveLength( 100 );
+		expect( argsOf( apiFetch.mock.calls[ 1 ] ).author_ids ).toBe( '101' );
+	} );
+
+	it( 'retries a failed request once before rejecting', async () => {
+		apiFetch.mockRejectedValueOnce( new Error( 'The response is not a valid JSON response.' ) ).mockResolvedValueOnce( [ user( 1, 'One' ) ] );
+
+		const lookup = fetchAuthorById( { authorId: 1, isGuestAuthor: false, fields: FIELDS } );
+		await flush();
+
+		await expect( lookup ).resolves.toEqual( user( 1, 'One' ) );
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'rejects every caller when the request keeps failing and tries again on the next lookup', async () => {
+		apiFetch.mockRejectedValue( new Error( 'The response is not a valid JSON response.' ) );
 
 		const first = fetchAuthorById( { authorId: 1, isGuestAuthor: false, fields: FIELDS } );
 		const second = fetchAuthorById( { authorId: 2, isGuestAuthor: false, fields: FIELDS } );
@@ -112,13 +146,14 @@ describe( 'fetchAuthorById', () => {
 
 		await expect( first ).rejects.toThrow( 'not a valid JSON response' );
 		await expect( second ).rejects.toThrow( 'not a valid JSON response' );
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
 
 		apiFetch.mockResolvedValue( [ user( 1, 'One' ) ] );
 		const retry = fetchAuthorById( { authorId: 1, isGuestAuthor: false, fields: FIELDS } );
 		await flush();
 
 		await expect( retry ).resolves.toEqual( user( 1, 'One' ) );
-		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+		expect( apiFetch ).toHaveBeenCalledTimes( 3 );
 	} );
 } );
 
@@ -158,5 +193,38 @@ describe( 'fetchAuthorList', () => {
 		await fetchAuthorList( { search: 'jo', offset: 0, fields: 'id,name' } );
 
 		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'serves the initial list from cache once it has loaded', async () => {
+		apiFetch.mockResolvedValue( response( [ user( 1, 'One' ) ], 1 ) );
+
+		await fetchAuthorList( { search: '', offset: 0, fields: 'id,name' } );
+		await fetchAuthorList( { search: '', offset: 0, fields: 'id,name' } );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not keep a typed search after it settles', async () => {
+		apiFetch.mockResolvedValue( response( [], 0 ) );
+
+		await fetchAuthorList( { search: 'jo', offset: 0, fields: 'id,name' } );
+		await fetchAuthorList( { search: 'jo', offset: 0, fields: 'id,name' } );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'does not keep a request that failed before it started', async () => {
+		apiFetch.mockImplementationOnce( () => {
+			throw new Error( 'boom' );
+		} );
+
+		await expect( fetchAuthorList( { search: 'jo', offset: 0, fields: 'id,name' } ) ).rejects.toThrow( 'boom' );
+
+		apiFetch.mockResolvedValue( response( [ user( 1, 'One' ) ], 1 ) );
+
+		await expect( fetchAuthorList( { search: 'jo', offset: 0, fields: 'id,name' } ) ).resolves.toEqual( {
+			authors: [ user( 1, 'One' ) ],
+			total: 1,
+		} );
 	} );
 } );

--- a/plugins/newspack-blocks/tests/test-authors-access.php
+++ b/plugins/newspack-blocks/tests/test-authors-access.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Tests what the author endpoints let an editing user see.
+ *
+ * @package Newspack_Blocks
+ */
+
+/**
+ * Both author routes are open to anyone who can edit posts. They should only ever describe
+ * authors, and only for content the caller can read.
+ */
+class AuthorsAccessTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
+
+	/**
+	 * Boot a REST server and act as a contributor, the lowest role the routes admit.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		do_action( 'rest_api_init', $wp_rest_server );
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'contributor' ] ) );
+	}
+
+	/**
+	 * Request an author route and return the decoded items.
+	 *
+	 * @param string $route  Route.
+	 * @param array  $params Query params.
+	 * @return array Response data.
+	 */
+	private function request( $route, $params ) {
+		$request = new WP_REST_Request( 'GET', $route );
+		$request->set_query_params( array_merge( [ 'fields' => 'id,name' ], $params ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		return $response->get_data();
+	}
+
+	/**
+	 * IDs of the WP users in a response.
+	 *
+	 * @param array $data Response data.
+	 * @return int[]
+	 */
+	private function user_ids( $data ) {
+		return array_values(
+			array_map(
+				function( $record ) {
+					return $record['id'];
+				},
+				array_filter(
+					$data,
+					function( $record ) {
+						return empty( $record['is_guest'] );
+					}
+				)
+			)
+		);
+	}
+
+	public function test_single_id_lookup_only_resolves_users_in_author_roles() {
+		$author     = self::factory()->user->create( [ 'role' => 'author' ] );
+		$subscriber = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+
+		$this->assertSame(
+			[ $author ],
+			$this->user_ids(
+				$this->request(
+					'/newspack-blocks/v1/authors',
+					[
+						'author_id'       => $author,
+						'is_guest_author' => 0,
+					]
+				)
+			)
+		);
+		$this->assertSame(
+			[],
+			$this->user_ids(
+				$this->request(
+					'/newspack-blocks/v1/authors',
+					[
+						'author_id'       => $subscriber,
+						'is_guest_author' => 0,
+					]
+				)
+			),
+			'A subscriber is not an author and must not resolve by id.'
+		);
+	}
+
+	public function test_batched_lookup_only_resolves_users_in_author_roles() {
+		$author     = self::factory()->user->create( [ 'role' => 'author' ] );
+		$subscriber = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+
+		$ids = $this->user_ids( $this->request( '/newspack-blocks/v1/authors', [ 'author_ids' => "$author,$subscriber" ] ) );
+
+		$this->assertSame( [ $author ], $ids, 'The batch resolved a user outside the author roles.' );
+	}
+
+	public function test_post_authors_are_withheld_for_posts_the_caller_cannot_read() {
+		$admin     = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$private   = self::factory()->post->create(
+			[
+				'post_author' => $admin,
+				'post_status' => 'private',
+			]
+		);
+		$draft     = self::factory()->post->create(
+			[
+				'post_author' => $admin,
+				'post_status' => 'draft',
+			]
+		);
+		$published = self::factory()->post->create(
+			[
+				'post_author' => $admin,
+				'post_status' => 'publish',
+			]
+		);
+
+		$this->assertSame( [], $this->request( '/newspack-blocks/v1/authors', [ 'post_id' => $private ] ), 'A private post revealed its author.' );
+		$this->assertSame( [], $this->request( '/newspack-blocks/v1/authors', [ 'post_id' => $draft ] ), 'Someone else\'s draft revealed its author.' );
+		$this->assertSame( [ $admin ], $this->user_ids( $this->request( '/newspack-blocks/v1/authors', [ 'post_id' => $published ] ) ) );
+	}
+
+	public function test_author_list_ignores_roles_outside_the_author_roles() {
+		$author     = self::factory()->user->create( [ 'role' => 'author' ] );
+		$subscriber = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+
+		$only_subscribers = $this->user_ids( $this->request( '/newspack-blocks/v1/author-list', [ 'author_roles' => [ 'subscriber' ] ] ) );
+		$this->assertNotContains( $subscriber, $only_subscribers, 'A caller-chosen role outside the author roles listed its users.' );
+		$this->assertSame( [], $only_subscribers, 'A role list with nothing usable must return no users, not every user.' );
+
+		$this->assertContains( $author, $this->user_ids( $this->request( '/newspack-blocks/v1/author-list', [ 'author_roles' => [ 'author', 'subscriber' ] ] ) ) );
+	}
+}

--- a/plugins/newspack-blocks/tests/test-authors-batch.php
+++ b/plugins/newspack-blocks/tests/test-authors-batch.php
@@ -23,7 +23,7 @@ class AuthorsBatchTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
 		// The endpoint reads guest authors from Co-Authors Plus's post type, which the test suite's
-		// CAP mock does not register. Its mock only formats the id, so guest assertions stay on ids.
+		// CAP mock does not register.
 		if ( ! post_type_exists( 'guest-author' ) ) {
 			register_post_type( 'guest-author', [ 'public' => true ] );
 			$this->registered_guest_author_type = true;
@@ -117,7 +117,7 @@ class AuthorsBatchTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 			$this->request_authors(
 				[
 					'guest_author_ids' => implode( ',', $ids ),
-					'fields'           => 'id',
+					'fields'           => 'id,name',
 				]
 			)
 		);
@@ -127,6 +127,7 @@ class AuthorsBatchTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 			$this->assertArrayHasKey( 'g:' . $id, $records, "Guest author $id was missing from the batched response." );
 			$this->assertTrue( $records[ 'g:' . $id ]['is_guest'] );
 		}
+		$this->assertSame( 'Guest Two', $records[ 'g:' . $ids[1] ]['name'] );
 	}
 
 	public function test_user_and_guest_author_ids_are_looked_up_in_their_own_namespaces() {
@@ -146,18 +147,45 @@ class AuthorsBatchTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 		$this->assertCount( 2, $records );
 		$this->assertArrayHasKey( 'u:' . $user_id, $records );
 		$this->assertArrayHasKey( 'g:' . $guest_id, $records );
+	}
 
-		// A user id sent in the guest list must not resolve to a guest author, and vice versa.
-		$crossed = $this->index_by_kind(
+	/**
+	 * Blocks saved before the `isGuestAuthor` attribute existed default to a guest lookup for every
+	 * author, so a guest id that matches no guest author has to resolve to the WP user with that id,
+	 * the way the single-id path (`is_guest_author=1`) and the front-end renderer still do.
+	 */
+	public function test_a_guest_id_with_no_guest_author_falls_back_to_the_wp_user() {
+		$user_id = self::factory()->user->create( [ 'role' => 'author', 'display_name' => 'Legacy User' ] );
+
+		$records = $this->index_by_kind(
 			$this->request_authors(
 				[
 					'guest_author_ids' => (string) $user_id,
-					'fields'           => 'id',
+					'fields'           => 'id,name',
 				]
 			)
 		);
-		$this->assertArrayNotHasKey( 'g:' . $user_id, $crossed );
-		$this->assertArrayNotHasKey( 'u:' . $user_id, $crossed );
+
+		$this->assertCount( 1, $records );
+		$this->assertArrayHasKey( 'u:' . $user_id, $records );
+		$this->assertArrayNotHasKey( 'g:' . $user_id, $records );
+		$this->assertSame( 'Legacy User', $records[ 'u:' . $user_id ]['name'] );
+	}
+
+	public function test_batched_guest_lookup_of_a_user_matches_the_single_lookup() {
+		$id = self::factory()->user->create( [ 'role' => 'author', 'display_name' => 'Same Author' ] );
+
+		$single  = $this->request_authors(
+			[
+				'author_id'       => $id,
+				'is_guest_author' => 1,
+			]
+		);
+		$batched = $this->request_authors( [ 'guest_author_ids' => (string) $id ] );
+
+		$this->assertCount( 1, $single );
+		$this->assertCount( 1, $batched );
+		$this->assertSame( $single[0], $batched[0] );
 	}
 
 	public function test_batched_user_record_matches_the_single_lookup() {
@@ -183,15 +211,17 @@ class AuthorsBatchTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 			$five[] = self::factory()->user->create( [ 'role' => 'author' ] );
 		}
 		$controller = new WP_REST_Newspack_Authors_Controller();
+		// The field set the Author Profile block requests in the editor.
+		$fields     = [ 'id', 'name', 'bio', 'email', 'social', 'avatar', 'url' ];
 
 		wp_cache_flush();
 		$before = get_num_queries();
-		$controller->get_authors_by_ids( $one, [], [ 'id', 'name' ], false );
+		$controller->get_authors_by_ids( $one, [], $fields, false );
 		$queries_for_one = get_num_queries() - $before;
 
 		wp_cache_flush();
 		$before = get_num_queries();
-		$controller->get_authors_by_ids( $five, [], [ 'id', 'name' ], false );
+		$controller->get_authors_by_ids( $five, [], $fields, false );
 		$queries_for_five = get_num_queries() - $before;
 
 		$this->assertSame( $queries_for_one, $queries_for_five, 'Looking up five uncached users must not cost more queries than looking up one.' );
@@ -204,5 +234,28 @@ class AuthorsBatchTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 
 		$this->assertCount( 1, $records );
 		$this->assertArrayHasKey( 'u:' . $id, $records );
+	}
+
+	public function test_a_list_with_no_valid_ids_returns_an_empty_response() {
+		// An author exists, so falling through to the recent-authors listing would return something.
+		self::factory()->user->create( [ 'role' => 'author' ] );
+
+		$this->assertSame( [], $this->request_authors( [ 'author_ids' => 'abc' ] ) );
+	}
+
+	public function test_id_lists_are_capped() {
+		$sanitized = WP_REST_Newspack_Authors_Controller::sanitize_id_list( implode( ',', range( 1, 150 ) ) );
+
+		$this->assertSame( range( 1, 100 ), $sanitized );
+	}
+
+	public function test_format_guest_author_skips_a_post_co_authors_plus_cannot_resolve() {
+		$orphan = (object) [
+			'ID'        => 999999,
+			'post_date' => '2026-01-01 00:00:00',
+			'post_name' => 'orphan',
+		];
+
+		$this->assertNull( WP_REST_Newspack_Authors_Controller::format_guest_author( $orphan, [ 'id', 'name' ], false ) );
 	}
 }

--- a/plugins/newspack-blocks/tests/test-authors-batch.php
+++ b/plugins/newspack-blocks/tests/test-authors-batch.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Tests batched author lookups on the authors REST endpoint.
+ *
+ * @package Newspack_Blocks
+ */
+
+/**
+ * Batched lookups let the Author Profile block load every author on a page with one request.
+ */
+class AuthorsBatchTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
+
+	/**
+	 * Boot a REST server and act as a user who may read the endpoint.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		do_action( 'rest_api_init', $wp_rest_server );
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		// The endpoint reads guest authors from Co-Authors Plus's post type, which the test suite's
+		// CAP mock does not register. Its mock only formats the id, so guest assertions stay on ids.
+		register_post_type( 'guest-author', [ 'public' => true ] );
+	}
+
+	/**
+	 * Create a guest author the way Co-Authors Plus stores one: a `guest-author` post.
+	 *
+	 * @param string $name Display name.
+	 * @return int Post ID.
+	 */
+	private function create_guest_author_post( $name ) {
+		return self::factory()->post->create(
+			[
+				'post_type'  => 'guest-author',
+				'post_title' => $name,
+			]
+		);
+	}
+
+	/**
+	 * Request the authors endpoint with the given query params and return the decoded items.
+	 *
+	 * @param array $params Query params.
+	 * @return array Response data.
+	 */
+	private function request_authors( $params ) {
+		$request = new WP_REST_Request( 'GET', '/newspack-blocks/v1/authors' );
+		$request->set_query_params( array_merge( [ 'fields' => 'id,name,url' ], $params ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status(), 'The authors endpoint did not return a successful response.' );
+
+		return $response->get_data();
+	}
+
+	/**
+	 * Index a response by "u:<id>" / "g:<id>" so assertions don't depend on ordering.
+	 *
+	 * @param array $data Response data.
+	 * @return array Records keyed by kind and id.
+	 */
+	private function index_by_kind( $data ) {
+		$indexed = [];
+		foreach ( $data as $record ) {
+			$indexed[ ( ! empty( $record['is_guest'] ) ? 'g:' : 'u:' ) . $record['id'] ] = $record;
+		}
+		return $indexed;
+	}
+
+	public function test_author_ids_returns_every_requested_user_in_one_response() {
+		$ids = [
+			self::factory()->user->create( [ 'role' => 'author', 'display_name' => 'First Author' ] ),
+			self::factory()->user->create( [ 'role' => 'author', 'display_name' => 'Second Author' ] ),
+			self::factory()->user->create( [ 'role' => 'author', 'display_name' => 'Third Author' ] ),
+		];
+
+		$records = $this->index_by_kind( $this->request_authors( [ 'author_ids' => implode( ',', $ids ) ] ) );
+
+		$this->assertCount( 3, $records );
+		foreach ( $ids as $id ) {
+			$this->assertArrayHasKey( 'u:' . $id, $records, "User $id was missing from the batched response." );
+			$this->assertFalse( $records[ 'u:' . $id ]['is_guest'] );
+		}
+		$this->assertSame( 'Second Author', $records[ 'u:' . $ids[1] ]['name'] );
+	}
+
+	public function test_guest_author_ids_returns_every_requested_guest_author() {
+		$ids = [ $this->create_guest_author_post( 'Guest One' ), $this->create_guest_author_post( 'Guest Two' ) ];
+
+		$records = $this->index_by_kind(
+			$this->request_authors(
+				[
+					'guest_author_ids' => implode( ',', $ids ),
+					'fields'           => 'id',
+				]
+			)
+		);
+
+		$this->assertCount( 2, $records );
+		foreach ( $ids as $id ) {
+			$this->assertArrayHasKey( 'g:' . $id, $records, "Guest author $id was missing from the batched response." );
+			$this->assertTrue( $records[ 'g:' . $id ]['is_guest'] );
+		}
+	}
+
+	public function test_user_and_guest_author_ids_are_looked_up_in_their_own_namespaces() {
+		$user_id  = self::factory()->user->create( [ 'role' => 'author', 'display_name' => 'A User' ] );
+		$guest_id = $this->create_guest_author_post( 'A Guest' );
+
+		$records = $this->index_by_kind(
+			$this->request_authors(
+				[
+					'author_ids'       => (string) $user_id,
+					'guest_author_ids' => (string) $guest_id,
+					'fields'           => 'id',
+				]
+			)
+		);
+
+		$this->assertCount( 2, $records );
+		$this->assertArrayHasKey( 'u:' . $user_id, $records );
+		$this->assertArrayHasKey( 'g:' . $guest_id, $records );
+
+		// A user id sent in the guest list must not resolve to a guest author, and vice versa.
+		$crossed = $this->index_by_kind(
+			$this->request_authors(
+				[
+					'guest_author_ids' => (string) $user_id,
+					'fields'           => 'id',
+				]
+			)
+		);
+		$this->assertArrayNotHasKey( 'g:' . $user_id, $crossed );
+		$this->assertArrayNotHasKey( 'u:' . $user_id, $crossed );
+	}
+
+	public function test_batched_user_record_matches_the_single_lookup() {
+		$id = self::factory()->user->create( [ 'role' => 'author', 'display_name' => 'Same Author' ] );
+
+		$single  = $this->request_authors(
+			[
+				'author_id'       => $id,
+				'is_guest_author' => 0,
+			]
+		);
+		$batched = $this->request_authors( [ 'author_ids' => (string) $id ] );
+
+		$this->assertCount( 1, $single );
+		$this->assertCount( 1, $batched );
+		$this->assertSame( $single[0], $batched[0] );
+	}
+
+	public function test_unknown_ids_are_skipped_without_failing_the_batch() {
+		$id = self::factory()->user->create( [ 'role' => 'author' ] );
+
+		$records = $this->index_by_kind( $this->request_authors( [ 'author_ids' => $id . ',999999' ] ) );
+
+		$this->assertCount( 1, $records );
+		$this->assertArrayHasKey( 'u:' . $id, $records );
+	}
+}

--- a/plugins/newspack-blocks/tests/test-authors-batch.php
+++ b/plugins/newspack-blocks/tests/test-authors-batch.php
@@ -24,7 +24,28 @@ class AuthorsBatchTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 
 		// The endpoint reads guest authors from Co-Authors Plus's post type, which the test suite's
 		// CAP mock does not register. Its mock only formats the id, so guest assertions stay on ids.
-		register_post_type( 'guest-author', [ 'public' => true ] );
+		if ( ! post_type_exists( 'guest-author' ) ) {
+			register_post_type( 'guest-author', [ 'public' => true ] );
+			$this->registered_guest_author_type = true;
+		}
+	}
+
+	/**
+	 * Whether this test registered the guest-author post type itself.
+	 *
+	 * @var bool
+	 */
+	private $registered_guest_author_type = false;
+
+	/**
+	 * Undo the post type registration so it cannot leak into other tests.
+	 */
+	public function tear_down() {
+		if ( $this->registered_guest_author_type ) {
+			unregister_post_type( 'guest-author' );
+			$this->registered_guest_author_type = false;
+		}
+		parent::tear_down();
 	}
 
 	/**
@@ -153,6 +174,27 @@ class AuthorsBatchTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 		$this->assertCount( 1, $single );
 		$this->assertCount( 1, $batched );
 		$this->assertSame( $single[0], $batched[0] );
+	}
+
+	public function test_batch_query_count_does_not_grow_with_the_number_of_users() {
+		$one  = [ self::factory()->user->create( [ 'role' => 'author' ] ) ];
+		$five = [];
+		for ( $i = 0; $i < 5; $i++ ) {
+			$five[] = self::factory()->user->create( [ 'role' => 'author' ] );
+		}
+		$controller = new WP_REST_Newspack_Authors_Controller();
+
+		wp_cache_flush();
+		$before = get_num_queries();
+		$controller->get_authors_by_ids( $one, [], [ 'id', 'name' ], false );
+		$queries_for_one = get_num_queries() - $before;
+
+		wp_cache_flush();
+		$before = get_num_queries();
+		$controller->get_authors_by_ids( $five, [], [ 'id', 'name' ], false );
+		$queries_for_five = get_num_queries() - $before;
+
+		$this->assertSame( $queries_for_one, $queries_for_five, 'Looking up five uncached users must not cost more queries than looking up one.' );
 	}
 
 	public function test_unknown_ids_are_skipped_without_failing_the_batch() {

--- a/plugins/newspack-blocks/tests/test-authors-controller.php
+++ b/plugins/newspack-blocks/tests/test-authors-controller.php
@@ -49,16 +49,20 @@ class AuthorsControllerTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	/**
 	 * Request an author endpoint and return the decoded items.
 	 *
-	 * @param string $route REST route, relative to the block namespace.
+	 * @param string $route  REST route, relative to the block namespace.
+	 * @param array  $params Extra query params.
 	 * @return array Response data.
 	 */
-	private function request_authors( $route = '/newspack-blocks/v1/authors' ) {
+	private function request_authors( $route = '/newspack-blocks/v1/authors', $params = [] ) {
 		$request = new WP_REST_Request( 'GET', $route );
 		$request->set_query_params(
-			[
-				'fields'   => 'email,name',
-				'perPage'  => 100,
-			]
+			array_merge(
+				[
+					'fields'   => 'email,name',
+					'perPage'  => 100,
+				],
+				$params
+			)
 		);
 
 		$response = rest_get_server()->dispatch( $request );
@@ -116,6 +120,30 @@ class AuthorsControllerTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 
 		$this->assertNotNull( $record, 'The author under test was missing from the response.' );
 		$this->assert_record_has_no_email( $record, 'The author list endpoint disclosed an address to a contributor.' );
+	}
+
+	/**
+	 * The batched lookup the Author Profile block uses in the editor is bound by the same rule.
+	 */
+	public function test_batched_lookup_withholds_email_from_post_editors() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'contributor' ] ) );
+
+		$record = $this->find_subject( $this->request_authors( '/newspack-blocks/v1/authors', [ 'author_ids' => (string) $this->subject_id ] ) );
+
+		$this->assertNotNull( $record, 'The author under test was missing from the batched response.' );
+		$this->assert_record_has_no_email( $record, 'The batched authors lookup disclosed an address to a contributor.' );
+	}
+
+	/**
+	 * Requesters who can manage users keep the field they already had access to.
+	 */
+	public function test_batched_lookup_returns_email_to_user_managers() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$record = $this->find_subject( $this->request_authors( '/newspack-blocks/v1/authors', [ 'author_ids' => (string) $this->subject_id ] ) );
+
+		$this->assertNotNull( $record, 'The author under test was missing from the batched response.' );
+		$this->assertArrayHasKey( 'email', $record, 'An administrator was denied a field they can already read.' );
 	}
 
 	/**

--- a/plugins/newspack-blocks/tests/wp-unittestcase-blocks.php
+++ b/plugins/newspack-blocks/tests/wp-unittestcase-blocks.php
@@ -20,7 +20,7 @@ class CoAuthors_Guest_Authors { // phpcs:ignore
 			case 'id':
 				$authors = get_posts(
 					[
-						'post_type'   => 'author',
+						'post_type'   => [ 'author', 'guest-author' ],
 						'numberposts' => 1,
 						'include'     => [ $value ],
 					]
@@ -28,6 +28,7 @@ class CoAuthors_Guest_Authors { // phpcs:ignore
 				if ( ! empty( $authors ) ) {
 					$author                = $authors[0];
 					$author->user_nicename = $author->post_title;
+					$author->display_name  = $author->post_title;
 				}
 				break;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Author Profile block fetches its author from the authors endpoint when it mounts in the editor, one request per block. A staff page with thirty blocks fires thirty requests at once, each a full PHP request, and on a site near its PHP worker limit the last ones wait in the queue until the platform drops them. Those blocks then show "The response is not a valid JSON response." and fall back to the author picker, which fires a further request each.

This makes a page of Author Profile blocks cost **one request**. The endpoint accepts `author_ids` and `guest_author_ids` and returns each record the same way the single-id lookup does. In the editor, a shared fetcher collects the lookups made within a 50ms window into one request, resolves each block from the shared response, keeps results for a minute so re-mounts don't refetch, and de-duplicates identical "recent authors" list requests. The contextual byline mode and the author picker go through the same fetcher.

A guest id that matches no guest author resolves to the WP user with that id, the way the single-id lookup and the front-end renderer do, so blocks saved before the `isGuestAuthor` attribute existed (#1143) keep resolving in the editor. Each id list is capped at 100 and the editor splits larger batches to match, a failed batch is retried once before every block in it reports an error, and blocks no longer write their own contact-link choices into the author record they now share.

It also closes two scanner findings in the same routes. By-id lookups, single and batched, now resolve only users in the component's author roles, as the listing already did. The contextual mode checks the caller can read the post before naming its authors. The author-list route intersects caller-chosen roles with the author roles and skips the user query when nothing usable remains, instead of running it without a role filter.

Closes NEWS-3049, NPPM-3288, and NPPM-3227.

### How to test the changes in this Pull Request:

1. On a site with Co-Authors Plus, add 25 or more Author Profile blocks to a page, mixing WP users and guest authors, and publish it.
2. Reload the page in the editor with the network panel filtered to `newspack-blocks/v1/authors`. One request carries all the ids, and every block renders its author.
3. Add an empty Author Profile block and search for an author. Suggestions load. Add a second empty block: it shows the same recent-authors list without a second request.
4. In a post, add an Author Profile block set to show the post's authors, then set a custom byline with two authors. Both render.
5. In the code editor, paste `<!-- wp:newspack-blocks/author-profile {"authorId":1} /-->` into a page and reload it in the visual editor. The block renders user 1, although the request carries `guest_author_ids=1`.
6. Log in as a Contributor. Request `/wp-json/newspack-blocks/v1/authors?author_id=<subscriber id>&is_guest_author=0`, then `?post_id=<another user's draft id>`, then `/wp-json/newspack-blocks/v1/author-list?author_roles[]=subscriber`. The first two return an empty list, and the third lists no WP users (Co-Authors Plus guest authors are not role-filtered and still appear). The same requests with an author's id, a published post, and `author_roles[]=author` return the users.
7. While logged in, request `/wp-json/newspack-blocks/v1/authors?author_ids=1,2&fields=id,name`. The response lists both users. An unknown id in the list is skipped rather than failing the request, a list with no valid id returns `[]`, and a list longer than 100 ids is trimmed to its first 100.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? (17 PHPUnit, 20 Jest.)
* [x] Have you successfully run tests with your changes locally? (Full blocks PHP suite, 227 tests, and JS suite, 186 tests.)

The single `author_id` lookup keeps its shape, so nothing else that calls the endpoint needs to move. An Author Profile block pointing at a user who has since lost their author role stops resolving in the editor; the front-end render is unchanged.


