### PR TITLE
refactor(components): replace the debug Notice with a plain badge

### DIFF
--- a/packages/components/DEVELOPMENT.md
+++ b/packages/components/DEVELOPMENT.md
@@ -131,6 +131,7 @@ When building a screen, use the **spacing scale** (8px unit: 16, 24, 32, 48, 64)
 
 ### Utility Components
 
+- **`DebugBadge`** - Floating indicator that Newspack debug mode is on. Takes no props and renders nothing unless the site defines `WP_NEWSPACK_DEBUG`
 - **`GlobalNotices`** - Global notice system component
 - **`InfoButton`** - Reveals supplementary context from a `description` prop. Anything a reader needs in order to use a control belongs in visible help text instead
 - **`Modal`** - Modal dialog component

--- a/packages/components/src/debug-badge/index.js
+++ b/packages/components/src/debug-badge/index.js
@@ -1,0 +1,36 @@
+/**
+ * Debug Badge
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { Icon, bug } from '@wordpress/icons';
+
+/**
+ * Internal dependencies.
+ */
+import './style.scss';
+
+/**
+ * Debug Badge component.
+ *
+ * Gates itself on `window.newspack_aux_data.is_debug_mode`, so consumers render
+ * it unconditionally and it stays absent outside debug mode.
+ *
+ * @return {JSX.Element|null} Debug Badge component, or nothing outside debug mode.
+ */
+const DebugBadge = () => {
+	if ( ! window.newspack_aux_data?.is_debug_mode ) {
+		return null;
+	}
+
+	return (
+		<div className="newspack-debug-badge" role="img" aria-label={ __( 'Debug mode', 'newspack-plugin' ) }>
+			<Icon icon={ bug } />
+		</div>
+	);
+};
+
+export default DebugBadge;

--- a/packages/components/src/debug-badge/index.test.js
+++ b/packages/components/src/debug-badge/index.test.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import DebugBadge from '.';
+
+describe( 'DebugBadge', () => {
+	afterEach( () => {
+		delete window.newspack_aux_data;
+	} );
+
+	it( 'renders the badge and its glyph in debug mode', () => {
+		window.newspack_aux_data = { is_debug_mode: true };
+		const { container } = render( <DebugBadge /> );
+		expect( container.querySelector( '.newspack-debug-badge' ) ).toBeInTheDocument();
+		expect( container.querySelector( '.newspack-debug-badge > svg' ) ).toBeInTheDocument();
+	} );
+
+	it( 'names itself for assistive tech', () => {
+		window.newspack_aux_data = { is_debug_mode: true };
+		render( <DebugBadge /> );
+		expect( screen.getByRole( 'img', { name: 'Debug mode' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders nothing outside debug mode', () => {
+		window.newspack_aux_data = { is_debug_mode: false };
+		const { container } = render( <DebugBadge /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders nothing when the global is absent', () => {
+		const { container } = render( <DebugBadge /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/packages/components/src/debug-badge/style.scss
+++ b/packages/components/src/debug-badge/style.scss
@@ -1,0 +1,26 @@
+/**
+ * Debug Badge
+ */
+
+@use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/variables" as wp-vars;
+@use "../../../colors/colors.module" as np-colors;
+
+.newspack-debug-badge {
+	background: np-colors.$primary-600;
+	border-radius: wp-vars.$radius-round;
+	bottom: 0;
+	box-shadow: var(--wpds-elevation-sm, #{wp-vars.$elevation-small});
+	display: grid;
+	height: wp-vars.$button-size;
+	margin: 0 wp-vars.$grid-unit-30 wp-vars.$grid-unit-30;
+	place-items: center;
+	pointer-events: none;
+	position: fixed;
+	width: wp-vars.$button-size;
+	z-index: 9997;
+
+	> svg {
+		fill: wp-colors.$white;
+	}
+}

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -17,6 +17,7 @@ export { default as ColorPicker } from './color-picker';
 export { default as ConfirmDialog } from './confirm-dialog';
 export { default as CustomSelectControl } from './custom-select-control';
 export { default as DataViews } from './dataviews';
+export { default as DebugBadge } from './debug-badge';
 export { default as Divider } from './divider';
 export { default as Drawer } from './drawer';
 export { default as EmptyState } from './empty-state';

--- a/packages/components/src/notice/index.js
+++ b/packages/components/src/notice/index.js
@@ -6,7 +6,7 @@
  * WordPress dependencies.
  */
 import { Component, RawHTML } from '@wordpress/element';
-import { Icon, bug, check, help, info } from '@wordpress/icons';
+import { Icon, check, help, info } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -23,23 +23,10 @@ class Notice extends Component {
 	 * Render
 	 */
 	render() {
-		const {
-			className,
-			debugMode,
-			isError,
-			isHandoff,
-			isHelp,
-			isSuccess,
-			isWarning,
-			noticeText,
-			rawHTML,
-			style = {},
-			children = null,
-		} = this.props;
+		const { className, isError, isHandoff, isHelp, isSuccess, isWarning, noticeText, rawHTML, style = {}, children = null } = this.props;
 		const classes = classnames(
 			'newspack-notice',
 			className,
-			debugMode && 'newspack-notice__is-debug',
 			isError && 'newspack-notice__is-error',
 			isHandoff && 'newspack-notice__is-handoff',
 			isHelp && 'newspack-notice__is-help',
@@ -51,8 +38,6 @@ class Notice extends Component {
 			noticeIcon = help;
 		} else if ( isSuccess ) {
 			noticeIcon = check;
-		} else if ( debugMode ) {
-			noticeIcon = bug;
 		} else {
 			noticeIcon = info;
 		}

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -22,25 +22,6 @@
 		margin-right: 4px;
 	}
 
-	&__is-debug {
-		background: np-colors.$primary-600;
-		border-radius: 50%;
-		bottom: 16px;
-		box-shadow: 0 0 8px 4px rgba(black, 0.08);
-		color: white;
-		font-weight: bold;
-		margin: 0 16px;
-		padding: 6px;
-		position: fixed;
-		text-transform: uppercase;
-		z-index: 9997;
-
-		> svg {
-			fill: white;
-			margin: 0;
-		}
-	}
-
 	&__is-error {
 		background: color.adjust(wp-colors.$alert-red, $lightness: 35%);
 

--- a/packages/components/src/with-wizard-screen/index.js
+++ b/packages/components/src/with-wizard-screen/index.js
@@ -6,7 +6,7 @@ import { cloneElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { Button, Handoff, Notice, HandoffMessage, TabbedNavigation, Page } from '../';
+import { Button, DebugBadge, Handoff, HandoffMessage, TabbedNavigation, Page } from '../';
 import { activeBreadcrumbs } from '../wizard/breadcrumbs-select';
 import { buttonProps } from '../button-props';
 import Router from '../proxied-imports/router';
@@ -112,7 +112,7 @@ export default function withWizardScreen( WrappedComponent, { hidePrimaryButton,
 			}
 			return (
 				<>
-					{ newspack_aux_data.is_debug_mode && <Notice debugMode /> }
+					<DebugBadge />
 					{ hideHeader ? (
 						// Without the Page shell the tabs still own the content: it
 						// renders inside the active tab's panel.

--- a/packages/components/src/with-wizard-screen/index.test.js
+++ b/packages/components/src/with-wizard-screen/index.test.js
@@ -9,8 +9,6 @@ import { HashRouter } from 'react-router-dom';
  */
 import withWizardScreen from './';
 
-global.newspack_aux_data = { is_debug_mode: false };
-
 describe( 'withWizardScreen', () => {
 	it( 'falls back to a single headerText breadcrumb when no breadcrumbItems are provided', () => {
 		const WrappedComponent = () => <div>Body content</div>;

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -6,12 +6,11 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies.
  */
-// Notice is aliased: `Notice` below is Newspack's own, which this file also uses.
 import {
 	DropdownMenu,
 	MenuGroup,
 	MenuItem,
-	Notice as CoreNotice,
+	Notice,
 	SlotFillProvider,
 	createSlotFill,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -25,7 +24,7 @@ import { category, chevronLeft, moreVertical } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { Footer, Notice, Button, TabbedNavigation, PluginInstaller, SectionHeader, HandoffMessage, Page, Waiting } from '../';
+import { Footer, DebugBadge, Button, TabbedNavigation, PluginInstaller, SectionHeader, HandoffMessage, Page, Waiting } from '../';
 import { activeBreadcrumbs, appendSectionName } from './breadcrumbs-select';
 import Router from '../proxied-imports/router';
 import registerStore, { WIZARD_STORE_NAMESPACE } from './store';
@@ -272,7 +271,7 @@ const Wizard = (
 	// as page chrome rather than as content.
 	const inertGating = window.newspack_aux_data?.inert_gating;
 	const inertGatingNotice = inertGating?.show && (
-		<CoreNotice status="warning" isDismissible={ false } className="newspack-wizard__inert-gating-notice">
+		<Notice status="warning" isDismissible={ false } className="newspack-wizard__inert-gating-notice">
 			{ /* The conversion map takes childless elements and fills them from the
 			     translated string, so jsx-a11y can't see the content they end up with. */ }
 			{ interpolateOrPlainText( inertGating.message, {
@@ -282,7 +281,7 @@ const Wizard = (
 				/* eslint-enable jsx-a11y/anchor-has-content */
 				strong: <strong />,
 			} ) }
-		</CoreNotice>
+		</Notice>
 	);
 
 	const content = (
@@ -406,7 +405,7 @@ const Wizard = (
 					} ) }
 				>
 					<HashRouter hashType="slash">
-						{ newspack_aux_data.is_debug_mode && <Notice debugMode /> }
+						<DebugBadge />
 						<WizardHeaderRegion
 							hideHeader={ hideHeader }
 							headerText={ headerText }

--- a/packages/components/src/wizard/index.test.js
+++ b/packages/components/src/wizard/index.test.js
@@ -19,9 +19,8 @@ import { WIZARD_STORE_NAMESPACE } from './store';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
-// Both globals are localized onto every real wizard screen. The footer's
-// ExternalLink needs a string href, and the debug Notice reads aux data.
-window.newspack_aux_data = { is_debug_mode: false };
+// Localized onto every real wizard screen; the footer's ExternalLink needs a
+// string href.
 window.newspack_urls = { support: 'https://help.newspack.com/' };
 window.scrollTo = jest.fn();
 

--- a/plugins/newspack-plugin/src/wizards/componentsDemo/index.js
+++ b/plugins/newspack-plugin/src/wizards/componentsDemo/index.js
@@ -38,6 +38,7 @@ import {
 	CardSettingsGroup,
 	CollapsibleGroup,
 	ColorPicker,
+	DebugBadge,
 	EmptyState,
 	Footer,
 	Grid,
@@ -45,7 +46,6 @@ import {
 	ImageUpload,
 	InfoButton,
 	Modal,
-	Notice,
 	Page,
 	PluginInstaller,
 	PluginSettings,
@@ -165,7 +165,7 @@ class ComponentsDemo extends Component {
 
 		return (
 			<Fragment>
-				{ newspack_aux_data.is_debug_mode && <Notice debugMode /> }
+				<DebugBadge />
 				<Page
 					breadcrumbItems={ [ { label: __( 'Components Demo', 'newspack-plugin' ) } ] }
 					subTitle={ __( 'Simple components used for composing the UI of Newspack', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/newspack/types/index.d.ts
+++ b/plugins/newspack-plugin/src/wizards/newspack/types/index.d.ts
@@ -96,9 +96,6 @@ declare global {
 				};
 			};
 		};
-		newspack_aux_data: {
-			is_debug_mode: boolean;
-		};
 		newspack_urls: {
 			site: string;
 		};

--- a/plugins/newspack-plugin/src/wizards/newspack/views/dashboard/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/dashboard/index.tsx
@@ -18,17 +18,12 @@ import sections from './sections';
 import BrandHeader from '../../components/brand-header';
 import QuickActions from '../../components/quick-actions';
 import SiteStatuses from '../../components/site-statuses';
-import { Divider, GlobalNotices, Notice, Wizard } from '../../../../../packages/components/src';
-
-const {
-	newspack_aux_data: { is_debug_mode: isDebugMode = false },
-} = window;
+import { Divider, GlobalNotices, Wizard } from '../../../../../packages/components/src';
 
 function Dashboard() {
 	return (
 		<Fragment>
 			<GlobalNotices />
-			{ isDebugMode && <Notice debugMode /> }
 			<Wizard
 				headerText={ __( 'Newspack / Dashboard', 'newspack' ) }
 				sections={ sections }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/index.tsx
@@ -16,16 +16,11 @@ import { Fragment } from '@wordpress/element';
 import './style.scss';
 import sections from './sections';
 import Wizard from '../../../../../packages/components/src/wizard';
-import { GlobalNotices, Notice } from '../../../../../packages/components/src/';
-
-const {
-	newspack_aux_data: { is_debug_mode: isDebugMode = false },
-} = window;
+import { GlobalNotices } from '../../../../../packages/components/src/';
 
 function Settings() {
 	return (
 		<Fragment>
-			{ isDebugMode && <Notice debugMode /> }
 			<GlobalNotices />
 			<Wizard
 				className="newspack-admin__tabs"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The debug-mode badge was a `Notice` variant, but it is not a notice: no text, no status, and none of the notice layout applies to it. It is a floating indicator that debug mode is on. `Notice` carried a `debugMode` prop and an `__is-debug` block whose only job was to undo the notice styling around it.

The badge is now its own `DebugBadge` component in `packages/components`, rendering a single `div` with its own stylesheet. `Notice` loses the prop, the icon branch and the stylesheet block.

It also rendered twice on the Dashboard and Settings screens, which each drew their own badge on top of the one `Wizard` already draws. Both now rely on the shell, leaving three call sites: the two wizard shells and the components demo, which uses neither.

Spacing, size, elevation and stacking come from `wp-vars` tokens rather than the literals the old block used.

### How to test the changes in this Pull Request:

1. Add `define( 'WP_NEWSPACK_DEBUG', true );` to `wp-config.php`.
2. Open Newspack &rarr; Dashboard. A blue circular badge sits in the bottom-left corner.
3. Inspect it. Exactly one `.newspack-debug-badge` element, 36&times;36, 24px from both edges.
4. Repeat on Newspack &rarr; Settings, and on Advertising, which uses the older wizard shell.
5. Open a wizard that shows a snackbar. The snackbar draws over the badge, and its action stays clickable.
6. Remove the constant. The badge disappears everywhere.
7. Check a screen with a real notice, such as Settings &rarr; SEO with an invalid ID. Notices render unchanged.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Two deliberate visual changes: the shadow moves from a symmetric halo to the `--wpds-elevation-sm` token, and the inset grows from 16px to 24px. Stacking stays at `9997` so the badge keeps sitting below modals and snackbars, and it is now `pointer-events: none` so it can never swallow a click in that corner.

The badge stays horizontally anchored to its static position rather than the viewport edge, as it was before. That keeps it clear of the admin menu; anchoring it with `left: 0` would put it underneath.

One behaviour change worth knowing when testing: on Dashboard and Settings the badge used to sit outside `Wizard` and stayed visible through a load. It now hides with the rest of the content during a non-quiet fetch, which is what every other wizard screen already did.

One thing to watch: our screenshot tooling hides the badge by its old `newspack-notice__is-debug` class, so it will start showing up in captures until that selector is updated.
