### PR TITLE
fix(subscriptions): use the shared EmptyState on both tabs

### DIFF
--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/discounts/index.tsx
@@ -14,14 +14,15 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { addQueryArgs } from '@wordpress/url';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import type { Action, View } from '@wordpress/dataviews';
-import { percent } from '@wordpress/icons';
+import { termCount } from '@wordpress/icons';
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 import { __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components';
 
 /**
  * Internal dependencies.
  */
-import { Button, DataViews, Grid, Notice, SectionHeader, Waiting } from '../../../../../../../packages/components/src';
+import { Button, DataViews, Notice, Waiting } from '../../../../../../../packages/components/src';
+import EmptyState from '../../../../../../../packages/components/src/empty-state';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../../../packages/components/src/wizard/store';
 import Router from '../../../../../../../packages/components/src/proxied-imports/router';
 import { SEARCH_ENDPOINTS, WIZARD_ENDPOINT } from '../../constants';
@@ -257,28 +258,21 @@ function SubscriberDiscounts() {
 			{ error && <Notice isError noticeText={ error } /> }
 			{ showEmptyState ? (
 				<div className="newspack-subscriber-discounts__empty">
-					<Grid className="newspack-empty-state" columns={ 4 } noMargin>
-						{ /* The Grid stylesheet matches start and end as DOM attributes, so they cannot be passed as typed props. */ }
-						<VStack { ...( { start: 2, end: 4 } as React.ComponentProps< 'div' > ) } spacing={ 8 }>
-							<SectionHeader
-								className="newspack-empty-state__header"
-								icon={ percent }
-								title={ __( 'Get started with subscriber discounts', 'newspack-plugin' ) }
-								description={ __(
-									'Offer subscribers a discount on your products. Create your first rule to choose which subscription gets what off which products.',
-									'newspack-plugin'
-								) }
-								heading={ 2 }
-								pageHeader
-								noMargin
-							/>
-							<HStack alignment="center" spacing={ 2 } wrap className="newspack-empty-state__actions">
-								<Button variant="primary" onClick={ () => history.push( `${ baseUrl }/new` ) }>
-									{ __( 'Add Discount', 'newspack-plugin' ) }
-								</Button>
-							</HStack>
-						</VStack>
-					</Grid>
+					<EmptyState.Root>
+						<EmptyState.Header
+							icon={ termCount }
+							title={ __( 'Get started with subscriber discounts', 'newspack-plugin' ) }
+							description={ __(
+								'Offer subscribers a discount on your products. Create your first rule to choose which subscription gets what off which products.',
+								'newspack-plugin'
+							) }
+						/>
+						<EmptyState.Actions>
+							<Button variant="primary" onClick={ () => history.push( `${ baseUrl }/new` ) }>
+								{ __( 'Add Discount', 'newspack-plugin' ) }
+							</Button>
+						</EmptyState.Actions>
+					</EmptyState.Root>
 				</div>
 			) : (
 				<DataViews

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscriptions/tabs/subscriber-only/index.tsx
@@ -11,13 +11,15 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { people } from '@wordpress/icons';
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 import { __experimentalHStack as HStack, CheckboxControl } from '@wordpress/components';
 
 /**
  * Internal dependencies.
  */
-import { Button, DataViews, Modal, Notice, SectionHeader, StatusIndicator, Waiting } from '../../../../../../../packages/components/src';
+import { Button, DataViews, Modal, Notice, StatusIndicator, Waiting } from '../../../../../../../packages/components/src';
+import EmptyState from '../../../../../../../packages/components/src/empty-state';
 import type { Action, Field, View } from '../../../../../../../packages/components/src/dataviews';
 import WizardsTab from '../../../../../wizards-tab';
 import WizardSection from '../../../../../wizards-section';
@@ -186,7 +188,8 @@ function SubscriberOnlyProducts() {
 							_n( 'Subscriber-only products (%d)', 'Subscriber-only products (%d)', total, 'newspack-plugin' ),
 							total
 					  )
-					: __( 'Subscriber-only products', 'newspack-plugin' )
+					: // The empty state carries its own heading, and the breadcrumb already names the screen.
+					  undefined
 			}
 		>
 			<WizardSection>
@@ -202,7 +205,7 @@ function SubscriberOnlyProducts() {
 										{ __( 'Settings', 'newspack-plugin' ) }
 									</Button>
 									<Button variant="primary" onClick={ () => setEditing( {} ) }>
-										{ __( 'Add restriction', 'newspack-plugin' ) }
+										{ __( 'Add Restriction', 'newspack-plugin' ) }
 									</Button>
 								</HStack>
 								{ /* The DataViews wrapper isn't generic — its props resolve to
@@ -221,18 +224,21 @@ function SubscriberOnlyProducts() {
 								/>
 							</>
 						) : (
-							<SectionHeader
-								title={ __( 'Get started with subscriber-only products', 'newspack-plugin' ) }
-								description={ __(
-									'Make selected products purchasable only by subscribers. Readers still see the product and its price — only the purchase is blocked.',
-									'newspack-plugin'
-								) }
-								noMargin
-							>
-								<Button variant="primary" onClick={ () => setEditing( {} ) }>
-									{ __( 'Add restriction', 'newspack-plugin' ) }
-								</Button>
-							</SectionHeader>
+							<EmptyState.Root>
+								<EmptyState.Header
+									icon={ people }
+									title={ __( 'Get started with subscriber-only products', 'newspack-plugin' ) }
+									description={ __(
+										'Make selected products purchasable only by subscribers. Readers still see the product and its price — only the purchase is blocked.',
+										'newspack-plugin'
+									) }
+								/>
+								<EmptyState.Actions>
+									<Button variant="primary" onClick={ () => setEditing( {} ) }>
+										{ __( 'Add Restriction', 'newspack-plugin' ) }
+									</Button>
+								</EmptyState.Actions>
+							</EmptyState.Root>
 						) }
 					</>
 				) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Subscriber Discounts empty state was rendering in a single grid column, roughly 228px inside a 1006px grid, which wrapped the copy into four short lines.

It hand-rolled the shared `EmptyState` component's markup: a `Grid` plus a `VStack` carrying bare `start` and `end` props. React's DOM allowlist carries `start`, a real attribute on `<ol>`, but not `end`, so `grid-column-end` was never set and the stack collapsed to one column. `packages/components/src/grid/style.scss` documents this trap as NEWS-2866, and it is exactly why `EmptyState.Root` positions itself with `data-start` and `data-end` instead. The branch was written weeks before the shared component landed, so it never picked it up.

Both Subscriptions tabs now use `EmptyState`:

* **Subscriber Discounts** swaps the hand-rolled markup for `EmptyState.Root` / `.Header` / `.Actions`, which restores the intended two-column span. Its icon moves from `percent` to `termCount`.
* **Subscriber-only products** was not an empty state at all, just a left-aligned `SectionHeader` with a button, so two sibling tabs on one screen looked nothing alike when empty. It now uses the same component, with the `people` icon.
* **Subscriber-only products** also named itself three times over when empty: the breadcrumb, the `WizardsTab` heading, and the empty state's own title. The `WizardsTab` heading is dropped in that state, matching the Discounts tab. The heading with its count still appears once there are restrictions to count.
* "Add restriction" becomes "Add Restriction", matching the Title Case used by the other buttons on these screens.

The `newspack-subscriber-discounts__empty` wrapper stays. The tab is deliberately full width for its table, and that wrapper is the only thing holding the empty state to the wizard section measure.

#### Subscriber Discounts

Before, in one column:

![Subscriber Discounts empty state before](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/04/3ogc8fz9-components-discounts-empty.png)

After:

![Subscriber Discounts empty state after](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/04/05vc9wmi-after-discounts.png)

#### Subscriber-only products

Before, left aligned with a duplicated heading:

![Subscriber-only products empty state before](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/04/k5h38652-components-subscriber-only-empty.png)

After:

![Subscriber-only products empty state after](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/04/a21z0gdc-after-subscriber-only.png)

### How to test the changes in this Pull Request:

1. On a site with Audience Management enabled and WooCommerce active, with no discount rules and no subscriber-only restrictions saved, go to **Audience → Subscriptions**.
2. On **Subscriber Discounts**, the empty state should be centred and span about half the content width rather than a narrow column, with the tag icon.
3. On **Subscriber-only products**, the empty state should match it, with the people icon, and there should be no second "Subscriber-only products" heading above it.
4. Add a restriction, then confirm the heading with its count returns on the populated view and the table still runs full width.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

No new tests: the change is presentational and swaps hand-rolled markup for a component that already has its own coverage. The existing suite passes (118 suites, 1319 tests), along with lint and the TypeScript check.
