### PR TITLE
fix(empty-state): adopt the shared component on three screens

### DIFF
--- a/packages/components/src/empty-state/README.md
+++ b/packages/components/src/empty-state/README.md
@@ -74,10 +74,10 @@ can drop a stack of cards in instead of `EmptyState.Actions`. Pass elements:
 `Root`'s stack keeps a lone string but drops one sitting beside an element, so
 wrap loose text in a `<p>`. The `Grid` margin reset reaches direct children
 only, so a `<p>` inside a slot keeps the browser's default block margin and you
-zero it where you use it. The component resets
-margins on the two elements it renders itself and stops there: a blanket reset on
-slot content would silently flatten a consumer's own stack of cards or prose, and
-the gaps this component owns all come from its stacks anyway.
+zero it where you use it. The component resets margins on the two elements it
+renders itself and stops there: a blanket reset on slot content would silently
+flatten a consumer's own stack of cards or prose, and the gaps this component
+owns all come from its stacks anyway.
 
 ## Consumers own their wrappers
 

--- a/packages/components/src/empty-state/README.md
+++ b/packages/components/src/empty-state/README.md
@@ -68,7 +68,8 @@ import { EmptyState } from 'newspack-components';
 ```
 
 Every slot except `Root` is optional, and anything else you pass to `Root`
-becomes a sibling of the header at the same 8-unit gap. A screen that offers
+becomes a sibling of the header at the same gap the stack uses: 8 units at the
+default size, 6 at `small`. A screen that offers
 choices rather than one action can drop a stack of cards in instead of
 `EmptyState.Actions`. Pass elements: `Root`'s stack keeps a lone string but drops
 one sitting beside an element, so wrap loose text in a `<p>`. The `Grid` margin

--- a/packages/components/src/empty-state/README.md
+++ b/packages/components/src/empty-state/README.md
@@ -69,12 +69,12 @@ import { EmptyState } from 'newspack-components';
 
 Every slot except `Root` is optional, and anything else you pass to `Root`
 becomes a sibling of the header at the same gap the stack uses: 8 units at the
-default size, 6 at `small`. A screen that offers
-choices rather than one action can drop a stack of cards in instead of
-`EmptyState.Actions`. Pass elements: `Root`'s stack keeps a lone string but drops
-one sitting beside an element, so wrap loose text in a `<p>`. The `Grid` margin
-reset reaches direct children only, so a `<p>` inside a slot keeps the browser's
-default block margin and you zero it where you use it. The component resets
+default size, 6 at `small`. A screen that offers choices rather than one action
+can drop a stack of cards in instead of `EmptyState.Actions`. Pass elements:
+`Root`'s stack keeps a lone string but drops one sitting beside an element, so
+wrap loose text in a `<p>`. The `Grid` margin reset reaches direct children
+only, so a `<p>` inside a slot keeps the browser's default block margin and you
+zero it where you use it. The component resets
 margins on the two elements it renders itself and stops there: a blanket reset on
 slot content would silently flatten a consumer's own stack of cards or prose, and
 the gaps this component owns all come from its stacks anyway.
@@ -121,7 +121,7 @@ With a children slot there is no pair to check. A button that navigates takes
 |------|------|---------|-------------|
 | `children` | `React.ReactNode` | — | The slots, plus any custom body. |
 | `className` | `string` | — | Merged onto the grid. |
-| `size` | `'default'` \| `'small'` | `'default'` | Read by `EmptyState.Header`. `small` suits an empty state standing in for a panel inside a card. |
+| `size` | `'default'` \| `'small'` | `'default'` | Sets the stack gap, and is read by `EmptyState.Header`. `small` suits an empty state standing in for a panel inside a card. |
 
 The grid always carries `newspack-empty-state`, and `className` lands there
 rather than on a wrapper, because consumers key off both. Inside it, the stack

--- a/packages/components/src/empty-state/index.test.js
+++ b/packages/components/src/empty-state/index.test.js
@@ -45,6 +45,16 @@ describe( 'EmptyState.Root', () => {
 		expect( stack ).toHaveStyle( { gap: 'var(--wpds-dimension-gap-2xl, 32px)' } );
 	} );
 
+	it( 'tightens the stack gap when small', () => {
+		const { container } = render(
+			<EmptyState.Root size="small">
+				<p>body</p>
+			</EmptyState.Root>
+		);
+		const stack = container.querySelector( '.newspack-empty-state' ).firstElementChild;
+		expect( stack ).toHaveStyle( { gap: 'var(--wpds-dimension-gap-xl, 24px)' } );
+	} );
+
 	// Consumers key `:has()` selectors off this class, so losing it changes their
 	// layout without failing anything.
 	it( 'merges className onto the grid', () => {

--- a/packages/components/src/empty-state/root.tsx
+++ b/packages/components/src/empty-state/root.tsx
@@ -24,11 +24,12 @@ const gridColumn = { 'data-start': '2', 'data-end': '4' };
 
 const Root = ( { size = 'default', className, children }: EmptyStateRootProps ) => {
 	const context = useMemo( () => ( { size } ), [ size ] );
+	const isSmall = size === 'small';
 
 	return (
 		<EmptyStateContext.Provider value={ context }>
 			<Grid className={ classnames( 'newspack-empty-state', className ) } columns={ 4 } noMargin>
-				<Stack className="newspack-empty-state__stack" direction="column" gap="2xl" { ...gridColumn }>
+				<Stack className="newspack-empty-state__stack" direction="column" gap={ isSmall ? 'xl' : '2xl' } { ...gridColumn }>
 					{ children }
 				</Stack>
 			</Grid>

--- a/packages/components/src/empty-state/types.ts
+++ b/packages/components/src/empty-state/types.ts
@@ -5,7 +5,7 @@ export type EmptyStateSize = 'default' | 'small';
 export type EmptyStateActionsOrientation = 'row' | 'column';
 
 export type EmptyStateRootProps = {
-	/** Read by `EmptyState.Header` through context. */
+	/** Sets the stack gap here, and is read by `EmptyState.Header` through context. */
 	size?: EmptyStateSize;
 	/** Merged onto the grid, which is the element consumers' `:has()` selectors look for. */
 	className?: string;

--- a/plugins/newspack-plugin/src/wizards/audience/components/audience-management-required.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/components/audience-management-required.test.js
@@ -29,7 +29,9 @@ import AudienceManagementRequired, { redirectWithoutAudienceManagement, requireA
 jest.mock( '@wordpress/components', () => {
 	const React = require( 'react' );
 	return {
-		ExternalLink: ( { children, href } ) => React.createElement( 'a', { href }, children ),
+		// Spread the rest: the accessible name comes from `aria-label`, so a stub that
+		// drops it would let the link's naming regress without failing anything.
+		ExternalLink: ( { children, ...props } ) => React.createElement( 'a', props, children ),
 	};
 } );
 
@@ -89,6 +91,8 @@ describe( 'requireAudienceManagement (NPPD-1846)', () => {
 		expect( screen.queryByText( 'the real section' ) ).not.toBeInTheDocument();
 		// The action must route to the setup flow, not merely carry a label.
 		expect( screen.getByText( ACTION_LABEL ) ).toHaveAttribute( 'href', SETUP_URL );
+		// "Learn more" alone does not say what it leads to, so the accessible name carries it.
+		expect( screen.getByRole( 'link', { name: /Learn more about Audience Management/ } ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the section untouched when Audience Management is on', () => {

--- a/plugins/newspack-plugin/src/wizards/audience/components/audience-management-required.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/components/audience-management-required.tsx
@@ -72,7 +72,12 @@ const AudienceManagementRequired = ( {
 						{ __( 'Set up Audience Management', 'newspack-plugin' ) }
 					</Button>
 				) }
-				<ExternalLink href={ learnMoreUrl }>{ __( 'Learn more', 'newspack-plugin' ) }</ExternalLink>
+				<ExternalLink
+					href={ learnMoreUrl }
+					aria-label={ __( 'Learn more about Audience Management (opens in a new tab)', 'newspack-plugin' ) }
+				>
+					{ __( 'Learn more', 'newspack-plugin' ) }
+				</ExternalLink>
 			</EmptyState.Actions>
 		</EmptyState.Root>
 	);

--- a/plugins/newspack-plugin/src/wizards/audience/components/audience-management-required.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/components/audience-management-required.tsx
@@ -56,8 +56,10 @@ const AudienceManagementRequired = ( {
 	description,
 	setupUrl = '',
 	learnMoreUrl = DEFAULT_LEARN_MORE_URL,
-	/* translators: accessibility text. Names the link's destination for screen readers; keep the new-tab clause, which replaces the one the link would otherwise announce. */
-	learnMoreLabel = __( 'Learn more about Audience Management (opens in a new tab)', 'newspack-plugin' ),
+	learnMoreLabel = /* translators: accessibility text. Names the link's destination for screen readers; keep the new-tab clause, which replaces the one the link would otherwise announce. */ __(
+		'Learn more about Audience Management (opens in a new tab)',
+		'newspack-plugin'
+	),
 }: {
 	description: string;
 	setupUrl?: string;

--- a/plugins/newspack-plugin/src/wizards/audience/components/audience-management-required.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/components/audience-management-required.tsx
@@ -56,10 +56,14 @@ const AudienceManagementRequired = ( {
 	description,
 	setupUrl = '',
 	learnMoreUrl = DEFAULT_LEARN_MORE_URL,
+	/* translators: accessibility text. Names the link's destination for screen readers; keep the new-tab clause, which replaces the one the link would otherwise announce. */
+	learnMoreLabel = __( 'Learn more about Audience Management (opens in a new tab)', 'newspack-plugin' ),
 }: {
 	description: string;
 	setupUrl?: string;
 	learnMoreUrl?: string;
+	/** Accessible name for the help link. Override alongside `learnMoreUrl` so the two cannot drift. */
+	learnMoreLabel?: string;
 } ) => {
 	return (
 		<EmptyState.Root>
@@ -72,10 +76,7 @@ const AudienceManagementRequired = ( {
 						{ __( 'Set up Audience Management', 'newspack-plugin' ) }
 					</Button>
 				) }
-				<ExternalLink
-					href={ learnMoreUrl }
-					aria-label={ __( 'Learn more about Audience Management (opens in a new tab)', 'newspack-plugin' ) }
-				>
+				<ExternalLink href={ learnMoreUrl } aria-label={ learnMoreLabel }>
 					{ __( 'Learn more', 'newspack-plugin' ) }
 				</ExternalLink>
 			</EmptyState.Actions>

--- a/plugins/newspack-plugin/src/wizards/audience/views/pricing-rules/schedule-prices.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/pricing-rules/schedule-prices.tsx
@@ -8,11 +8,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo, useEffect, useCallback, useId, useRef } from '@wordpress/element';
-import {
-	Button,
-	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-} from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 // Not the Newspack wrapper: with-wizard-screen/style.scss gives `.newspack-dataviews`
 // a -48px page bleed that hangs this embedded table past the form column.
@@ -23,7 +19,8 @@ import { currencyDollar } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { ConfirmDialog, Grid, SectionHeader, TableCard } from '../../../../../packages/components/src';
+import { ConfirmDialog, TableCard } from '../../../../../packages/components/src';
+import EmptyState from '../../../../../packages/components/src/empty-state';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 import { byCycle, cycleRange, priceSummary } from './schedule-format';
 import SchedulePriceDrawer from './schedule-price-drawer';
@@ -228,27 +225,21 @@ export default function SchedulePrices( { steps, onChange, publicize, calcTypes,
 			>
 				{ rows.length === 0 ? (
 					<div className="newspack-pricing-rules__schedule-empty">
-						<Grid columns={ 4 } noMargin>
-							<VStack start={ 2 } end={ 4 } spacing={ 6 }>
-								<SectionHeader
-									icon={ currencyDollar }
-									title={ __( 'No prices yet', 'newspack-plugin' ) }
-									description={ __(
-										'Each price applies from its billing cycle until the next takes over. Add the first one to build the schedule.',
-										'newspack-plugin'
-									) }
-									pageHeader
-									size="small"
-									noMargin
-									heading={ 3 }
-								/>
-								<HStack justify="center">
-									<Button ref={ addRef } variant="secondary" onClick={ add } __next40pxDefaultSize>
-										{ __( 'Add Price', 'newspack-plugin' ) }
-									</Button>
-								</HStack>
-							</VStack>
-						</Grid>
+						<EmptyState.Root size="small">
+							<EmptyState.Header
+								icon={ currencyDollar }
+								title={ __( 'No prices yet', 'newspack-plugin' ) }
+								description={ __(
+									'Each price applies from its billing cycle until the next takes over. Add the first one to build the schedule.',
+									'newspack-plugin'
+								) }
+							/>
+							<EmptyState.Actions>
+								<Button ref={ addRef } variant="secondary" onClick={ add } __next40pxDefaultSize>
+									{ __( 'Add Price', 'newspack-plugin' ) }
+								</Button>
+							</EmptyState.Actions>
+						</EmptyState.Root>
 					</div>
 				) : (
 					<div ref={ tableRef } className="newspack-pricing-rules__schedule-table" role="region" aria-labelledby={ titleId }>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brands.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brands.test.jsx
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Brands from './brands';
+
+// The list rows are their own component with their own fetches; this file is about
+// which of the four load states the screen picks, not how a row looks.
+jest.mock( './brand', () => ( { brand } ) => <div data-testid="brand-row">{ brand.name }</div> );
+
+const BRAND = { id: 1, name: 'Evening Edition', meta: {} };
+
+const renderBrands = ( props = {} ) =>
+	render( <Brands brands={ [] } isFetching={ false } hasLoaded={ false } loadError="" deleteBrand={ jest.fn() } { ...props } /> );
+
+const emptyState = () => screen.queryByRole( 'heading', { name: 'Get started with brands' } );
+
+describe( 'Additional Brands list', () => {
+	// The regression this guards: `isFetching` starts false and the fetch is kicked
+	// off in an effect, so "no brands" and "not asked yet" look identical from the
+	// list alone. Offering onboarding here tells a publisher with brands they have none.
+	it( 'does not offer onboarding before the brands have loaded', () => {
+		renderBrands( { hasLoaded: false } );
+
+		expect( emptyState() ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Fetching brands…' ) ).toBeInTheDocument();
+	} );
+
+	it( 'offers onboarding once an empty list has actually loaded', () => {
+		renderBrands( { hasLoaded: true } );
+
+		expect( emptyState() ).toBeInTheDocument();
+		expect( screen.queryByText( 'Fetching brands…' ) ).not.toBeInTheDocument();
+	} );
+
+	// A failed request leaves the list empty too, and an empty state would claim the
+	// site has no brands when nobody managed to ask.
+	it( 'reports a failed load rather than claiming there are no brands', () => {
+		renderBrands( { hasLoaded: false, loadError: 'The API went away.' } );
+
+		expect( screen.getByText( 'The API went away.' ) ).toBeInTheDocument();
+		expect( emptyState() ).not.toBeInTheDocument();
+	} );
+
+	it( 'lists the brands once there are some', () => {
+		renderBrands( { hasLoaded: true, brands: [ BRAND ] } );
+
+		expect( screen.getByTestId( 'brand-row' ) ).toHaveTextContent( 'Evening Edition' );
+		expect( emptyState() ).not.toBeInTheDocument();
+	} );
+
+	// Both CTAs navigate rather than submitting, so they must be anchors: a Button
+	// nested in a link gives assistive tech two controls for one action.
+	it( 'routes to the new-brand form from a single control', () => {
+		renderBrands( { hasLoaded: true } );
+
+		const cta = screen.getByRole( 'link', { name: 'Add Brand' } );
+		expect( cta ).toHaveAttribute( 'href', '#/additional-brands/new' );
+		expect( cta.querySelector( 'button' ) ).toBeNull();
+	} );
+
+	it( 'names the help link for screen readers', () => {
+		renderBrands( { hasLoaded: true } );
+
+		expect( screen.getByRole( 'link', { name: /Learn more about brands/ } ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brands.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brands.tsx
@@ -14,11 +14,9 @@ import { siteLogo } from '@wordpress/icons';
  * Internal dependencies
  */
 import Brand from './brand';
-import { Card, Button, Router } from '../../../../../../packages/components/src';
+import { Card, Button } from '../../../../../../packages/components/src';
 import EmptyState from '../../../../../../packages/components/src/empty-state';
 import { TAB_PATH } from './constants';
-
-const { NavLink } = Router;
 
 const LEARN_MORE_URL = 'https://help.newspack.com/federated-sites/multi-branded-site/';
 
@@ -61,11 +59,9 @@ export default function Brands( {
 		<Fragment>
 			<Card headerActions noBorder>
 				<h2>{ __( 'Site brands', 'newspack-plugin' ) }</h2>
-				<NavLink to={ `${ TAB_PATH }/new` }>
-					<Button variant="primary" disabled={ isFetching }>
-						{ __( 'Add Brand', 'newspack-plugin' ) }
-					</Button>
-				</NavLink>
+				<Button variant="primary" href={ `#${ TAB_PATH }/new` } disabled={ isFetching }>
+					{ __( 'Add Brand', 'newspack-plugin' ) }
+				</Button>
 			</Card>
 			{ brands.length ? (
 				brands.map( brand => <Brand key={ brand.id } brand={ brand } deleteBrand={ deleteBrand } /> )

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brands.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brands.tsx
@@ -14,7 +14,7 @@ import { siteLogo } from '@wordpress/icons';
  * Internal dependencies
  */
 import Brand from './brand';
-import { Card, Button } from '../../../../../../packages/components/src';
+import { Card, Button, Notice } from '../../../../../../packages/components/src';
 import EmptyState from '../../../../../../packages/components/src/empty-state';
 import { TAB_PATH } from './constants';
 
@@ -23,15 +23,21 @@ const LEARN_MORE_URL = 'https://help.newspack.com/federated-sites/multi-branded-
 export default function Brands( {
 	brands,
 	isFetching,
-	hasFetched,
+	hasLoaded,
+	loadError,
 	deleteBrand,
 }: {
 	brands: Brand[];
 	isFetching: boolean;
-	hasFetched: boolean;
+	hasLoaded: boolean;
+	loadError: string;
 	deleteBrand: ( brand: Brand ) => void;
 } ) {
-	if ( hasFetched && ! isFetching && ! brands.length ) {
+	if ( loadError ) {
+		return <Notice isError noticeText={ loadError } />;
+	}
+
+	if ( hasLoaded && ! isFetching && ! brands.length ) {
 		return (
 			<EmptyState.Root>
 				<EmptyState.Header

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brands.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brands.tsx
@@ -7,6 +7,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
+import { ExternalLink } from '@wordpress/components';
 import { siteLogo } from '@wordpress/icons';
 
 /**
@@ -18,6 +19,8 @@ import EmptyState from '../../../../../../packages/components/src/empty-state';
 import { TAB_PATH } from './constants';
 
 const { NavLink } = Router;
+
+const LEARN_MORE_URL = 'https://help.newspack.com/federated-sites/multi-branded-site/';
 
 export default function Brands( {
 	brands,
@@ -33,13 +36,16 @@ export default function Brands( {
 			<EmptyState.Root>
 				<EmptyState.Header
 					icon={ siteLogo }
-					title={ __( 'You have no saved brands.', 'newspack-plugin' ) }
-					description={ __( 'Create brands to enhance your readers experience.', 'newspack-plugin' ) }
+					title={ __( 'Get started with brands', 'newspack-plugin' ) }
+					description={ __( 'Give parts of your site their own name, logo, colors, and menus.', 'newspack-plugin' ) }
 				/>
-				<EmptyState.Actions>
+				<EmptyState.Actions orientation="column" gap="lg">
 					<NavLink to={ `${ TAB_PATH }/new` }>
 						<Button variant="primary">{ __( 'Add Brand', 'newspack-plugin' ) }</Button>
 					</NavLink>
+					<ExternalLink href={ LEARN_MORE_URL } aria-label={ __( 'Learn more about brands (opens in a new tab)', 'newspack-plugin' ) }>
+						{ __( 'Learn more', 'newspack-plugin' ) }
+					</ExternalLink>
 				</EmptyState.Actions>
 			</EmptyState.Root>
 		);

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brands.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brands.tsx
@@ -25,13 +25,15 @@ const LEARN_MORE_URL = 'https://help.newspack.com/federated-sites/multi-branded-
 export default function Brands( {
 	brands,
 	isFetching,
+	hasFetched,
 	deleteBrand,
 }: {
 	brands: Brand[];
 	isFetching: boolean;
+	hasFetched: boolean;
 	deleteBrand: ( brand: Brand ) => void;
 } ) {
-	if ( ! isFetching && ! brands.length ) {
+	if ( hasFetched && ! isFetching && ! brands.length ) {
 		return (
 			<EmptyState.Root>
 				<EmptyState.Header
@@ -40,10 +42,14 @@ export default function Brands( {
 					description={ __( 'Give parts of your site their own name, logo, colors, and menus.', 'newspack-plugin' ) }
 				/>
 				<EmptyState.Actions orientation="column" gap="lg">
-					<NavLink to={ `${ TAB_PATH }/new` }>
-						<Button variant="primary">{ __( 'Add Brand', 'newspack-plugin' ) }</Button>
-					</NavLink>
-					<ExternalLink href={ LEARN_MORE_URL } aria-label={ __( 'Learn more about brands (opens in a new tab)', 'newspack-plugin' ) }>
+					<Button variant="primary" href={ `#${ TAB_PATH }/new` }>
+						{ __( 'Add Brand', 'newspack-plugin' ) }
+					</Button>
+					<ExternalLink
+						href={ LEARN_MORE_URL }
+						/* translators: accessibility text. Names the link's destination for screen readers; keep the new-tab clause, which replaces the one the link would otherwise announce. */
+						aria-label={ __( 'Learn more about brands (opens in a new tab)', 'newspack-plugin' ) }
+					>
 						{ __( 'Learn more', 'newspack-plugin' ) }
 					</ExternalLink>
 				</EmptyState.Actions>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brands.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brands.tsx
@@ -51,8 +51,10 @@ export default function Brands( {
 					</Button>
 					<ExternalLink
 						href={ LEARN_MORE_URL }
-						/* translators: accessibility text. Names the link's destination for screen readers; keep the new-tab clause, which replaces the one the link would otherwise announce. */
-						aria-label={ __( 'Learn more about brands (opens in a new tab)', 'newspack-plugin' ) }
+						aria-label={
+							/* translators: accessibility text. Names the link's destination for screen readers; keep the new-tab clause, which replaces the one the link would otherwise announce. */
+							__( 'Learn more about brands (opens in a new tab)', 'newspack-plugin' )
+						}
 					>
 						{ __( 'Learn more', 'newspack-plugin' ) }
 					</ExternalLink>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brands.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brands.tsx
@@ -7,12 +7,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
+import { siteLogo } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import Brand from './brand';
 import { Card, Button, Router } from '../../../../../../packages/components/src';
+import EmptyState from '../../../../../../packages/components/src/empty-state';
 import { TAB_PATH } from './constants';
 
 const { NavLink } = Router;
@@ -26,14 +28,27 @@ export default function Brands( {
 	isFetching: boolean;
 	deleteBrand: ( brand: Brand ) => void;
 } ) {
+	if ( ! isFetching && ! brands.length ) {
+		return (
+			<EmptyState.Root>
+				<EmptyState.Header
+					icon={ siteLogo }
+					title={ __( 'You have no saved brands.', 'newspack-plugin' ) }
+					description={ __( 'Create brands to enhance your readers experience.', 'newspack-plugin' ) }
+				/>
+				<EmptyState.Actions>
+					<NavLink to={ `${ TAB_PATH }/new` }>
+						<Button variant="primary">{ __( 'Add Brand', 'newspack-plugin' ) }</Button>
+					</NavLink>
+				</EmptyState.Actions>
+			</EmptyState.Root>
+		);
+	}
+
 	return (
 		<Fragment>
 			<Card headerActions noBorder>
-				<h2>
-					{ ! brands.length && ! isFetching
-						? __( 'You have no saved brands.', 'newspack-plugin' )
-						: __( 'Site brands', 'newspack-plugin' ) }
-				</h2>
+				<h2>{ __( 'Site brands', 'newspack-plugin' ) }</h2>
 				<NavLink to={ `${ TAB_PATH }/new` }>
 					<Button variant="primary" disabled={ isFetching }>
 						{ __( 'Add Brand', 'newspack-plugin' ) }
@@ -43,13 +58,7 @@ export default function Brands( {
 			{ brands.length ? (
 				brands.map( brand => <Brand key={ brand.id } brand={ brand } deleteBrand={ deleteBrand } /> )
 			) : (
-				<Fragment>
-					{ isFetching ? (
-						<p>{ __( 'Fetching brands…', 'newspack-plugin' ) }</p>
-					) : (
-						<p>{ __( 'Create brands to enhance your readers experience.', 'newspack-plugin' ) }</p>
-					) }
-				</Fragment>
+				<p>{ __( 'Fetching brands…', 'newspack-plugin' ) }</p>
 			) }
 		</Fragment>
 	);

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/index.tsx
@@ -162,7 +162,11 @@ export default function AdditionalBrands() {
 	useEffect( fetchBrands, [] );
 
 	return (
-		<WizardsTab isFetching={ isFetching } title={ __( 'Additional Brands', 'newspack-plugin' ) }>
+		<WizardsTab
+			isFetching={ isFetching }
+			// The empty state carries its own heading, and the breadcrumb already names the screen.
+			title={ brands.length ? __( 'Additional Brands', 'newspack-plugin' ) : undefined }
+		>
 			<WizardSection>
 				<Switch>
 					<Route exact path={ path } render={ () => <Brands { ...wizardScreenProps } brands={ brands } deleteBrand={ deleteBrand } /> } />

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/index.tsx
@@ -28,6 +28,9 @@ export default function AdditionalBrands() {
 	const brandsCache = cache( '/wp/v2/brand' );
 
 	const [ brands, setBrands ] = useState< Brand[] >( [] );
+	// `isFetching` starts false and the fetch is kicked off in an effect, so an empty
+	// list alone cannot tell "nothing saved" from "not asked yet".
+	const [ hasFetched, setHasFetched ] = useState( false );
 	const history = useHistory();
 	const location = useLocation();
 	const { path } = useRouteMatch();
@@ -58,6 +61,9 @@ export default function AdditionalBrands() {
 				path: addQueryArgs( '/wp/v2/brand', { per_page: 100 } ),
 			},
 			{
+				onFinally() {
+					setHasFetched( true );
+				},
 				onSuccess( response ) {
 					setBrands(
 						response.map( ( brand: Brand ) => ( {
@@ -162,14 +168,16 @@ export default function AdditionalBrands() {
 	useEffect( fetchBrands, [] );
 
 	return (
-		<WizardsTab
-			isFetching={ isFetching }
-			// The empty state carries its own heading, and the breadcrumb already names the screen.
-			title={ brands.length ? __( 'Additional Brands', 'newspack-plugin' ) : undefined }
-		>
+		// No title: the breadcrumb's last crumb is the page's h1 on every route here, so
+		// a tab heading would repeat it.
+		<WizardsTab isFetching={ isFetching }>
 			<WizardSection>
 				<Switch>
-					<Route exact path={ path } render={ () => <Brands { ...wizardScreenProps } brands={ brands } deleteBrand={ deleteBrand } /> } />
+					<Route
+						exact
+						path={ path }
+						render={ () => <Brands { ...wizardScreenProps } brands={ brands } hasFetched={ hasFetched } deleteBrand={ deleteBrand } /> }
+					/>
 					<Route
 						path={ `${ path }/new` }
 						render={ () => (

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/index.tsx
@@ -29,8 +29,11 @@ export default function AdditionalBrands() {
 
 	const [ brands, setBrands ] = useState< Brand[] >( [] );
 	// `isFetching` starts false and the fetch is kicked off in an effect, so an empty
-	// list alone cannot tell "nothing saved" from "not asked yet".
-	const [ hasFetched, setHasFetched ] = useState( false );
+	// list alone cannot tell "nothing saved" from "not asked yet". Set from `onSuccess`
+	// rather than `onFinally`: the hook returns early on a cache hit without running
+	// its finally callback, and a failed load must not read as "no brands".
+	const [ hasLoaded, setHasLoaded ] = useState( false );
+	const [ loadError, setLoadError ] = useState( '' );
 	const history = useHistory();
 	const location = useLocation();
 	const { path } = useRouteMatch();
@@ -61,10 +64,12 @@ export default function AdditionalBrands() {
 				path: addQueryArgs( '/wp/v2/brand', { per_page: 100 } ),
 			},
 			{
-				onFinally() {
-					setHasFetched( true );
+				onError( error: { message?: string } ) {
+					setLoadError( error?.message || __( 'Brands could not be loaded.', 'newspack-plugin' ) );
 				},
 				onSuccess( response ) {
+					setLoadError( '' );
+					setHasLoaded( true );
 					setBrands(
 						response.map( ( brand: Brand ) => ( {
 							...brand,
@@ -176,7 +181,15 @@ export default function AdditionalBrands() {
 					<Route
 						exact
 						path={ path }
-						render={ () => <Brands { ...wizardScreenProps } brands={ brands } hasFetched={ hasFetched } deleteBrand={ deleteBrand } /> }
+						render={ () => (
+							<Brands
+								{ ...wizardScreenProps }
+								brands={ brands }
+								hasLoaded={ hasLoaded }
+								loadError={ loadError }
+								deleteBrand={ deleteBrand }
+							/>
+						) }
 					/>
 					<Route
 						path={ `${ path }/new` }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/index.tsx
@@ -42,12 +42,14 @@ export default function AdditionalBrands() {
 		resetError();
 	}, [ location.pathname ] );
 
-	/**
-	 * Cache brands data.
-	 */
+	// Gated on `hasLoaded`: this runs before the first request is issued, and caching
+	// the initial empty list would answer the next visit with one the server never sent.
 	useEffect( () => {
+		if ( ! hasLoaded ) {
+			return;
+		}
 		brandsCache.set( brands );
-	}, [ brands ] );
+	}, [ brands, hasLoaded ] );
 
 	const wizardScreenProps = {
 		isFetching,

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/index.tsx
@@ -8,6 +8,8 @@
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState, Fragment } from '@wordpress/element';
 import { __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { connection } from '@wordpress/icons';
+import { Card as UICard } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -16,7 +18,8 @@ import { API_NAMESPACE } from './constants';
 import EndpointActionsCard from './endpoint-actions-card';
 import EndpointActionsModals from './endpoint-actions-modals';
 import { useWizardApiFetch } from '../../../../../hooks/use-wizard-api-fetch';
-import { Card, Button, Notice, SectionHeader } from '../../../../../../../packages/components/src';
+import { Card, Button, SectionHeader } from '../../../../../../../packages/components/src';
+import EmptyState from '../../../../../../../packages/components/src/empty-state';
 
 const defaultEndpoint: Endpoint = {
 	url: '',
@@ -76,6 +79,8 @@ function Webhooks() {
 		}
 	}
 
+	const isEmpty = ! inFlight && ! endpoints?.length;
+
 	return (
 		<Card noBorder className="newspack-webhooks">
 			<HStack justify="space-between" alignment="bottom" spacing={ 4 } className="newspack-webhooks__header">
@@ -88,9 +93,11 @@ function Webhooks() {
 					) }
 					noMargin
 				/>
-				<Button variant="primary" onClick={ () => setActionHandler( 'new' ) } disabled={ inFlight }>
-					{ inFlight ? __( 'Loading…', 'newspack-plugin' ) : __( 'Add Endpoint', 'newspack-plugin' ) }
-				</Button>
+				{ ! isEmpty && (
+					<Button variant="primary" onClick={ () => setActionHandler( 'new' ) } disabled={ inFlight }>
+						{ inFlight ? __( 'Loading…', 'newspack-plugin' ) : __( 'Add Endpoint', 'newspack-plugin' ) }
+					</Button>
+				) }
 			</HStack>
 			{ ! inFlight &&
 				( endpoints && endpoints.length > 0 ? (
@@ -100,7 +107,22 @@ function Webhooks() {
 						) ) }
 					</Fragment>
 				) : (
-					<Notice noticeText={ __( 'No endpoints found', 'newspack-plugin' ) } />
+					<UICard.Root>
+						<UICard.Content>
+							<EmptyState.Root size="small">
+								<EmptyState.Header
+									icon={ connection }
+									title={ __( 'No endpoints found', 'newspack-plugin' ) }
+									description={ __( 'Add an endpoint to start sending reader activity data.', 'newspack-plugin' ) }
+								/>
+								<EmptyState.Actions>
+									<Button variant="primary" onClick={ () => setActionHandler( 'new' ) }>
+										{ __( 'Add Endpoint', 'newspack-plugin' ) }
+									</Button>
+								</EmptyState.Actions>
+							</EmptyState.Root>
+						</UICard.Content>
+					</UICard.Root>
 				) ) }
 			{ selectedEndpoint && (
 				<EndpointActionsModals

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/index.tsx
@@ -90,17 +90,16 @@ function Webhooks() {
 	const claimFocus = useRef( false );
 
 	// The empty state's button is unmounted by the very success it triggers, so the
-	// modal has nothing to restore focus to; the header button replaces it. Waiting for
-	// the request to settle matters: the save flips `inFlight` first, and focusing the
-	// header button while it is still disabled silently does nothing.
+	// modal has nothing to restore focus to; the header button replaces it. Both guards
+	// return rather than clearing the claim, because it has to survive the renders in
+	// between: the header button does not exist while the empty state is up, and it is
+	// disabled for as long as the save is in flight.
 	useEffect( () => {
-		if ( ! claimFocus.current || inFlight ) {
+		if ( ! claimFocus.current || inFlight || isEmpty ) {
 			return;
 		}
 		claimFocus.current = false;
-		if ( ! isEmpty ) {
-			addRef.current?.focus();
-		}
+		addRef.current?.focus();
 	}, [ inFlight, isEmpty, selectedEndpoint ] );
 
 	return (

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/index.tsx
@@ -7,7 +7,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState, Fragment } from '@wordpress/element';
-import { __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { ExternalLink, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { connection } from '@wordpress/icons';
 import { Card as UICard } from '@wordpress/ui';
 
@@ -20,6 +20,8 @@ import EndpointActionsModals from './endpoint-actions-modals';
 import { useWizardApiFetch } from '../../../../../hooks/use-wizard-api-fetch';
 import { Card, Button, SectionHeader } from '../../../../../../../packages/components/src';
 import EmptyState from '../../../../../../../packages/components/src/empty-state';
+
+const LEARN_MORE_URL = 'https://help.newspack.com/plugins-and-themes/third-party-services-integrations/webhooks/';
 
 const defaultEndpoint: Endpoint = {
 	url: '',
@@ -112,13 +114,19 @@ function Webhooks() {
 							<EmptyState.Root size="small">
 								<EmptyState.Header
 									icon={ connection }
-									title={ __( 'No endpoints found', 'newspack-plugin' ) }
+									title={ __( 'No endpoints yet', 'newspack-plugin' ) }
 									description={ __( 'Add an endpoint to start sending reader activity data.', 'newspack-plugin' ) }
 								/>
-								<EmptyState.Actions>
+								<EmptyState.Actions orientation="column" gap="lg">
 									<Button variant="primary" onClick={ () => setActionHandler( 'new' ) }>
 										{ __( 'Add Endpoint', 'newspack-plugin' ) }
 									</Button>
+									<ExternalLink
+										href={ LEARN_MORE_URL }
+										aria-label={ __( 'Learn more about webhooks (opens in a new tab)', 'newspack-plugin' ) }
+									>
+										{ __( 'Learn more', 'newspack-plugin' ) }
+									</ExternalLink>
 								</EmptyState.Actions>
 							</EmptyState.Root>
 						</UICard.Content>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/index.tsx
@@ -6,7 +6,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState, Fragment } from '@wordpress/element';
+import { useEffect, useRef, useState, Fragment } from '@wordpress/element';
 import { ExternalLink, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { connection } from '@wordpress/icons';
 import { Card as UICard } from '@wordpress/ui';
@@ -81,7 +81,22 @@ function Webhooks() {
 		}
 	}
 
-	const isEmpty = ! inFlight && ! endpoints?.length;
+	// `endpoints` is null until the fetch resolves, and stays null if it fails.
+	// Treating either as empty would offer onboarding to a site that has endpoints.
+	const isLoaded = null !== endpoints;
+	const isEmpty = ! inFlight && isLoaded && 0 === endpoints.length;
+
+	const addRef = useRef< HTMLButtonElement >( null );
+	const claimFocus = useRef( false );
+
+	// The empty state's button is unmounted by the very success it triggers, so the
+	// modal has nothing to restore focus to; the header button replaces it.
+	useEffect( () => {
+		if ( claimFocus.current && ! isEmpty ) {
+			claimFocus.current = false;
+			addRef.current?.focus();
+		}
+	}, [ isEmpty ] );
 
 	return (
 		<Card noBorder className="newspack-webhooks">
@@ -96,13 +111,14 @@ function Webhooks() {
 					noMargin
 				/>
 				{ ! isEmpty && (
-					<Button variant="primary" onClick={ () => setActionHandler( 'new' ) } disabled={ inFlight }>
+					<Button ref={ addRef } variant="primary" onClick={ () => setActionHandler( 'new' ) } disabled={ inFlight }>
 						{ inFlight ? __( 'Loading…', 'newspack-plugin' ) : __( 'Add Endpoint', 'newspack-plugin' ) }
 					</Button>
 				) }
 			</HStack>
 			{ ! inFlight &&
-				( endpoints && endpoints.length > 0 ? (
+				isLoaded &&
+				( endpoints.length > 0 ? (
 					<Fragment>
 						{ endpoints.map( endpoint => (
 							<EndpointActionsCard key={ endpoint.id } endpoint={ endpoint } setAction={ setActionHandler } />
@@ -114,15 +130,25 @@ function Webhooks() {
 							<EmptyState.Root size="small">
 								<EmptyState.Header
 									icon={ connection }
+									// Subordinate to the section header above, which is already a level 3.
+									heading={ 4 }
 									title={ __( 'No endpoints yet', 'newspack-plugin' ) }
 									description={ __( 'Add an endpoint to start sending reader activity data.', 'newspack-plugin' ) }
 								/>
 								<EmptyState.Actions orientation="column" gap="lg">
-									<Button variant="primary" onClick={ () => setActionHandler( 'new' ) }>
+									<Button
+										ref={ addRef }
+										variant="primary"
+										onClick={ () => {
+											claimFocus.current = true;
+											setActionHandler( 'new' );
+										} }
+									>
 										{ __( 'Add Endpoint', 'newspack-plugin' ) }
 									</Button>
 									<ExternalLink
 										href={ LEARN_MORE_URL }
+										/* translators: accessibility text. Names the link's destination for screen readers; keep the new-tab clause, which replaces the one the link would otherwise announce. */
 										aria-label={ __( 'Learn more about webhooks (opens in a new tab)', 'newspack-plugin' ) }
 									>
 										{ __( 'Learn more', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/index.tsx
@@ -18,7 +18,7 @@ import { API_NAMESPACE } from './constants';
 import EndpointActionsCard from './endpoint-actions-card';
 import EndpointActionsModals from './endpoint-actions-modals';
 import { useWizardApiFetch } from '../../../../../hooks/use-wizard-api-fetch';
-import { Card, Button, SectionHeader } from '../../../../../../../packages/components/src';
+import { Card, Button, Notice, SectionHeader } from '../../../../../../../packages/components/src';
 import EmptyState from '../../../../../../../packages/components/src/empty-state';
 
 const LEARN_MORE_URL = 'https://help.newspack.com/plugins-and-themes/third-party-services-integrations/webhooks/';
@@ -90,13 +90,18 @@ function Webhooks() {
 	const claimFocus = useRef( false );
 
 	// The empty state's button is unmounted by the very success it triggers, so the
-	// modal has nothing to restore focus to; the header button replaces it.
+	// modal has nothing to restore focus to; the header button replaces it. Waiting for
+	// the request to settle matters: the save flips `inFlight` first, and focusing the
+	// header button while it is still disabled silently does nothing.
 	useEffect( () => {
-		if ( claimFocus.current && ! isEmpty ) {
-			claimFocus.current = false;
+		if ( ! claimFocus.current || inFlight ) {
+			return;
+		}
+		claimFocus.current = false;
+		if ( ! isEmpty ) {
 			addRef.current?.focus();
 		}
-	}, [ isEmpty ] );
+	}, [ inFlight, isEmpty, selectedEndpoint ] );
 
 	return (
 		<Card noBorder className="newspack-webhooks">
@@ -158,6 +163,11 @@ function Webhooks() {
 						</UICard.Content>
 					</UICard.Root>
 				) ) }
+			{ /* A failed load leaves `endpoints` null, which is neither a list nor an
+			     empty state; without this the section renders as blank space. */ }
+			{ ! inFlight && ! isLoaded && (
+				<Notice isError noticeText={ errorMessage || __( 'Webhook endpoints could not be loaded.', 'newspack-plugin' ) } />
+			) }
 			{ selectedEndpoint && (
 				<EndpointActionsModals
 					actions={ actions }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/index.tsx
@@ -153,8 +153,10 @@ function Webhooks() {
 									</Button>
 									<ExternalLink
 										href={ LEARN_MORE_URL }
-										/* translators: accessibility text. Names the link's destination for screen readers; keep the new-tab clause, which replaces the one the link would otherwise announce. */
-										aria-label={ __( 'Learn more about webhooks (opens in a new tab)', 'newspack-plugin' ) }
+										aria-label={
+											/* translators: accessibility text. Names the link's destination for screen readers; keep the new-tab clause, which replaces the one the link would otherwise announce. */
+											__( 'Learn more about webhooks (opens in a new tab)', 'newspack-plugin' )
+										}
 									>
 										{ __( 'Learn more', 'newspack-plugin' ) }
 									</ExternalLink>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Follow-up to #1034, which moved the two Subscriptions tabs onto the shared `EmptyState`. Sweeping the rest of the plugin turned up one more screen carrying the same rendering bug, plus two that never had a real empty state.

**Price Schedule was collapsing into one column.** `schedule-prices.tsx` hand-rolled the component's markup, `Grid columns={ 4 }` wrapping a `VStack` with bare `start` and `end` props. React's DOM allowlist carries `start` but not `end`, so `grid-column-end` was never set. `packages/components/src/grid/style.scss` documents this as NEWS-2866, and it is why `EmptyState.Root` positions itself with `data-start` and `data-end`. Measured on a local env: 239px inside a 956px grid before, 462px after.

**Additional Brands had no empty state.** It swapped the card's `<h2>` between "Site brands" and "You have no saved brands.", leaving the message stranded in a header with a paragraph below it. It now renders `EmptyState` with the `siteLogo` icon. The `WizardsTab` heading is dropped in that state, since the breadcrumb already names the screen and the empty state carries its own title, matching what #1034 did for Subscriber-only products.

The copy changed too. "You have no saved brands." was the only empty-state title in the plugin written as a sentence, so it now follows the "Get started with X" form the other five use, and the description says what a brand actually is rather than "enhance your readers experience", which never explained anything.

**Webhook Endpoints used a Notice.** An informational `Notice` stood in for a list empty state. It now uses a `@wordpress/ui` `Card` around the small `EmptyState`, the same composition as `pricing-rules/impact-empty.tsx`, with the `connection` icon and a short description. "Add Endpoint" moves into the empty state and the header button is hidden while it shows, so the action is not offered twice. The title becomes "No endpoints yet": nothing was searched, so "found" implied a lookup that never happened.

**The small `EmptyState` gap was too loose.** `Root` hardcoded `gap="2xl"` (32px) at every size. The small variant now uses `xl` (24px). `newspack-newsletters` is the only consumer outside this plugin and it never passes `size`, so nothing moves there; the default stays 32px, checked live alongside the 24px.

**Help links are named for screen readers.** Brands and Webhooks each gained a "Learn more" link, following the existing pattern in `audience-management-required.tsx`. A bare "Learn more" fails WCAG 2.4.9, since out of context it does not say what you would be learning about, so each carries an `aria-label`. That label overrides content-based naming, which drops `ExternalLink`'s own "(opens in a new tab)" from the accessible name, so each label includes it. The same fix is applied to the existing link in `audience-management-required.tsx`.

#### Price Schedule

![Price Schedule empty state](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/04/9cnwakzc-r3-schedule.png)

#### Additional Brands

![Additional Brands empty state](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/04/xn36ms4r-r3-brands.png)

#### Webhook Endpoints

![Webhook Endpoints empty state](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/04/7lru5yim-r3-webhooks.png)

### How to test the changes in this Pull Request:

1. **Price Schedule.** With WooCommerce and Audience Management on, go to **Audience → Pricing Rules → Add Rule**, pick a goal, then choose **Price Schedule** under Pricing Details. The empty state should be centred and span about half the panel, not a narrow column, and the gap between the description and "Add Price" should be 24px.
2. **Additional Brands.** With the Multibranded Site plugin active and no brands saved, go to **Newspack → Settings → Additional Brands**. The empty state should be centred with the site-logo icon, and "Additional Brands" should appear only in the breadcrumb, not twice. Add a brand and confirm the heading and card list come back.
3. **Webhook Endpoints.** With no endpoints registered, go to **Newspack → Settings → Connections**. The empty state should sit inside a card, with exactly one "Add Endpoint" button, inside the empty state rather than the section header. Register an endpoint and confirm the header button returns and the list renders.
4. **Help links.** On both empty states, check the "Learn more" link reads as "Learn more about brands (opens in a new tab)" / "Learn more about webhooks (opens in a new tab)" in the accessibility tree, while still showing "Learn more" on screen.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Added a `packages/components` test for the small variant's stack gap, alongside the existing one for the default. Both suites pass: newspack-plugin 118 suites / 1319 tests, newspack-components 29 suites / 435 tests. Lint and the TypeScript check are clean.
