### PR TITLE
test(e2e): drop the picsum interception from provisioning

### DIFF
--- a/e2e/site-setup.sh
+++ b/e2e/site-setup.sh
@@ -280,52 +280,6 @@ log_success "Sample Page removed"
 if [ "$POSTS_ENABLED" = true ]; then
     log_info "Step 2: Creating $POSTS_COUNT posts with categories..."
     wp eval '
-        // Answer starter content-s featured-image request from disk.
-        //
-        // Newspack releases up to 6.48.22 download one image per post from
-        // picsum.photos, so provisioning pays a third-party round trip per post
-        // and stalls entirely when that host is down. Newspack 6.49 onwards uses
-        // a bundled image and never makes the request, leaving this filter inert;
-        // it can go once every site this script provisions is past 6.48.22.
-        add_filter(
-            "pre_http_request",
-            function ( $preempt, $args, $url ) {
-                if ( strpos( $url, "picsum.photos" ) === false ) {
-                    return $preempt;
-                }
-                $give_up = new WP_Error( "no_remote_images", "Remote images are disabled during provisioning." );
-                // download_url() streams to a temp file and reads it back, so the
-                // bytes go there rather than into the response body.
-                if ( empty( $args["stream"] ) || empty( $args["filename"] ) || ! function_exists( "imagecreatetruecolor" ) ) {
-                    return $give_up;
-                }
-                static $jpeg = null;
-                if ( $jpeg === null ) {
-                    $image = imagecreatetruecolor( 1200, 800 );
-                    for ( $y = 0; $y < 800; $y++ ) {
-                        $color = imagecolorallocate( $image, (int) ( 30 + $y / 20 ), (int) ( 40 + $y / 13 ), (int) ( 140 + $y / 9 ) );
-                        imageline( $image, 0, $y, 1199, $y, $color );
-                    }
-                    ob_start();
-                    imagejpeg( $image, null, 82 );
-                    $jpeg = ob_get_clean();
-                    imagedestroy( $image );
-                }
-                if ( ! $jpeg || false === file_put_contents( $args["filename"], $jpeg ) ) {
-                    return $give_up;
-                }
-                return [
-                    "headers"  => [],
-                    "body"     => "",
-                    "response" => [ "code" => 200, "message" => "OK" ],
-                    "cookies"  => [],
-                    "filename" => $args["filename"],
-                ];
-            },
-            10,
-            3
-        );
-
         if ( class_exists( "Newspack\Starter_Content_Generated" ) ) {
             Newspack\Starter_Content_Generated::create_categories();
             echo "Categories created\n";


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Removes the `pre_http_request` filter that `site-setup.sh` installs to answer starter content's featured-image request locally.

The filter arrived in #1003 as the immediate unblock for the nightly, which was timing out because `Starter_Content_Generated::add_featured_image()` fetched one image per post from a third-party host. #1002 replaced that fetch with a bundled asset, so once the plugin change reaches the sites this script provisions, the filter never matches and the ~50 lines of GD image generation are dead weight.

**Do not merge until #1002 is on `release`.** The nightly runs `e2e/` from `main` against a site pinned to the stable channel, and the local `e2e-release` env mounts the same branch. Both still call the third-party host, so merging early re-exposes the nightly to that dependency. The gate:

```
git merge-base --is-ancestor bff78d9ed2 origin/release
```

#1002 is already on `alpha`, so it should land at the next stable promotion. A version number is not the test here: `release` is 6.49.2 while `main` is 6.49.1, and the fix is on neither of those numbers but on the promotion.

### How to test the changes in this Pull Request:

1. Confirm the gate has passed. Run `git merge-base --is-ancestor bff78d9ed2 origin/release; echo $?`. The result is `0`.
2. Check out this branch.
3. Provision a local env against release-channel code. Run `USE_SETUP=true npx playwright test --project="Vanilla in Desktop Chrome"` with `SITE_URL` pointing at `e2e-release.test`.
4. Watch the provisioning output. The posts are created at roughly one per second.
5. Open a starter-content post. It has a featured image.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? n/a: this removes test tooling.
* [x] Have you successfully run tests with your changes locally? `bash -n` on the edited script; the provisioning run above is the real check, and it needs the gate to have passed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019naMVH96y256r3QTSMqi2u
