### PR TITLE
fix(settings): show and announce wizard notices

### DIFF
--- a/plugins/newspack-plugin/AGENTS.md
+++ b/plugins/newspack-plugin/AGENTS.md
@@ -225,6 +225,23 @@ Blocks in `src/blocks/` with `block.json` metadata. Central registration in `src
 - `__experimentalHStack`/`__experimentalVStack` from `@wordpress/components` (spacing on a 4px scale) remain throughout older code and are fine to leave in place. Don't mix the two scales inside one component: a `gap="xl"` Stack wrapping an `HStack spacing={ 2 }` puts two different spacing systems in the same tree.
 - Shared mixins in `src/shared/scss/_mixins.scss`.
 
+### Notices and announcements
+
+Use `Notice` from `@wordpress/components`. It announces itself through `speak()` on mount, which `packages/components`' own `Notice` never did.
+
+- **Errors and action results announce.** An error raised by something the user just did stays on the default assertive politeness.
+- **An error that can render on arrival takes `politeness="polite"`.** Anything fed by a mount `GET` qualifies, including a notice that doubles as a save error. `status="error"` maps to assertive, which cuts off the page title on load.
+- **Standing state carries `spokenMessage=""`.** Info and warnings that describe how the site is configured, rather than reporting an action, should be silent on every visit.
+
+Re-announcing an unchanged message needs help, because `useSpokenMessage` only fires when the string changes. Which mechanism depends on where the message comes from:
+
+| The error arrives | Use |
+| --- | --- |
+| From a promise (a failed request) | `resetError()` at the top of the handler, so the string transitions |
+| From synchronous validation | A submit counter as the `Notice`'s `key`; a clear and a set in one handler batch into a single commit, so the string never transitions |
+| From several validators at once | One `speak()` in the handler with the notices silenced; `speak()` empties the live region before each write, so the last to render is the only one heard |
+| On a form whose button sits far below the notice | `useErrorNoticeFocus`, which scrolls, moves focus, and picks between focus and `speak()` |
+
 ### JS Testing
 
 ```bash

--- a/plugins/newspack-plugin/AGENTS.md
+++ b/plugins/newspack-plugin/AGENTS.md
@@ -240,7 +240,9 @@ Re-announcing an unchanged message needs help, because `useSpokenMessage` only f
 | From a promise (a failed request) | `resetError()` at the top of the handler, so the string transitions |
 | From synchronous validation | A submit counter as the `Notice`'s `key`; a clear and a set in one handler batch into a single commit, so the string never transitions |
 | From several validators at once | One `speak()` in the handler with the notices silenced; `speak()` empties the live region before each write, so the last to render is the only one heard |
-| On a form whose button sits far below the notice | `useErrorNoticeFocus`, which scrolls, moves focus, and picks between focus and `speak()` |
+| On a form whose button sits far below the notice | `useErrorNoticeFocus`, which moves focus to the notice, bringing it into view, and picks between focus and `speak()` depending on whether the reader stayed put |
+
+Moving focus cancels a smooth `scrollTo`, in either order and across a frame's delay, so the two do not combine: `useErrorNoticeFocus` lets focus do the scrolling. A screen that scrolls without moving focus, like the webhook modal, can still animate it.
 
 ### JS Testing
 

--- a/plugins/newspack-plugin/AGENTS.md
+++ b/plugins/newspack-plugin/AGENTS.md
@@ -221,7 +221,8 @@ Blocks in `src/blocks/` with `block.json` metadata. Central registration in `src
 - Design tokens in `packages/colors/colors.module.scss` (primary, secondary, tertiary, quaternary, neutral + semantic colors, each with 000-1000 scale).
 - See `packages/colors/DEVELOPMENT.md` for the color usage decision tree: backend admin uses WordPress colors (with `primary-600` accent override), block icons must use `primary-400`, frontend Newspack UI uses `newspack-colors`, theme elements use the theme palette.
 - BEM-ish naming with `newspack-` prefix (e.g., `.newspack-wizard__header`, `.newspack-card`).
-- No utility-class library. For layout, use `__experimentalHStack`/`__experimentalVStack` from `@wordpress/components`; spacing via the `spacing` prop (4px units).
+- No utility-class library. For layout, use `Stack` from `@wordpress/ui`; spacing via the `gap` prop, which takes the design-token scale (`xs` 4px, `sm` 8px, `md` 12px, `lg` 16px, `xl` 24px, `2xl` 32px, `3xl` 40px) and is typed, so a bad value fails `tsc`. `Stack` sets only `display: flex`, so a child bringing its own margin adds to the gap: reach for the component's own `noMargin` prop where it has one, or scope a `> * { margin: 0 }` reset to the container.
+- `__experimentalHStack`/`__experimentalVStack` from `@wordpress/components` (spacing on a 4px scale) remain throughout older code and are fine to leave in place. Don't mix the two scales inside one component: a `gap="xl"` Stack wrapping an `HStack spacing={ 2 }` puts two different spacing systems in the same tree.
 - Shared mixins in `src/shared/scss/_mixins.scss`.
 
 ### JS Testing

--- a/plugins/newspack-plugin/src/wizards/hooks/use-error-notice-focus.ts
+++ b/plugins/newspack-plugin/src/wizards/hooks/use-error-notice-focus.ts
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies.
+ */
+import { useEffect, useRef, useState } from '@wordpress/element';
+import { speak } from '@wordpress/a11y';
+
+/**
+ * Carry a reader to the notice reporting a failed submit.
+ *
+ * For a form whose button sits far below its notice. Focus doubles as the
+ * announcement here, which is why the notice goes silent once a submit has happened;
+ * where focus would interrupt someone who carried on while the request was in flight
+ * it is declined and the message is spoken instead, so nobody is left with neither.
+ *
+ * @param errorMessage The current failure message, or null when there is none.
+ * @param label        Accessible name for the notice container.
+ * @return Props for the notice wrapper, a submit handler to register, and the notice's `spokenMessage`.
+ */
+export function useErrorNoticeFocus( errorMessage: string | null | undefined, label: string ) {
+	const noticeRef = useRef< HTMLDivElement | null >( null );
+	const submittedFrom = useRef< Element | null >( null );
+	const [ submitCount, setSubmitCount ] = useState( 0 );
+
+	const registerSubmit = ( event?: { currentTarget: Element | null } ) => {
+		submittedFrom.current = event?.currentTarget ?? null;
+		setSubmitCount( count => count + 1 );
+	};
+
+	useEffect( () => {
+		if ( ! errorMessage || ! submitCount ) {
+			return;
+		}
+		const notice = noticeRef.current;
+		if ( ! notice ) {
+			speak( errorMessage, 'polite' );
+			return;
+		}
+		const { activeElement, body } = notice.ownerDocument;
+		const hasMovedOn = submittedFrom.current && activeElement !== submittedFrom.current && activeElement !== body;
+		if ( hasMovedOn ) {
+			speak( errorMessage, 'polite' );
+			return;
+		}
+		// Focus brings the notice into view by itself. A separate smooth `scrollTo` was
+		// tried and does not survive: moving focus cancels it, in either order and across
+		// a frame's delay, so the animation never ran and only the jump was ever seen.
+		notice.focus();
+	}, [ errorMessage, submitCount ] );
+
+	return {
+		wrapperProps: {
+			ref: noticeRef,
+			tabIndex: -1,
+			role: 'group',
+			'aria-label': label,
+		},
+		registerSubmit,
+		spokenMessage: submitCount ? '' : errorMessage ?? '',
+	};
+}
+
+export default useErrorNoticeFocus;

--- a/plugins/newspack-plugin/src/wizards/hooks/use-error-notice-focus.ts
+++ b/plugins/newspack-plugin/src/wizards/hooks/use-error-notice-focus.ts
@@ -14,7 +14,10 @@ import { speak } from '@wordpress/a11y';
  *
  * @param errorMessage The current failure message, or null when there is none.
  * @param label        Accessible name for the notice container.
- * @return Props for the notice wrapper, a submit handler to register, and the notice's `spokenMessage`.
+ * @return Props for the notice wrapper, a submit handler, and the notice's `spokenMessage`.
+ *         Pass the click event to the submit handler: the element it came from is what
+ *         tells the effect whether the reader has since moved on, and without it focus
+ *         is taken unconditionally.
  */
 export function useErrorNoticeFocus( errorMessage: string | null | undefined, label: string ) {
 	const noticeRef = useRef< HTMLDivElement | null >( null );

--- a/plugins/newspack-plugin/src/wizards/hooks/use-fields-validation.ts
+++ b/plugins/newspack-plugin/src/wizards/hooks/use-fields-validation.ts
@@ -60,7 +60,16 @@ type ValidationMap< TData, TConfig > = [
 export function useFieldsValidation< TData, TConfig = Record< string, unknown > >( config: ValidationMap< TData, TConfig >, data: TData ) {
 	const [ errorMessage, setErrorMessage ] = useState< WizardError | null >( null );
 	return {
-		isInputsValid() {
+		/**
+		 * Validates every configured field.
+		 *
+		 * Returns the message rather than a boolean so a caller running several
+		 * validators can gather what each one said: `errorMessage` below is state,
+		 * so it still holds the previous render's value at this point.
+		 *
+		 * @return The first failing field's message, or an empty string when valid.
+		 */
+		validateInputs() {
 			for ( const [ key, callback, options ] of config ) {
 				const inputValue = data[ key ] as string;
 				const isFieldValid = ( typeof callback === 'string' ? knownValidationCallbacks[ callback ] : callback )(
@@ -69,11 +78,11 @@ export function useFieldsValidation< TData, TConfig = Record< string, unknown > 
 				);
 				if ( '' !== isFieldValid ) {
 					setErrorMessage( new WizardError( isFieldValid, `invalid_field_${ key.toString() }` ) );
-					return false;
+					return isFieldValid;
 				}
 			}
 			setErrorMessage( null );
-			return true;
+			return '';
 		},
 		errorMessage: errorMessage instanceof WizardError ? errorMessage.message : '',
 	};

--- a/plugins/newspack-plugin/src/wizards/hooks/use-fields-validation.ts
+++ b/plugins/newspack-plugin/src/wizards/hooks/use-fields-validation.ts
@@ -63,9 +63,8 @@ export function useFieldsValidation< TData, TConfig = Record< string, unknown > 
 		/**
 		 * Validates every configured field.
 		 *
-		 * Returns the message rather than a boolean so a caller running several
-		 * validators can gather what each one said: `errorMessage` below is state,
-		 * so it still holds the previous render's value at this point.
+		 * Returns the message rather than a boolean because `errorMessage` below is state,
+		 * so a caller running several validators cannot read them back this render.
 		 *
 		 * @return The first failing field's message, or an empty string when valid.
 		 */

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brand-upsert.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brand-upsert.tsx
@@ -27,6 +27,8 @@ import {
 	hooks,
 } from '../../../../../../packages/components/src';
 
+import { useErrorNoticeFocus } from '../../../../hooks/use-error-notice-focus';
+
 import './style.scss';
 import { TAB_PATH } from './constants';
 
@@ -54,6 +56,12 @@ export default function Brand( {
 } ) {
 	const { brandId = '0' } = useParams();
 	const selectedBrand = brands.find( ( { id } ) => id === Number( brandId ) );
+
+	const {
+		wrapperProps: noticeWrapperProps,
+		registerSubmit,
+		spokenMessage,
+	} = useErrorNoticeFocus( errorMessage, __( 'Brand error', 'newspack-plugin' ) );
 
 	const [ brand, updateBrand ] = hooks.useObjectState< Brand >( {
 		id: 0,
@@ -176,9 +184,11 @@ export default function Brand( {
 	return (
 		<Fragment>
 			{ errorMessage && (
-				<Notice status="error" isDismissible={ false } politeness="polite" className="newspack-brand__notice">
-					{ errorMessage }
-				</Notice>
+				<div { ...noticeWrapperProps } className="newspack-brand__notice">
+					<Notice status="error" isDismissible={ false } politeness="polite" spokenMessage={ spokenMessage }>
+						{ errorMessage }
+					</Notice>
+				</div>
 			) }
 			<SectionHeader title={ __( 'Brand', 'newspack-plugin' ) } description={ __( 'Set your brand identity', 'newspack-plugin' ) } />
 			<Grid gutter={ 32 }>
@@ -334,7 +344,14 @@ export default function Brand( {
 				) ) }
 			{ /* Action Buttons */ }
 			<div className="newspack-buttons-card">
-				<Button disabled={ ! isBrandValid } variant="primary" onClick={ () => upsertBrand( Number( brandId ), brand ) }>
+				<Button
+					disabled={ ! isBrandValid }
+					variant="primary"
+					onClick={ ( event?: React.MouseEvent< HTMLElement > ) => {
+						registerSubmit( event );
+						upsertBrand( Number( brandId ), brand );
+					} }
+				>
 					{ __( 'Save', 'newspack-plugin' ) }
 				</Button>
 				<Button variant="secondary" href={ `#${ TAB_PATH }` }>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brand-upsert.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brand-upsert.tsx
@@ -176,7 +176,7 @@ export default function Brand( {
 	return (
 		<Fragment>
 			{ errorMessage && (
-				<Notice status="error" isDismissible={ false } className="newspack-brand__notice">
+				<Notice status="error" isDismissible={ false } politeness="polite" className="newspack-brand__notice">
 					{ errorMessage }
 				</Notice>
 			) }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brand-upsert.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brand-upsert.tsx
@@ -8,6 +8,7 @@
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs, cleanForSlug } from '@wordpress/url';
 import { Fragment, useState, useEffect } from '@wordpress/element';
+import { Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies.
@@ -24,7 +25,6 @@ import {
 	SelectControl,
 	RadioControl,
 	hooks,
-	Notice,
 } from '../../../../../../packages/components/src';
 
 import './style.scss';
@@ -175,6 +175,11 @@ export default function Brand( {
 
 	return (
 		<Fragment>
+			{ errorMessage && (
+				<Notice status="error" isDismissible={ false } className="newspack-additional-brands__notice">
+					{ errorMessage }
+				</Notice>
+			) }
 			<SectionHeader title={ __( 'Brand', 'newspack-plugin' ) } description={ __( 'Set your brand identity', 'newspack-plugin' ) } />
 			<Grid gutter={ 32 }>
 				<Grid columns={ 1 } gutter={ 16 }>
@@ -327,7 +332,6 @@ export default function Brand( {
 						onChange={ ( menuId: number ) => updateMenus( location, menuId ) }
 					/>
 				) ) }
-			{ errorMessage && <Notice isError>{ errorMessage }</Notice> }
 			{ /* Action Buttons */ }
 			<div className="newspack-buttons-card">
 				<Button disabled={ ! isBrandValid } variant="primary" onClick={ () => upsertBrand( Number( brandId ), brand ) }>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brand-upsert.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/brand-upsert.tsx
@@ -176,7 +176,7 @@ export default function Brand( {
 	return (
 		<Fragment>
 			{ errorMessage && (
-				<Notice status="error" isDismissible={ false } className="newspack-additional-brands__notice">
+				<Notice status="error" isDismissible={ false } className="newspack-brand__notice">
 					{ errorMessage }
 				</Notice>
 			) }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/index.tsx
@@ -75,8 +75,8 @@ export default function AdditionalBrands() {
 	};
 
 	const upsertBrand = ( brandId: number, brand: Brand ) => {
-		// A repeat of the same failure produces an identical message, and core's Notice
-		// only announces when that string changes. Clearing first restores the transition.
+		// Core's Notice announces only when the message changes, so a repeat of the same
+		// failure needs the clear to be heard at all.
 		resetError();
 		// BrandId is NaN when inserting new brand.
 		wizardApiFetch< Brand >(

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/index.tsx
@@ -175,6 +175,7 @@ export default function AdditionalBrands() {
 								upsertBrand={ upsertBrand }
 								fetchLogoAttachment={ fetchLogoAttachment }
 								wizardApiFetch={ wizardApiFetch }
+								errorMessage={ errorMessage }
 							/>
 						) }
 					/>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/index.tsx
@@ -75,6 +75,9 @@ export default function AdditionalBrands() {
 	};
 
 	const upsertBrand = ( brandId: number, brand: Brand ) => {
+		// A repeat of the same failure produces an identical message, and core's Notice
+		// only announces when that string changes. Clearing first restores the transition.
+		resetError();
 		// BrandId is NaN when inserting new brand.
 		wizardApiFetch< Brand >(
 			{

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/index.tsx
@@ -75,8 +75,8 @@ export default function AdditionalBrands() {
 	};
 
 	const upsertBrand = ( brandId: number, brand: Brand ) => {
-		// Core's Notice announces only when the message changes, so a repeat of the same
-		// failure needs the clear to be heard at all.
+		// The fetch hook leaves the error in place on success, so a retry that works would
+		// otherwise keep the failed attempt's notice on screen.
 		resetError();
 		// BrandId is NaN when inserting new brand.
 		wizardApiFetch< Brand >(

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/style.scss
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/additional-brands/style.scss
@@ -1,3 +1,9 @@
+@use "~@wordpress/base-styles/variables" as wp-vars;
+
+.newspack-brand__notice {
+	margin-bottom: wp-vars.$grid-unit-40;
+}
+
 .newspack-brand {
 	&__header {
 		&__logo {

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
@@ -10,6 +10,10 @@ import { useEffect, useState } from '@wordpress/element';
 import { ExternalLink, Notice } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
 import { speak } from '@wordpress/a11y';
+
+/**
+ * Internal dependencies.
+ */
 import { Button, Card, SectionHeader } from '../../../../../../packages/components/src';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
 
@@ -74,6 +78,9 @@ export default function AccessibilityStatement( { isFetching }: AccessibilitySta
 	}, [] );
 
 	const createPage = () => {
+		// A repeat of the same failure produces an identical message, and core's Notice
+		// only announces when that string changes. Clearing first restores the transition.
+		resetError();
 		setLocalIsFetching( true );
 		wizardApiFetch< PageResponse >(
 			{

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
@@ -7,10 +7,10 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink, Notice } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { speak } from '@wordpress/a11y';
-import { decodeEntities } from '@wordpress/html-entities';
-import { Button, Card, Notice, SectionHeader } from '../../../../../../packages/components/src';
+import { Button, Card, SectionHeader } from '../../../../../../packages/components/src';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
 
 interface AccessibilityStatementProps {
@@ -56,13 +56,10 @@ export default function AccessibilityStatement( { isFetching }: AccessibilitySta
 		}
 	};
 
-	const handleError = ( error: { message?: string } ) => {
+	const handleError = () => {
 		setLocalPageData( null );
 		setIsPageMissing( false );
 		setLocalIsFetching( false );
-		// The notice is a plain div, so nothing else announces the failure. It
-		// renders the message decoded, so announce the decoded text too.
-		speak( decodeEntities( error?.message ?? __( 'Something went wrong.', 'newspack-plugin' ) ), 'assertive' );
 	};
 
 	useEffect( () => {
@@ -93,7 +90,7 @@ export default function AccessibilityStatement( { isFetching }: AccessibilitySta
 		).catch( () => {} );
 	};
 
-	const getStatusMessage = () => {
+	const getStatusMessage = (): { type: 'error' | 'warning' | 'success'; message: string } => {
 		if ( errorMessage ) {
 			return { type: 'error', message: errorMessage };
 		}
@@ -161,7 +158,7 @@ export default function AccessibilityStatement( { isFetching }: AccessibilitySta
 	const statusInfo = getStatusMessage();
 
 	return (
-		<>
+		<Stack className="newspack-accessibility-statement" direction="column" gap="xl">
 			<Card noBorder headerActions>
 				<SectionHeader
 					title={ __( 'Accessibility Statement Page', 'newspack-plugin' ) }
@@ -174,37 +171,38 @@ export default function AccessibilityStatement( { isFetching }: AccessibilitySta
 				{ renderAction() }
 			</Card>
 
-			<Notice
-				isError={ statusInfo.type === 'error' }
-				isSuccess={ statusInfo.type === 'success' }
-				isWarning={ statusInfo.type === 'warning' }
-				noticeText={ statusInfo.message }
-			/>
+			<Notice status={ statusInfo.type } isDismissible={ false } spokenMessage={ statusInfo.type === 'error' ? statusInfo.message : '' }>
+				{ statusInfo.message }
+			</Notice>
 
-			<p>
-				{ __(
-					'An accessibility statement helps your readers understand how your site supports accessibility standards and what to do if they encounter accessibility issues. ',
-					'newspack-plugin'
-				) }
-				<ExternalLink href="https://www.w3.org/WAI/planning/statements/">
-					{ __( 'What makes a good accessibility statement.', 'newspack-plugin' ) }{ ' ' }
-				</ExternalLink>
-			</p>
+			<Stack className="newspack-accessibility-statement__prose" direction="column" gap="lg">
+				<p>
+					{ __(
+						'An accessibility statement helps your readers understand how your site supports accessibility standards and what to do if they encounter accessibility issues. ',
+						'newspack-plugin'
+					) }
+					<ExternalLink href="https://www.w3.org/WAI/planning/statements/">
+						{ __( 'What makes a good accessibility statement.', 'newspack-plugin' ) }{ ' ' }
+					</ExternalLink>
+				</p>
 
-			<p>
-				{ __( 'The page you create here will include a boilerplate accessibility statement. ', 'newspack-plugin' ) }
-				<strong>{ __( 'Please review and make edits to ensure it meets the requirements before publishing. ', 'newspack-plugin' ) }</strong>
-				{ __( 'You can also use the W3C Accessibility Statement Generator to create a custom statement. ', 'newspack-plugin' ) }
-				<ExternalLink href="https://www.w3.org/WAI/planning/statements/generator/#create">
-					{ __( 'Try out the Accessibility Statement Generator.', 'newspack-plugin' ) }{ ' ' }
-				</ExternalLink>
-			</p>
+				<p>
+					{ __( 'The page you create here will include a boilerplate accessibility statement. ', 'newspack-plugin' ) }
+					<strong>
+						{ __( 'Please review and make edits to ensure it meets the requirements before publishing. ', 'newspack-plugin' ) }
+					</strong>
+					{ __( 'You can also use the W3C Accessibility Statement Generator to create a custom statement. ', 'newspack-plugin' ) }
+					<ExternalLink href="https://www.w3.org/WAI/planning/statements/generator/#create">
+						{ __( 'Try out the Accessibility Statement Generator.', 'newspack-plugin' ) }{ ' ' }
+					</ExternalLink>
+				</p>
 
-			<p>
-				<ExternalLink href="https://help.newspack.com/revenue/reader-revenue/how-to-add-an-accessibility-statement/">
-					{ __( 'Learn more about this feature in our documentation.', 'newspack-plugin' ) }{ ' ' }
-				</ExternalLink>
-			</p>
-		</>
+				<p>
+					<ExternalLink href="https://help.newspack.com/revenue/reader-revenue/how-to-add-an-accessibility-statement/">
+						{ __( 'Learn more about this feature in our documentation.', 'newspack-plugin' ) }{ ' ' }
+					</ExternalLink>
+				</p>
+			</Stack>
+		</Stack>
 	);
 }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
@@ -78,8 +78,8 @@ export default function AccessibilityStatement( { isFetching }: AccessibilitySta
 	}, [] );
 
 	const createPage = () => {
-		// A repeat of the same failure produces an identical message, and core's Notice
-		// only announces when that string changes. Clearing first restores the transition.
+		// Core's Notice announces only when the message changes, so a repeat of the same
+		// failure needs the clear to be heard at all.
 		resetError();
 		setLocalIsFetching( true );
 		wizardApiFetch< PageResponse >(

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
@@ -178,7 +178,12 @@ export default function AccessibilityStatement( { isFetching }: AccessibilitySta
 				{ renderAction() }
 			</Card>
 
-			<Notice status={ statusInfo.type } isDismissible={ false } spokenMessage={ statusInfo.type === 'error' ? statusInfo.message : '' }>
+			<Notice
+				status={ statusInfo.type }
+				isDismissible={ false }
+				politeness="polite"
+				spokenMessage={ statusInfo.type === 'error' ? statusInfo.message : '' }
+			>
 				{ statusInfo.message }
 			</Notice>
 

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/featured-image-posts-all.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/featured-image-posts-all.tsx
@@ -18,7 +18,7 @@ export default function FeaturedImagePostsAll( { data, update, postCount }: Them
 	return (
 		<Fragment>
 			{ Number( postCount ) > 1000 && (
-				<Notice isDismissible={ false } status="warning" className="newspack-notice--spaced-bottom">
+				<Notice isDismissible={ false } status="warning" spokenMessage="" className="newspack-notice--spaced-bottom">
 					{ __( 'You have more than 1000 posts. Applying these settings might take a moment.', 'newspack-plugin' ) }
 				</Notice>
 			) }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/index.tsx
@@ -6,7 +6,7 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { Notice } from '@wordpress/components';
 
 /**
@@ -59,8 +59,12 @@ export default function AdvancedSettings() {
 		resetError: resetPrimaryCategoryError,
 	} = useWizardApiFetch( 'newspack-settings/primary-category' );
 
-	// Save writes through three namespaces, any of which can fail on its own.
+	// This tab reads and writes through three namespaces, so a failure in any of them,
+	// on load or on save, has to reach the one notice at the top.
 	const saveErrorMessage = errorMessage || recirculationErrorMessage || primaryCategoryErrorMessage;
+
+	const noticeRef = useRef< HTMLDivElement | null >( null );
+	const [ saveAttempt, setSaveAttempt ] = useState( 0 );
 
 	const [ primaryCategoryData, setPrimaryCategoryData ] = hooks.useObjectState< PrimaryCategoryData >( {
 		enabled: true,
@@ -115,15 +119,19 @@ export default function AdvancedSettings() {
 		);
 	}, [] );
 
-	// The Save button sits at the foot of a long page, so a failure reported at the
-	// top would otherwise land off-screen.
+	// The Save button sits at the foot of a long page, so a failure reported at the top
+	// would otherwise land off-screen. Focus follows the scroll, or the next key press
+	// would send the viewport straight back down to the button the user left it on.
 	useEffect( () => {
-		if ( saveErrorMessage ) {
-			window.scrollTo( { top: 0, behavior: window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches ? 'auto' : 'smooth' } );
+		if ( ! saveErrorMessage || ! saveAttempt ) {
+			return;
 		}
-	}, [ saveErrorMessage ] );
+		window.scrollTo( { top: 0, behavior: window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches ? 'auto' : 'smooth' } );
+		noticeRef.current?.focus();
+	}, [ saveErrorMessage, saveAttempt ] );
 
 	function save() {
+		setSaveAttempt( attempt => attempt + 1 );
 		// A repeat of the same failure produces an identical message, and both the notice's
 		// announcement and the scroll above key on that string changing.
 		resetError();
@@ -190,9 +198,18 @@ export default function AdvancedSettings() {
 			isFetching={ isFetching || isFetchingRecirculation || isFetchingPrimaryCategory }
 		>
 			{ saveErrorMessage && (
-				<Notice status="error" isDismissible={ false } className="newspack-advanced-settings__notice">
-					{ saveErrorMessage }
-				</Notice>
+				<div ref={ noticeRef } tabIndex={ -1 } className="newspack-advanced-settings__notice">
+					<Notice
+						status="error"
+						isDismissible={ false }
+						politeness="polite"
+						// After a save the notice takes focus, which reads it out; letting it
+						// also speak would say the same thing twice.
+						spokenMessage={ saveAttempt ? '' : saveErrorMessage }
+					>
+						{ saveErrorMessage }
+					</Notice>
+				</div>
 			) }
 			<WizardSection title={ __( 'Recirculation', 'newspack-plugin' ) }>
 				<Recirculation isFetching={ isFetchingRecirculation } update={ setRecirculationData } data={ recirculationData } />

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/index.tsx
@@ -109,7 +109,7 @@ export default function AdvancedSettings() {
 	// top would otherwise land off-screen.
 	useEffect( () => {
 		if ( errorMessage ) {
-			window.scrollTo( { top: 0, behavior: 'smooth' } );
+			window.scrollTo( { top: 0, behavior: window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches ? 'auto' : 'smooth' } );
 		}
 	}, [ errorMessage ] );
 

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/index.tsx
@@ -6,7 +6,7 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import { Notice } from '@wordpress/components';
 
 /**
@@ -17,6 +17,7 @@ import WizardsTab from '../../../../wizards-tab';
 import WizardSection from '../../../../wizards-section';
 import { Button, Grid, hooks, ImageUpload, utils } from '../../../../../../packages/components/src';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
+import { useErrorNoticeFocus } from '../../../../hooks/use-error-notice-focus';
 import Recirculation from './recirculation';
 import AuthorBio from './author-bio';
 import FeaturedImagePostsAll from './featured-image-posts-all';
@@ -59,12 +60,13 @@ export default function AdvancedSettings() {
 		resetError: resetPrimaryCategoryError,
 	} = useWizardApiFetch( 'newspack-settings/primary-category' );
 
-	// This tab reads and writes through three namespaces, so a failure in any of them,
-	// on load or on save, has to reach the one notice at the top.
 	const saveErrorMessage = errorMessage || recirculationErrorMessage || primaryCategoryErrorMessage;
 
-	const noticeRef = useRef< HTMLDivElement | null >( null );
-	const [ saveAttempt, setSaveAttempt ] = useState( 0 );
+	const {
+		wrapperProps: noticeWrapperProps,
+		registerSubmit,
+		spokenMessage,
+	} = useErrorNoticeFocus( saveErrorMessage, __( 'Advanced Settings error', 'newspack-plugin' ) );
 
 	const [ primaryCategoryData, setPrimaryCategoryData ] = hooks.useObjectState< PrimaryCategoryData >( {
 		enabled: true,
@@ -119,21 +121,10 @@ export default function AdvancedSettings() {
 		);
 	}, [] );
 
-	// The Save button sits at the foot of a long page, so a failure reported at the top
-	// would otherwise land off-screen. Focus follows the scroll, or the next key press
-	// would send the viewport straight back down to the button the user left it on.
-	useEffect( () => {
-		if ( ! saveErrorMessage || ! saveAttempt ) {
-			return;
-		}
-		window.scrollTo( { top: 0, behavior: window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches ? 'auto' : 'smooth' } );
-		noticeRef.current?.focus();
-	}, [ saveErrorMessage, saveAttempt ] );
-
-	function save() {
-		setSaveAttempt( attempt => attempt + 1 );
-		// A repeat of the same failure produces an identical message, and both the notice's
-		// announcement and the scroll above key on that string changing.
+	function save( event?: { currentTarget: Element | null } ) {
+		registerSubmit( event );
+		// The fetch hook leaves the error in place on success, so a retry that works would
+		// otherwise keep the failed attempt's notice on screen.
 		resetError();
 		resetRecirculationError();
 		resetPrimaryCategoryError();
@@ -198,15 +189,8 @@ export default function AdvancedSettings() {
 			isFetching={ isFetching || isFetchingRecirculation || isFetchingPrimaryCategory }
 		>
 			{ saveErrorMessage && (
-				<div ref={ noticeRef } tabIndex={ -1 } className="newspack-advanced-settings__notice">
-					<Notice
-						status="error"
-						isDismissible={ false }
-						politeness="polite"
-						// After a save the notice takes focus, which reads it out; letting it
-						// also speak would say the same thing twice.
-						spokenMessage={ saveAttempt ? '' : saveErrorMessage }
-					>
+				<div { ...noticeWrapperProps } className="newspack-advanced-settings__notice">
+					<Notice status="error" isDismissible={ false } politeness="polite" spokenMessage={ spokenMessage }>
 						{ saveErrorMessage }
 					</Notice>
 				</div>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/index.tsx
@@ -7,6 +7,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
+import { Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies.
@@ -14,7 +15,7 @@ import { useEffect } from '@wordpress/element';
 import { ADVANCED_SETTINGS_DEFAULTS } from '../constants';
 import WizardsTab from '../../../../wizards-tab';
 import WizardSection from '../../../../wizards-section';
-import { Button, Grid, hooks, ImageUpload, Notice, utils } from '../../../../../../packages/components/src';
+import { Button, Grid, hooks, ImageUpload, utils } from '../../../../../../packages/components/src';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
 import Recirculation from './recirculation';
 import AuthorBio from './author-bio';
@@ -104,6 +105,14 @@ export default function AdvancedSettings() {
 		);
 	}, [] );
 
+	// The Save button sits at the foot of a long page, so a failure reported at the
+	// top would otherwise land off-screen.
+	useEffect( () => {
+		if ( errorMessage ) {
+			window.scrollTo( { top: 0, behavior: 'smooth' } );
+		}
+	}, [ errorMessage ] );
+
 	function save() {
 		wizardApiFetchRecirculation(
 			{
@@ -165,6 +174,11 @@ export default function AdvancedSettings() {
 			title={ __( 'Advanced Settings', 'newspack-plugin' ) }
 			isFetching={ isFetching || isFetchingRecirculation || isFetchingPrimaryCategory }
 		>
+			{ errorMessage && (
+				<Notice status="error" isDismissible={ false } className="newspack-advanced-settings__notice">
+					{ errorMessage }
+				</Notice>
+			) }
 			<WizardSection title={ __( 'Recirculation', 'newspack-plugin' ) }>
 				<Recirculation isFetching={ isFetchingRecirculation } update={ setRecirculationData } data={ recirculationData } />
 			</WizardSection>
@@ -232,7 +246,6 @@ export default function AdvancedSettings() {
 					<PrivateTags data={ data } update={ setData } isFetching={ isFetching } />
 				</WizardSection>
 			) : null }
-			{ errorMessage && <Notice /> }
 			<div className="newspack-buttons-card">
 				<Button variant="primary" onClick={ save }>
 					{ __( 'Save', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/index.tsx
@@ -45,12 +45,22 @@ export default function AdvancedSettings() {
 		relatedPostsUpdated: false,
 	} );
 
-	const { wizardApiFetch, isFetching, errorMessage } = useWizardApiFetch( 'newspack-settings/theme-mods' );
-	const { wizardApiFetch: wizardApiFetchRecirculation, isFetching: isFetchingRecirculation } = useWizardApiFetch(
-		'newspack-settings/advanced-settings/recirculation'
-	);
-	const { wizardApiFetch: wizardApiFetchPrimaryCategory, isFetching: isFetchingPrimaryCategory } =
-		useWizardApiFetch( 'newspack-settings/primary-category' );
+	const { wizardApiFetch, isFetching, errorMessage, resetError } = useWizardApiFetch( 'newspack-settings/theme-mods' );
+	const {
+		wizardApiFetch: wizardApiFetchRecirculation,
+		isFetching: isFetchingRecirculation,
+		errorMessage: recirculationErrorMessage,
+		resetError: resetRecirculationError,
+	} = useWizardApiFetch( 'newspack-settings/advanced-settings/recirculation' );
+	const {
+		wizardApiFetch: wizardApiFetchPrimaryCategory,
+		isFetching: isFetchingPrimaryCategory,
+		errorMessage: primaryCategoryErrorMessage,
+		resetError: resetPrimaryCategoryError,
+	} = useWizardApiFetch( 'newspack-settings/primary-category' );
+
+	// Save writes through three namespaces, any of which can fail on its own.
+	const saveErrorMessage = errorMessage || recirculationErrorMessage || primaryCategoryErrorMessage;
 
 	const [ primaryCategoryData, setPrimaryCategoryData ] = hooks.useObjectState< PrimaryCategoryData >( {
 		enabled: true,
@@ -108,12 +118,17 @@ export default function AdvancedSettings() {
 	// The Save button sits at the foot of a long page, so a failure reported at the
 	// top would otherwise land off-screen.
 	useEffect( () => {
-		if ( errorMessage ) {
+		if ( saveErrorMessage ) {
 			window.scrollTo( { top: 0, behavior: window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches ? 'auto' : 'smooth' } );
 		}
-	}, [ errorMessage ] );
+	}, [ saveErrorMessage ] );
 
 	function save() {
+		// A repeat of the same failure produces an identical message, and both the notice's
+		// announcement and the scroll above key on that string changing.
+		resetError();
+		resetRecirculationError();
+		resetPrimaryCategoryError();
 		wizardApiFetchRecirculation(
 			{
 				path: '/newspack/v1/wizard/newspack-settings/related-posts-max-age',
@@ -174,9 +189,9 @@ export default function AdvancedSettings() {
 			title={ __( 'Advanced Settings', 'newspack-plugin' ) }
 			isFetching={ isFetching || isFetchingRecirculation || isFetchingPrimaryCategory }
 		>
-			{ errorMessage && (
+			{ saveErrorMessage && (
 				<Notice status="error" isDismissible={ false } className="newspack-advanced-settings__notice">
-					{ errorMessage }
+					{ saveErrorMessage }
 				</Notice>
 			) }
 			<WizardSection title={ __( 'Recirculation', 'newspack-plugin' ) }>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/pwa-display-mode.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/advanced-settings/pwa-display-mode.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
-import { SelectControl } from '@wordpress/components';
+import { Notice, SelectControl } from '@wordpress/components';
 
-import { Grid, Notice } from '../../../../../../packages/components/src';
+import { Grid } from '../../../../../../packages/components/src';
 
 interface PwaDisplayModeProps extends ThemeModComponentProps< AdvancedSettings > {}
 
@@ -39,13 +39,12 @@ export default function PwaDisplayMode( { data, isFetching, update }: PwaDisplay
 					onChange={ ( pwa_display_mode: string ) => update( { pwa_display_mode } ) }
 					disabled={ isFetching }
 				/>
-				<Notice
-					noticeText={ __(
+				<Notice status="info" isDismissible={ false } spokenMessage="">
+					{ __(
 						'This setting controls how your site appears when users install it as a Progressive Web App on their devices.',
 						'newspack-plugin'
 					) }
-					isInfo
-				/>
+				</Notice>
 			</Grid>
 		</Grid>
 	);

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/custom-events.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/custom-events.tsx
@@ -7,14 +7,15 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
-import { __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { Notice, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
  */
 import { WizardError } from '../../../../errors';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
-import { Button, Grid, Notice, TextControl, utils } from '../../../../../../packages/components/src';
+import { Button, Grid, TextControl, utils } from '../../../../../../packages/components/src';
 import { ERROR_MESSAGES } from './constants';
 
 /**
@@ -102,7 +103,7 @@ function CustomEvents() {
 	}
 
 	return (
-		<div className="newspack__analytics-configuration">
+		<Stack className="newspack__analytics-configuration" direction="column" gap="xl">
 			<div className="newspack__analytics-configuration__header">
 				<p>
 					{ __(
@@ -134,7 +135,11 @@ function CustomEvents() {
 					autoComplete="one-time-code"
 				/>
 			</Grid>
-			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
+			{ errorMessage && (
+				<Notice status="error" isDismissible={ false }>
+					{ errorMessage }
+				</Notice>
+			) }
 			<HStack justify="flex-start" spacing={ 2 }>
 				<Button variant="primary" onClick={ updateGa4Credentials } disabled={ isInputsEmpty() || !! errorMessage }>
 					{ __( 'Save', 'newspack-plugin' ) }
@@ -143,7 +148,7 @@ function CustomEvents() {
 					{ __( 'Reset', 'newspack-plugin' ) }
 				</Button>
 			</HStack>
-		</div>
+		</Stack>
 	);
 }
 

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/custom-events.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/custom-events.tsx
@@ -7,7 +7,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
-import { Notice, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { Notice } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
 
 /**
@@ -140,14 +140,14 @@ function CustomEvents() {
 					{ errorMessage }
 				</Notice>
 			) }
-			<HStack justify="flex-start" spacing={ 2 }>
+			<Stack direction="row" justify="flex-start" gap="sm">
 				<Button variant="primary" onClick={ updateGa4Credentials } disabled={ isInputsEmpty() || !! errorMessage }>
 					{ __( 'Save', 'newspack-plugin' ) }
 				</Button>
 				<Button variant="secondary" onClick={ resetGa4Credentials } disabled={ isInputsEmpty() }>
 					{ __( 'Reset', 'newspack-plugin' ) }
 				</Button>
-			</HStack>
+			</Stack>
 		</Stack>
 	);
 }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/custom-events.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/custom-events.tsx
@@ -136,7 +136,7 @@ function CustomEvents() {
 				/>
 			</Grid>
 			{ errorMessage && (
-				<Notice status="error" isDismissible={ false }>
+				<Notice status="error" isDismissible={ false } politeness="polite">
 					{ errorMessage }
 				</Notice>
 			) }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/jetpack-sso.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/jetpack-sso.tsx
@@ -2,14 +2,15 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { BaseControl, CheckboxControl, ExternalLink } from '@wordpress/components';
+import { BaseControl, CheckboxControl, ExternalLink, Notice } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 import { useEffect, useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
-import { ActionCard, Button, Grid, Notice, SelectControl } from '../../../../../../packages/components/src';
+import { ActionCard, Button, SelectControl } from '../../../../../../packages/components/src';
 
 const isValidError = ( e: unknown ): e is WpRestApiError => {
 	return e instanceof Error && 'message' in e;
@@ -84,11 +85,15 @@ const JetpackSSO = () => {
 				disabled={ isLoading }
 			>
 				{ settings.force_2fa && (
-					<>
-						{ error && <Notice isError noticeText={ error } /> }
+					<Stack className="newspack-jetpack-sso__settings" direction="column" gap="xl">
+						{ error && (
+							<Notice status="error" isDismissible={ false }>
+								{ error }
+							</Notice>
+						) }
 						{ settings.jetpack_sso_force_2fa && (
 							<>
-								<Notice isWarning>
+								<Notice status="warning" isDismissible={ false } spokenMessage="">
 									{ __(
 										'Two-factor authentication is currently enforced for all users via Jetpack configuration.',
 										'newspack-plugin'
@@ -105,34 +110,30 @@ const JetpackSSO = () => {
 								</p>
 							</>
 						) }
-						<Grid columns={ 1 }>
-							<BaseControl
-								id="force-2fa-cap"
-								label={ __( 'Select the user capability to enforce two-factor authentication', 'newspack-plugin' ) }
-							>
-								<SelectControl
-									label={ __( 'Capability', 'newspack-plugin' ) }
-									hideLabelFromVision
-									value={ settingsToUpdate?.force_2fa_cap || '' }
-									onChange={ ( value: JetpackSSOCaps ) => setSettingsToUpdate( { ...settingsToUpdate, force_2fa_cap: value } ) }
-									options={ Object.keys( settings.available_caps || {} ).map( ( cap: string ) => ( {
-										label: getCapLabel( cap as JetpackSSOCaps ),
-										value: cap,
-									} ) ) }
-								/>
-							</BaseControl>
-						</Grid>
-						<Grid columns={ 1 }>
-							<CheckboxControl
-								checked={ settingsToUpdate?.obfuscate_account || false }
-								onChange={ value => setSettingsToUpdate( { ...settingsToUpdate, obfuscate_account: value } ) }
-								label={ __(
-									'Obfuscate restricted accounts by throwing WP’s “user not found” errors on login form attempts.',
-									'newspack-plugin'
-								) }
+						<BaseControl
+							id="force-2fa-cap"
+							label={ __( 'Select the user capability to enforce two-factor authentication', 'newspack-plugin' ) }
+						>
+							<SelectControl
+								label={ __( 'Capability', 'newspack-plugin' ) }
+								hideLabelFromVision
+								value={ settingsToUpdate?.force_2fa_cap || '' }
+								onChange={ ( value: JetpackSSOCaps ) => setSettingsToUpdate( { ...settingsToUpdate, force_2fa_cap: value } ) }
+								options={ Object.keys( settings.available_caps || {} ).map( ( cap: string ) => ( {
+									label: getCapLabel( cap as JetpackSSOCaps ),
+									value: cap,
+								} ) ) }
 							/>
-						</Grid>
-					</>
+						</BaseControl>
+						<CheckboxControl
+							checked={ settingsToUpdate?.obfuscate_account || false }
+							onChange={ value => setSettingsToUpdate( { ...settingsToUpdate, obfuscate_account: value } ) }
+							label={ __(
+								'Obfuscate restricted accounts by throwing WP’s “user not found” errors on login form attempts.',
+								'newspack-plugin'
+							) }
+						/>
+					</Stack>
 				) }
 			</ActionCard>
 		</>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/jetpack-sso.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/jetpack-sso.tsx
@@ -84,14 +84,14 @@ const JetpackSSO = () => {
 				}
 				disabled={ isLoading }
 			>
-				{ settings.force_2fa && (
+				{ ( settings.force_2fa || error ) && (
 					<Stack className="newspack-jetpack-sso__settings" direction="column" gap="xl">
 						{ error && (
-							<Notice status="error" isDismissible={ false }>
+							<Notice status="error" isDismissible={ false } politeness="polite">
 								{ error }
 							</Notice>
 						) }
-						{ settings.jetpack_sso_force_2fa && (
+						{ settings.force_2fa && settings.jetpack_sso_force_2fa && (
 							<>
 								<Notice status="warning" isDismissible={ false } spokenMessage="">
 									{ __(
@@ -110,29 +110,33 @@ const JetpackSSO = () => {
 								</p>
 							</>
 						) }
-						<BaseControl
-							id="force-2fa-cap"
-							label={ __( 'Select the user capability to enforce two-factor authentication', 'newspack-plugin' ) }
-						>
-							<SelectControl
-								label={ __( 'Capability', 'newspack-plugin' ) }
-								hideLabelFromVision
-								value={ settingsToUpdate?.force_2fa_cap || '' }
-								onChange={ ( value: JetpackSSOCaps ) => setSettingsToUpdate( { ...settingsToUpdate, force_2fa_cap: value } ) }
-								options={ Object.keys( settings.available_caps || {} ).map( ( cap: string ) => ( {
-									label: getCapLabel( cap as JetpackSSOCaps ),
-									value: cap,
-								} ) ) }
-							/>
-						</BaseControl>
-						<CheckboxControl
-							checked={ settingsToUpdate?.obfuscate_account || false }
-							onChange={ value => setSettingsToUpdate( { ...settingsToUpdate, obfuscate_account: value } ) }
-							label={ __(
-								'Obfuscate restricted accounts by throwing WP’s “user not found” errors on login form attempts.',
-								'newspack-plugin'
-							) }
-						/>
+						{ settings.force_2fa && (
+							<>
+								<BaseControl
+									id="force-2fa-cap"
+									label={ __( 'Select the user capability to enforce two-factor authentication', 'newspack-plugin' ) }
+								>
+									<SelectControl
+										label={ __( 'Capability', 'newspack-plugin' ) }
+										hideLabelFromVision
+										value={ settingsToUpdate?.force_2fa_cap || '' }
+										onChange={ ( value: JetpackSSOCaps ) => setSettingsToUpdate( { ...settingsToUpdate, force_2fa_cap: value } ) }
+										options={ Object.keys( settings.available_caps || {} ).map( ( cap: string ) => ( {
+											label: getCapLabel( cap as JetpackSSOCaps ),
+											value: cap,
+										} ) ) }
+									/>
+								</BaseControl>
+								<CheckboxControl
+									checked={ settingsToUpdate?.obfuscate_account || false }
+									onChange={ value => setSettingsToUpdate( { ...settingsToUpdate, obfuscate_account: value } ) }
+									label={ __(
+										'Obfuscate restricted accounts by throwing WP’s “user not found” errors on login form attempts.',
+										'newspack-plugin'
+									) }
+								/>
+							</>
+						) }
 					</Stack>
 				) }
 			</ActionCard>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/style.scss
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/style.scss
@@ -1,7 +1,21 @@
 @use "sass:color";
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
+.newspack-jetpack-sso__settings {
+	margin-top: 32px;
+
+	> * {
+		margin: 0;
+	}
+}
+
 /** Webhooks */
+.newspack-webhooks__requests-modal {
+	> * {
+		margin: 0;
+	}
+}
+
 .newspack-webhooks {
 	&__header {
 		margin-bottom: 32px;

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/index.tsx
@@ -7,7 +7,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState, Fragment } from '@wordpress/element';
-import { __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { Notice, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
 /**
  * Internal dependencies
@@ -16,7 +16,7 @@ import { API_NAMESPACE } from './constants';
 import EndpointActionsCard from './endpoint-actions-card';
 import EndpointActionsModals from './endpoint-actions-modals';
 import { useWizardApiFetch } from '../../../../../hooks/use-wizard-api-fetch';
-import { Card, Button, Notice, SectionHeader } from '../../../../../../../packages/components/src';
+import { Card, Button, SectionHeader } from '../../../../../../../packages/components/src';
 
 const defaultEndpoint: Endpoint = {
 	url: '',
@@ -100,7 +100,9 @@ function Webhooks() {
 						) ) }
 					</Fragment>
 				) : (
-					<Notice noticeText={ __( 'No endpoints found', 'newspack-plugin' ) } />
+					<Notice status="info" isDismissible={ false } spokenMessage="">
+						{ __( 'No endpoints found', 'newspack-plugin' ) }
+					</Notice>
 				) ) }
 			{ selectedEndpoint && (
 				<EndpointActionsModals

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Validation runs synchronously, so a clear and a set in one handler batch into a
+ * single commit and the message never transitions. Without something else forcing it,
+ * a second submit against the same bad input announces nothing.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { speak } from '@wordpress/a11y';
+
+/**
+ * Internal dependencies
+ */
+import Upsert from './upsert';
+
+jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
+
+const ENDPOINT = { id: 0, url: '', actions: [], disabled: false, label: '' };
+
+// `error` lives on the parent screen, so the modal only sees a message once it comes back down.
+const Harness = () => {
+	const [ error, setError ] = useState< string | null >( null );
+	return (
+		<Upsert
+			endpoint={ ENDPOINT as never }
+			actions={ [ 'reader_registered' ] }
+			errorMessage={ error }
+			inFlight={ false }
+			setError={ setError as never }
+			setAction={ jest.fn() }
+			setEndpoints={ jest.fn() }
+			wizardApiFetch={ jest.fn() as never }
+		/>
+	);
+};
+
+const save = () => fireEvent.click( screen.getByRole( 'button', { name: 'Save' } ) );
+
+// jsdom ships no Element.scrollTo.
+beforeAll( () => {
+	Element.prototype.scrollTo = jest.fn();
+} );
+
+beforeEach( () => jest.clearAllMocks() );
+
+describe( 'submitting the endpoint form with an invalid URL', () => {
+	it( 'announces the same failure again on a second submit', () => {
+		render( <Harness /> );
+
+		save();
+		expect( speak ).toHaveBeenCalledTimes( 1 );
+
+		save();
+		expect( speak ).toHaveBeenCalledTimes( 2 );
+		expect( ( speak as jest.Mock ).mock.calls[ 1 ][ 0 ] ).toEqual( ( speak as jest.Mock ).mock.calls[ 0 ][ 0 ] );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.tsx
@@ -103,7 +103,11 @@ const Upsert = ( {
 
 	useEffect( () => {
 		if ( errorMessage ) {
-			modalRef?.current?.querySelector( '.components-modal__content' )?.scrollTo( { top: 0, left: 0, behavior: 'smooth' } );
+			modalRef?.current?.querySelector( '.components-modal__content' )?.scrollTo( {
+				top: 0,
+				left: 0,
+				behavior: window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches ? 'auto' : 'smooth',
+			} );
 		}
 	}, [ errorMessage ] );
 

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.tsx
@@ -206,14 +206,11 @@ const Upsert = ( {
 											checked={ ( editing.actions && editing.actions.includes( actionKey ) ) || false }
 											onChange={ () => {
 												const currentActions = editing.actions || [];
-												if ( currentActions.includes( actionKey ) ) {
-													currentActions.splice( currentActions.indexOf( actionKey ), 1 );
-												} else {
-													currentActions.push( actionKey );
-												}
 												setEditing( {
 													...editing,
-													actions: currentActions,
+													actions: currentActions.includes( actionKey )
+														? currentActions.filter( action => action !== actionKey )
+														: [ ...currentActions, actionKey ],
 												} );
 											} }
 										/>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.tsx
@@ -39,8 +39,8 @@ const Upsert = ( {
 	wizardApiFetch,
 }: Omit< ModalComponentProps, 'action' > ) => {
 	const [ editing, setEditing ] = useState< Endpoint >( endpoint );
-	// Validation runs synchronously, so re-failing on the same input leaves the message
-	// byte-identical and neither the announcement nor the scroll below would fire again.
+	// Validation is synchronous, so re-failing on the same input leaves the message
+	// byte-identical and nothing keyed on it would fire again.
 	const [ submitAttempt, setSubmitAttempt ] = useState( 0 );
 	// Test request
 	const [ testResponse, setTestResponse ] = useState< {

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.tsx
@@ -7,14 +7,15 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useRef, Fragment } from '@wordpress/element';
-import { CheckboxControl as WpCheckboxControl, TextControl, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { CheckboxControl as WpCheckboxControl, Notice, TextControl, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
  */
 import { ENDPOINTS_CACHE_KEY } from '../constants';
 import { WizardApiError } from '../../../../../../errors';
-import { Button, Notice, Modal, Grid, Divider } from '../../../../../../../../packages/components/src';
+import { Button, Modal, Grid, Divider } from '../../../../../../../../packages/components/src';
 import { validateEndpoint, validateUrl } from '../utils';
 
 /**
@@ -110,101 +111,117 @@ const Upsert = ( {
 		<Fragment>
 			<Modal
 				ref={ modalRef }
-				size="full"
+				size="large"
 				title={ __( 'Webhook Endpoint', 'newspack-plugin' ) }
 				onRequestClose={ () => {
 					setAction( null, endpoint.id );
 				} }
 			>
-				{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
-				{ true === editing.disabled && <Notice noticeText={ __( 'This webhook endpoint is currently disabled.', 'newspack-plugin' ) } /> }
-				{ editing.disabled && editing.disabled_error && (
-					<Notice isError noticeText={ __( 'Request Error: ', 'newspack-plugin' ) + editing.disabled_error } />
-				) }
-				{ testResponse.success && <Notice isSuccess noticeText={ `${ testResponse.message }: ${ testResponse.code }` } /> }
-				<Grid columns={ 1 } gutter={ 16 } noMargin>
-					<TextControl
-						label={ __( 'URL', 'newspack-plugin' ) }
-						help={ __(
-							"The URL to send requests to. It's required for the URL to be under a valid TLS/SSL certificate. You can use the test button below to verify the endpoint response.",
-							'newspack-plugin'
-						) }
-						className="code"
-						value={ editing.url }
-						onChange={ ( value: string ) => setEditing( { ...editing, url: value } ) }
-						disabled={ inFlight }
-					/>
-					<TextControl
-						label={ __( 'Authentication token (optional)', 'newspack-plugin' ) }
-						help={ __(
-							'If your endpoint requires a token authentication, enter it here. It will be sent as a Bearer token in the Authorization header.',
-							'newspack-plugin'
-						) }
-						value={ editing.bearer_token ?? '' }
-						onChange={ ( value: string ) => setEditing( { ...editing, bearer_token: value } ) }
-						disabled={ inFlight }
-					/>
-					<HStack justify="flex-end" spacing={ 4 } wrap>
-						<Button
-							variant="secondary"
-							disabled={ inFlight || ! editing.url }
-							onClick={ () => testEndpoint( editing.url, editing.bearer_token ) }
-						>
-							{ __( 'Send a test request', 'newspack-plugin' ) }
-						</Button>
-					</HStack>
-				</Grid>
-				<Divider alignment="full-width" variant="tertiary" />
-				<TextControl
-					label={ __( 'Label (optional)', 'newspack-plugin' ) }
-					help={ __( 'A label to help you identify this endpoint. It will not be sent to the endpoint.', 'newspack-plugin' ) }
-					value={ editing.label }
-					onChange={ ( value: string ) => setEditing( { ...editing, label: value } ) }
-					disabled={ inFlight }
-				/>
-				<Grid columns={ 1 } gutter={ 16 }>
-					<h3>{ __( 'Actions', 'newspack-plugin' ) }</h3>
-					{ actions.length > 0 && (
-						<Fragment>
-							<p>{ __( 'Select which actions should trigger this endpoint:', 'newspack-plugin' ) }</p>
-							<Grid columns={ 2 } gutter={ 16 }>
-								{ actions.map( ( actionKey, i ) => (
-									<CheckboxControl
-										key={ i }
-										disabled={ inFlight }
-										label={ actionKey }
-										checked={ ( editing.actions && editing.actions.includes( actionKey ) ) || false }
-										onChange={ () => {
-											const currentActions = editing.actions || [];
-											if ( currentActions.includes( actionKey ) ) {
-												currentActions.splice( currentActions.indexOf( actionKey ), 1 );
-											} else {
-												currentActions.push( actionKey );
-											}
-											setEditing( {
-												...editing,
-												actions: currentActions,
-											} );
-										} }
-									/>
-								) ) }
-							</Grid>
-						</Fragment>
+				<Stack direction="column" gap="xl">
+					{ errorMessage && (
+						<Notice status="error" isDismissible={ false }>
+							{ errorMessage }
+						</Notice>
 					) }
-					<HStack justify="flex-end" spacing={ 4 } wrap className="newspack-modal__footer">
-						<Button
-							isPrimary
-							onClick={ () => {
-								if ( null !== editing && 'url' in editing ) {
-									upsertEndpoint( editing );
-								}
-							} }
-							disabled={ inFlight || null === editing }
-						>
-							{ __( 'Save', 'newspack-plugin' ) }
-						</Button>
-					</HStack>
-				</Grid>
+					{ true === editing.disabled && (
+						<Notice status="info" isDismissible={ false } spokenMessage="">
+							{ __( 'This webhook endpoint is currently disabled.', 'newspack-plugin' ) }
+						</Notice>
+					) }
+					{ editing.disabled && editing.disabled_error && (
+						<Notice status="error" isDismissible={ false }>
+							{ __( 'Request Error: ', 'newspack-plugin' ) + editing.disabled_error }
+						</Notice>
+					) }
+					{ testResponse.success && (
+						<Notice status="success" isDismissible={ false }>
+							{ `${ testResponse.message }: ${ testResponse.code }` }
+						</Notice>
+					) }
+					<Grid columns={ 1 } gutter={ 16 } noMargin>
+						<TextControl
+							label={ __( 'URL', 'newspack-plugin' ) }
+							help={ __(
+								"The URL to send requests to. It's required for the URL to be under a valid TLS/SSL certificate. You can use the test button below to verify the endpoint response.",
+								'newspack-plugin'
+							) }
+							className="code"
+							value={ editing.url }
+							onChange={ ( value: string ) => setEditing( { ...editing, url: value } ) }
+							disabled={ inFlight }
+						/>
+						<TextControl
+							label={ __( 'Authentication token (optional)', 'newspack-plugin' ) }
+							help={ __(
+								'If your endpoint requires a token authentication, enter it here. It will be sent as a Bearer token in the Authorization header.',
+								'newspack-plugin'
+							) }
+							value={ editing.bearer_token ?? '' }
+							onChange={ ( value: string ) => setEditing( { ...editing, bearer_token: value } ) }
+							disabled={ inFlight }
+						/>
+						<HStack justify="flex-end" spacing={ 4 } wrap>
+							<Button
+								variant="secondary"
+								disabled={ inFlight || ! editing.url }
+								onClick={ () => testEndpoint( editing.url, editing.bearer_token ) }
+							>
+								{ __( 'Send a test request', 'newspack-plugin' ) }
+							</Button>
+						</HStack>
+					</Grid>
+					<Divider variant="tertiary" marginTop={ 0 } marginBottom={ 0 } />
+					<TextControl
+						label={ __( 'Label (optional)', 'newspack-plugin' ) }
+						help={ __( 'A label to help you identify this endpoint. It will not be sent to the endpoint.', 'newspack-plugin' ) }
+						value={ editing.label }
+						onChange={ ( value: string ) => setEditing( { ...editing, label: value } ) }
+						disabled={ inFlight }
+					/>
+					<Grid columns={ 1 } gutter={ 16 } noMargin>
+						<h3>{ __( 'Actions', 'newspack-plugin' ) }</h3>
+						{ actions.length > 0 && (
+							<Fragment>
+								<p>{ __( 'Select which actions should trigger this endpoint:', 'newspack-plugin' ) }</p>
+								<Grid columns={ 2 } gutter={ 16 }>
+									{ actions.map( ( actionKey, i ) => (
+										<CheckboxControl
+											key={ i }
+											disabled={ inFlight }
+											label={ actionKey }
+											checked={ ( editing.actions && editing.actions.includes( actionKey ) ) || false }
+											onChange={ () => {
+												const currentActions = editing.actions || [];
+												if ( currentActions.includes( actionKey ) ) {
+													currentActions.splice( currentActions.indexOf( actionKey ), 1 );
+												} else {
+													currentActions.push( actionKey );
+												}
+												setEditing( {
+													...editing,
+													actions: currentActions,
+												} );
+											} }
+										/>
+									) ) }
+								</Grid>
+							</Fragment>
+						) }
+						<HStack justify="flex-end" spacing={ 4 } wrap className="newspack-modal__footer">
+							<Button
+								isPrimary
+								onClick={ () => {
+									if ( null !== editing && 'url' in editing ) {
+										upsertEndpoint( editing );
+									}
+								} }
+								disabled={ inFlight || null === editing }
+							>
+								{ __( 'Save', 'newspack-plugin' ) }
+							</Button>
+						</HStack>
+					</Grid>
+				</Stack>
 			</Modal>
 		</Fragment>
 	);

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.tsx
@@ -5,9 +5,9 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect, useRef, Fragment } from '@wordpress/element';
-import { CheckboxControl as WpCheckboxControl, Notice, TextControl, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { CheckboxControl as WpCheckboxControl, Notice, TextControl } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
 
 /**
@@ -55,11 +55,11 @@ const Upsert = ( {
 
 	function upsertEndpoint( endpointToUpsert: Endpoint ) {
 		const errors = validateEndpoint( endpointToUpsert );
+		setError( null );
 		if ( errors.length ) {
 			setError( errors.join( ' ' ) );
 			return;
 		}
-		setError( null );
 		wizardApiFetch< Endpoint[] >(
 			{
 				path: `/newspack/v1/webhooks/endpoints/${ endpointToUpsert.id || '' }`,
@@ -75,6 +75,7 @@ const Upsert = ( {
 
 	function testEndpoint( url: string, bearer_token: string | undefined ) {
 		const urlError = validateUrl( url );
+		setError( null );
 		if ( urlError ) {
 			setError( urlError );
 			return;
@@ -133,8 +134,12 @@ const Upsert = ( {
 						</Notice>
 					) }
 					{ editing.disabled && editing.disabled_error && (
-						<Notice status="error" isDismissible={ false }>
-							{ __( 'Request Error: ', 'newspack-plugin' ) + editing.disabled_error }
+						<Notice status="error" isDismissible={ false } politeness="polite">
+							{ sprintf(
+								// translators: %s is the error returned by the endpoint.
+								__( 'Request error: %s', 'newspack-plugin' ),
+								String( editing.disabled_error )
+							) }
 						</Notice>
 					) }
 					{ testResponse.success && (
@@ -164,7 +169,7 @@ const Upsert = ( {
 							onChange={ ( value: string ) => setEditing( { ...editing, bearer_token: value } ) }
 							disabled={ inFlight }
 						/>
-						<HStack justify="flex-end" spacing={ 4 } wrap>
+						<Stack direction="row" justify="flex-end" gap="lg" wrap="wrap">
 							<Button
 								variant="secondary"
 								disabled={ inFlight || ! editing.url }
@@ -172,7 +177,7 @@ const Upsert = ( {
 							>
 								{ __( 'Send a test request', 'newspack-plugin' ) }
 							</Button>
-						</HStack>
+						</Stack>
 					</Grid>
 					<Divider variant="tertiary" marginTop={ 0 } marginBottom={ 0 } />
 					<TextControl
@@ -211,7 +216,7 @@ const Upsert = ( {
 								</Grid>
 							</Fragment>
 						) }
-						<HStack justify="flex-end" spacing={ 4 } wrap className="newspack-modal__footer">
+						<Stack direction="row" justify="flex-end" gap="lg" wrap="wrap" className="newspack-modal__footer">
 							<Button
 								isPrimary
 								onClick={ () => {
@@ -223,7 +228,7 @@ const Upsert = ( {
 							>
 								{ __( 'Save', 'newspack-plugin' ) }
 							</Button>
-						</HStack>
+						</Stack>
 					</Grid>
 				</Stack>
 			</Modal>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/upsert.tsx
@@ -39,6 +39,9 @@ const Upsert = ( {
 	wizardApiFetch,
 }: Omit< ModalComponentProps, 'action' > ) => {
 	const [ editing, setEditing ] = useState< Endpoint >( endpoint );
+	// Validation runs synchronously, so re-failing on the same input leaves the message
+	// byte-identical and neither the announcement nor the scroll below would fire again.
+	const [ submitAttempt, setSubmitAttempt ] = useState( 0 );
 	// Test request
 	const [ testResponse, setTestResponse ] = useState< {
 		success?: boolean;
@@ -55,11 +58,12 @@ const Upsert = ( {
 
 	function upsertEndpoint( endpointToUpsert: Endpoint ) {
 		const errors = validateEndpoint( endpointToUpsert );
-		setError( null );
+		setSubmitAttempt( attempt => attempt + 1 );
 		if ( errors.length ) {
 			setError( errors.join( ' ' ) );
 			return;
 		}
+		setError( null );
 		wizardApiFetch< Endpoint[] >(
 			{
 				path: `/newspack/v1/webhooks/endpoints/${ endpointToUpsert.id || '' }`,
@@ -75,11 +79,12 @@ const Upsert = ( {
 
 	function testEndpoint( url: string, bearer_token: string | undefined ) {
 		const urlError = validateUrl( url );
-		setError( null );
+		setSubmitAttempt( attempt => attempt + 1 );
 		if ( urlError ) {
 			setError( urlError );
 			return;
 		}
+		setError( null );
 		wizardApiFetch< { success: boolean; code: number; message: string } >(
 			{
 				path: '/newspack/v1/webhooks/endpoints/test',
@@ -110,7 +115,7 @@ const Upsert = ( {
 				behavior: window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches ? 'auto' : 'smooth',
 			} );
 		}
-	}, [ errorMessage ] );
+	}, [ errorMessage, submitAttempt ] );
 
 	return (
 		<Fragment>
@@ -124,7 +129,7 @@ const Upsert = ( {
 			>
 				<Stack direction="column" gap="xl">
 					{ errorMessage && (
-						<Notice status="error" isDismissible={ false }>
+						<Notice key={ submitAttempt } status="error" isDismissible={ false }>
 							{ errorMessage }
 						</Notice>
 					) }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/view.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/view.tsx
@@ -7,7 +7,8 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import { Icon } from '@wordpress/components';
+import { Icon, Notice } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
 
 /**
  * External dependencies
@@ -17,67 +18,71 @@ import moment from 'moment';
 /**
  * Internal dependencies
  */
-import { Notice, Modal } from '../../../../../../../../packages/components/src';
+import { Modal } from '../../../../../../../../packages/components/src';
 import { getEndpointLabel, getRequestStatusIcon, hasEndpointErrors } from '../utils';
 
 const View = ( { endpoint, setAction }: { endpoint: ModalComponentProps[ 'endpoint' ]; setAction: ModalComponentProps[ 'setAction' ] } ) => {
 	return (
 		<Modal title={ __( 'Latest Requests', 'newspack-plugin' ) } onRequestClose={ () => setAction( null, endpoint.id ) }>
-			<p>
-				{ sprintf(
-					// translators: %s is the endpoint title (shortened URL).
-					__( 'Most recent requests for %s', 'newspack-plugin' ),
-					getEndpointLabel( endpoint )
-				) }
-			</p>
-			{ endpoint.requests.length > 0 ? (
-				<table className={ `newspack-webhooks__requests ${ hasEndpointErrors( endpoint ) ? 'has-error' : '' }` }>
-					<tr>
-						<th />
-						<th colSpan={ 2 }>{ __( 'Action', 'newspack-plugin' ) }</th>
-						{ hasEndpointErrors( endpoint ) && <th colSpan={ 2 }>{ __( 'Error', 'newspack-plugin' ) }</th> }
-					</tr>
-					{ endpoint.requests.map( request => (
-						<tr key={ request.id }>
-							<td className={ `status status--${ request.status }` }>
-								<Icon icon={ getRequestStatusIcon( request.status ) } />
-							</td>
-							<td className="action-name">{ request.action_name }</td>
-							<td className="scheduled">
-								{ 'pending' === request.status
-									? sprintf(
-											// translators: %s is a human-readable time difference.
-											__( 'sending in %s', 'newspack-plugin' ),
-											moment( parseInt( request.scheduled ) * 1000 ).fromNow( true )
-									  )
-									: sprintf(
-											// translators: %s is a human-readable time difference.
-											__( 'processed %s', 'newspack-plugin' ),
-											moment( parseInt( request.scheduled ) * 1000 ).fromNow()
-									  ) }
-							</td>
-							{ hasEndpointErrors( endpoint ) && (
-								<Fragment>
-									<td className="error">
-										{ request.errors && request.errors.length > 0 ? request.errors[ request.errors.length - 1 ] : '--' }
-									</td>
-									<td>
-										<span className="error-count">
-											{ sprintf(
-												// translators: %s is the number of errors.
-												__( 'Attempt #%s', 'newspack-plugin' ),
-												String( request.errors.length )
-											) }
-										</span>
-									</td>
-								</Fragment>
-							) }
+			<Stack className="newspack-webhooks__requests-modal" direction="column" gap="xl">
+				<p>
+					{ sprintf(
+						// translators: %s is the endpoint title (shortened URL).
+						__( 'Most recent requests for %s', 'newspack-plugin' ),
+						getEndpointLabel( endpoint )
+					) }
+				</p>
+				{ endpoint.requests.length > 0 ? (
+					<table className={ `newspack-webhooks__requests ${ hasEndpointErrors( endpoint ) ? 'has-error' : '' }` }>
+						<tr>
+							<th />
+							<th colSpan={ 2 }>{ __( 'Action', 'newspack-plugin' ) }</th>
+							{ hasEndpointErrors( endpoint ) && <th colSpan={ 2 }>{ __( 'Error', 'newspack-plugin' ) }</th> }
 						</tr>
-					) ) }
-				</table>
-			) : (
-				<Notice noticeText={ __( "This endpoint hasn't received any requests yet.", 'newspack-plugin' ) } />
-			) }
+						{ endpoint.requests.map( request => (
+							<tr key={ request.id }>
+								<td className={ `status status--${ request.status }` }>
+									<Icon icon={ getRequestStatusIcon( request.status ) } />
+								</td>
+								<td className="action-name">{ request.action_name }</td>
+								<td className="scheduled">
+									{ 'pending' === request.status
+										? sprintf(
+												// translators: %s is a human-readable time difference.
+												__( 'sending in %s', 'newspack-plugin' ),
+												moment( parseInt( request.scheduled ) * 1000 ).fromNow( true )
+										  )
+										: sprintf(
+												// translators: %s is a human-readable time difference.
+												__( 'processed %s', 'newspack-plugin' ),
+												moment( parseInt( request.scheduled ) * 1000 ).fromNow()
+										  ) }
+								</td>
+								{ hasEndpointErrors( endpoint ) && (
+									<Fragment>
+										<td className="error">
+											{ request.errors && request.errors.length > 0 ? request.errors[ request.errors.length - 1 ] : '--' }
+										</td>
+										<td>
+											<span className="error-count">
+												{ sprintf(
+													// translators: %s is the number of errors.
+													__( 'Attempt #%s', 'newspack-plugin' ),
+													String( request.errors.length )
+												) }
+											</span>
+										</td>
+									</Fragment>
+								) }
+							</tr>
+						) ) }
+					</table>
+				) : (
+					<Notice status="info" isDismissible={ false } spokenMessage="">
+						{ __( "This endpoint hasn't received any requests yet.", 'newspack-plugin' ) }
+					</Notice>
+				) }
+			</Stack>
 		</Modal>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/view.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/view.tsx
@@ -3,17 +3,17 @@
  */
 
 /**
+ * External dependencies
+ */
+import moment from 'moment';
+
+/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { Icon, Notice } from '@wordpress/components';
 import { Stack } from '@wordpress/ui';
-
-/**
- * External dependencies
- */
-import moment from 'moment';
 
 /**
  * Internal dependencies

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/view.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/view.tsx
@@ -34,48 +34,58 @@ const View = ( { endpoint, setAction }: { endpoint: ModalComponentProps[ 'endpoi
 				</p>
 				{ endpoint.requests.length > 0 ? (
 					<table className={ `newspack-webhooks__requests ${ hasEndpointErrors( endpoint ) ? 'has-error' : '' }` }>
-						<tr>
-							<th />
-							<th colSpan={ 2 }>{ __( 'Action', 'newspack-plugin' ) }</th>
-							{ hasEndpointErrors( endpoint ) && <th colSpan={ 2 }>{ __( 'Error', 'newspack-plugin' ) }</th> }
-						</tr>
-						{ endpoint.requests.map( request => (
-							<tr key={ request.id }>
-								<td className={ `status status--${ request.status }` }>
-									<Icon icon={ getRequestStatusIcon( request.status ) } />
-								</td>
-								<td className="action-name">{ request.action_name }</td>
-								<td className="scheduled">
-									{ 'pending' === request.status
-										? sprintf(
-												// translators: %s is a human-readable time difference.
-												__( 'sending in %s', 'newspack-plugin' ),
-												moment( parseInt( request.scheduled ) * 1000 ).fromNow( true )
-										  )
-										: sprintf(
-												// translators: %s is a human-readable time difference.
-												__( 'processed %s', 'newspack-plugin' ),
-												moment( parseInt( request.scheduled ) * 1000 ).fromNow()
-										  ) }
-								</td>
+						<thead>
+							<tr>
+								<th scope="col" />
+								<th scope="col" colSpan={ 2 }>
+									{ __( 'Action', 'newspack-plugin' ) }
+								</th>
 								{ hasEndpointErrors( endpoint ) && (
-									<Fragment>
-										<td className="error">
-											{ request.errors && request.errors.length > 0 ? request.errors[ request.errors.length - 1 ] : '--' }
-										</td>
-										<td>
-											<span className="error-count">
-												{ sprintf(
-													// translators: %s is the number of errors.
-													__( 'Attempt #%s', 'newspack-plugin' ),
-													String( request.errors.length )
-												) }
-											</span>
-										</td>
-									</Fragment>
+									<th scope="col" colSpan={ 2 }>
+										{ __( 'Error', 'newspack-plugin' ) }
+									</th>
 								) }
 							</tr>
-						) ) }
+						</thead>
+						<tbody>
+							{ endpoint.requests.map( request => (
+								<tr key={ request.id }>
+									<td className={ `status status--${ request.status }` }>
+										<Icon icon={ getRequestStatusIcon( request.status ) } />
+									</td>
+									<td className="action-name">{ request.action_name }</td>
+									<td className="scheduled">
+										{ 'pending' === request.status
+											? sprintf(
+													// translators: %s is a human-readable time difference.
+													__( 'sending in %s', 'newspack-plugin' ),
+													moment( parseInt( request.scheduled ) * 1000 ).fromNow( true )
+											  )
+											: sprintf(
+													// translators: %s is a human-readable time difference.
+													__( 'processed %s', 'newspack-plugin' ),
+													moment( parseInt( request.scheduled ) * 1000 ).fromNow()
+											  ) }
+									</td>
+									{ hasEndpointErrors( endpoint ) && (
+										<Fragment>
+											<td className="error">
+												{ request.errors && request.errors.length > 0 ? request.errors[ request.errors.length - 1 ] : '--' }
+											</td>
+											<td>
+												<span className="error-count">
+													{ sprintf(
+														// translators: %s is the number of errors.
+														__( 'Attempt #%s', 'newspack-plugin' ),
+														String( request.errors.length )
+													) }
+												</span>
+											</td>
+										</Fragment>
+									) }
+								</tr>
+							) ) }
+						</tbody>
 					</table>
 				) : (
 					<Notice status="info" isDismissible={ false } spokenMessage="">

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/view.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/connections/webhooks/modals/view.tsx
@@ -36,7 +36,9 @@ const View = ( { endpoint, setAction }: { endpoint: ModalComponentProps[ 'endpoi
 					<table className={ `newspack-webhooks__requests ${ hasEndpointErrors( endpoint ) ? 'has-error' : '' }` }>
 						<thead>
 							<tr>
-								<th scope="col" />
+								<th scope="col">
+									<span className="screen-reader-text">{ __( 'Status', 'newspack-plugin' ) }</span>
+								</th>
 								<th scope="col" colSpan={ 2 }>
 									{ __( 'Action', 'newspack-plugin' ) }
 								</th>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/seo/constants.ts
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/seo/constants.ts
@@ -18,10 +18,16 @@ export const ACCOUNTS = [
 				return '';
 			}
 			if ( inputValue.length > 15 ) {
-				return __( 'X handle cannot exceed 15 characters!', 'newspack-plugin' );
+				return __(
+					'X handles can be up to 15 characters. Enter just the username, without the @ or the full profile URL.',
+					'newspack-plugin'
+				);
 			}
 			if ( ! /^[a-zA-Z0-9_]+$/.test( inputValue ) ) {
-				return __( 'X handle may only contain letters, numbers, and underscores!', 'newspack-plugin' );
+				return __(
+					'X handles use only letters, numbers, and underscores. Enter just the username, without the @ or the full profile URL.',
+					'newspack-plugin'
+				);
 			}
 			return '';
 		},

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/seo/index.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/seo/index.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Both validators can fail on one click, and `speak` empties the live region before
+ * each write, so notices left to announce themselves report only the last one rendered.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { speak } from '@wordpress/a11y';
+
+/**
+ * Internal dependencies
+ */
+import Seo from './index';
+
+jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
+jest.mock( '../../../../hooks/use-wizard-api-fetch', () => ( {
+	useWizardApiFetch: () => ( {
+		wizardApiFetch: jest.fn(),
+		isFetching: false,
+		errorMessage: null,
+		resetError: jest.fn(),
+	} ),
+} ) );
+
+const typeInto = ( label: string, value: string ) => fireEvent.change( screen.getByLabelText( label ), { target: { value } } );
+
+const save = () => fireEvent.click( screen.getByRole( 'button', { name: 'Save Settings' } ) );
+
+beforeEach( () => jest.clearAllMocks() );
+
+describe( 'saving SEO settings with more than one invalid field', () => {
+	it( 'announces every message that blocked the save, in one announcement', () => {
+		render( <Seo /> );
+
+		typeInto( 'Google', 'nope!' );
+		typeInto( 'Facebook', 'not-a-url' );
+		save();
+
+		expect( speak ).toHaveBeenCalledTimes( 1 );
+		const [ announcement ] = ( speak as jest.Mock ).mock.calls[ 0 ];
+		expect( announcement ).toContain( 'Google verification codes' );
+		expect( announcement ).toContain( 'Facebook' );
+	} );
+
+	it( 'announces again when the same fields are submitted unchanged', () => {
+		render( <Seo /> );
+
+		typeInto( 'Google', 'nope!' );
+		save();
+		save();
+
+		expect( speak ).toHaveBeenCalledTimes( 2 );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/seo/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/seo/index.tsx
@@ -7,6 +7,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
+import { Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies.
@@ -16,7 +17,7 @@ import { ACCOUNTS } from './constants';
 import WizardsTab from '../../../../wizards-tab';
 import VerificationCodes from './verification-codes';
 import WizardSection from '../../../../wizards-section';
-import { Button, Notice } from '../../../../../../packages/components/src';
+import { Button } from '../../../../../../packages/components/src';
 import WizardsActionCard from '../../../../wizards-action-card';
 import useFieldsValidation from '../../../../hooks/use-fields-validation';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
@@ -44,11 +45,26 @@ function Seo() {
 
 	const codesValidation = useFieldsValidation< SeoData[ 'verification' ] >(
 		[
-			[ 'google', 'isId', { message: __( 'Invalid Google verification code!', 'newspack-plugin' ) } ],
+			[
+				'google',
+				'isId',
+				{
+					message: __(
+						'Google verification codes use only letters, numbers, hyphens, and underscores. Copy just the code from Search Console, not the full meta tag.',
+						'newspack-plugin'
+					),
+				},
+			],
 			[
 				'bing',
 				/** JS version of [WPSEO PHP regex](https://github.com/Yoast/wordpress-seo/blob/trunk/inc/options/class-wpseo-option.php#L313) */
-				v => ( /^[A-Fa-f0-9_-]*$/.test( v ) ? '' : __( 'Invalid Bing verification code!', 'newspack-plugin' ) ),
+				v =>
+					/^[A-Fa-f0-9_-]*$/.test( v )
+						? ''
+						: __(
+								'Bing verification codes use only the letters A-F, numbers, hyphens, and underscores. Copy just the code from Bing Webmaster Tools, not the full meta tag.',
+								'newspack-plugin'
+						  ),
 			],
 		],
 		data.verification
@@ -112,14 +128,22 @@ function Seo() {
 				title={ __( 'Webmaster Tools', 'newspack-plugin' ) }
 				description={ __( 'Add verification meta tags to your site', 'newspack-plugin' ) }
 			>
-				{ codesValidation.errorMessage && <Notice isError noticeText={ codesValidation.errorMessage } /> }
+				{ codesValidation.errorMessage && (
+					<Notice status="error" isDismissible={ false }>
+						{ codesValidation.errorMessage }
+					</Notice>
+				) }
 				<VerificationCodes setData={ verification => setData( { ...data, verification } ) } data={ data.verification } />
 			</WizardSection>
 			<WizardSection
 				title={ __( 'Social Accounts', 'newspack-plugin' ) }
 				description={ __( 'Let search engines know which social profiles are associated to your site', 'newspack-plugin' ) }
 			>
-				{ accountsValidation.errorMessage && <Notice isError noticeText={ accountsValidation.errorMessage } /> }
+				{ accountsValidation.errorMessage && (
+					<Notice status="error" isDismissible={ false }>
+						{ accountsValidation.errorMessage }
+					</Notice>
+				) }
 				<Accounts setData={ urls => setData( { ...data, urls } ) } data={ data.urls } />
 			</WizardSection>
 			<WizardSection>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/seo/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/seo/index.tsx
@@ -8,6 +8,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import { Notice } from '@wordpress/components';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies.
@@ -105,9 +106,13 @@ function Seo() {
 	}
 
 	function post() {
-		const isVerificationCodesValid = codesValidation.isInputsValid();
-		const isAccountsValid = accountsValidation.isInputsValid();
-		if ( ! isVerificationCodesValid || ! isAccountsValid ) {
+		// Both notices mount in the same commit, and `speak` empties the live region
+		// before each write, so leaving them to announce themselves would drop whichever
+		// rendered first. Announcing once here also repeats on an unchanged message,
+		// which a re-render of the same string would not.
+		const validationErrors = [ codesValidation.validateInputs(), accountsValidation.validateInputs() ].filter( Boolean );
+		if ( validationErrors.length ) {
+			speak( validationErrors.join( ' ' ), 'assertive' );
 			return;
 		}
 		wizardApiFetch(
@@ -129,7 +134,7 @@ function Seo() {
 				description={ __( 'Add verification meta tags to your site', 'newspack-plugin' ) }
 			>
 				{ codesValidation.errorMessage && (
-					<Notice status="error" isDismissible={ false }>
+					<Notice status="error" isDismissible={ false } spokenMessage="">
 						{ codesValidation.errorMessage }
 					</Notice>
 				) }
@@ -140,7 +145,7 @@ function Seo() {
 				description={ __( 'Let search engines know which social profiles are associated to your site', 'newspack-plugin' ) }
 			>
 				{ accountsValidation.errorMessage && (
-					<Notice status="error" isDismissible={ false }>
+					<Notice status="error" isDismissible={ false } spokenMessage="">
 						{ accountsValidation.errorMessage }
 					</Notice>
 				) }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/seo/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/seo/index.tsx
@@ -26,7 +26,7 @@ import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
 const PATH = '/newspack/v1/wizard/newspack-settings/seo';
 
 function Seo() {
-	const { wizardApiFetch, isFetching } = useWizardApiFetch( 'newspack-settings/seo' );
+	const { wizardApiFetch, isFetching, errorMessage, resetError } = useWizardApiFetch( 'newspack-settings/seo' );
 
 	const [ data, setData ] = useState< SeoData >( {
 		under_construction: false,
@@ -106,15 +106,14 @@ function Seo() {
 	}
 
 	function post() {
-		// Both notices mount in the same commit, and `speak` empties the live region
-		// before each write, so leaving them to announce themselves would drop whichever
-		// rendered first. Announcing once here also repeats on an unchanged message,
-		// which a re-render of the same string would not.
+		// `speak` empties the live region before each write, so two notices mounting in one
+		// commit would report only the last. Announcing here also repeats an unchanged message.
 		const validationErrors = [ codesValidation.validateInputs(), accountsValidation.validateInputs() ].filter( Boolean );
 		if ( validationErrors.length ) {
 			speak( validationErrors.join( ' ' ), 'assertive' );
 			return;
 		}
+		resetError();
 		wizardApiFetch(
 			{
 				path: PATH,
@@ -129,6 +128,11 @@ function Seo() {
 	}
 	return (
 		<WizardsTab title={ __( 'SEO', 'newspack-plugin' ) } className={ isFetching ? 'is-fetching' : '' }>
+			{ errorMessage && (
+				<Notice status="error" isDismissible={ false } politeness="polite">
+					{ errorMessage }
+				</Notice>
+			) }
 			<WizardSection
 				title={ __( 'Webmaster Tools', 'newspack-plugin' ) }
 				description={ __( 'Add verification meta tags to your site', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * The Settings pane branches on the connection status that arrives with the rest of
+ * the section's data. Mirroring that status into component state put the branch a
+ * commit behind the switch that mounts the pane, so a connected site rendered, and
+ * spoke, "not connected" on every visit.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { speak } from '@wordpress/a11y';
+
+/**
+ * Internal dependencies
+ */
+import Nextdoor from './nextdoor';
+import useWizardApiFetchToggle from '../../../../hooks/use-wizard-api-fetch-toggle';
+
+jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
+jest.mock( '../../../../hooks/use-wizard-api-fetch-toggle', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+const CONNECTED = {
+	module_enabled_nextdoor: true,
+	is_connected: true,
+	connection_status: {
+		is_connected: true,
+		has_credentials: true,
+		has_centralized_credentials: false,
+		has_tokens: true,
+		has_page: true,
+		token_valid: true,
+	},
+	settings: {
+		client_id: 'client-id',
+		client_secret: 'client-secret',
+		publication_url: 'https://example.test',
+		allowed_roles: [ 'administrator' ],
+	},
+};
+
+const NOT_CONNECTED_MESSAGE = 'Nextdoor is not connected. Please complete the setup process first.';
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	( useWizardApiFetchToggle as jest.Mock ).mockReturnValue( {
+		description: 'Nextdoor',
+		apiData: CONNECTED,
+		isFetching: false,
+		actionText: 'Enabled',
+		apiFetchToggle: jest.fn(),
+		errorMessage: null,
+	} );
+} );
+
+describe( 'the Nextdoor section on a connected site', () => {
+	it( 'never says the integration is not connected', () => {
+		render( <Nextdoor /> );
+
+		expect( screen.queryByText( NOT_CONNECTED_MESSAGE ) ).not.toBeInTheDocument();
+		expect( speak ).not.toHaveBeenCalledWith( expect.stringContaining( 'not connected' ), expect.anything() );
+	} );
+
+	// Without this the case above would also pass on a pane that rendered nothing at all.
+	it( 'shows the connection as established on the first render', () => {
+		render( <Nextdoor /> );
+
+		expect( screen.getByText( 'Connected' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor.test.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor.test.tsx
@@ -46,7 +46,8 @@ const CONNECTED = {
 	},
 };
 
-const NOT_CONNECTED_MESSAGE = 'Nextdoor is not connected. Please complete the setup process first.';
+// Matched on the notice, not its wording: a copy change would otherwise turn this green.
+const errorNotice = () => document.querySelector( '.components-notice.is-error' );
 
 beforeEach( () => {
 	jest.clearAllMocks();
@@ -64,7 +65,7 @@ describe( 'the Nextdoor section on a connected site', () => {
 	it( 'never says the integration is not connected', () => {
 		render( <Nextdoor /> );
 
-		expect( screen.queryByText( NOT_CONNECTED_MESSAGE ) ).not.toBeInTheDocument();
+		expect( errorNotice() ).toBeNull();
 		expect( speak ).not.toHaveBeenCalledWith( expect.stringContaining( 'not connected' ), expect.anything() );
 	} );
 

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor.tsx
@@ -65,7 +65,7 @@ function Nextdoor() {
 		// With the module off the endpoint sends `settings` as an empty array, so the
 		// roles it should carry are not there to copy.
 		if ( apiData.settings?.allowed_roles ) {
-			setSettings( { ...settings, allowed_roles: apiData.settings.allowed_roles } );
+			setSettings( current => ( { ...current, allowed_roles: apiData.settings.allowed_roles } ) );
 		}
 	}, [ apiData ] );
 

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor.tsx
@@ -58,12 +58,13 @@ function Nextdoor() {
 		),
 	} );
 
-	// Read straight from the fetched data rather than mirroring it into state: a copy
-	// updated by an effect is a commit behind, and the children branch on it.
+	// A copy kept in state would be a commit behind, and the children branch on this.
 	const status = apiData.connection_status;
 
 	useEffect( () => {
-		if ( apiData.connection_status ) {
+		// With the module off the endpoint sends `settings` as an empty array, so the
+		// roles it should carry are not there to copy.
+		if ( apiData.settings?.allowed_roles ) {
 			setSettings( { ...settings, allowed_roles: apiData.settings.allowed_roles } );
 		}
 	}, [ apiData ] );

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor.tsx
@@ -18,7 +18,7 @@ import WizardsActionCard from '../../../../wizards-action-card';
 /**
  * Components
  */
-import { NextdoorData, NextdoorSettings, NextdoorStatus, OAuthResponse, ClaimPageResponse } from './nextdoor/types';
+import { NextdoorData, NextdoorSettings, OAuthResponse, ClaimPageResponse } from './nextdoor/types';
 import { Onboarding } from './nextdoor/onboarding';
 import { Settings } from './nextdoor/settings';
 
@@ -28,14 +28,6 @@ function Nextdoor() {
 		client_secret: '',
 		publication_url: '',
 		allowed_roles: [],
-	} );
-	const [ status, setStatus ] = useState< NextdoorStatus >( {
-		is_connected: false,
-		has_credentials: false,
-		has_centralized_credentials: false,
-		has_tokens: false,
-		has_page: false,
-		token_valid: false,
 	} );
 	const [ error, setError ] = useState< string | null >( null );
 
@@ -66,9 +58,12 @@ function Nextdoor() {
 		),
 	} );
 
+	// Read straight from the fetched data rather than mirroring it into state: a copy
+	// updated by an effect is a commit behind, and the children branch on it.
+	const status = apiData.connection_status;
+
 	useEffect( () => {
 		if ( apiData.connection_status ) {
-			setStatus( apiData.connection_status );
 			setSettings( { ...settings, allowed_roles: apiData.settings.allowed_roles } );
 		}
 	}, [ apiData ] );

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor/onboarding/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor/onboarding/index.tsx
@@ -162,7 +162,7 @@ export const Onboarding = ( { settings, status, error, updateSettings, startOAut
 	return (
 		<>
 			{ error && (
-				<Notice status="error" isDismissible={ false }>
+				<Notice status="error" isDismissible={ false } politeness="polite">
 					{ error }
 				</Notice>
 			) }

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor/onboarding/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor/onboarding/index.tsx
@@ -7,12 +7,12 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink, Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { ActionCard, Button, Card, Grid, Notice, SelectControl, TextControl } from '../../../../../../../../packages/components/src';
+import { ActionCard, Button, Card, Grid, SelectControl, TextControl } from '../../../../../../../../packages/components/src';
 import { OnboardingProps } from '../types';
 
 /**
@@ -161,7 +161,11 @@ export const Onboarding = ( { settings, status, error, updateSettings, startOAut
 
 	return (
 		<>
-			{ error && <Notice noticeText={ error } isError onClose={ () => setError( null ) } /> }
+			{ error && (
+				<Notice status="error" isDismissible={ false }>
+					{ error }
+				</Notice>
+			) }
 
 			{ /* Step 1: API Credentials - Only shown in manual mode */ }
 			{ isManualMode && currentStep === STEPS.manual.CREDENTIALS && (

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor/settings/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor/settings/index.tsx
@@ -66,7 +66,7 @@ export const Settings = ( { settings, status, error, updateSettings, disconnect,
 
 	if ( ! status.is_connected ) {
 		return (
-			<Notice status="error" isDismissible={ false } spokenMessage="">
+			<Notice status="error" isDismissible={ false }>
 				{ __( 'Nextdoor is not connected. Please complete the setup process first.', 'newspack-plugin' ) }
 			</Notice>
 		);

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor/settings/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor/settings/index.tsx
@@ -66,7 +66,7 @@ export const Settings = ( { settings, status, error, updateSettings, disconnect,
 
 	if ( ! status.is_connected ) {
 		return (
-			<Notice status="error" isDismissible={ false }>
+			<Notice status="error" isDismissible={ false } politeness="polite">
 				{ __( 'Nextdoor is not connected. Please complete the setup process first.', 'newspack-plugin' ) }
 			</Notice>
 		);

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor/settings/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/social/nextdoor/settings/index.tsx
@@ -8,12 +8,12 @@
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-import { CheckboxControl, CardHeader, __experimentalHeading as Heading, CardBody } from '@wordpress/components';
+import { CheckboxControl, CardHeader, __experimentalHeading as Heading, CardBody, Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { Button, Card, Grid, Notice } from '../../../../../../../../packages/components/src';
+import { Button, Card, Grid } from '../../../../../../../../packages/components/src';
 import { SettingsProps } from '../types';
 
 /**
@@ -66,18 +66,19 @@ export const Settings = ( { settings, status, error, updateSettings, disconnect,
 
 	if ( ! status.is_connected ) {
 		return (
-			<Card>
-				<Notice
-					noticeText={ __( 'Nextdoor is not connected. Please complete the setup process first.', 'newspack-plugin' ) }
-					isError={ false }
-				/>
-			</Card>
+			<Notice status="error" isDismissible={ false } spokenMessage="">
+				{ __( 'Nextdoor is not connected. Please complete the setup process first.', 'newspack-plugin' ) }
+			</Notice>
 		);
 	}
 
 	return (
 		<>
-			{ error && <Notice noticeText={ error } isError onClose={ () => setError( null ) } /> }
+			{ error && (
+				<Notice status="error" isDismissible={ false }>
+					{ error }
+				</Notice>
+			) }
 			<Card>
 				<CardHeader>
 					<Heading level={ 4 }>{ __( 'Connection Information', 'newspack-plugin' ) }</Heading>

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/style.scss
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/style.scss
@@ -1,3 +1,15 @@
 .newspack-settings {
 	box-sizing: border-box;
 }
+
+.newspack-additional-brands__notice,
+.newspack-advanced-settings__notice {
+	margin-bottom: 32px;
+}
+
+.newspack-accessibility-statement,
+.newspack-accessibility-statement__prose {
+	> * {
+		margin: 0;
+	}
+}

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/style.scss
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/style.scss
@@ -1,10 +1,11 @@
+@use "~@wordpress/base-styles/variables" as wp-vars;
+
 .newspack-settings {
 	box-sizing: border-box;
 }
 
-.newspack-additional-brands__notice,
 .newspack-advanced-settings__notice {
-	margin-bottom: 32px;
+	margin-bottom: wp-vars.$grid-unit-40;
 }
 
 .newspack-accessibility-statement,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Eighteen `Notice` call sites on Newspack > Settings still used `packages/components`' own `Notice`, a plain `div` with an `aria-hidden` icon, so nothing they said ever reached a screen reader. This converts them to core's `Notice` and settles what each one should announce.

This branch has `main` merged into it, so it carries #1035's shared `EmptyState` on the webhooks screen. Where that PR added a load-failure notice using the old component, this one converts it; the notice #1035 added in `brands.tsx` is left alone, since it arrived after this work and belongs to that screen's own review.

Four notices could never say anything useful at all:

- Advanced Settings rendered `<Notice />` with no children, so a failed save showed an empty grey box while the message sat unused in the hook.
- Advanced Settings also reads and writes through three namespaces, and only the first had its error rendered, so a `recirculation` or `primary-category` failure stayed silent even once the box had text in it.
- Additional Brands passed `errorMessage` to the edit route but not the create route, so a failed **Add Brand** reported nothing.
- Nextdoor's "not connected" notice was `isError={ false }`, rendering neutral grey for what is an error.

Repeat failures were silent too, and the reason differs by screen, so the fix does:

- Where the error arrives from a promise (Advanced Settings, the Accessibility Statement, Additional Brands), clearing it at the top of the handler restores the null-to-message transition that core's `Notice` announces on.
- In the webhook modal, validation is synchronous, so a clear and a set in the same handler batch into one commit and the message never transitions. A submit counter keys the notice and the scroll effect instead.
- On SEO, two validators run in one click and both notices mount together. `speak` empties the live region before each write, so the first message was wiped before anything read it. The handler now composes one announcement covering both, which also repeats on an unchanged message.

**A connected Nextdoor integration announced that it was not connected, on every page load.** The section renders its Settings pane as soon as the fetched data says the integration is connected, but the pane branched on a copy of that status held in component state and filled by an effect. Passive effects run child before parent, so the pane mounted, rendered the not-connected notice, and spoke it, one commit before the copy caught up. The one-frame flash was already there; converting the notice to core's is what gave it a voice. The copy is gone and the pane reads the fetched status directly. `nextdoor.test.tsx` covers it.

Announcement policy, settled on #890: errors announce, standing state does not.

- Errors that render in response to an action announce assertively.
- Errors that can render on arrival, because a mount GET or a redirect fed them, carry `politeness="polite"` so they queue rather than cutting off the page title. That covers the webhook modal's request error, the four save errors that double as load errors, Jetpack SSO's, SEO's, and Nextdoor's onboarding error, which an OAuth failure redirects into.
- Standing-state info and warnings carry `spokenMessage=""`. That now includes the "more than 1000 posts" warning, which renders on arrival; the warnings beside it fire on a select change and still speak.
- The Accessibility Statement's success message is standing state, so it stays silent; only its error speaks.

Alongside that:

- **Focus moves to the notice a failed save reports**, on Advanced Settings and Additional Brands, whose Save buttons sit well below it. Scrolling without moving focus meant the next key press sent the viewport straight back down. Focus doubles as the announcement, so the notice goes quiet on that path rather than saying the same thing twice; a reader who carried on while the request was in flight keeps their place and gets the message spoken instead. `useErrorNoticeFocus` holds all of it. Note there is no smooth scroll: moving focus cancels one, in either order and across a frame's delay, so `focus()` does the scrolling on its own.
- **Two more notices could not report what they were given.** Jetpack SSO's error sat inside the `force_2fa` branch, so a failed settings fetch, which leaves `settings` empty, could never show it. SEO never read `errorMessage` at all, so a failed save left the button back at "Save Settings" and nothing else. Both now render.
- **Spacing** moved onto `@wordpress/ui`'s `Stack` in four places rather than per-notice margins. The Jetpack SSO card body is one Stack now, which let two single-child `Grid` wrappers go. The three `HStack` uses left in the files this PR already touches follow, and `AGENTS.md` now names `Stack` as the layout primitive. The `HStack`/`VStack` uses elsewhere in the wizard are left alone.
- **Size and nesting.** The webhook **Edit endpoint** modal drops from `full` to `large`; it holds a short form, and full width left the fields stranded across the screen. Nextdoor's not-connected branch no longer wraps its notice in a `Card`, which nested it inside the surrounding `WizardsActionCard`.
- **Two dead props.** Both Nextdoor notices passed `onClose`, which our component ignores, so they looked dismissible in the source and were not in the browser. `pwa-display-mode` passed a similarly ignored `isInfo`.
- **Copy.** The four SEO validation messages were terse and shouty ("Invalid Google verification code!"). They now name the rule and what to do. The webhook request error moved from a concatenated string to a `sprintf` placeholder, so translators get the whole sentence rather than a fragment.
- `useFieldsValidation`'s `isInputsValid` becomes `validateInputs` and returns the message rather than a boolean, so a caller running several validators can gather what each one said. SEO is its only consumer.
- `AGENTS.md` now records the announcement policy and which mechanism suits which shape of error, since re-announcing an unchanged message needs a different answer depending on where the message comes from.

Part of the DSGNEWS-215 audit. Not a `Notice` wrapper rewrite; this converts the call sites and leaves `packages/components`' own `Notice` in place for the other wizards.

![Advanced Settings save error shown at the top of the tab](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/04/p0oejff4-notice-15-moved-top.png)

![Additional Brands save error shown above the Brand section](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/04/4hzb82n5-notice-18-brand-top.png)

![Nextdoor not-connected error rendered without a nested card](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/04/hmcbp2td-notice-11-no-card.png)

### How to test the changes in this Pull Request:

Most of these are failure paths. The quickest way to reach them is to reject the relevant request from the console on the Settings page. Watching `#a11y-speak-polite` and `#a11y-speak-assertive` in devtools shows what a screen reader would hear.

1. Go to **Newspack > Settings > Connections**. With no webhook endpoints configured you get #1035's empty state, not a notice. Open **Add Endpoint** and **Save** with the form empty. The error appears at the top of the modal, which is now `large` rather than full-width. Press **Save** again without changing anything. The message is announced a second time.
2. Still in that modal, **Send a test request** to a URL that rejects POST. The error appears and the modal scrolls to it.
3. **SEO**: put `nope!` in **Google** and any non-URL in **Facebook**, then **Save Settings**. Both notices appear, and a single announcement carries both messages. Save again unchanged; it is announced again. Note that an alphanumeric value like `G-WRONG` passes: the validator only rejects characters outside `[A-Za-z0-9_-]`.
4. **SEO** again: paste an X profile URL into the handle field. The length message now tells you to enter just the username.
5. **Advanced Settings**: make `POST /newspack/v1/wizard/newspack-setup-wizard/theme` fail, scroll to the bottom, and **Save**. Before this branch you got an empty grey box. Now the message renders at the top, the page scrolls to it, and focus lands on it, so pressing Tab continues from the notice rather than from the Save button. Save again unchanged; it scrolls and re-focuses.
6. **Advanced Settings** again: make `POST /newspack/v1/wizard/newspack-settings/related-posts-max-age` fail instead and **Save**. Before this branch nothing appeared, since only the theme-mods error was rendered.
7. **Additional Brands > Add Brand**: make `POST /wp/v2/brand` fail and **Save**. Before this branch nothing appeared at all.
8. **Advanced Settings > Accessibility Statement Page**: trash the page, reload, create it, publish it. The notice moves through warning, warning, success, and the section sits in nested Stacks (24px outer, 16px between the paragraphs).
9. Add an endpoint, then make `GET /newspack/v1/webhooks/endpoints` fail and reload. "Webhook endpoints could not be loaded." renders as a core error notice rather than the old component.
10. With a screen reader, open **Social > Nextdoor** on a connected site. It should say nothing about the connection. Then visit a tab carrying a standing info or warning notice and confirm it stays quiet.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Three test files, each checked red against the code it guards. `nextdoor.test.tsx` fails on the previous code with `speak` called as `["Nextdoor is not connected. Please complete the setup process first.", "polite"]`. `upsert.test.tsx` fails when the notice's `key` is removed, and `seo/index.test.tsx` when the composed announcement is replaced by the notices announcing themselves. `tsc`, `lint:js` and `lint:scss` are clean, the build is clean, and all 1330 JS tests pass.
