### PR TITLE
fix(settings): show and announce wizard notices

### DIFF
--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brand-upsert.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brand-upsert.tsx
@@ -8,6 +8,7 @@
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs, cleanForSlug } from '@wordpress/url';
 import { Fragment, useState, useEffect } from '@wordpress/element';
+import { Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies.
@@ -24,7 +25,6 @@ import {
 	SelectControl,
 	RadioControl,
 	hooks,
-	Notice,
 } from '../../../../../../packages/components/src';
 
 import './style.scss';
@@ -175,6 +175,11 @@ export default function Brand( {
 
 	return (
 		<Fragment>
+			{ errorMessage && (
+				<Notice status="error" isDismissible={ false } className="newspack-additional-brands__notice">
+					{ errorMessage }
+				</Notice>
+			) }
 			<SectionHeader title={ __( 'Brand', 'newspack-plugin' ) } description={ __( 'Set your brand identity', 'newspack-plugin' ) } />
 			<Grid gutter={ 32 }>
 				<Grid columns={ 1 } gutter={ 16 }>
@@ -327,7 +332,6 @@ export default function Brand( {
 						onChange={ ( menuId: number ) => updateMenus( location, menuId ) }
 					/>
 				) ) }
-			{ errorMessage && <Notice isError>{ errorMessage }</Notice> }
 			{ /* Action Buttons */ }
 			<div className="newspack-buttons-card">
 				<Button disabled={ ! isBrandValid } variant="primary" onClick={ () => upsertBrand( Number( brandId ), brand ) }>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/index.tsx
@@ -175,6 +175,7 @@ export default function AdditionalBrands() {
 								upsertBrand={ upsertBrand }
 								fetchLogoAttachment={ fetchLogoAttachment }
 								wizardApiFetch={ wizardApiFetch }
+								errorMessage={ errorMessage }
 							/>
 						) }
 					/>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
@@ -7,10 +7,10 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink, Notice } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { speak } from '@wordpress/a11y';
-import { decodeEntities } from '@wordpress/html-entities';
-import { Button, Card, Notice, SectionHeader } from '../../../../../../packages/components/src';
+import { Button, Card, SectionHeader } from '../../../../../../packages/components/src';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
 
 interface AccessibilityStatementProps {
@@ -56,13 +56,10 @@ export default function AccessibilityStatement( { isFetching }: AccessibilitySta
 		}
 	};
 
-	const handleError = ( error: { message?: string } ) => {
+	const handleError = () => {
 		setLocalPageData( null );
 		setIsPageMissing( false );
 		setLocalIsFetching( false );
-		// The notice is a plain div, so nothing else announces the failure. It
-		// renders the message decoded, so announce the decoded text too.
-		speak( decodeEntities( error?.message ?? __( 'Something went wrong.', 'newspack-plugin' ) ), 'assertive' );
 	};
 
 	useEffect( () => {
@@ -93,7 +90,7 @@ export default function AccessibilityStatement( { isFetching }: AccessibilitySta
 		).catch( () => {} );
 	};
 
-	const getStatusMessage = () => {
+	const getStatusMessage = (): { type: 'error' | 'warning' | 'success'; message: string } => {
 		if ( errorMessage ) {
 			return { type: 'error', message: errorMessage };
 		}
@@ -161,7 +158,7 @@ export default function AccessibilityStatement( { isFetching }: AccessibilitySta
 	const statusInfo = getStatusMessage();
 
 	return (
-		<>
+		<Stack className="newspack-accessibility-statement" direction="column" gap="xl">
 			<Card noBorder headerActions>
 				<SectionHeader
 					title={ __( 'Accessibility Statement Page', 'newspack-plugin' ) }
@@ -174,37 +171,38 @@ export default function AccessibilityStatement( { isFetching }: AccessibilitySta
 				{ renderAction() }
 			</Card>
 
-			<Notice
-				isError={ statusInfo.type === 'error' }
-				isSuccess={ statusInfo.type === 'success' }
-				isWarning={ statusInfo.type === 'warning' }
-				noticeText={ statusInfo.message }
-			/>
+			<Notice status={ statusInfo.type } isDismissible={ false } spokenMessage={ statusInfo.type === 'error' ? statusInfo.message : '' }>
+				{ statusInfo.message }
+			</Notice>
 
-			<p>
-				{ __(
-					'An accessibility statement helps your readers understand how your site supports accessibility standards and what to do if they encounter accessibility issues. ',
-					'newspack-plugin'
-				) }
-				<ExternalLink href="https://www.w3.org/WAI/planning/statements/">
-					{ __( 'What makes a good accessibility statement.', 'newspack-plugin' ) }{ ' ' }
-				</ExternalLink>
-			</p>
+			<Stack className="newspack-accessibility-statement__prose" direction="column" gap="lg">
+				<p>
+					{ __(
+						'An accessibility statement helps your readers understand how your site supports accessibility standards and what to do if they encounter accessibility issues. ',
+						'newspack-plugin'
+					) }
+					<ExternalLink href="https://www.w3.org/WAI/planning/statements/">
+						{ __( 'What makes a good accessibility statement.', 'newspack-plugin' ) }{ ' ' }
+					</ExternalLink>
+				</p>
 
-			<p>
-				{ __( 'The page you create here will include a boilerplate accessibility statement. ', 'newspack-plugin' ) }
-				<strong>{ __( 'Please review and make edits to ensure it meets the requirements before publishing. ', 'newspack-plugin' ) }</strong>
-				{ __( 'You can also use the W3C Accessibility Statement Generator to create a custom statement. ', 'newspack-plugin' ) }
-				<ExternalLink href="https://www.w3.org/WAI/planning/statements/generator/#create">
-					{ __( 'Try out the Accessibility Statement Generator.', 'newspack-plugin' ) }{ ' ' }
-				</ExternalLink>
-			</p>
+				<p>
+					{ __( 'The page you create here will include a boilerplate accessibility statement. ', 'newspack-plugin' ) }
+					<strong>
+						{ __( 'Please review and make edits to ensure it meets the requirements before publishing. ', 'newspack-plugin' ) }
+					</strong>
+					{ __( 'You can also use the W3C Accessibility Statement Generator to create a custom statement. ', 'newspack-plugin' ) }
+					<ExternalLink href="https://www.w3.org/WAI/planning/statements/generator/#create">
+						{ __( 'Try out the Accessibility Statement Generator.', 'newspack-plugin' ) }{ ' ' }
+					</ExternalLink>
+				</p>
 
-			<p>
-				<ExternalLink href="https://help.newspack.com/revenue/reader-revenue/how-to-add-an-accessibility-statement/">
-					{ __( 'Learn more about this feature in our documentation.', 'newspack-plugin' ) }{ ' ' }
-				</ExternalLink>
-			</p>
-		</>
+				<p>
+					<ExternalLink href="https://help.newspack.com/revenue/reader-revenue/how-to-add-an-accessibility-statement/">
+						{ __( 'Learn more about this feature in our documentation.', 'newspack-plugin' ) }{ ' ' }
+					</ExternalLink>
+				</p>
+			</Stack>
+		</Stack>
 	);
 }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/index.tsx
@@ -7,6 +7,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
+import { Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies.
@@ -14,7 +15,7 @@ import { useEffect } from '@wordpress/element';
 import { ADVANCED_SETTINGS_DEFAULTS } from '../constants';
 import WizardsTab from '../../../../wizards-tab';
 import WizardSection from '../../../../wizards-section';
-import { Button, Grid, hooks, ImageUpload, Notice, utils } from '../../../../../../packages/components/src';
+import { Button, Grid, hooks, ImageUpload, utils } from '../../../../../../packages/components/src';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
 import Recirculation from './recirculation';
 import AuthorBio from './author-bio';
@@ -104,6 +105,14 @@ export default function AdvancedSettings() {
 		);
 	}, [] );
 
+	// The Save button sits at the foot of a long page, so a failure reported at the
+	// top would otherwise land off-screen.
+	useEffect( () => {
+		if ( errorMessage ) {
+			window.scrollTo( { top: 0, behavior: 'smooth' } );
+		}
+	}, [ errorMessage ] );
+
 	function save() {
 		wizardApiFetchRecirculation(
 			{
@@ -165,6 +174,11 @@ export default function AdvancedSettings() {
 			title={ __( 'Advanced Settings', 'newspack-plugin' ) }
 			isFetching={ isFetching || isFetchingRecirculation || isFetchingPrimaryCategory }
 		>
+			{ errorMessage && (
+				<Notice status="error" isDismissible={ false } className="newspack-advanced-settings__notice">
+					{ errorMessage }
+				</Notice>
+			) }
 			<WizardSection title={ __( 'Recirculation', 'newspack-plugin' ) }>
 				<Recirculation isFetching={ isFetchingRecirculation } update={ setRecirculationData } data={ recirculationData } />
 			</WizardSection>
@@ -232,7 +246,6 @@ export default function AdvancedSettings() {
 					<PrivateTags data={ data } update={ setData } isFetching={ isFetching } />
 				</WizardSection>
 			) : null }
-			{ errorMessage && <Notice /> }
 			<div className="newspack-buttons-card">
 				<Button variant="primary" onClick={ save }>
 					{ __( 'Save', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/pwa-display-mode.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/pwa-display-mode.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
-import { SelectControl } from '@wordpress/components';
+import { Notice, SelectControl } from '@wordpress/components';
 
-import { Grid, Notice } from '../../../../../../packages/components/src';
+import { Grid } from '../../../../../../packages/components/src';
 
 interface PwaDisplayModeProps extends ThemeModComponentProps< AdvancedSettings > {}
 
@@ -39,13 +39,12 @@ export default function PwaDisplayMode( { data, isFetching, update }: PwaDisplay
 					onChange={ ( pwa_display_mode: string ) => update( { pwa_display_mode } ) }
 					disabled={ isFetching }
 				/>
-				<Notice
-					noticeText={ __(
+				<Notice status="info" isDismissible={ false } spokenMessage="">
+					{ __(
 						'This setting controls how your site appears when users install it as a Progressive Web App on their devices.',
 						'newspack-plugin'
 					) }
-					isInfo
-				/>
+				</Notice>
 			</Grid>
 		</Grid>
 	);

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/custom-events.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/custom-events.tsx
@@ -7,14 +7,15 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
-import { __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { Notice, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
  */
 import { WizardError } from '../../../../errors';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
-import { Button, Grid, Notice, TextControl, utils } from '../../../../../../packages/components/src';
+import { Button, Grid, TextControl, utils } from '../../../../../../packages/components/src';
 import { ERROR_MESSAGES } from './constants';
 
 /**
@@ -102,7 +103,7 @@ function CustomEvents() {
 	}
 
 	return (
-		<div className="newspack__analytics-configuration">
+		<Stack className="newspack__analytics-configuration" direction="column" gap="xl">
 			<div className="newspack__analytics-configuration__header">
 				<p>
 					{ __(
@@ -134,7 +135,11 @@ function CustomEvents() {
 					autoComplete="one-time-code"
 				/>
 			</Grid>
-			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
+			{ errorMessage && (
+				<Notice status="error" isDismissible={ false }>
+					{ errorMessage }
+				</Notice>
+			) }
 			<HStack justify="flex-start" spacing={ 2 }>
 				<Button variant="primary" onClick={ updateGa4Credentials } disabled={ isInputsEmpty() || !! errorMessage }>
 					{ __( 'Save', 'newspack-plugin' ) }
@@ -143,7 +148,7 @@ function CustomEvents() {
 					{ __( 'Reset', 'newspack-plugin' ) }
 				</Button>
 			</HStack>
-		</div>
+		</Stack>
 	);
 }
 

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/jetpack-sso.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/jetpack-sso.tsx
@@ -2,14 +2,15 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { BaseControl, CheckboxControl, ExternalLink } from '@wordpress/components';
+import { BaseControl, CheckboxControl, ExternalLink, Notice } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { useEffect, useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
-import { ActionCard, Button, Grid, Notice, SelectControl } from '../../../../../../packages/components/src';
+import { ActionCard, Button, SelectControl } from '../../../../../../packages/components/src';
 
 const isValidError = ( e: unknown ): e is WpRestApiError => {
 	return e instanceof Error && 'message' in e;
@@ -84,11 +85,15 @@ const JetpackSSO = () => {
 				disabled={ isLoading }
 			>
 				{ settings.force_2fa && (
-					<>
-						{ error && <Notice isError noticeText={ error } /> }
+					<Stack className="newspack-jetpack-sso__settings" direction="column" gap="xl">
+						{ error && (
+							<Notice status="error" isDismissible={ false }>
+								{ error }
+							</Notice>
+						) }
 						{ settings.jetpack_sso_force_2fa && (
 							<>
-								<Notice isWarning>
+								<Notice status="warning" isDismissible={ false } spokenMessage="">
 									{ __(
 										'Two-factor authentication is currently enforced for all users via Jetpack configuration.',
 										'newspack-plugin'
@@ -105,34 +110,30 @@ const JetpackSSO = () => {
 								</p>
 							</>
 						) }
-						<Grid columns={ 1 }>
-							<BaseControl
-								id="force-2fa-cap"
-								label={ __( 'Select the user capability to enforce two-factor authentication', 'newspack-plugin' ) }
-							>
-								<SelectControl
-									label={ __( 'Capability', 'newspack-plugin' ) }
-									hideLabelFromVision
-									value={ settingsToUpdate?.force_2fa_cap || '' }
-									onChange={ ( value: JetpackSSOCaps ) => setSettingsToUpdate( { ...settingsToUpdate, force_2fa_cap: value } ) }
-									options={ Object.keys( settings.available_caps || {} ).map( ( cap: string ) => ( {
-										label: getCapLabel( cap as JetpackSSOCaps ),
-										value: cap,
-									} ) ) }
-								/>
-							</BaseControl>
-						</Grid>
-						<Grid columns={ 1 }>
-							<CheckboxControl
-								checked={ settingsToUpdate?.obfuscate_account || false }
-								onChange={ value => setSettingsToUpdate( { ...settingsToUpdate, obfuscate_account: value } ) }
-								label={ __(
-									'Obfuscate restricted accounts by throwing WP’s “user not found” errors on login form attempts.',
-									'newspack-plugin'
-								) }
+						<BaseControl
+							id="force-2fa-cap"
+							label={ __( 'Select the user capability to enforce two-factor authentication', 'newspack-plugin' ) }
+						>
+							<SelectControl
+								label={ __( 'Capability', 'newspack-plugin' ) }
+								hideLabelFromVision
+								value={ settingsToUpdate?.force_2fa_cap || '' }
+								onChange={ ( value: JetpackSSOCaps ) => setSettingsToUpdate( { ...settingsToUpdate, force_2fa_cap: value } ) }
+								options={ Object.keys( settings.available_caps || {} ).map( ( cap: string ) => ( {
+									label: getCapLabel( cap as JetpackSSOCaps ),
+									value: cap,
+								} ) ) }
 							/>
-						</Grid>
-					</>
+						</BaseControl>
+						<CheckboxControl
+							checked={ settingsToUpdate?.obfuscate_account || false }
+							onChange={ value => setSettingsToUpdate( { ...settingsToUpdate, obfuscate_account: value } ) }
+							label={ __(
+								'Obfuscate restricted accounts by throwing WP’s “user not found” errors on login form attempts.',
+								'newspack-plugin'
+							) }
+						/>
+					</Stack>
 				) }
 			</ActionCard>
 		</>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/style.scss
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/style.scss
@@ -1,7 +1,21 @@
 @use "sass:color";
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
+.newspack-jetpack-sso__settings {
+	margin-top: 32px;
+
+	> * {
+		margin: 0;
+	}
+}
+
 /** Webhooks */
+.newspack-webhooks__requests-modal {
+	> * {
+		margin: 0;
+	}
+}
+
 .newspack-webhooks {
 	&__header {
 		margin-bottom: 32px;

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/index.tsx
@@ -7,7 +7,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState, Fragment } from '@wordpress/element';
-import { __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { Notice, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
 /**
  * Internal dependencies
@@ -16,7 +16,7 @@ import { API_NAMESPACE } from './constants';
 import EndpointActionsCard from './endpoint-actions-card';
 import EndpointActionsModals from './endpoint-actions-modals';
 import { useWizardApiFetch } from '../../../../../hooks/use-wizard-api-fetch';
-import { Card, Button, Notice, SectionHeader } from '../../../../../../../packages/components/src';
+import { Card, Button, SectionHeader } from '../../../../../../../packages/components/src';
 
 const defaultEndpoint: Endpoint = {
 	url: '',
@@ -100,7 +100,9 @@ function Webhooks() {
 						) ) }
 					</Fragment>
 				) : (
-					<Notice noticeText={ __( 'No endpoints found', 'newspack-plugin' ) } />
+					<Notice status="info" isDismissible={ false } spokenMessage="">
+						{ __( 'No endpoints found', 'newspack-plugin' ) }
+					</Notice>
 				) ) }
 			{ selectedEndpoint && (
 				<EndpointActionsModals

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.tsx
@@ -7,14 +7,15 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useRef, Fragment } from '@wordpress/element';
-import { CheckboxControl as WpCheckboxControl, TextControl, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { CheckboxControl as WpCheckboxControl, Notice, TextControl, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
  */
 import { ENDPOINTS_CACHE_KEY } from '../constants';
 import { WizardApiError } from '../../../../../../errors';
-import { Button, Notice, Modal, Grid, Divider } from '../../../../../../../../packages/components/src';
+import { Button, Modal, Grid, Divider } from '../../../../../../../../packages/components/src';
 import { validateEndpoint, validateUrl } from '../utils';
 
 /**
@@ -110,101 +111,117 @@ const Upsert = ( {
 		<Fragment>
 			<Modal
 				ref={ modalRef }
-				size="full"
+				size="large"
 				title={ __( 'Webhook Endpoint', 'newspack-plugin' ) }
 				onRequestClose={ () => {
 					setAction( null, endpoint.id );
 				} }
 			>
-				{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
-				{ true === editing.disabled && <Notice noticeText={ __( 'This webhook endpoint is currently disabled.', 'newspack-plugin' ) } /> }
-				{ editing.disabled && editing.disabled_error && (
-					<Notice isError noticeText={ __( 'Request Error: ', 'newspack-plugin' ) + editing.disabled_error } />
-				) }
-				{ testResponse.success && <Notice isSuccess noticeText={ `${ testResponse.message }: ${ testResponse.code }` } /> }
-				<Grid columns={ 1 } gutter={ 16 } noMargin>
-					<TextControl
-						label={ __( 'URL', 'newspack-plugin' ) }
-						help={ __(
-							"The URL to send requests to. It's required for the URL to be under a valid TLS/SSL certificate. You can use the test button below to verify the endpoint response.",
-							'newspack-plugin'
-						) }
-						className="code"
-						value={ editing.url }
-						onChange={ ( value: string ) => setEditing( { ...editing, url: value } ) }
-						disabled={ inFlight }
-					/>
-					<TextControl
-						label={ __( 'Authentication token (optional)', 'newspack-plugin' ) }
-						help={ __(
-							'If your endpoint requires a token authentication, enter it here. It will be sent as a Bearer token in the Authorization header.',
-							'newspack-plugin'
-						) }
-						value={ editing.bearer_token ?? '' }
-						onChange={ ( value: string ) => setEditing( { ...editing, bearer_token: value } ) }
-						disabled={ inFlight }
-					/>
-					<HStack justify="flex-end" spacing={ 4 } wrap>
-						<Button
-							variant="secondary"
-							disabled={ inFlight || ! editing.url }
-							onClick={ () => testEndpoint( editing.url, editing.bearer_token ) }
-						>
-							{ __( 'Send a test request', 'newspack-plugin' ) }
-						</Button>
-					</HStack>
-				</Grid>
-				<Divider alignment="full-width" variant="tertiary" />
-				<TextControl
-					label={ __( 'Label (optional)', 'newspack-plugin' ) }
-					help={ __( 'A label to help you identify this endpoint. It will not be sent to the endpoint.', 'newspack-plugin' ) }
-					value={ editing.label }
-					onChange={ ( value: string ) => setEditing( { ...editing, label: value } ) }
-					disabled={ inFlight }
-				/>
-				<Grid columns={ 1 } gutter={ 16 }>
-					<h3>{ __( 'Actions', 'newspack-plugin' ) }</h3>
-					{ actions.length > 0 && (
-						<Fragment>
-							<p>{ __( 'Select which actions should trigger this endpoint:', 'newspack-plugin' ) }</p>
-							<Grid columns={ 2 } gutter={ 16 }>
-								{ actions.map( ( actionKey, i ) => (
-									<CheckboxControl
-										key={ i }
-										disabled={ inFlight }
-										label={ actionKey }
-										checked={ ( editing.actions && editing.actions.includes( actionKey ) ) || false }
-										onChange={ () => {
-											const currentActions = editing.actions || [];
-											if ( currentActions.includes( actionKey ) ) {
-												currentActions.splice( currentActions.indexOf( actionKey ), 1 );
-											} else {
-												currentActions.push( actionKey );
-											}
-											setEditing( {
-												...editing,
-												actions: currentActions,
-											} );
-										} }
-									/>
-								) ) }
-							</Grid>
-						</Fragment>
+				<Stack direction="column" gap="xl">
+					{ errorMessage && (
+						<Notice status="error" isDismissible={ false }>
+							{ errorMessage }
+						</Notice>
 					) }
-					<HStack justify="flex-end" spacing={ 4 } wrap className="newspack-modal__footer">
-						<Button
-							isPrimary
-							onClick={ () => {
-								if ( null !== editing && 'url' in editing ) {
-									upsertEndpoint( editing );
-								}
-							} }
-							disabled={ inFlight || null === editing }
-						>
-							{ __( 'Save', 'newspack-plugin' ) }
-						</Button>
-					</HStack>
-				</Grid>
+					{ true === editing.disabled && (
+						<Notice status="info" isDismissible={ false } spokenMessage="">
+							{ __( 'This webhook endpoint is currently disabled.', 'newspack-plugin' ) }
+						</Notice>
+					) }
+					{ editing.disabled && editing.disabled_error && (
+						<Notice status="error" isDismissible={ false }>
+							{ __( 'Request Error: ', 'newspack-plugin' ) + editing.disabled_error }
+						</Notice>
+					) }
+					{ testResponse.success && (
+						<Notice status="success" isDismissible={ false }>
+							{ `${ testResponse.message }: ${ testResponse.code }` }
+						</Notice>
+					) }
+					<Grid columns={ 1 } gutter={ 16 } noMargin>
+						<TextControl
+							label={ __( 'URL', 'newspack-plugin' ) }
+							help={ __(
+								"The URL to send requests to. It's required for the URL to be under a valid TLS/SSL certificate. You can use the test button below to verify the endpoint response.",
+								'newspack-plugin'
+							) }
+							className="code"
+							value={ editing.url }
+							onChange={ ( value: string ) => setEditing( { ...editing, url: value } ) }
+							disabled={ inFlight }
+						/>
+						<TextControl
+							label={ __( 'Authentication token (optional)', 'newspack-plugin' ) }
+							help={ __(
+								'If your endpoint requires a token authentication, enter it here. It will be sent as a Bearer token in the Authorization header.',
+								'newspack-plugin'
+							) }
+							value={ editing.bearer_token ?? '' }
+							onChange={ ( value: string ) => setEditing( { ...editing, bearer_token: value } ) }
+							disabled={ inFlight }
+						/>
+						<HStack justify="flex-end" spacing={ 4 } wrap>
+							<Button
+								variant="secondary"
+								disabled={ inFlight || ! editing.url }
+								onClick={ () => testEndpoint( editing.url, editing.bearer_token ) }
+							>
+								{ __( 'Send a test request', 'newspack-plugin' ) }
+							</Button>
+						</HStack>
+					</Grid>
+					<Divider variant="tertiary" marginTop={ 0 } marginBottom={ 0 } />
+					<TextControl
+						label={ __( 'Label (optional)', 'newspack-plugin' ) }
+						help={ __( 'A label to help you identify this endpoint. It will not be sent to the endpoint.', 'newspack-plugin' ) }
+						value={ editing.label }
+						onChange={ ( value: string ) => setEditing( { ...editing, label: value } ) }
+						disabled={ inFlight }
+					/>
+					<Grid columns={ 1 } gutter={ 16 } noMargin>
+						<h3>{ __( 'Actions', 'newspack-plugin' ) }</h3>
+						{ actions.length > 0 && (
+							<Fragment>
+								<p>{ __( 'Select which actions should trigger this endpoint:', 'newspack-plugin' ) }</p>
+								<Grid columns={ 2 } gutter={ 16 }>
+									{ actions.map( ( actionKey, i ) => (
+										<CheckboxControl
+											key={ i }
+											disabled={ inFlight }
+											label={ actionKey }
+											checked={ ( editing.actions && editing.actions.includes( actionKey ) ) || false }
+											onChange={ () => {
+												const currentActions = editing.actions || [];
+												if ( currentActions.includes( actionKey ) ) {
+													currentActions.splice( currentActions.indexOf( actionKey ), 1 );
+												} else {
+													currentActions.push( actionKey );
+												}
+												setEditing( {
+													...editing,
+													actions: currentActions,
+												} );
+											} }
+										/>
+									) ) }
+								</Grid>
+							</Fragment>
+						) }
+						<HStack justify="flex-end" spacing={ 4 } wrap className="newspack-modal__footer">
+							<Button
+								isPrimary
+								onClick={ () => {
+									if ( null !== editing && 'url' in editing ) {
+										upsertEndpoint( editing );
+									}
+								} }
+								disabled={ inFlight || null === editing }
+							>
+								{ __( 'Save', 'newspack-plugin' ) }
+							</Button>
+						</HStack>
+					</Grid>
+				</Stack>
 			</Modal>
 		</Fragment>
 	);

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/view.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/view.tsx
@@ -7,7 +7,8 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import { Icon } from '@wordpress/components';
+import { Icon, Notice } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * External dependencies
@@ -17,67 +18,71 @@ import moment from 'moment';
 /**
  * Internal dependencies
  */
-import { Notice, Modal } from '../../../../../../../../packages/components/src';
+import { Modal } from '../../../../../../../../packages/components/src';
 import { getEndpointLabel, getRequestStatusIcon, hasEndpointErrors } from '../utils';
 
 const View = ( { endpoint, setAction }: { endpoint: ModalComponentProps[ 'endpoint' ]; setAction: ModalComponentProps[ 'setAction' ] } ) => {
 	return (
 		<Modal title={ __( 'Latest Requests', 'newspack-plugin' ) } onRequestClose={ () => setAction( null, endpoint.id ) }>
-			<p>
-				{ sprintf(
-					// translators: %s is the endpoint title (shortened URL).
-					__( 'Most recent requests for %s', 'newspack-plugin' ),
-					getEndpointLabel( endpoint )
-				) }
-			</p>
-			{ endpoint.requests.length > 0 ? (
-				<table className={ `newspack-webhooks__requests ${ hasEndpointErrors( endpoint ) ? 'has-error' : '' }` }>
-					<tr>
-						<th />
-						<th colSpan={ 2 }>{ __( 'Action', 'newspack-plugin' ) }</th>
-						{ hasEndpointErrors( endpoint ) && <th colSpan={ 2 }>{ __( 'Error', 'newspack-plugin' ) }</th> }
-					</tr>
-					{ endpoint.requests.map( request => (
-						<tr key={ request.id }>
-							<td className={ `status status--${ request.status }` }>
-								<Icon icon={ getRequestStatusIcon( request.status ) } />
-							</td>
-							<td className="action-name">{ request.action_name }</td>
-							<td className="scheduled">
-								{ 'pending' === request.status
-									? sprintf(
-											// translators: %s is a human-readable time difference.
-											__( 'sending in %s', 'newspack-plugin' ),
-											moment( parseInt( request.scheduled ) * 1000 ).fromNow( true )
-									  )
-									: sprintf(
-											// translators: %s is a human-readable time difference.
-											__( 'processed %s', 'newspack-plugin' ),
-											moment( parseInt( request.scheduled ) * 1000 ).fromNow()
-									  ) }
-							</td>
-							{ hasEndpointErrors( endpoint ) && (
-								<Fragment>
-									<td className="error">
-										{ request.errors && request.errors.length > 0 ? request.errors[ request.errors.length - 1 ] : '--' }
-									</td>
-									<td>
-										<span className="error-count">
-											{ sprintf(
-												// translators: %s is the number of errors.
-												__( 'Attempt #%s', 'newspack-plugin' ),
-												String( request.errors.length )
-											) }
-										</span>
-									</td>
-								</Fragment>
-							) }
+			<Stack className="newspack-webhooks__requests-modal" direction="column" gap="xl">
+				<p>
+					{ sprintf(
+						// translators: %s is the endpoint title (shortened URL).
+						__( 'Most recent requests for %s', 'newspack-plugin' ),
+						getEndpointLabel( endpoint )
+					) }
+				</p>
+				{ endpoint.requests.length > 0 ? (
+					<table className={ `newspack-webhooks__requests ${ hasEndpointErrors( endpoint ) ? 'has-error' : '' }` }>
+						<tr>
+							<th />
+							<th colSpan={ 2 }>{ __( 'Action', 'newspack-plugin' ) }</th>
+							{ hasEndpointErrors( endpoint ) && <th colSpan={ 2 }>{ __( 'Error', 'newspack-plugin' ) }</th> }
 						</tr>
-					) ) }
-				</table>
-			) : (
-				<Notice noticeText={ __( "This endpoint hasn't received any requests yet.", 'newspack-plugin' ) } />
-			) }
+						{ endpoint.requests.map( request => (
+							<tr key={ request.id }>
+								<td className={ `status status--${ request.status }` }>
+									<Icon icon={ getRequestStatusIcon( request.status ) } />
+								</td>
+								<td className="action-name">{ request.action_name }</td>
+								<td className="scheduled">
+									{ 'pending' === request.status
+										? sprintf(
+												// translators: %s is a human-readable time difference.
+												__( 'sending in %s', 'newspack-plugin' ),
+												moment( parseInt( request.scheduled ) * 1000 ).fromNow( true )
+										  )
+										: sprintf(
+												// translators: %s is a human-readable time difference.
+												__( 'processed %s', 'newspack-plugin' ),
+												moment( parseInt( request.scheduled ) * 1000 ).fromNow()
+										  ) }
+								</td>
+								{ hasEndpointErrors( endpoint ) && (
+									<Fragment>
+										<td className="error">
+											{ request.errors && request.errors.length > 0 ? request.errors[ request.errors.length - 1 ] : '--' }
+										</td>
+										<td>
+											<span className="error-count">
+												{ sprintf(
+													// translators: %s is the number of errors.
+													__( 'Attempt #%s', 'newspack-plugin' ),
+													String( request.errors.length )
+												) }
+											</span>
+										</td>
+									</Fragment>
+								) }
+							</tr>
+						) ) }
+					</table>
+				) : (
+					<Notice status="info" isDismissible={ false } spokenMessage="">
+						{ __( "This endpoint hasn't received any requests yet.", 'newspack-plugin' ) }
+					</Notice>
+				) }
+			</Stack>
 		</Modal>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/seo/constants.ts
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/seo/constants.ts
@@ -18,10 +18,16 @@ export const ACCOUNTS = [
 				return '';
 			}
 			if ( inputValue.length > 15 ) {
-				return __( 'X handle cannot exceed 15 characters!', 'newspack-plugin' );
+				return __(
+					'X handles can be up to 15 characters. Enter just the username, without the @ or the full profile URL.',
+					'newspack-plugin'
+				);
 			}
 			if ( ! /^[a-zA-Z0-9_]+$/.test( inputValue ) ) {
-				return __( 'X handle may only contain letters, numbers, and underscores!', 'newspack-plugin' );
+				return __(
+					'X handles use only letters, numbers, and underscores. Enter just the username, without the @ or the full profile URL.',
+					'newspack-plugin'
+				);
 			}
 			return '';
 		},

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/seo/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/seo/index.tsx
@@ -7,6 +7,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
+import { Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies.
@@ -16,7 +17,7 @@ import { ACCOUNTS } from './constants';
 import WizardsTab from '../../../../wizards-tab';
 import VerificationCodes from './verification-codes';
 import WizardSection from '../../../../wizards-section';
-import { Button, Notice } from '../../../../../../packages/components/src';
+import { Button } from '../../../../../../packages/components/src';
 import WizardsActionCard from '../../../../wizards-action-card';
 import useFieldsValidation from '../../../../hooks/use-fields-validation';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
@@ -44,11 +45,26 @@ function Seo() {
 
 	const codesValidation = useFieldsValidation< SeoData[ 'verification' ] >(
 		[
-			[ 'google', 'isId', { message: __( 'Invalid Google verification code!', 'newspack-plugin' ) } ],
+			[
+				'google',
+				'isId',
+				{
+					message: __(
+						'Google verification codes use only letters, numbers, hyphens, and underscores. Copy just the code from Search Console, not the full meta tag.',
+						'newspack-plugin'
+					),
+				},
+			],
 			[
 				'bing',
 				/** JS version of [WPSEO PHP regex](https://github.com/Yoast/wordpress-seo/blob/trunk/inc/options/class-wpseo-option.php#L313) */
-				v => ( /^[A-Fa-f0-9_-]*$/.test( v ) ? '' : __( 'Invalid Bing verification code!', 'newspack-plugin' ) ),
+				v =>
+					/^[A-Fa-f0-9_-]*$/.test( v )
+						? ''
+						: __(
+								'Bing verification codes use only the letters A-F, numbers, hyphens, and underscores. Copy just the code from Bing Webmaster Tools, not the full meta tag.',
+								'newspack-plugin'
+						  ),
 			],
 		],
 		data.verification
@@ -112,14 +128,22 @@ function Seo() {
 				title={ __( 'Webmaster Tools', 'newspack-plugin' ) }
 				description={ __( 'Add verification meta tags to your site', 'newspack-plugin' ) }
 			>
-				{ codesValidation.errorMessage && <Notice isError noticeText={ codesValidation.errorMessage } /> }
+				{ codesValidation.errorMessage && (
+					<Notice status="error" isDismissible={ false }>
+						{ codesValidation.errorMessage }
+					</Notice>
+				) }
 				<VerificationCodes setData={ verification => setData( { ...data, verification } ) } data={ data.verification } />
 			</WizardSection>
 			<WizardSection
 				title={ __( 'Social Accounts', 'newspack-plugin' ) }
 				description={ __( 'Let search engines know which social profiles are associated to your site', 'newspack-plugin' ) }
 			>
-				{ accountsValidation.errorMessage && <Notice isError noticeText={ accountsValidation.errorMessage } /> }
+				{ accountsValidation.errorMessage && (
+					<Notice status="error" isDismissible={ false }>
+						{ accountsValidation.errorMessage }
+					</Notice>
+				) }
 				<Accounts setData={ urls => setData( { ...data, urls } ) } data={ data.urls } />
 			</WizardSection>
 			<WizardSection>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor/onboarding/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor/onboarding/index.tsx
@@ -7,12 +7,12 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink, Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { ActionCard, Button, Card, Grid, Notice, SelectControl, TextControl } from '../../../../../../../../packages/components/src';
+import { ActionCard, Button, Card, Grid, SelectControl, TextControl } from '../../../../../../../../packages/components/src';
 import { OnboardingProps } from '../types';
 
 /**
@@ -161,7 +161,11 @@ export const Onboarding = ( { settings, status, error, updateSettings, startOAut
 
 	return (
 		<>
-			{ error && <Notice noticeText={ error } isError onClose={ () => setError( null ) } /> }
+			{ error && (
+				<Notice status="error" isDismissible={ false }>
+					{ error }
+				</Notice>
+			) }
 
 			{ /* Step 1: API Credentials - Only shown in manual mode */ }
 			{ isManualMode && currentStep === STEPS.manual.CREDENTIALS && (

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor/settings/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor/settings/index.tsx
@@ -8,12 +8,12 @@
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-import { CheckboxControl, CardHeader, __experimentalHeading as Heading, CardBody } from '@wordpress/components';
+import { CheckboxControl, CardHeader, __experimentalHeading as Heading, CardBody, Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { Button, Card, Grid, Notice } from '../../../../../../../../packages/components/src';
+import { Button, Card, Grid } from '../../../../../../../../packages/components/src';
 import { SettingsProps } from '../types';
 
 /**
@@ -66,18 +66,19 @@ export const Settings = ( { settings, status, error, updateSettings, disconnect,
 
 	if ( ! status.is_connected ) {
 		return (
-			<Card>
-				<Notice
-					noticeText={ __( 'Nextdoor is not connected. Please complete the setup process first.', 'newspack-plugin' ) }
-					isError={ false }
-				/>
-			</Card>
+			<Notice status="error" isDismissible={ false } spokenMessage="">
+				{ __( 'Nextdoor is not connected. Please complete the setup process first.', 'newspack-plugin' ) }
+			</Notice>
 		);
 	}
 
 	return (
 		<>
-			{ error && <Notice noticeText={ error } isError onClose={ () => setError( null ) } /> }
+			{ error && (
+				<Notice status="error" isDismissible={ false }>
+					{ error }
+				</Notice>
+			) }
 			<Card>
 				<CardHeader>
 					<Heading level={ 4 }>{ __( 'Connection Information', 'newspack-plugin' ) }</Heading>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/style.scss
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/style.scss
@@ -1,3 +1,15 @@
 .newspack-settings {
 	box-sizing: border-box;
 }
+
+.newspack-additional-brands__notice,
+.newspack-advanced-settings__notice {
+	margin-bottom: 32px;
+}
+
+.newspack-accessibility-statement,
+.newspack-accessibility-statement__prose {
+	> * {
+		margin: 0;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Every notice on Newspack > Settings now uses core's `Notice` instead of our own. Ours renders a plain `div` with an `aria-hidden` icon, so nothing it said ever reached a screen reader. All 18 call sites across the 11 tabs are converted, and the 11 error notices among them now announce.

Two of those notices could never say anything at all, to anyone:

- Advanced Settings rendered `<Notice />` with no children, so a failed save showed an empty grey box while the message sat unused in the hook.
- Additional Brands passed `errorMessage` to the edit route but not the create route, so a failed **Add Brand** reported nothing.

Alongside that, a few things the conversion made obvious:

- **Spacing** moved onto `@wordpress/ui`'s `Stack` in four places (Custom Events, Accessibility Statement, and both webhook modals) rather than per-notice margins. The Jetpack SSO card body is one Stack now, which let two single-child `Grid` wrappers go.
- **Two dead props.** Both Nextdoor notices passed `onClose`, which our component ignores, so they looked dismissible in the source and were not in the browser. Both are explicitly non-dismissible now. `pwa-display-mode` passed a similarly ignored `isInfo`.
- **Two wrong statuses.** Nextdoor's "not connected" was `isError={ false }`, rendering neutral grey; it is an error. The Accessibility Statement notice computed three booleans where core takes one `status` string.
- **Copy.** The four SEO validation messages were terse and shouty ("Invalid Google verification code!"). They now name the rule and what to do.
- **Placement.** The Advanced Settings and Additional Brands save errors moved to the top of their screens. Advanced Settings scrolls to it on failure, since its Save button sits ~2,000px below.

Announcement follows the policy settled on #890: errors and successes speak, standing-state info and warnings carry `spokenMessage=""` so they don't interrupt on every visit.

Part of the DSGNEWS-215 audit. Not a `Notice` wrapper rewrite; this converts the call sites and leaves `packages/components`' own `Notice` in place for the other wizards.

![Advanced Settings save error shown at the top of the tab](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/04/p0oejff4-notice-15-moved-top.png)

![Additional Brands save error shown above the Brand section](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/04/4hzb82n5-notice-18-brand-top.png)

![Nextdoor not-connected error rendered without a nested card](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/04/hmcbp2td-notice-11-no-card.png)

### How to test the changes in this Pull Request:

Most of these are failure paths. The quickest way to reach them is to reject the relevant request from the console on the Settings page.

1. Go to **Newspack > Settings > Connections**. With no webhook endpoints configured, "No endpoints found" renders as a core info notice. Add one, open **Endpoint Actions > Edit**, and **Send a test request** to a URL that rejects POST: the error appears at the top of the modal, which is now `large` rather than full-width, with an even 24px between its children.
2. **SEO**: put `nope!` in **Google** and any non-URL in **Facebook**, then **Save Settings**. Both messages appear, and both now explain the rule. Note that an alphanumeric value like `G-WRONG` passes: the validator only rejects characters outside `[A-Za-z0-9_-]`.
3. **SEO** again: paste an X profile URL into the handle field. The length message now tells you to enter just the username.
4. **Advanced Settings**: make `POST /newspack/v1/wizard/newspack-setup-wizard/theme` fail, scroll to the bottom, and **Save**. Before this branch you got an empty grey box; now the message renders at the top of the tab and the page scrolls to it.
5. **Additional Brands > Add Brand**: make `POST /wp/v2/brand` fail and **Save**. Before this branch nothing appeared at all.
6. **Advanced Settings > Accessibility Statement Page**: trash the page, reload, create it, publish it. The notice moves through warning, warning, success, and the section sits in nested Stacks (24px outer, 16px between the paragraphs).
7. With a screen reader, confirm an error announces and that revisiting a tab with a standing info or warning notice stays quiet.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

No new tests: the change is which component renders and where it sits, and the existing suite covers the surrounding behaviour. `tsc`, `lint:js` and `lint:scss` are clean, the build is clean, and all 1319 JS tests pass.
