### PR TITLE
feat(content-gate): improve usability of the user Access Control report

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
@@ -944,44 +944,106 @@ class Access_Rules {
 	}
 
 	/**
+	 * Paid orders that satisfy a one-time purchase rule for the user.
+	 *
+	 * The report-side counterpart of has_one_time_purchase(): where the rule only
+	 * needs a yes/no, this names the orders behind the yes. It reads the rule
+	 * value the same way (paid statuses only, order creation date anchors the
+	 * duration, misconfigured durations grant nothing), but it always lists from
+	 * the customer's order history rather than wc_customer_bought_product(),
+	 * since that helper can only answer whether a purchase exists.
+	 *
+	 * Unlike has_one_time_purchase() this does not run the
+	 * `newspack_access_rules_has_one_time_purchase` filter, so access granted by
+	 * a third party has no order here.
+	 *
+	 * @param int   $user_id User ID.
+	 * @param array $args    Rule value, as accepted by has_one_time_purchase().
+	 * @return int[] Order IDs, newest first.
+	 */
+	public static function get_one_time_purchase_order_ids( $user_id, $args ) {
+		$value = self::sanitize_one_time_purchase_value( $args );
+		if ( empty( $value['product_ids'] ) || ! function_exists( 'wc_get_orders' ) ) {
+			return [];
+		}
+		$user     = \get_userdata( $user_id );
+		$email    = $user ? $user->user_email : '';
+		$customer = array_values( array_filter( [ $user_id, $email ] ) );
+		if ( empty( $customer ) ) {
+			return [];
+		}
+		if ( 'forever' === $value['duration_unit'] ) {
+			$cutoff = null;
+		} elseif ( in_array( $value['duration_unit'], [ 'days', 'months' ], true ) && $value['duration_value'] > 0 ) {
+			$cutoff = strtotime( sprintf( '-%d %s', $value['duration_value'], $value['duration_unit'] ) );
+		} else {
+			return [];
+		}
+		return array_map(
+			function ( $order ) {
+				return (int) $order->get_id();
+			},
+			self::get_paid_orders_with_products( $customer, $value['product_ids'], $cutoff )
+		);
+	}
+
+	/**
 	 * Whether the user has a paid order containing one of the given products,
 	 * created after the given cutoff timestamp.
 	 *
-	 * The query is bounded by customer, paid statuses, and the date window, so it
-	 * stays cheap on front-end requests even without a persistent cache. The
-	 * `customer` parameter matches the user ID or the billing email, so guest
-	 * orders count — mirroring wc_customer_bought_product() on the lifetime path.
-	 *
-	 * @param array $customer    Non-empty list of user IDs and/or billing emails to
-	 *                           match. Callers must reject an empty list: both
-	 *                           WooCommerce order stores drop an empty `customer`
-	 *                           constraint and return every customer's orders.
+	 * @param array $customer    Non-empty list of user IDs and/or billing emails to match.
 	 * @param int[] $product_ids Product IDs to look for.
 	 * @param int   $cutoff      Unix timestamp orders must be created after.
 	 *
 	 * @return bool
 	 */
 	private static function customer_bought_product_after( $customer, $product_ids, $cutoff ) {
+		return ! empty( self::get_paid_orders_with_products( $customer, $product_ids, $cutoff ) );
+	}
+
+	/**
+	 * The customer's paid orders containing one of the given products, optionally
+	 * limited to orders created after a cutoff timestamp.
+	 *
+	 * The query is bounded by customer, paid statuses, and the date window, so it
+	 * stays cheap on front-end requests even without a persistent cache. The
+	 * `customer` parameter matches the user ID or the billing email, so guest
+	 * orders count — mirroring wc_customer_bought_product() on the lifetime path.
+	 *
+	 * @param array    $customer    Non-empty list of user IDs and/or billing emails to
+	 *                              match. Callers must reject an empty list: both
+	 *                              WooCommerce order stores drop an empty `customer`
+	 *                              constraint and return every customer's orders.
+	 * @param int[]    $product_ids Product IDs to look for.
+	 * @param int|null $cutoff      Unix timestamp orders must be created after, or
+	 *                              null for the customer's whole order history.
+	 *
+	 * @return \WC_Order[] Matching orders, newest first.
+	 */
+	private static function get_paid_orders_with_products( $customer, $product_ids, $cutoff ) {
 		$paid_statuses = function_exists( 'wc_get_is_paid_statuses' ) ? \wc_get_is_paid_statuses() : [ 'processing', 'completed' ];
-		$orders        = \wc_get_orders(
-			[
-				'customer'     => $customer,
-				'status'       => $paid_statuses,
-				'date_created' => '>' . $cutoff,
-				'limit'        => -1,
-				'return'       => 'objects',
-			]
-		);
+		$query         = [
+			'customer' => $customer,
+			'status'   => $paid_statuses,
+			'limit'    => -1,
+			'return'   => 'objects',
+		];
+		if ( null !== $cutoff ) {
+			$query['date_created'] = '>' . $cutoff;
+		}
+		$orders  = \wc_get_orders( $query );
+		$matches = [];
 		foreach ( $orders as $order ) {
 			foreach ( $order->get_items() as $item ) {
 				$item_product_id   = method_exists( $item, 'get_product_id' ) ? (int) $item->get_product_id() : 0;
 				$item_variation_id = method_exists( $item, 'get_variation_id' ) ? (int) $item->get_variation_id() : 0;
 				if ( in_array( $item_product_id, $product_ids, true ) || ( $item_variation_id && in_array( $item_variation_id, $product_ids, true ) ) ) {
-					return true;
+					$matches[] = $order;
+					break;
 				}
 			}
 		}
-		return false;
+		return $matches;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
@@ -63,6 +63,14 @@ class Access_Rules {
 	private static $one_time_purchase_memo = [];
 
 	/**
+	 * Request-scoped memo of one-time purchase order listings, keyed by user ID,
+	 * rule value, and limit. Flushed together with $one_time_purchase_memo.
+	 *
+	 * @var array<string,int[]>
+	 */
+	private static $one_time_purchase_orders_memo = [];
+
+	/**
 	 * Reader ID the email-domain rule should treat as verified for the duration of a
 	 * hypothetical evaluation. Zero outside one. See with_assumed_verification().
 	 *
@@ -744,46 +752,7 @@ class Access_Rules {
 			return false;
 		}
 
-		$has_subscription = false;
-
-		// Whether on-hold subscriptions in payment recovery (failed-payment retry
-		// window) still grant access. Controlled per-gate by the custom_access
-		// `payment_recovery_grace` setting; defaults to ON so gates saved before
-		// the setting existed — and evaluations outside a gate context — keep
-		// paying readers' access while their payment is being retried.
-		$payment_recovery_grace = (bool) self::get_evaluation_context( 'payment_recovery_grace', true );
-
-		// Check user's own subscriptions.
-		if ( ! empty( WooCommerce_Connection::get_active_subscriptions_for_user( $user_id, $product_ids, $payment_recovery_grace ) ) ) {
-			$has_subscription = true;
-		}
-
-		// Check group subscriptions the user is a member of.
-		if ( ! $strict && ! $has_subscription && function_exists( 'wcs_get_subscription' ) ) {
-			$group_subscriptions = Group_Subscription::get_group_subscriptions_for_user( $user_id );
-			foreach ( $group_subscriptions as $subscription ) {
-				if ( ! $subscription ) {
-					continue;
-				}
-				$grants_access = $subscription->has_status( WooCommerce_Connection::ACTIVE_SUBSCRIPTION_STATUSES )
-					|| ( $payment_recovery_grace && WooCommerce_Connection::is_subscription_in_payment_recovery( $subscription ) );
-				if ( ! $grants_access ) {
-					continue;
-				}
-				// If no product filter, any active group subscription grants access.
-				if ( empty( $product_ids ) ) {
-					$has_subscription = true;
-					break;
-				}
-				// Check if the subscription has any of the required products.
-				foreach ( $product_ids as $product_id ) {
-					if ( $subscription->has_product( $product_id ) ) {
-						$has_subscription = true;
-						break 2;
-					}
-				}
-			}
-		}
+		$has_subscription = ! empty( self::get_active_subscription_ids( $user_id, $product_ids, $strict, 1 ) );
 
 		/**
 		 * Filters whether a user has an active subscription for the given products.
@@ -794,6 +763,71 @@ class Access_Rules {
 		 * @param bool  $strict           If true, only consider active subscriptions owned by $user_id (ignore group subscription memberships).
 		 */
 		return apply_filters( 'newspack_access_rules_has_active_subscription', $has_subscription, $user_id, $product_ids, $strict );
+	}
+
+	/**
+	 * IDs of the user's subscriptions that satisfy a subscription rule: owned
+	 * subscriptions, plus (unless $strict) group subscriptions the user is a
+	 * member of. This is the listing behind has_active_subscription(); keeping
+	 * the two on one code path is what stops the report and the rule from
+	 * disagreeing about statuses, payment-recovery grace, or gifting.
+	 *
+	 * The `newspack_access_rules_has_active_subscription` filter is not run
+	 * here, so access granted by a third party (e.g. a Newspack Network sibling
+	 * site) has no ID in this list even though the rule passes.
+	 *
+	 * @param int   $user_id     User ID.
+	 * @param mixed $product_ids Required product IDs; empty means any subscription qualifies.
+	 * @param bool  $strict      If true, ignore group subscription memberships.
+	 * @param int   $max_matches Stop after this many IDs; 0 for all.
+	 * @return int[] Subscription IDs.
+	 */
+	public static function get_active_subscription_ids( $user_id, $product_ids, $strict = false, $max_matches = 0 ) {
+		$product_ids = is_array( $product_ids ) ? $product_ids : [];
+
+		// Whether on-hold subscriptions in payment recovery (failed-payment retry
+		// window) still grant access. Controlled per-gate by the custom_access
+		// `payment_recovery_grace` setting; defaults to ON so gates saved before
+		// the setting existed — and evaluations outside a gate context — keep
+		// paying readers' access while their payment is being retried.
+		$payment_recovery_grace = (bool) self::get_evaluation_context( 'payment_recovery_grace', true );
+
+		$ids = array_map( 'intval', WooCommerce_Connection::get_active_subscriptions_for_user( $user_id, $product_ids, $payment_recovery_grace ) );
+		if ( $max_matches > 0 && count( $ids ) >= $max_matches ) {
+			return array_slice( array_values( array_unique( $ids ) ), 0, $max_matches );
+		}
+
+		// Group subscriptions the user is a member of.
+		if ( ! $strict && function_exists( 'wcs_get_subscription' ) ) {
+			foreach ( Group_Subscription::get_group_subscriptions_for_user( $user_id ) as $subscription ) {
+				if ( ! $subscription ) {
+					continue;
+				}
+				$grants_access = $subscription->has_status( WooCommerce_Connection::ACTIVE_SUBSCRIPTION_STATUSES )
+					|| ( $payment_recovery_grace && WooCommerce_Connection::is_subscription_in_payment_recovery( $subscription ) );
+				if ( ! $grants_access ) {
+					continue;
+				}
+				// If no product filter, any active group subscription grants access.
+				$has_product = empty( $product_ids );
+				foreach ( $product_ids as $product_id ) {
+					if ( $subscription->has_product( $product_id ) ) {
+						$has_product = true;
+						break;
+					}
+				}
+				if ( ! $has_product ) {
+					continue;
+				}
+				$ids[] = (int) $subscription->get_id();
+				if ( $max_matches > 0 && count( array_unique( $ids ) ) >= $max_matches ) {
+					break;
+				}
+			}
+		}
+
+		$ids = array_values( array_unique( $ids ) );
+		return $max_matches > 0 ? array_slice( $ids, 0, $max_matches ) : $ids;
 	}
 
 	/**
@@ -859,7 +893,8 @@ class Access_Rules {
 	 * Primarily for tests; in production the memo is per-request by nature.
 	 */
 	public static function flush_one_time_purchase_memo() {
-		self::$one_time_purchase_memo = [];
+		self::$one_time_purchase_memo        = [];
+		self::$one_time_purchase_orders_memo = [];
 	}
 
 	/**
@@ -951,7 +986,9 @@ class Access_Rules {
 	 * value the same way (paid statuses only, order creation date anchors the
 	 * duration, misconfigured durations grant nothing), but it always lists from
 	 * the customer's order history rather than wc_customer_bought_product(),
-	 * since that helper can only answer whether a purchase exists.
+	 * since that helper can only answer whether a purchase exists. A lifetime
+	 * rule therefore walks the whole history, which is why callers pass a
+	 * $limit and why the result is memoized for the request.
 	 *
 	 * Unlike has_one_time_purchase() this does not run the
 	 * `newspack_access_rules_has_one_time_purchase` filter, so access granted by
@@ -959,32 +996,41 @@ class Access_Rules {
 	 *
 	 * @param int   $user_id User ID.
 	 * @param array $args    Rule value, as accepted by has_one_time_purchase().
+	 * @param int   $limit   Stop after this many orders; 0 for all.
 	 * @return int[] Order IDs, newest first.
 	 */
-	public static function get_one_time_purchase_order_ids( $user_id, $args ) {
+	public static function get_one_time_purchase_order_ids( $user_id, $args, $limit = 0 ) {
 		$value = self::sanitize_one_time_purchase_value( $args );
 		if ( empty( $value['product_ids'] ) || ! function_exists( 'wc_get_orders' ) ) {
 			return [];
 		}
+		$memo_key = $user_id . ':' . md5( wp_json_encode( $value ) ) . ':' . (int) $limit;
+		if ( isset( self::$one_time_purchase_orders_memo[ $memo_key ] ) ) {
+			return self::$one_time_purchase_orders_memo[ $memo_key ];
+		}
 		$user     = \get_userdata( $user_id );
 		$email    = $user ? $user->user_email : '';
 		$customer = array_values( array_filter( [ $user_id, $email ] ) );
+		$cutoff   = false;
 		if ( empty( $customer ) ) {
-			return [];
-		}
-		if ( 'forever' === $value['duration_unit'] ) {
+			$order_ids = [];
+		} elseif ( 'forever' === $value['duration_unit'] ) {
 			$cutoff = null;
 		} elseif ( in_array( $value['duration_unit'], [ 'days', 'months' ], true ) && $value['duration_value'] > 0 ) {
 			$cutoff = strtotime( sprintf( '-%d %s', $value['duration_value'], $value['duration_unit'] ) );
 		} else {
-			return [];
+			$order_ids = [];
 		}
-		return array_map(
-			function ( $order ) {
-				return (int) $order->get_id();
-			},
-			self::get_paid_orders_with_products( $customer, $value['product_ids'], $cutoff )
-		);
+		if ( false !== $cutoff ) {
+			$order_ids = array_map(
+				function ( $order ) {
+					return (int) $order->get_id();
+				},
+				self::get_paid_orders_with_products( $customer, $value['product_ids'], $cutoff, (int) $limit )
+			);
+		}
+		self::$one_time_purchase_orders_memo[ $memo_key ] = $order_ids;
+		return $order_ids;
 	}
 
 	/**
@@ -998,17 +1044,27 @@ class Access_Rules {
 	 * @return bool
 	 */
 	private static function customer_bought_product_after( $customer, $product_ids, $cutoff ) {
-		return ! empty( self::get_paid_orders_with_products( $customer, $product_ids, $cutoff ) );
+		return ! empty( self::get_paid_orders_with_products( $customer, $product_ids, $cutoff, 1 ) );
 	}
 
 	/**
-	 * The customer's paid orders containing one of the given products, optionally
-	 * limited to orders created after a cutoff timestamp.
+	 * Orders are fetched in pages of this many.
 	 *
-	 * The query is bounded by customer, paid statuses, and the date window, so it
-	 * stays cheap on front-end requests even without a persistent cache. The
-	 * `customer` parameter matches the user ID or the billing email, so guest
-	 * orders count — mirroring wc_customer_bought_product() on the lifetime path.
+	 * @var int
+	 */
+	const PAID_ORDERS_PAGE_SIZE = 50;
+
+	/**
+	 * The customer's paid orders containing one of the given products, newest
+	 * first, optionally limited to orders created after a cutoff timestamp.
+	 *
+	 * Orders are read newest-first in pages and the walk stops as soon as
+	 * $max_matches is reached, so the rule evaluator (which needs one match)
+	 * hydrates at most one page of a customer's history on a front-end request.
+	 * A null $cutoff walks the whole history and is only appropriate for a
+	 * bounded, admin-side caller. The `customer` parameter matches the user ID
+	 * or the billing email, so guest orders count — mirroring
+	 * wc_customer_bought_product() on the lifetime path.
 	 *
 	 * @param array    $customer    Non-empty list of user IDs and/or billing emails to
 	 *                              match. Callers must reject an empty list: both
@@ -1017,33 +1073,58 @@ class Access_Rules {
 	 * @param int[]    $product_ids Product IDs to look for.
 	 * @param int|null $cutoff      Unix timestamp orders must be created after, or
 	 *                              null for the customer's whole order history.
+	 * @param int      $max_matches Stop after this many matching orders; 0 for all.
 	 *
 	 * @return \WC_Order[] Matching orders, newest first.
 	 */
-	private static function get_paid_orders_with_products( $customer, $product_ids, $cutoff ) {
+	private static function get_paid_orders_with_products( $customer, $product_ids, $cutoff, $max_matches = 0 ) {
 		$paid_statuses = function_exists( 'wc_get_is_paid_statuses' ) ? \wc_get_is_paid_statuses() : [ 'processing', 'completed' ];
 		$query         = [
 			'customer' => $customer,
 			'status'   => $paid_statuses,
-			'limit'    => -1,
+			'orderby'  => 'date',
+			'order'    => 'DESC',
+			'limit'    => self::PAID_ORDERS_PAGE_SIZE,
 			'return'   => 'objects',
 		];
 		if ( null !== $cutoff ) {
 			$query['date_created'] = '>' . $cutoff;
 		}
-		$orders  = \wc_get_orders( $query );
 		$matches = [];
-		foreach ( $orders as $order ) {
-			foreach ( $order->get_items() as $item ) {
-				$item_product_id   = method_exists( $item, 'get_product_id' ) ? (int) $item->get_product_id() : 0;
-				$item_variation_id = method_exists( $item, 'get_variation_id' ) ? (int) $item->get_variation_id() : 0;
-				if ( in_array( $item_product_id, $product_ids, true ) || ( $item_variation_id && in_array( $item_variation_id, $product_ids, true ) ) ) {
+		for ( $page = 1; true; $page++ ) {
+			$query['page'] = $page;
+			$orders        = \wc_get_orders( $query );
+			foreach ( $orders as $order ) {
+				if ( self::order_has_product( $order, $product_ids ) ) {
 					$matches[] = $order;
-					break;
+					if ( $max_matches > 0 && count( $matches ) >= $max_matches ) {
+						return $matches;
+					}
 				}
 			}
+			if ( count( $orders ) < self::PAID_ORDERS_PAGE_SIZE ) {
+				return $matches;
+			}
 		}
-		return $matches;
+	}
+
+	/**
+	 * Whether an order has a line item for one of the given products, matching
+	 * on the variation ID as well as the parent product ID.
+	 *
+	 * @param \WC_Order $order       Order.
+	 * @param int[]     $product_ids Product IDs to look for.
+	 * @return bool
+	 */
+	private static function order_has_product( $order, $product_ids ) {
+		foreach ( $order->get_items() as $item ) {
+			$item_product_id   = method_exists( $item, 'get_product_id' ) ? (int) $item->get_product_id() : 0;
+			$item_variation_id = method_exists( $item, 'get_variation_id' ) ? (int) $item->get_variation_id() : 0;
+			if ( in_array( $item_product_id, $product_ids, true ) || ( $item_variation_id && in_array( $item_variation_id, $product_ids, true ) ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-access-rules.php
@@ -766,15 +766,14 @@ class Access_Rules {
 	}
 
 	/**
-	 * IDs of the user's subscriptions that satisfy a subscription rule: owned
-	 * subscriptions, plus (unless $strict) group subscriptions the user is a
-	 * member of. This is the listing behind has_active_subscription(); keeping
-	 * the two on one code path is what stops the report and the rule from
-	 * disagreeing about statuses, payment-recovery grace, or gifting.
+	 * The listing behind has_active_subscription(). Keeping the rule and the
+	 * report on one code path is what stops them disagreeing about statuses,
+	 * payment-recovery grace, or gifting.
 	 *
-	 * The `newspack_access_rules_has_active_subscription` filter is not run
-	 * here, so access granted by a third party (e.g. a Newspack Network sibling
-	 * site) has no ID in this list even though the rule passes.
+	 * A malformed $product_ids fails closed here as it does in the rule. The
+	 * `newspack_access_rules_has_active_subscription` filter is not run, so
+	 * access granted by a third party (e.g. a Newspack Network sibling site)
+	 * has no ID in this list even though the rule passes.
 	 *
 	 * @param int   $user_id     User ID.
 	 * @param mixed $product_ids Required product IDs; empty means any subscription qualifies.
@@ -783,6 +782,9 @@ class Access_Rules {
 	 * @return int[] Subscription IDs.
 	 */
 	public static function get_active_subscription_ids( $user_id, $product_ids, $strict = false, $max_matches = 0 ) {
+		if ( self::is_malformed_options_backed_value( $product_ids ) ) {
+			return [];
+		}
 		$product_ids = is_array( $product_ids ) ? $product_ids : [];
 
 		// Whether on-hold subscriptions in payment recovery (failed-payment retry
@@ -927,6 +929,7 @@ class Access_Rules {
 				$user     = \get_userdata( $user_id );
 				$email    = $user ? $user->user_email : '';
 				$customer = array_values( array_filter( [ $user_id, $email ] ) );
+				$cutoff   = self::get_one_time_purchase_cutoff( $value );
 				if ( empty( $customer ) ) {
 					// Fail closed with no identity to match a purchase against. Both
 					// paths need this guard, for different reasons. The finite path:
@@ -938,7 +941,7 @@ class Access_Rules {
 					// identity check, so a third-party filter can answer truthy for
 					// nobody in particular. Neither branch is redundant.
 					$has_purchase = false;
-				} elseif ( 'forever' === $value['duration_unit'] ) {
+				} elseif ( null === $cutoff ) {
 					// Lifetime access: any paid order ever. wc_customer_bought_product()
 					// is exhaustive across the customer's order history (matching both
 					// user ID and billing email, so guest orders count), runs SQL-side,
@@ -949,21 +952,10 @@ class Access_Rules {
 							break;
 						}
 					}
-				} elseif ( in_array( $value['duration_unit'], [ 'days', 'months' ], true ) && $value['duration_value'] > 0 ) {
-					// One cutoff shared by every order, rather than a per-order expiry
-					// of purchase + N. Month arithmetic follows strtotime()'s rollover
-					// semantics, and rolling backwards from now is the conservative
-					// direction: "-1 month" from Mar 1 lands on Feb 1, so a Jan 31
-					// purchase stops granting once the calendar month is up, whereas
-					// "+1 month" from Jan 31 rolls forward through Feb 31 to Mar 3 and
-					// would grant three extra days. The two readings agree except on
-					// month-end anchors, where this one is both deny-biased and closer
-					// to what "N months from purchase" means on a calendar.
-					$cutoff       = strtotime( sprintf( '-%d %s', $value['duration_value'], $value['duration_unit'] ) );
+				} elseif ( false !== $cutoff ) {
 					$has_purchase = self::customer_bought_product_after( $customer, $value['product_ids'], $cutoff );
 				}
-				// Any other duration configuration (missing/unrecognized unit, zero
-				// finite duration) is misconfigured and fails closed.
+				// A false cutoff is a misconfigured duration and fails closed.
 				self::$one_time_purchase_memo[ $memo_key ] = $has_purchase;
 			}
 		}
@@ -979,20 +971,44 @@ class Access_Rules {
 	}
 
 	/**
-	 * Paid orders that satisfy a one-time purchase rule for the user.
+	 * The point in time a one-time purchase rule's orders must postdate.
 	 *
-	 * The report-side counterpart of has_one_time_purchase(): where the rule only
-	 * needs a yes/no, this names the orders behind the yes. It reads the rule
-	 * value the same way (paid statuses only, order creation date anchors the
-	 * duration, misconfigured durations grant nothing), but it always lists from
-	 * the customer's order history rather than wc_customer_bought_product(),
-	 * since that helper can only answer whether a purchase exists. A lifetime
-	 * rule therefore walks the whole history, which is why callers pass a
-	 * $limit and why the result is memoized for the request.
+	 * One cutoff shared by every order, rather than a per-order expiry of
+	 * purchase + N. Month arithmetic follows strtotime()'s rollover semantics,
+	 * and rolling backwards from now is the conservative direction: "-1 month"
+	 * from Mar 1 lands on Feb 1, so a Jan 31 purchase stops granting once the
+	 * calendar month is up, whereas "+1 month" from Jan 31 rolls forward through
+	 * Feb 31 to Mar 3 and would grant three extra days. The two readings agree
+	 * except on month-end anchors, where this one is both deny-biased and closer
+	 * to what "N months from purchase" means on a calendar.
 	 *
-	 * Unlike has_one_time_purchase() this does not run the
-	 * `newspack_access_rules_has_one_time_purchase` filter, so access granted by
-	 * a third party has no order here.
+	 * Shared by the rule and its listing so the two cannot drift.
+	 *
+	 * @param array $value Sanitized rule value.
+	 * @return int|null|false Unix timestamp; null for lifetime access (no cutoff);
+	 *                        false for a misconfigured duration, which grants nothing.
+	 */
+	private static function get_one_time_purchase_cutoff( $value ) {
+		if ( 'forever' === $value['duration_unit'] ) {
+			return null;
+		}
+		if ( in_array( $value['duration_unit'], [ 'days', 'months' ], true ) && $value['duration_value'] > 0 ) {
+			return strtotime( sprintf( '-%d %s', $value['duration_value'], $value['duration_unit'] ) );
+		}
+		return false;
+	}
+
+	/**
+	 * Paid orders that satisfy a one-time purchase rule for the user; the
+	 * listing behind has_one_time_purchase().
+	 *
+	 * The rule answers a lifetime duration through wc_customer_bought_product(),
+	 * which is SQL-side and cached; this has to walk the order store to name the
+	 * orders, so a lifetime rule walks the whole history. Callers pass a $limit
+	 * for that reason, and the result is memoized for the request.
+	 *
+	 * The `newspack_access_rules_has_one_time_purchase` filter is not run, so
+	 * access granted by a third party has no order here.
 	 *
 	 * @param int   $user_id User ID.
 	 * @param array $args    Rule value, as accepted by has_one_time_purchase().
@@ -1008,20 +1024,12 @@ class Access_Rules {
 		if ( isset( self::$one_time_purchase_orders_memo[ $memo_key ] ) ) {
 			return self::$one_time_purchase_orders_memo[ $memo_key ];
 		}
-		$user     = \get_userdata( $user_id );
-		$email    = $user ? $user->user_email : '';
-		$customer = array_values( array_filter( [ $user_id, $email ] ) );
-		$cutoff   = false;
-		if ( empty( $customer ) ) {
-			$order_ids = [];
-		} elseif ( 'forever' === $value['duration_unit'] ) {
-			$cutoff = null;
-		} elseif ( in_array( $value['duration_unit'], [ 'days', 'months' ], true ) && $value['duration_value'] > 0 ) {
-			$cutoff = strtotime( sprintf( '-%d %s', $value['duration_value'], $value['duration_unit'] ) );
-		} else {
-			$order_ids = [];
-		}
-		if ( false !== $cutoff ) {
+		$user      = \get_userdata( $user_id );
+		$email     = $user ? $user->user_email : '';
+		$customer  = array_values( array_filter( [ $user_id, $email ] ) );
+		$cutoff    = self::get_one_time_purchase_cutoff( $value );
+		$order_ids = [];
+		if ( ! empty( $customer ) && false !== $cutoff ) {
 			$order_ids = array_map(
 				function ( $order ) {
 					return (int) $order->get_id();
@@ -1048,23 +1056,34 @@ class Access_Rules {
 	}
 
 	/**
-	 * Orders are fetched in pages of this many.
+	 * Orders are fetched in pages of this many. Tests shrink it to exercise the walk.
 	 *
 	 * @var int
 	 */
-	const PAID_ORDERS_PAGE_SIZE = 50;
+	private static $paid_orders_page_size = 50;
+
+	/**
+	 * The walk gives up after this many pages even if the store keeps answering.
+	 * A filter on `woocommerce_order_query_args` that pins `limit` or ignores
+	 * `page` would otherwise hand back the same rows forever, and this runs on
+	 * front-end requests through has_one_time_purchase(). Fifty pages of fifty
+	 * covers 2,500 paid orders for one customer before the walk returns what it
+	 * has collected.
+	 *
+	 * @var int
+	 */
+	const PAID_ORDERS_MAX_PAGES = 50;
 
 	/**
 	 * The customer's paid orders containing one of the given products, newest
 	 * first, optionally limited to orders created after a cutoff timestamp.
 	 *
-	 * Orders are read newest-first in pages and the walk stops as soon as
-	 * $max_matches is reached, so the rule evaluator (which needs one match)
-	 * hydrates at most one page of a customer's history on a front-end request.
 	 * A null $cutoff walks the whole history and is only appropriate for a
 	 * bounded, admin-side caller. The `customer` parameter matches the user ID
-	 * or the billing email, so guest orders count — mirroring
-	 * wc_customer_bought_product() on the lifetime path.
+	 * or the billing email, so guest orders count, mirroring
+	 * wc_customer_bought_product() on the lifetime path. `date ID` is the sort
+	 * key because `date` alone is not unique: same-second orders (imports, batch
+	 * renewals) could straddle a page boundary and be skipped or repeated.
 	 *
 	 * @param array    $customer    Non-empty list of user IDs and/or billing emails to
 	 *                              match. Callers must reject an empty list: both
@@ -1079,19 +1098,20 @@ class Access_Rules {
 	 */
 	private static function get_paid_orders_with_products( $customer, $product_ids, $cutoff, $max_matches = 0 ) {
 		$paid_statuses = function_exists( 'wc_get_is_paid_statuses' ) ? \wc_get_is_paid_statuses() : [ 'processing', 'completed' ];
+		$page_size     = max( 1, (int) self::$paid_orders_page_size );
 		$query         = [
 			'customer' => $customer,
 			'status'   => $paid_statuses,
-			'orderby'  => 'date',
+			'orderby'  => 'date ID',
 			'order'    => 'DESC',
-			'limit'    => self::PAID_ORDERS_PAGE_SIZE,
+			'limit'    => $page_size,
 			'return'   => 'objects',
 		];
 		if ( null !== $cutoff ) {
 			$query['date_created'] = '>' . $cutoff;
 		}
 		$matches = [];
-		for ( $page = 1; true; $page++ ) {
+		for ( $page = 1; $page <= self::PAID_ORDERS_MAX_PAGES; $page++ ) {
 			$query['page'] = $page;
 			$orders        = \wc_get_orders( $query );
 			foreach ( $orders as $order ) {
@@ -1102,10 +1122,11 @@ class Access_Rules {
 					}
 				}
 			}
-			if ( count( $orders ) < self::PAID_ORDERS_PAGE_SIZE ) {
-				return $matches;
+			if ( count( $orders ) < $page_size ) {
+				break;
 			}
 		}
+		return $matches;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/content-gate/class-user-gate-access.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-user-gate-access.php
@@ -159,11 +159,11 @@ class User_Gate_Access {
 			return self::format_institution_names( $value );
 		}
 
-		if ( is_array( $value ) ) {
-			return implode( ', ', $value );
-		}
-
-		return (string) $value;
+		return sprintf(
+			/* translators: %s: value or comma-separated list of values. */
+			'<code>%s</code>',
+			is_array( $value ) ? implode( ', ', $value ) : (string) $value
+		);
 	}
 
 	/**
@@ -397,8 +397,16 @@ class User_Gate_Access {
 												<?php echo wp_kses( $rule['passes'] ? '<span style="color: #00a32a;">&#10003;</span>' : '<span style="color: #d63638;">&#10005;</span>', [ 'span' => [ 'style' => [] ] ] ); ?>
 											</span>
 											<span class="screen-reader-text"><?php echo $rule['passes'] ? esc_html__( 'Pass', 'newspack-plugin' ) : esc_html__( 'Fail', 'newspack-plugin' ); ?></span>
-											<?php echo esc_html( $rule['name'] ); ?>:
-											<code><?php echo wp_kses( self::format_rule_value( $rule['slug'], $rule['value'] ), [ 'a' => [ 'href' => [] ] ] ); ?></code>
+											<strong><?php echo esc_html( $rule['name'] ); ?>:</strong>
+											<?php
+											echo wp_kses(
+												self::format_rule_value( $rule['slug'], $rule['value'] ),
+												[
+													'a'    => [ 'href' => [] ],
+													'code' => [],
+												]
+											);
+											?>
 											<?php
 											$granting_links = $rule['passes'] ? self::get_granting_entity_links( $rule['slug'], $rule['value'], $user->ID, $result['context'] ) : [];
 											if ( ! empty( $granting_links ) ) :

--- a/plugins/newspack-plugin/includes/content-gate/class-user-gate-access.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-user-gate-access.php
@@ -20,8 +20,8 @@ class User_Gate_Access {
 	 * Initialize hooks.
 	 */
 	public static function init() {
-		add_action( 'edit_user_profile', [ __CLASS__, 'render_user_gate_access' ] );
-		add_action( 'show_user_profile', [ __CLASS__, 'render_user_gate_access' ] );
+		add_action( 'edit_user_profile', [ __CLASS__, 'render_user_gate_access' ], 9 );
+		add_action( 'show_user_profile', [ __CLASS__, 'render_user_gate_access' ], 9 );
 	}
 
 	/**
@@ -155,6 +155,9 @@ class User_Gate_Access {
 		if ( 'subscription' === $slug && is_array( $value ) ) {
 			return self::format_product_names( $value );
 		}
+		if ( 'institution' === $slug && is_array( $value ) ) {
+			return self::format_institution_names( $value );
+		}
 
 		if ( is_array( $value ) ) {
 			return implode( ', ', $value );
@@ -164,11 +167,11 @@ class User_Gate_Access {
 	}
 
 	/**
-	 * Format a list of product IDs as a comma-separated list of product names.
+	 * Format a list of product IDs as a comma-separated list of linked product names.
 	 *
 	 * @param array $product_ids Product IDs.
 	 *
-	 * @return string Comma-separated product names.
+	 * @return string Comma-separated, linked product names.
 	 */
 	private static function format_product_names( $product_ids ) {
 		$names = array_map(
@@ -176,12 +179,43 @@ class User_Gate_Access {
 				if ( function_exists( 'wc_get_product' ) ) {
 					$product = wc_get_product( $product_id );
 					if ( $product ) {
-						return $product->get_name();
+						return sprintf(
+							/* translators: 1: product edit URL. 2: product name. */
+							__( '<a href="%1$s">%2$s</a>', 'newspack-plugin' ),
+							esc_url( get_edit_post_link( $product_id ) ),
+							$product->get_name()
+						);
 					}
 				}
 				return '#' . $product_id;
 			},
 			$product_ids
+		);
+		return implode( ', ', $names );
+	}
+
+	/**
+	 * Format a list of institution IDs as a comma-separated list of linked institution names.
+	 *
+	 * @param array $institution_ids Institution IDs.
+	 *
+	 * @return string Comma-separated, linked institution names.
+	 */
+	private static function format_institution_names( $institution_ids ) {
+		$names = array_map(
+			function( $institution_id ) {
+				$institution = get_post( $institution_id );
+				if ( $institution && Institution::POST_TYPE === $institution->post_type ) {
+					return sprintf(
+						/* translators: 1: institution edit URL. 2: institution name. */
+						__( '<a href="%1$s">%2$s</a>', 'newspack-plugin' ),
+						esc_url( admin_url( 'admin.php?page=newspack-audience-access-control#/institutions/' . $institution_id ) ),
+						$institution->post_title
+					);
+				}
+				return '#' . $institution_id;
+			},
+			$institution_ids
 		);
 		return implode( ', ', $names );
 	}
@@ -201,7 +235,20 @@ class User_Gate_Access {
 			return;
 		}
 		?>
-		<h2><?php esc_html_e( 'Content Gate Access', 'newspack-plugin' ); ?></h2>
+		<h2><?php esc_html_e( 'Access Control', 'newspack-plugin' ); ?></h2>
+		<p>
+			<?php esc_html_e( 'Shows the active content gate(s) the user can bypass, which access rules grant access, and how.', 'newspack-plugin' ); ?>
+			<?php
+			echo wp_kses(
+				sprintf(
+				/* translators: %s: link to the Newspack Content Gate settings page. */
+					__( '<a href="%s">Configure content gates</a>.', 'newspack-plugin' ),
+					esc_url( admin_url( 'admin.php?page=newspack-audience-access-control' ) )
+				),
+				[ 'a' => [ 'href' => [] ] ]
+			);
+			?>
+		</p>
 		<table class="form-table" role="presentation">
 			<?php foreach ( $gates as $gate ) : ?>
 				<?php $result = self::evaluate_gate_for_user( $gate, $user->ID ); ?>
@@ -211,7 +258,17 @@ class User_Gate_Access {
 							<?php echo wp_kses( $result['can_bypass'] ? '<span style="color: #00a32a;">&#10003;</span>' : '<span style="color: #d63638;">&#10005;</span>', [ 'span' => [ 'style' => [] ] ] ); ?>
 						</span>
 						<span class="screen-reader-text"><?php echo $result['can_bypass'] ? esc_html__( 'Pass', 'newspack-plugin' ) : esc_html__( 'Fail', 'newspack-plugin' ); ?></span>
-						<?php echo esc_html( $gate['title'] ); ?>
+						<?php
+						echo wp_kses(
+							sprintf(
+								/* translators: 1: gate edit URL. 2: gate title. */
+								__( '<a href="%1$s">%2$s</a>', 'newspack-plugin' ),
+								esc_url( admin_url( 'admin.php?page=newspack-audience-access-control#/edit/' . $gate['id'] ) ),
+								$gate['title']
+							),
+							[ 'a' => [ 'href' => [] ] ]
+						);
+						?>
 					</th>
 					<td>
 						<?php if ( empty( $result['groups'] ) ) : ?>
@@ -248,7 +305,14 @@ class User_Gate_Access {
 											</span>
 											<span class="screen-reader-text"><?php echo $rule['passes'] ? esc_html__( 'Pass', 'newspack-plugin' ) : esc_html__( 'Fail', 'newspack-plugin' ); ?></span>
 											<?php echo esc_html( $rule['name'] ); ?>:
-											<code><?php echo esc_html( self::format_rule_value( $rule['slug'], $rule['value'] ) ); ?></code>
+											<code>
+												<?php
+												echo wp_kses(
+													self::format_rule_value( $rule['slug'], $rule['value'] ),
+													[ 'a' => [ 'href' => [] ] ]
+												);
+												?>
+											</code>
 										</li>
 									<?php endforeach; ?>
 								</ul>

--- a/plugins/newspack-plugin/includes/content-gate/class-user-gate-access.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-user-gate-access.php
@@ -171,7 +171,7 @@ class User_Gate_Access {
 	 *
 	 * @param array $product_ids Product IDs.
 	 *
-	 * @return string Comma-separated, linked product names.
+	 * @return string Comma-separated, linked product names (HTML).
 	 */
 	private static function format_product_names( $product_ids ) {
 		$names = array_map(
@@ -179,15 +179,13 @@ class User_Gate_Access {
 				if ( function_exists( 'wc_get_product' ) ) {
 					$product = wc_get_product( $product_id );
 					if ( $product ) {
-						return sprintf(
-							/* translators: 1: product edit URL. 2: product name. */
-							__( '<a href="%1$s">%2$s</a>', 'newspack-plugin' ),
-							esc_url( get_edit_post_link( $product_id ) ),
-							$product->get_name()
-						);
+						// A variation has no edit screen of its own; its parent's
+						// product editor is where it is managed.
+						$edit_id = $product->get_parent_id() ? $product->get_parent_id() : $product->get_id();
+						return self::link( get_edit_post_link( $edit_id ), $product->get_name() );
 					}
 				}
-				return '#' . $product_id;
+				return '#' . intval( $product_id );
 			},
 			$product_ids
 		);
@@ -199,25 +197,125 @@ class User_Gate_Access {
 	 *
 	 * @param array $institution_ids Institution IDs.
 	 *
-	 * @return string Comma-separated, linked institution names.
+	 * @return string Comma-separated, linked institution names (HTML).
 	 */
 	private static function format_institution_names( $institution_ids ) {
 		$names = array_map(
 			function( $institution_id ) {
 				$institution = get_post( $institution_id );
 				if ( $institution && Institution::POST_TYPE === $institution->post_type ) {
-					return sprintf(
-						/* translators: 1: institution edit URL. 2: institution name. */
-						__( '<a href="%1$s">%2$s</a>', 'newspack-plugin' ),
-						esc_url( admin_url( 'admin.php?page=newspack-audience-access-control#/institutions/' . $institution_id ) ),
+					return self::link(
+						admin_url( 'admin.php?page=newspack-audience-access-control#/institutions/' . intval( $institution_id ) ),
 						$institution->post_title
 					);
 				}
-				return '#' . $institution_id;
+				return '#' . intval( $institution_id );
 			},
 			$institution_ids
 		);
 		return implode( ', ', $names );
+	}
+
+	/**
+	 * Build an escaped link, or plain escaped text when there is nothing to link to.
+	 *
+	 * @param string|null $url  URL, or empty when the item has no admin screen.
+	 * @param string      $text Link text (unescaped).
+	 *
+	 * @return string HTML safe to print through wp_kses() with `a[href]` allowed.
+	 */
+	private static function link( $url, $text ) {
+		if ( empty( $url ) ) {
+			return esc_html( $text );
+		}
+		return sprintf( '<a href="%1$s">%2$s</a>', esc_url( $url ), esc_html( $text ) );
+	}
+
+	/**
+	 * Links to the specific subscriptions or orders that satisfy a passing rule
+	 * for the user.
+	 *
+	 * Only the two ownership rules map to concrete records a publisher can open;
+	 * every other rule returns nothing. Access granted by a third-party filter
+	 * (e.g. a Newspack Network sibling site) has no local record, so a rule can
+	 * pass with an empty list here.
+	 *
+	 * @param string $slug    Rule slug.
+	 * @param mixed  $value   Rule value.
+	 * @param int    $user_id User ID.
+	 * @param array  $context Evaluation context from evaluate_gate_for_user().
+	 *
+	 * @return string[] Escaped `<a>` links labelled `#<id>`, safe to print through wp_kses() with `a[href]` allowed.
+	 */
+	public static function get_granting_entity_links( $slug, $value, $user_id, $context = [] ) {
+		$entities = [];
+		if ( 'subscription' === $slug && function_exists( 'wcs_get_subscription' ) ) {
+			foreach ( self::get_granting_subscription_ids( $value, $user_id, $context ) as $subscription_id ) {
+				$entities[ $subscription_id ] = \wcs_get_subscription( $subscription_id );
+			}
+		} elseif ( 'one_time_purchase' === $slug && function_exists( 'wc_get_order' ) ) {
+			foreach ( Access_Rules::get_one_time_purchase_order_ids( $user_id, $value ) as $order_id ) {
+				$entities[ $order_id ] = \wc_get_order( $order_id );
+			}
+		}
+
+		$links = [];
+		foreach ( $entities as $id => $entity ) {
+			$url = $entity && method_exists( $entity, 'get_edit_order_url' ) ? $entity->get_edit_order_url() : '';
+			$links[] = self::link( $url, '#' . $id );
+		}
+		return $links;
+	}
+
+	/**
+	 * IDs of the user's subscriptions that satisfy a subscription rule: owned
+	 * subscriptions plus group subscriptions the user is a member of, using
+	 * the same status and payment-recovery-grace reading as the rule itself.
+	 *
+	 * @param mixed $value   Rule value: product IDs, or empty for any subscription.
+	 * @param int   $user_id User ID.
+	 * @param array $context Evaluation context from evaluate_gate_for_user().
+	 *
+	 * @return int[] Subscription IDs.
+	 */
+	private static function get_granting_subscription_ids( $value, $user_id, $context ) {
+		// A malformed value fails the rule closed, so there is nothing to list.
+		if ( Access_Rules::is_malformed_options_backed_value( $value ) ) {
+			return [];
+		}
+		$product_ids = is_array( $value ) ? $value : [];
+		return Access_Rules::with_evaluation_context(
+			$context,
+			function () use ( $product_ids, $user_id ) {
+				$grace = (bool) Access_Rules::get_evaluation_context( 'payment_recovery_grace', true );
+				$ids   = WooCommerce_Connection::get_active_subscriptions_for_user( $user_id, $product_ids, $grace );
+
+				if ( class_exists( __NAMESPACE__ . '\\Group_Subscription' ) ) {
+					foreach ( Group_Subscription::get_group_subscriptions_for_user( $user_id ) as $subscription ) {
+						if ( ! $subscription ) {
+							continue;
+						}
+						$grants_access = $subscription->has_status( WooCommerce_Connection::ACTIVE_SUBSCRIPTION_STATUSES )
+							|| ( $grace && WooCommerce_Connection::is_subscription_in_payment_recovery( $subscription ) );
+						if ( ! $grants_access ) {
+							continue;
+						}
+						$has_product = empty( $product_ids );
+						foreach ( $product_ids as $product_id ) {
+							if ( $subscription->has_product( $product_id ) ) {
+								$has_product = true;
+								break;
+							}
+						}
+						if ( $has_product ) {
+							$ids[] = $subscription->get_id();
+						}
+					}
+				}
+
+				return array_values( array_unique( array_map( 'intval', $ids ) ) );
+			}
+		);
 	}
 
 	/**
@@ -260,12 +358,7 @@ class User_Gate_Access {
 						<span class="screen-reader-text"><?php echo $result['can_bypass'] ? esc_html__( 'Pass', 'newspack-plugin' ) : esc_html__( 'Fail', 'newspack-plugin' ); ?></span>
 						<?php
 						echo wp_kses(
-							sprintf(
-								/* translators: 1: gate edit URL. 2: gate title. */
-								__( '<a href="%1$s">%2$s</a>', 'newspack-plugin' ),
-								esc_url( admin_url( 'admin.php?page=newspack-audience-access-control#/edit/' . $gate['id'] ) ),
-								$gate['title']
-							),
+							self::link( admin_url( 'admin.php?page=newspack-audience-access-control#/edit/' . intval( $gate['id'] ) ), $gate['title'] ),
 							[ 'a' => [ 'href' => [] ] ]
 						);
 						?>
@@ -305,14 +398,13 @@ class User_Gate_Access {
 											</span>
 											<span class="screen-reader-text"><?php echo $rule['passes'] ? esc_html__( 'Pass', 'newspack-plugin' ) : esc_html__( 'Fail', 'newspack-plugin' ); ?></span>
 											<?php echo esc_html( $rule['name'] ); ?>:
-											<code>
-												<?php
-												echo wp_kses(
-													self::format_rule_value( $rule['slug'], $rule['value'] ),
-													[ 'a' => [ 'href' => [] ] ]
-												);
+											<code><?php echo wp_kses( self::format_rule_value( $rule['slug'], $rule['value'] ), [ 'a' => [ 'href' => [] ] ] ); ?></code>
+											<?php
+											$granting_links = $rule['passes'] ? self::get_granting_entity_links( $rule['slug'], $rule['value'], $user->ID, $result['context'] ) : [];
+											if ( ! empty( $granting_links ) ) :
 												?>
-											</code>
+												(<?php echo wp_kses( implode( ', ', $granting_links ), [ 'a' => [ 'href' => [] ] ] ); ?>)
+											<?php endif; ?>
 										</li>
 									<?php endforeach; ?>
 								</ul>

--- a/plugins/newspack-plugin/includes/content-gate/class-user-gate-access.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-user-gate-access.php
@@ -160,9 +160,8 @@ class User_Gate_Access {
 		}
 
 		return sprintf(
-			/* translators: %s: value or comma-separated list of values. */
 			'<code>%s</code>',
-			is_array( $value ) ? implode( ', ', $value ) : (string) $value
+			esc_html( is_array( $value ) ? implode( ', ', $value ) : (string) $value )
 		);
 	}
 
@@ -203,13 +202,18 @@ class User_Gate_Access {
 		$names = array_map(
 			function( $institution_id ) {
 				$institution = get_post( $institution_id );
-				if ( $institution && Institution::POST_TYPE === $institution->post_type ) {
-					return self::link(
-						admin_url( 'admin.php?page=newspack-audience-access-control#/institutions/' . intval( $institution_id ) ),
-						$institution->post_title
-					);
+				if ( ! $institution || Institution::POST_TYPE !== $institution->post_type ) {
+					return '#' . intval( $institution_id );
 				}
-				return '#' . intval( $institution_id );
+				// Only a published institution has a screen worth linking to; a
+				// draft or trashed one is named but left unlinked.
+				if ( 'publish' !== $institution->post_status ) {
+					return esc_html( $institution->post_title );
+				}
+				return self::link(
+					admin_url( 'admin.php?page=newspack-audience-access-control#/institutions/' . intval( $institution_id ) ),
+					$institution->post_title
+				);
 			},
 			$institution_ids
 		);
@@ -232,90 +236,96 @@ class User_Gate_Access {
 	}
 
 	/**
+	 * How many granting orders a rule lists before trailing off with an ellipsis.
+	 * A lifetime one-time-purchase rule can match every renewal order a
+	 * long-standing customer ever placed; the report needs a few examples, not
+	 * the whole ledger.
+	 *
+	 * @var int
+	 */
+	const GRANTING_ORDERS_LIMIT = 10;
+
+	/**
+	 * Request-scoped memo of granting-entity links, keyed by rule, value, user,
+	 * and grace setting, so gates that share a rule don't repeat the lookups.
+	 *
+	 * @var array<string,string[]>
+	 */
+	private static $granting_links_memo = [];
+
+	/**
+	 * Clear the request memo. Used by tests.
+	 */
+	public static function reset_memo() {
+		self::$granting_links_memo = [];
+	}
+
+	/**
 	 * Links to the specific subscriptions or orders that satisfy a passing rule
 	 * for the user.
 	 *
 	 * Only the two ownership rules map to concrete records a publisher can open;
 	 * every other rule returns nothing. Access granted by a third-party filter
 	 * (e.g. a Newspack Network sibling site) has no local record, so a rule can
-	 * pass with an empty list here.
+	 * pass with an empty list here. Callers own the capability check: this
+	 * returns admin edit URLs for whichever user it is asked about.
 	 *
 	 * @param string $slug    Rule slug.
 	 * @param mixed  $value   Rule value.
 	 * @param int    $user_id User ID.
 	 * @param array  $context Evaluation context from evaluate_gate_for_user().
 	 *
-	 * @return string[] Escaped `<a>` links labelled `#<id>`, safe to print through wp_kses() with `a[href]` allowed.
+	 * @return string[] Escaped items labelled `#<id>` (an `<a>` when the record has an
+	 *                  edit screen, plain text otherwise), safe to print through
+	 *                  wp_kses() with `a[href]` allowed. When more orders qualify
+	 *                  than GRANTING_ORDERS_LIMIT, the last item is an ellipsis.
 	 */
 	public static function get_granting_entity_links( $slug, $value, $user_id, $context = [] ) {
-		$entities = [];
+		$grace    = (bool) ( $context['payment_recovery_grace'] ?? true );
+		$memo_key = $slug . ':' . $user_id . ':' . md5( wp_json_encode( $value ) ) . ':' . ( $grace ? '1' : '0' );
+		if ( isset( self::$granting_links_memo[ $memo_key ] ) ) {
+			return self::$granting_links_memo[ $memo_key ];
+		}
+
+		$entities  = [];
+		$truncated = false;
 		if ( 'subscription' === $slug && function_exists( 'wcs_get_subscription' ) ) {
-			foreach ( self::get_granting_subscription_ids( $value, $user_id, $context ) as $subscription_id ) {
-				$entities[ $subscription_id ] = \wcs_get_subscription( $subscription_id );
+			// A malformed value fails the rule closed, so there is nothing to list.
+			if ( ! Access_Rules::is_malformed_options_backed_value( $value ) ) {
+				// Evaluate under the gate's own settings — notably payment-recovery
+				// grace — rather than the callback's defaults.
+				$subscription_ids = Access_Rules::with_evaluation_context(
+					$context,
+					function () use ( $user_id, $value ) {
+						return Access_Rules::get_active_subscription_ids( $user_id, $value );
+					}
+				);
+				foreach ( $subscription_ids as $subscription_id ) {
+					$entities[ $subscription_id ] = \wcs_get_subscription( $subscription_id );
+				}
 			}
 		} elseif ( 'one_time_purchase' === $slug && function_exists( 'wc_get_order' ) ) {
-			foreach ( Access_Rules::get_one_time_purchase_order_ids( $user_id, $value ) as $order_id ) {
+			$order_ids = Access_Rules::get_one_time_purchase_order_ids( $user_id, $value, self::GRANTING_ORDERS_LIMIT + 1 );
+			if ( count( $order_ids ) > self::GRANTING_ORDERS_LIMIT ) {
+				$order_ids = array_slice( $order_ids, 0, self::GRANTING_ORDERS_LIMIT );
+				$truncated = true;
+			}
+			foreach ( $order_ids as $order_id ) {
 				$entities[ $order_id ] = \wc_get_order( $order_id );
 			}
 		}
 
 		$links = [];
 		foreach ( $entities as $id => $entity ) {
-			$url = $entity && method_exists( $entity, 'get_edit_order_url' ) ? $entity->get_edit_order_url() : '';
+			$url     = $entity && method_exists( $entity, 'get_edit_order_url' ) ? $entity->get_edit_order_url() : '';
 			$links[] = self::link( $url, '#' . $id );
 		}
-		return $links;
-	}
-
-	/**
-	 * IDs of the user's subscriptions that satisfy a subscription rule: owned
-	 * subscriptions plus group subscriptions the user is a member of, using
-	 * the same status and payment-recovery-grace reading as the rule itself.
-	 *
-	 * @param mixed $value   Rule value: product IDs, or empty for any subscription.
-	 * @param int   $user_id User ID.
-	 * @param array $context Evaluation context from evaluate_gate_for_user().
-	 *
-	 * @return int[] Subscription IDs.
-	 */
-	private static function get_granting_subscription_ids( $value, $user_id, $context ) {
-		// A malformed value fails the rule closed, so there is nothing to list.
-		if ( Access_Rules::is_malformed_options_backed_value( $value ) ) {
-			return [];
+		if ( $truncated ) {
+			$links[] = esc_html( '…' );
 		}
-		$product_ids = is_array( $value ) ? $value : [];
-		return Access_Rules::with_evaluation_context(
-			$context,
-			function () use ( $product_ids, $user_id ) {
-				$grace = (bool) Access_Rules::get_evaluation_context( 'payment_recovery_grace', true );
-				$ids   = WooCommerce_Connection::get_active_subscriptions_for_user( $user_id, $product_ids, $grace );
 
-				if ( class_exists( __NAMESPACE__ . '\\Group_Subscription' ) ) {
-					foreach ( Group_Subscription::get_group_subscriptions_for_user( $user_id ) as $subscription ) {
-						if ( ! $subscription ) {
-							continue;
-						}
-						$grants_access = $subscription->has_status( WooCommerce_Connection::ACTIVE_SUBSCRIPTION_STATUSES )
-							|| ( $grace && WooCommerce_Connection::is_subscription_in_payment_recovery( $subscription ) );
-						if ( ! $grants_access ) {
-							continue;
-						}
-						$has_product = empty( $product_ids );
-						foreach ( $product_ids as $product_id ) {
-							if ( $subscription->has_product( $product_id ) ) {
-								$has_product = true;
-								break;
-							}
-						}
-						if ( $has_product ) {
-							$ids[] = $subscription->get_id();
-						}
-					}
-				}
-
-				return array_values( array_unique( array_map( 'intval', $ids ) ) );
-			}
-		);
+		self::$granting_links_memo[ $memo_key ] = $links;
+		return $links;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/content-gate/class-user-gate-access.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-user-gate-access.php
@@ -181,7 +181,7 @@ class User_Gate_Access {
 						// A variation has no edit screen of its own; its parent's
 						// product editor is where it is managed.
 						$edit_id = $product->get_parent_id() ? $product->get_parent_id() : $product->get_id();
-						return self::link( get_edit_post_link( $edit_id ), $product->get_name() );
+						return self::link( get_edit_post_link( $edit_id, 'raw' ), $product->get_name() );
 					}
 				}
 				return '#' . intval( $product_id );
@@ -236,25 +236,25 @@ class User_Gate_Access {
 	}
 
 	/**
-	 * How many granting orders a rule lists before trailing off with an ellipsis.
-	 * A lifetime one-time-purchase rule can match every renewal order a
-	 * long-standing customer ever placed; the report needs a few examples, not
-	 * the whole ledger.
+	 * How many granting records a rule lists before trailing off. A lifetime
+	 * one-time-purchase rule can match every renewal order a long-standing
+	 * customer ever placed, and a reader can sit in many group subscriptions;
+	 * the report needs a few examples, not the whole ledger.
 	 *
 	 * @var int
 	 */
-	const GRANTING_ORDERS_LIMIT = 10;
+	const GRANTING_ENTITIES_LIMIT = 10;
 
 	/**
 	 * Request-scoped memo of granting-entity links, keyed by rule, value, user,
-	 * and grace setting, so gates that share a rule don't repeat the lookups.
+	 * and evaluation context, so gates that share a rule don't repeat the lookups.
 	 *
 	 * @var array<string,string[]>
 	 */
 	private static $granting_links_memo = [];
 
 	/**
-	 * Clear the request memo. Used by tests.
+	 * Clear the request memo. Registered in the test suite's per-test reset hook.
 	 */
 	public static function reset_memo() {
 		self::$granting_links_memo = [];
@@ -277,51 +277,45 @@ class User_Gate_Access {
 	 *
 	 * @return string[] Escaped items labelled `#<id>` (an `<a>` when the record has an
 	 *                  edit screen, plain text otherwise), safe to print through
-	 *                  wp_kses() with `a[href]` allowed. When more orders qualify
-	 *                  than GRANTING_ORDERS_LIMIT, the last item is an ellipsis.
+	 *                  wp_kses() with `a[href]` and `span[class|aria-hidden]` allowed.
+	 *                  When more records qualify than GRANTING_ENTITIES_LIMIT, the
+	 *                  last item is a truncation marker.
 	 */
 	public static function get_granting_entity_links( $slug, $value, $user_id, $context = [] ) {
-		$grace    = (bool) ( $context['payment_recovery_grace'] ?? true );
-		$memo_key = $slug . ':' . $user_id . ':' . md5( wp_json_encode( $value ) ) . ':' . ( $grace ? '1' : '0' );
+		$memo_key = $slug . ':' . $user_id . ':' . md5( wp_json_encode( $value ) ) . ':' . md5( wp_json_encode( $context ) );
 		if ( isset( self::$granting_links_memo[ $memo_key ] ) ) {
 			return self::$granting_links_memo[ $memo_key ];
 		}
 
-		$entities  = [];
-		$truncated = false;
+		$ids   = [];
+		$fetch = null;
 		if ( 'subscription' === $slug && function_exists( 'wcs_get_subscription' ) ) {
-			// A malformed value fails the rule closed, so there is nothing to list.
-			if ( ! Access_Rules::is_malformed_options_backed_value( $value ) ) {
-				// Evaluate under the gate's own settings — notably payment-recovery
-				// grace — rather than the callback's defaults.
-				$subscription_ids = Access_Rules::with_evaluation_context(
-					$context,
-					function () use ( $user_id, $value ) {
-						return Access_Rules::get_active_subscription_ids( $user_id, $value );
-					}
-				);
-				foreach ( $subscription_ids as $subscription_id ) {
-					$entities[ $subscription_id ] = \wcs_get_subscription( $subscription_id );
+			// Evaluate under the gate's own settings — notably payment-recovery
+			// grace — rather than the callback's defaults.
+			$ids   = Access_Rules::with_evaluation_context(
+				$context,
+				function () use ( $user_id, $value ) {
+					return Access_Rules::get_active_subscription_ids( $user_id, $value, false, self::GRANTING_ENTITIES_LIMIT + 1 );
 				}
-			}
+			);
+			$fetch = 'wcs_get_subscription';
 		} elseif ( 'one_time_purchase' === $slug && function_exists( 'wc_get_order' ) ) {
-			$order_ids = Access_Rules::get_one_time_purchase_order_ids( $user_id, $value, self::GRANTING_ORDERS_LIMIT + 1 );
-			if ( count( $order_ids ) > self::GRANTING_ORDERS_LIMIT ) {
-				$order_ids = array_slice( $order_ids, 0, self::GRANTING_ORDERS_LIMIT );
-				$truncated = true;
-			}
-			foreach ( $order_ids as $order_id ) {
-				$entities[ $order_id ] = \wc_get_order( $order_id );
-			}
+			$ids   = Access_Rules::get_one_time_purchase_order_ids( $user_id, $value, self::GRANTING_ENTITIES_LIMIT + 1 );
+			$fetch = 'wc_get_order';
 		}
 
-		$links = [];
-		foreach ( $entities as $id => $entity ) {
+		$truncated = count( $ids ) > self::GRANTING_ENTITIES_LIMIT;
+		$links     = [];
+		foreach ( array_slice( $ids, 0, self::GRANTING_ENTITIES_LIMIT ) as $id ) {
+			$entity  = call_user_func( $fetch, $id );
 			$url     = $entity && method_exists( $entity, 'get_edit_order_url' ) ? $entity->get_edit_order_url() : '';
 			$links[] = self::link( $url, '#' . $id );
 		}
 		if ( $truncated ) {
-			$links[] = esc_html( '…' );
+			$links[] = sprintf(
+				'<span aria-hidden="true">…</span><span class="screen-reader-text">%s</span>',
+				esc_html__( 'and more', 'newspack-plugin' )
+			);
 		}
 
 		self::$granting_links_memo[ $memo_key ] = $links;
@@ -368,7 +362,7 @@ class User_Gate_Access {
 						<span class="screen-reader-text"><?php echo $result['can_bypass'] ? esc_html__( 'Pass', 'newspack-plugin' ) : esc_html__( 'Fail', 'newspack-plugin' ); ?></span>
 						<?php
 						echo wp_kses(
-							self::link( admin_url( 'admin.php?page=newspack-audience-access-control#/edit/' . intval( $gate['id'] ) ), $gate['title'] ),
+							self::link( get_edit_post_link( $gate['id'], 'raw' ), $gate['title'] ),
 							[ 'a' => [ 'href' => [] ] ]
 						);
 						?>
@@ -421,7 +415,18 @@ class User_Gate_Access {
 											$granting_links = $rule['passes'] ? self::get_granting_entity_links( $rule['slug'], $rule['value'], $user->ID, $result['context'] ) : [];
 											if ( ! empty( $granting_links ) ) :
 												?>
-												(<?php echo wp_kses( implode( ', ', $granting_links ), [ 'a' => [ 'href' => [] ] ] ); ?>)
+												<?php
+												echo wp_kses(
+													'(' . implode( ', ', $granting_links ) . ')',
+													[
+														'a'    => [ 'href' => [] ],
+														'span' => [
+															'class'       => [],
+															'aria-hidden' => [],
+														],
+													]
+												);
+												?>
 											<?php endif; ?>
 										</li>
 									<?php endforeach; ?>

--- a/plugins/newspack-plugin/tests/class-newspack-request-memo-reset.php
+++ b/plugins/newspack-plugin/tests/class-newspack-request-memo-reset.php
@@ -6,6 +6,7 @@
  */
 
 use Newspack\Access_Rules;
+use Newspack\User_Gate_Access;
 use PHPUnit\Runner\BeforeTestHook;
 
 /**
@@ -28,5 +29,6 @@ class Newspack_Request_Memo_Reset implements BeforeTestHook {
 	public function executeBeforeTest( string $test ): void { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Defined by PHPUnit's BeforeTestHook.
 		Access_Rules::flush_product_options_memos();
 		Access_Rules::flush_one_time_purchase_memo();
+		User_Gate_Access::reset_memo();
 	}
 }

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -805,6 +805,9 @@ class WC_Order {
 	public function get_id() {
 		return $this->data['id'];
 	}
+	public function get_edit_order_url() {
+		return admin_url( 'post.php?post=' . $this->get_id() . '&action=edit' );
+	}
 	public function get_customer_id() {
 		return $this->data['customer_id'];
 	}

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -1784,12 +1784,9 @@ function wc_get_is_paid_statuses() {
 	return [ 'processing', 'completed' ];
 }
 function wc_get_orders( $args ) {
-	global $orders_database;
-	// For simplicity, this mock will only return a single page of results.
-	if ( isset( $args['page'] ) && $args['page'] > 1 ) {
-		return [];
-	}
-	$orders = $orders_database;
+	global $orders_database, $wc_mocks_get_orders_calls, $wc_mocks_orders_ignore_page;
+	$wc_mocks_get_orders_calls = (int) $wc_mocks_get_orders_calls + 1;
+	$orders                    = $orders_database;
 	if ( isset( $args['customer_id'] ) ) {
 		// Filter by customer.
 		$orders = array_filter(
@@ -1860,7 +1857,11 @@ function wc_get_orders( $args ) {
 		}
 	);
 	if ( isset( $args['limit'] ) && (int) $args['limit'] > 0 ) {
-		$orders = array_slice( $orders, 0, (int) $args['limit'] );
+		// Real WC pages with `page` as a 1-based offset into the limited set. A test
+		// can set $wc_mocks_orders_ignore_page to model a store (or a filter on the
+		// query args) that hands back the same rows for every page.
+		$page   = ( empty( $wc_mocks_orders_ignore_page ) && isset( $args['page'] ) ) ? max( 1, (int) $args['page'] ) : 1;
+		$orders = array_slice( $orders, ( $page - 1 ) * (int) $args['limit'], (int) $args['limit'] );
 	}
 	return $orders;
 }

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-user-gate-access.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-user-gate-access.php
@@ -5,6 +5,7 @@
  * @package Newspack\Tests
  */
 
+use Newspack\Access_Attribution;
 use Newspack\Access_Rules;
 use Newspack\Content_Gate;
 use Newspack\Reader_Activation;
@@ -44,6 +45,8 @@ class Newspack_Test_User_Gate_Access extends WP_UnitTestCase {
 		);
 		Reader_Activation::set_reader_verified( self::$user_id );
 		self::$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		Access_Attribution::reset_memo();
+		Access_Rules::flush_one_time_purchase_memo();
 	}
 
 	/**
@@ -187,7 +190,7 @@ class Newspack_Test_User_Gate_Access extends WP_UnitTestCase {
 		User_Gate_Access::render_user_gate_access( $user );
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'Content Gate Access', $output, 'Should render heading for admin users.' );
+		$this->assertStringContainsString( 'Access Control', $output, 'Should render heading for admin users.' );
 	}
 
 	/**
@@ -255,5 +258,231 @@ class Newspack_Test_User_Gate_Access extends WP_UnitTestCase {
 			$format_rule_value_method->invoke( null, 'email_domain', '' ),
 			'An empty value for a rule that reads it as no constraint should still read "(any)".'
 		);
+	}
+
+	/**
+	 * A passing subscription rule names every subscription that satisfies it —
+	 * owned or via group membership — and only those: a cancelled subscription
+	 * and one for an unrelated product grant nothing and must not be listed.
+	 */
+	public function test_subscription_rule_lists_the_subscriptions_that_grant_access() {
+		\wc_create_mock_product(
+			[
+				'id'   => 101,
+				'name' => 'All Access',
+			]
+		);
+		$owned     = \wcs_create_subscription(
+			[
+				'customer_id'    => self::$user_id,
+				'status'         => 'active',
+				'billing_period' => 'month',
+				'products'       => [ 101 ],
+			]
+		);
+		$cancelled = \wcs_create_subscription(
+			[
+				'customer_id'    => self::$user_id,
+				'status'         => 'cancelled',
+				'billing_period' => 'month',
+				'products'       => [ 101 ],
+			]
+		);
+		$unrelated = \wcs_create_subscription(
+			[
+				'customer_id'    => self::$user_id,
+				'status'         => 'active',
+				'billing_period' => 'month',
+				'products'       => [ 999 ],
+			]
+		);
+
+		$links = User_Gate_Access::get_granting_entity_links( 'subscription', [ 101 ], self::$user_id, [ 'payment_recovery_grace' => true ] );
+
+		$this->assertCount( 1, $links );
+		$this->assertStringContainsString( '#' . $owned->get_id() . '</a>', $links[0] );
+		$this->assertStringContainsString( 'post=' . $owned->get_id() . '&#038;action=edit', $links[0], 'The label must link to the subscription edit screen.' );
+		$this->assertStringNotContainsString( '#' . $cancelled->get_id() . '<', implode( '', $links ) );
+		$this->assertStringNotContainsString( '#' . $unrelated->get_id() . '<', implode( '', $links ) );
+	}
+
+	/**
+	 * An "any subscription" rule (empty value) lists every active subscription.
+	 */
+	public function test_subscription_rule_with_no_products_lists_all_active_subscriptions() {
+		$first  = \wcs_create_subscription(
+			[
+				'customer_id'    => self::$user_id,
+				'status'         => 'active',
+				'billing_period' => 'month',
+				'products'       => [ 101 ],
+			]
+		);
+		$second = \wcs_create_subscription(
+			[
+				'customer_id'    => self::$user_id,
+				'status'         => 'active',
+				'billing_period' => 'year',
+				'products'       => [ 102 ],
+			]
+		);
+
+		$links = User_Gate_Access::get_granting_entity_links( 'subscription', '', self::$user_id );
+
+		$this->assertCount( 2, $links );
+		$this->assertStringContainsString( '#' . $first->get_id() . '</a>', $links[0] );
+		$this->assertStringContainsString( '#' . $second->get_id() . '</a>', $links[1] );
+	}
+
+	/**
+	 * A passing one-time purchase rule names the paid orders inside the access
+	 * window and only those: an order older than the window and a refunded
+	 * order grant nothing.
+	 */
+	public function test_one_time_purchase_rule_lists_the_orders_that_grant_access() {
+		\wc_create_mock_product(
+			[
+				'id'   => 201,
+				'name' => 'Day Pass',
+			]
+		);
+		$recent = \wc_create_order(
+			[
+				'customer_id'  => self::$user_id,
+				'status'       => 'completed',
+				'total'        => 10,
+				'date_created' => gmdate( 'Y-m-d H:i:s' ),
+				'items'        => [ new \WC_Order_Item_Product( [ 'product_id' => 201 ] ) ],
+			]
+		);
+		$stale  = \wc_create_order(
+			[
+				'customer_id'  => self::$user_id,
+				'status'       => 'completed',
+				'total'        => 10,
+				'date_created' => gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) ),
+				'items'        => [ new \WC_Order_Item_Product( [ 'product_id' => 201 ] ) ],
+			]
+		);
+		$refund = \wc_create_order(
+			[
+				'customer_id'  => self::$user_id,
+				'status'       => 'refunded',
+				'total'        => 10,
+				'date_created' => gmdate( 'Y-m-d H:i:s' ),
+				'items'        => [ new \WC_Order_Item_Product( [ 'product_id' => 201 ] ) ],
+			]
+		);
+		$value  = [
+			'product_ids'    => [ 201 ],
+			'duration_value' => 30,
+			'duration_unit'  => 'days',
+		];
+
+		$links = User_Gate_Access::get_granting_entity_links( 'one_time_purchase', $value, self::$user_id );
+
+		$this->assertCount( 1, $links );
+		$this->assertStringContainsString( '#' . $recent->get_id() . '</a>', $links[0] );
+		$this->assertStringContainsString( 'post=' . $recent->get_id() . '&#038;action=edit', $links[0], 'The label must link to the order edit screen.' );
+		$this->assertStringNotContainsString( '#' . $stale->get_id() . '<', $links[0] );
+		$this->assertStringNotContainsString( '#' . $refund->get_id() . '<', $links[0] );
+
+		// Lifetime access has no window, so the older order counts too.
+		$value['duration_unit'] = 'forever';
+		$links                  = User_Gate_Access::get_granting_entity_links( 'one_time_purchase', $value, self::$user_id );
+		$this->assertCount( 2, $links, 'A forever rule lists every paid order for the product.' );
+	}
+
+	/**
+	 * Rules other than the two ownership rules have no records to point at, and
+	 * neither does access granted by a filter with no local record behind it.
+	 */
+	public function test_non_ownership_rules_and_filter_granted_access_list_nothing() {
+		$this->assertSame( [], User_Gate_Access::get_granting_entity_links( 'email_domain', 'example.com', self::$user_id ) );
+
+		add_filter( 'newspack_access_rules_has_active_subscription', '__return_true' );
+		$links = User_Gate_Access::get_granting_entity_links( 'subscription', [ 101 ], self::$user_id );
+		remove_all_filters( 'newspack_access_rules_has_active_subscription' );
+
+		$this->assertSame( [], $links );
+	}
+
+	/**
+	 * The report links each granting subscription next to the rule it satisfies,
+	 * and never lists records for a failing rule.
+	 */
+	public function test_render_links_granting_subscriptions_next_to_a_passing_rule() {
+		wp_set_current_user( self::$admin_id );
+		\wc_create_mock_product(
+			[
+				'id'   => 101,
+				'name' => 'All Access',
+			]
+		);
+		$owned = \wcs_create_subscription(
+			[
+				'customer_id'    => self::$user_id,
+				'status'         => 'active',
+				'billing_period' => 'month',
+				'products'       => [ 101 ],
+			]
+		);
+		$this->create_gate_with_rules(
+			'Members Gate',
+			[
+				[
+					[
+						'slug'  => 'subscription',
+						'value' => [ 101 ],
+					],
+				],
+				[
+					[
+						'slug'  => 'subscription',
+						'value' => [ 999 ],
+					],
+				],
+			]
+		);
+
+		ob_start();
+		User_Gate_Access::render_user_gate_access( get_user_by( 'id', self::$user_id ) );
+		$output = ob_get_clean();
+
+		$this->assertSame( 1, substr_count( $output, '#' . $owned->get_id() . '</a>' ), 'The subscription is listed once, for the rule it satisfies, and not for the failing rule.' );
+	}
+
+	/**
+	 * Titles that reach the report from the database are printed as text, not
+	 * markup: a product named with a tag must not inject it into the page.
+	 */
+	public function test_render_escapes_titles_inside_links() {
+		wp_set_current_user( self::$admin_id );
+		\wc_create_mock_product(
+			[
+				'id'   => 101,
+				'name' => 'Plan <b>Bold</b> & Co',
+			]
+		);
+		$this->create_gate_with_rules(
+			'Gate <i>Italic</i>',
+			[
+				[
+					[
+						'slug'  => 'subscription',
+						'value' => [ 101 ],
+					],
+				],
+			]
+		);
+
+		ob_start();
+		User_Gate_Access::render_user_gate_access( get_user_by( 'id', self::$user_id ) );
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( '<b>', $output );
+		$this->assertStringNotContainsString( '<i>', $output );
+		$this->assertStringContainsString( 'Plan &lt;b&gt;Bold&lt;/b&gt; &amp; Co', $output );
+		$this->assertStringContainsString( 'Gate &lt;i&gt;Italic&lt;/i&gt;', $output );
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-user-gate-access.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-user-gate-access.php
@@ -339,6 +339,9 @@ class Newspack_Test_User_Gate_Access extends WP_UnitTestCase {
 			]
 		);
 		$subscription->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled', 'yes' );
+		// Real WC only persists meta on save(); the group lookup re-loads each
+		// subscription, so an unsaved flag would never be seen outside the mock.
+		$subscription->save();
 		return $subscription;
 	}
 

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-user-gate-access.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-user-gate-access.php
@@ -8,6 +8,9 @@
 use Newspack\Access_Attribution;
 use Newspack\Access_Rules;
 use Newspack\Content_Gate;
+use Newspack\Group_Subscription;
+use Newspack\Group_Subscription_Settings;
+use Newspack\Institution;
 use Newspack\Reader_Activation;
 use Newspack\User_Gate_Access;
 
@@ -47,6 +50,7 @@ class Newspack_Test_User_Gate_Access extends WP_UnitTestCase {
 		self::$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
 		Access_Attribution::reset_memo();
 		Access_Rules::flush_one_time_purchase_memo();
+		User_Gate_Access::reset_memo();
 	}
 
 	/**
@@ -296,14 +300,46 @@ class Newspack_Test_User_Gate_Access extends WP_UnitTestCase {
 				'products'       => [ 999 ],
 			]
 		);
+		// Group subscriptions owned by someone else, where the reader is a member:
+		// an active one grants access, a cancelled one does not.
+		$manager_id      = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		$group           = $this->create_group_subscription( $manager_id, 'active', [ 101 ] );
+		$cancelled_group = $this->create_group_subscription( $manager_id, 'cancelled', [ 101 ] );
+		add_user_meta( self::$user_id, Group_Subscription::GROUP_SUBSCRIPTION_USER_META_KEY, $group->get_id() );
+		add_user_meta( self::$user_id, Group_Subscription::GROUP_SUBSCRIPTION_USER_META_KEY, $cancelled_group->get_id() );
 
 		$links = User_Gate_Access::get_granting_entity_links( 'subscription', [ 101 ], self::$user_id, [ 'payment_recovery_grace' => true ] );
 
-		$this->assertCount( 1, $links );
+		$this->assertCount( 2, $links );
 		$this->assertStringContainsString( '#' . $owned->get_id() . '</a>', $links[0] );
-		$this->assertStringContainsString( 'post=' . $owned->get_id() . '&#038;action=edit', $links[0], 'The label must link to the subscription edit screen.' );
-		$this->assertStringNotContainsString( '#' . $cancelled->get_id() . '<', implode( '', $links ) );
-		$this->assertStringNotContainsString( '#' . $unrelated->get_id() . '<', implode( '', $links ) );
+		$this->assertStringContainsString( 'href="' . esc_url( $owned->get_edit_order_url() ) . '"', $links[0], 'The label must link to the subscription edit screen.' );
+		$this->assertStringContainsString( '#' . $group->get_id() . '</a>', $links[1], 'A group subscription the reader is a member of grants access and is listed.' );
+		$joined = implode( '', $links );
+		$this->assertStringNotContainsString( '#' . $cancelled->get_id() . '<', $joined );
+		$this->assertStringNotContainsString( '#' . $unrelated->get_id() . '<', $joined );
+		$this->assertStringNotContainsString( '#' . $cancelled_group->get_id() . '<', $joined );
+	}
+
+	/**
+	 * Create a subscription with group membership enabled.
+	 *
+	 * @param int    $customer_id Owner user ID.
+	 * @param string $status      Subscription status.
+	 * @param int[]  $products    Product IDs on the subscription.
+	 *
+	 * @return \WC_Subscription
+	 */
+	private function create_group_subscription( $customer_id, $status, $products ) {
+		$subscription = \wcs_create_subscription(
+			[
+				'customer_id'    => $customer_id,
+				'status'         => $status,
+				'billing_period' => 'month',
+				'products'       => $products,
+			]
+		);
+		$subscription->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled', 'yes' );
+		return $subscription;
 	}
 
 	/**
@@ -379,18 +415,68 @@ class Newspack_Test_User_Gate_Access extends WP_UnitTestCase {
 			'duration_unit'  => 'days',
 		];
 
-		$links = User_Gate_Access::get_granting_entity_links( 'one_time_purchase', $value, self::$user_id );
+		// A guest checkout under the reader's email counts as theirs, as it does
+		// for the rule itself.
+		$guest = \wc_create_order(
+			[
+				'customer_id'   => 0,
+				'billing_email' => 'reader@example.com',
+				'status'        => 'processing',
+				'total'         => 10,
+				'date_created'  => gmdate( 'Y-m-d H:i:s' ),
+				'items'         => [ new \WC_Order_Item_Product( [ 'product_id' => 201 ] ) ],
+			]
+		);
 
-		$this->assertCount( 1, $links );
-		$this->assertStringContainsString( '#' . $recent->get_id() . '</a>', $links[0] );
-		$this->assertStringContainsString( 'post=' . $recent->get_id() . '&#038;action=edit', $links[0], 'The label must link to the order edit screen.' );
-		$this->assertStringNotContainsString( '#' . $stale->get_id() . '<', $links[0] );
-		$this->assertStringNotContainsString( '#' . $refund->get_id() . '<', $links[0] );
+		$links  = User_Gate_Access::get_granting_entity_links( 'one_time_purchase', $value, self::$user_id );
+		$joined = implode( '', $links );
+
+		$this->assertCount( 2, $links );
+		$this->assertStringContainsString( '#' . $recent->get_id() . '</a>', $joined );
+		$this->assertStringContainsString( '#' . $guest->get_id() . '</a>', $joined, 'A guest order under the reader\'s billing email is listed.' );
+		$this->assertStringContainsString( 'href="' . esc_url( $recent->get_edit_order_url() ) . '"', $joined, 'The label must link to the order edit screen.' );
+		$this->assertStringNotContainsString( '#' . $stale->get_id() . '<', $joined );
+		$this->assertStringNotContainsString( '#' . $refund->get_id() . '<', $joined );
 
 		// Lifetime access has no window, so the older order counts too.
 		$value['duration_unit'] = 'forever';
 		$links                  = User_Gate_Access::get_granting_entity_links( 'one_time_purchase', $value, self::$user_id );
-		$this->assertCount( 2, $links, 'A forever rule lists every paid order for the product.' );
+		$this->assertCount( 3, $links, 'A forever rule lists every paid order for the product.' );
+	}
+
+	/**
+	 * A lifetime rule can match every order a long-standing customer placed;
+	 * the report lists a handful and trails off rather than the whole ledger.
+	 */
+	public function test_one_time_purchase_listing_is_capped() {
+		\wc_create_mock_product(
+			[
+				'id'   => 201,
+				'name' => 'Day Pass',
+			]
+		);
+		for ( $i = 0; $i < User_Gate_Access::GRANTING_ORDERS_LIMIT + 2; $i++ ) {
+			\wc_create_order(
+				[
+					'customer_id'  => self::$user_id,
+					'status'       => 'completed',
+					'total'        => 10,
+					'date_created' => gmdate( 'Y-m-d H:i:s', strtotime( "-$i days" ) ),
+					'items'        => [ new \WC_Order_Item_Product( [ 'product_id' => 201 ] ) ],
+				]
+			);
+		}
+		$value = [
+			'product_ids'    => [ 201 ],
+			'duration_value' => 0,
+			'duration_unit'  => 'forever',
+		];
+
+		$links = User_Gate_Access::get_granting_entity_links( 'one_time_purchase', $value, self::$user_id );
+
+		$this->assertCount( User_Gate_Access::GRANTING_ORDERS_LIMIT + 1, $links );
+		$this->assertSame( '…', end( $links ), 'The list ends with an ellipsis when more orders qualify.' );
+		$this->assertStringNotContainsString( '<', end( $links ) );
 	}
 
 	/**
@@ -400,9 +486,20 @@ class Newspack_Test_User_Gate_Access extends WP_UnitTestCase {
 	public function test_non_ownership_rules_and_filter_granted_access_list_nothing() {
 		$this->assertSame( [], User_Gate_Access::get_granting_entity_links( 'email_domain', 'example.com', self::$user_id ) );
 
+		// A cancelled subscription is the only local record; the filter forcing the
+		// rule to pass must not turn it into a granting one.
+		\wcs_create_subscription(
+			[
+				'customer_id'    => self::$user_id,
+				'status'         => 'cancelled',
+				'billing_period' => 'month',
+				'products'       => [ 101 ],
+			]
+		);
 		add_filter( 'newspack_access_rules_has_active_subscription', '__return_true' );
+		$this->assertTrue( Access_Rules::has_active_subscription( self::$user_id, [ 101 ] ), 'The filter grants access.' );
 		$links = User_Gate_Access::get_granting_entity_links( 'subscription', [ 101 ], self::$user_id );
-		remove_all_filters( 'newspack_access_rules_has_active_subscription' );
+		remove_filter( 'newspack_access_rules_has_active_subscription', '__return_true' );
 
 		$this->assertSame( [], $links );
 	}
@@ -484,5 +581,84 @@ class Newspack_Test_User_Gate_Access extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( '<i>', $output );
 		$this->assertStringContainsString( 'Plan &lt;b&gt;Bold&lt;/b&gt; &amp; Co', $output );
 		$this->assertStringContainsString( 'Gate &lt;i&gt;Italic&lt;/i&gt;', $output );
+	}
+
+	/**
+	 * Free-text rule values (email domains, reader data) are stored as typed, so
+	 * the report prints them as text: markup in a value must not become markup
+	 * on the page.
+	 */
+	public function test_render_escapes_free_text_rule_values() {
+		wp_set_current_user( self::$admin_id );
+		$this->create_gate_with_rules(
+			'Domain Gate',
+			[
+				[
+					[
+						'slug'  => 'email_domain',
+						'value' => 'example.com<a href="https://evil.example">x</a>',
+					],
+				],
+			]
+		);
+
+		ob_start();
+		User_Gate_Access::render_user_gate_access( get_user_by( 'id', self::$user_id ) );
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'href="https://evil.example"', $output );
+		$this->assertStringContainsString( '<code>example.com&lt;a href=&quot;https://evil.example&quot;&gt;x&lt;/a&gt;</code>', $output );
+	}
+
+	/**
+	 * A variation has no edit screen of its own, so its link goes to the parent
+	 * product's editor.
+	 */
+	public function test_variation_links_to_its_parent_product() {
+		wp_set_current_user( self::$admin_id );
+		$parent_id = $this->factory->post->create( [ 'post_title' => 'Membership' ] );
+		\wc_create_mock_product(
+			[
+				'id'        => 102,
+				'name'      => 'Membership - Annual',
+				'parent_id' => $parent_id,
+			]
+		);
+
+		$format_rule_value_method = new ReflectionMethod( User_Gate_Access::class, 'format_rule_value' );
+		$format_rule_value_method->setAccessible( true );
+		$html = $format_rule_value_method->invoke( null, 'subscription', [ 102 ] );
+
+		$this->assertStringContainsString( 'href="' . esc_url( get_edit_post_link( $parent_id ) ) . '"', $html );
+		$this->assertStringContainsString( '>Membership - Annual</a>', $html );
+	}
+
+	/**
+	 * Only a published institution links to its screen; a draft or trashed one
+	 * is named without a link, and a missing one shows its ID.
+	 */
+	public function test_institution_links_only_when_published() {
+		$published = $this->factory->post->create(
+			[
+				'post_type'   => Institution::POST_TYPE,
+				'post_status' => 'publish',
+				'post_title'  => 'State University',
+			]
+		);
+		$trashed   = $this->factory->post->create(
+			[
+				'post_type'   => Institution::POST_TYPE,
+				'post_status' => 'trash',
+				'post_title'  => 'Old College',
+			]
+		);
+
+		$format_rule_value_method = new ReflectionMethod( User_Gate_Access::class, 'format_rule_value' );
+		$format_rule_value_method->setAccessible( true );
+		$html = $format_rule_value_method->invoke( null, 'institution', [ $published, $trashed, 999999 ] );
+
+		$this->assertStringContainsString( '#/institutions/' . $published . '">State University</a>', $html );
+		$this->assertStringContainsString( ', Old College, #999999', $html );
+		$this->assertStringNotContainsString( '#/institutions/' . $trashed, $html );
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-user-gate-access.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-user-gate-access.php
@@ -5,7 +5,6 @@
  * @package Newspack\Tests
  */
 
-use Newspack\Access_Attribution;
 use Newspack\Access_Rules;
 use Newspack\Content_Gate;
 use Newspack\Group_Subscription;
@@ -48,9 +47,27 @@ class Newspack_Test_User_Gate_Access extends WP_UnitTestCase {
 		);
 		Reader_Activation::set_reader_verified( self::$user_id );
 		self::$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
-		Access_Attribution::reset_memo();
-		Access_Rules::flush_one_time_purchase_memo();
-		User_Gate_Access::reset_memo();
+
+		// The mock order and subscription stores are process globals; without a
+		// reset, this file's guest order (matched by email) would leak into every
+		// later test that seeds a reader with the same address.
+		global $orders_database, $subscriptions_database, $wc_mocks_get_orders_calls, $wc_mocks_orders_ignore_page;
+		$orders_database             = [];
+		$subscriptions_database      = [];
+		$wc_mocks_get_orders_calls   = 0;
+		$wc_mocks_orders_ignore_page = false;
+		$this->set_paid_orders_page_size( 50 );
+	}
+
+	/**
+	 * Shrink or restore the order walk's page size.
+	 *
+	 * @param int $size Page size.
+	 */
+	private function set_paid_orders_page_size( $size ) {
+		$property = new ReflectionProperty( Access_Rules::class, 'paid_orders_page_size' );
+		$property->setAccessible( true );
+		$property->setValue( null, $size );
 	}
 
 	/**
@@ -458,7 +475,7 @@ class Newspack_Test_User_Gate_Access extends WP_UnitTestCase {
 				'name' => 'Day Pass',
 			]
 		);
-		for ( $i = 0; $i < User_Gate_Access::GRANTING_ORDERS_LIMIT + 2; $i++ ) {
+		for ( $i = 0; $i < User_Gate_Access::GRANTING_ENTITIES_LIMIT + 2; $i++ ) {
 			\wc_create_order(
 				[
 					'customer_id'  => self::$user_id,
@@ -477,9 +494,108 @@ class Newspack_Test_User_Gate_Access extends WP_UnitTestCase {
 
 		$links = User_Gate_Access::get_granting_entity_links( 'one_time_purchase', $value, self::$user_id );
 
-		$this->assertCount( User_Gate_Access::GRANTING_ORDERS_LIMIT + 1, $links );
-		$this->assertSame( '…', end( $links ), 'The list ends with an ellipsis when more orders qualify.' );
-		$this->assertStringNotContainsString( '<', end( $links ) );
+		$this->assertCount( User_Gate_Access::GRANTING_ENTITIES_LIMIT + 1, $links );
+		$this->assertStringContainsString( 'screen-reader-text">and more</span>', end( $links ), 'The list ends with a labelled truncation marker when more orders qualify.' );
+		$this->assertStringNotContainsString( '<a', end( $links ) );
+	}
+
+	/**
+	 * The subscription list is capped the same way: a reader in many group
+	 * subscriptions gets a handful of examples and a marker, not every ID.
+	 */
+	public function test_subscription_listing_is_capped() {
+		for ( $i = 0; $i < User_Gate_Access::GRANTING_ENTITIES_LIMIT + 2; $i++ ) {
+			\wcs_create_subscription(
+				[
+					'customer_id'    => self::$user_id,
+					'status'         => 'active',
+					'billing_period' => 'month',
+					'products'       => [ 101 ],
+				]
+			);
+		}
+
+		$links = User_Gate_Access::get_granting_entity_links( 'subscription', [ 101 ], self::$user_id );
+
+		$this->assertCount( User_Gate_Access::GRANTING_ENTITIES_LIMIT + 1, $links );
+		$this->assertStringContainsString( 'screen-reader-text">and more</span>', end( $links ) );
+	}
+
+	/**
+	 * The order walk pages through the store. A match that sits past the first
+	 * page must still grant access, and a store that ignores paging (as a
+	 * filter pinning `limit` on `woocommerce_order_query_args` would make it)
+	 * must still let the walk return rather than hang a front-end request.
+	 */
+	public function test_order_walk_pages_and_is_bounded() {
+		global $wc_mocks_get_orders_calls, $wc_mocks_orders_ignore_page;
+		$this->set_paid_orders_page_size( 5 );
+		\wc_create_mock_product(
+			[
+				'id'   => 201,
+				'name' => 'Day Pass',
+			]
+		);
+		// Twelve newer orders for another product push the one matching order onto page 3.
+		for ( $i = 0; $i < 12; $i++ ) {
+			$when = gmdate( 'Y-m-d H:i:s', strtotime( "-$i hours" ) );
+			\wc_create_order(
+				[
+					'customer_id'  => self::$user_id,
+					'status'       => 'completed',
+					'total'        => 10,
+					'date_paid'    => $when,
+					'date_created' => $when,
+					'items'        => [ new \WC_Order_Item_Product( [ 'product_id' => 999 ] ) ],
+				]
+			);
+		}
+		$when  = gmdate( 'Y-m-d H:i:s', strtotime( '-2 days' ) );
+		$match = \wc_create_order(
+			[
+				'customer_id'  => self::$user_id,
+				'status'       => 'completed',
+				'total'        => 10,
+				'date_paid'    => $when,
+				'date_created' => $when,
+				'items'        => [ new \WC_Order_Item_Product( [ 'product_id' => 201 ] ) ],
+			]
+		);
+		$value = [
+			'product_ids'    => [ 201 ],
+			'duration_value' => 30,
+			'duration_unit'  => 'days',
+		];
+
+		$this->assertTrue( Access_Rules::has_one_time_purchase( self::$user_id, $value ), 'A matching order on a later page still grants access.' );
+		$this->assertSame( 3, $wc_mocks_get_orders_calls, 'The walk stops on the page that holds the first match.' );
+		$this->assertSame( [ $match->get_id() ], Access_Rules::get_one_time_purchase_order_ids( self::$user_id, $value ) );
+
+		// A store that returns the same rows for every page: the walk must give up.
+		Access_Rules::flush_one_time_purchase_memo();
+		$wc_mocks_orders_ignore_page = true;
+		$wc_mocks_get_orders_calls   = 0;
+		$this->assertFalse( Access_Rules::has_one_time_purchase( self::$user_id, [ 'product_ids' => [ 555 ] ] + $value ), 'No match, so the rule fails.' );
+		$this->assertSame( Access_Rules::PAID_ORDERS_MAX_PAGES, $wc_mocks_get_orders_calls, 'The walk stops at the page ceiling instead of looping.' );
+	}
+
+	/**
+	 * A malformed subscription value fails the listing closed, as it does the
+	 * rule; it must not be read as "any subscription".
+	 */
+	public function test_malformed_subscription_value_lists_nothing() {
+		\wcs_create_subscription(
+			[
+				'customer_id'    => self::$user_id,
+				'status'         => 'active',
+				'billing_period' => 'month',
+				'products'       => [ 101 ],
+			]
+		);
+
+		$this->assertFalse( Access_Rules::has_active_subscription( self::$user_id, 'gold' ) );
+		$this->assertSame( [], Access_Rules::get_active_subscription_ids( self::$user_id, 'gold' ) );
+		$this->assertSame( [], User_Gate_Access::get_granting_entity_links( 'subscription', 'gold', self::$user_id ) );
 	}
 
 	/**
@@ -564,6 +680,14 @@ class Newspack_Test_User_Gate_Access extends WP_UnitTestCase {
 				'name' => 'Plan <b>Bold</b> & Co',
 			]
 		);
+		$owned = \wcs_create_subscription(
+			[
+				'customer_id'    => self::$user_id,
+				'status'         => 'active',
+				'billing_period' => 'month',
+				'products'       => [ 101 ],
+			]
+		);
 		$this->create_gate_with_rules(
 			'Gate <i>Italic</i>',
 			[
@@ -584,6 +708,9 @@ class Newspack_Test_User_Gate_Access extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( '<i>', $output );
 		$this->assertStringContainsString( 'Plan &lt;b&gt;Bold&lt;/b&gt; &amp; Co', $output );
 		$this->assertStringContainsString( 'Gate &lt;i&gt;Italic&lt;/i&gt;', $output );
+		// The sink is an allowlist, not strip-everything: the granting link it exists
+		// to let through survives alongside the stripped markup.
+		$this->assertStringContainsString( '#' . $owned->get_id() . '</a>', $output, 'A legitimate link passes the same sink that strips injected tags.' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Access Control report on a user's profile told support *whether* a reader passes each gate, but not *which* record grants it. Finding the subscription or order meant a separate trip through WooCommerce. This is especially difficult when the user is granted access through a gifted or group subscription: searching the Subscriptions list page for a gift recipient or group member's name or email address fails to find their subscriptions, as the search only matches subscriptions by owner, not giftee or group member.

The report now links gate titles, product names, and institution names to their admin screens, and for passing "Active subscription" and "One-time purchase" rules lists the granting subscriptions or orders as `#id` links to their edit screens.

The rule evaluators are unchanged in behavior: `has_active_subscription()` now delegates to a shared subscription-listing method, and the one-time-purchase order scan reads newest-first in pages and stops at the first match, so the front-end path does no more work than before.

The report's profile hooks run at priority 9 so the section appears above other profile sections from this plugin and third parties. Anecdotal feedback from publishers suggests that they're looking at this info pretty frequently, so it should live relatively high-up in the user profile page.

**Before**

![Before: Content Gate Access report with plain-text rule values and no links](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/03/j4g6lg8h-access-control-report-before.png)

**After**

![Access Control report on a user profile with linked gate, products, institution, and granting subscription](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/03/9k87nx3c-access-control-report.png)

Closes NPPD-2243.

### How to test the changes in this Pull Request:

1. On a site with `NEWSPACK_CONTENT_GATES` defined, publish a content gate with custom access rules for a subscription product, a one-time product, and an institution.
2. Open the profile of a reader with an active subscription to the required subscription product. Expect ✓ and a linked subscription ID after the rule value.
3. Click the `#id`. Expect the subscription edit screen.
4. Open a reader who is only a member of a group subscription for that product. Expect their group subscription to be listed.
5. Open a reader who owns no subscriptions, but has accepted a subscription gifted by another user. Expect their gifted subscription to be listed.
6. Open a reader with a paid order for the one-time product inside the rule's duration. Expect the linked order ID to be listed; refunded or expired orders are not listed.
7. Open a reader who owns nothing. Expect ✗ with no `#id` list.
8. Click a product name and the gate title. Expect the product editor and the gate's Access Control screen.
9. Trash the institution. Expect its name to be shown without a link.
10. Save an email-domain rule containing HTML markup such as `<b>`. Expect the profile to show it as literal text.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
