### PR TITLE
fix(pricing-rules): keep the impact stats on a four-column grid

### DIFF
--- a/plugins/newspack-plugin/src/wizards/audience/views/pricing-rules/impact-stats.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/pricing-rules/impact-stats.test.jsx
@@ -53,8 +53,7 @@ describe( 'ImpactStats', () => {
 		expect( screen.getByText( 'At least 500' ) ).toHaveAttribute( 'data-visually-hidden' );
 	} );
 
-	// Grid ships no `columns-1` rule; one tile goes full width off the base `1fr`.
-	it( 'renders one tile and passes the count through as the column count', () => {
+	it( 'renders one tile and keeps the four-column track', () => {
 		const { container } = render( stats( { totalMatching: 36, countLimited: false } ) );
 
 		expect( screen.getByText( 'Products affected' ) ).toBeInTheDocument();
@@ -62,7 +61,7 @@ describe( 'ImpactStats', () => {
 		expect( screen.queryByText( 'Eligible at renewal' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Protected' ) ).not.toBeInTheDocument();
 		expect( container.querySelectorAll( '.newspack-stat-card' ) ).toHaveLength( 1 );
-		expect( container.querySelector( '.newspack-pricing-rules__stats' ) ).toHaveClass( 'newspack-grid__columns-1' );
+		expect( container.querySelector( '.newspack-pricing-rules__stats' ) ).toHaveClass( 'newspack-grid__columns-4' );
 	} );
 
 	it( 'renders four tiles when the audience arrives', () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/pricing-rules/impact-stats.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/pricing-rules/impact-stats.tsx
@@ -131,7 +131,9 @@ export default function ImpactStats( {
 	}
 
 	return (
-		<Grid className="newspack-pricing-rules__stats" columns={ tiles.length } gutter={ 16 } noMargin>
+		// Fixed rather than the tile count, so the catalog route's lone card keeps the
+		// width it has on the rule preview instead of stretching to the full row.
+		<Grid className="newspack-pricing-rules__stats" columns={ 4 } gutter={ 16 } noMargin>
 			{ tiles.map( ( { id, label, value, valueLabel, description, note, actionLabel, onAction } ) => (
 				<StatCard.Root key={ id }>
 					<StatCard.Label>{ label }</StatCard.Label>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The impact stats sized their grid to the number of cards rather than to a fixed row, so the count of cards decided the layout. The Pricing Rules list shows one card, because the catalogue route carries no audience block, and that card stretched across the full content width with its figure marooned in the corner. The rule preview, which gets all four, looked like a different component.

The grid is now four columns on both screens, so the lone card keeps the width it has in the preview.

![Pricing Rules list, before and after: the lone stats card stretched full width, now on the same quarter-width track as the rule preview](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/04/7eqbpu3g-pricing-rules-stats-grid-before-after.png)

### How to test the changes in this Pull Request:

1. With WooCommerce Subscriptions and the dynamic pricing engine active, go to Audience → Pricing Rules.
2. Confirm the "Products affected" card sits at a quarter of the content width, not the full width.
3. Open a rule and scroll to Impact Preview. Confirm its four cards are unchanged, four across with a 16px gap.
4. Check both screens line up: the single card matches the width of the preview's first card.
5. Narrow the window below 1054px. Confirm both screens fall back to two columns together.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
