### PR TITLE
fix(theme): offer page templates on election profiles

### DIFF
--- a/themes/newspack-theme/newspack-theme/single-feature.php
+++ b/themes/newspack-theme/newspack-theme/single-feature.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Template Name: One column
- * Template Post Type: post, page, newspack_lst_event, newspack_lst_generic, newspack_lst_mktplce, newspack_lst_place
+ * Template Post Type: post, page, newspack_lst_event, newspack_lst_generic, newspack_lst_mktplce, newspack_lst_place, govpack_profiles
  *
  * The template for displaying all single posts
  *

--- a/themes/newspack-theme/newspack-theme/single-wide.php
+++ b/themes/newspack-theme/newspack-theme/single-wide.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Template Name: One column wide
- * Template Post Type: post, page, newspack_lst_event, newspack_lst_generic, newspack_lst_mktplce, newspack_lst_place
+ * Template Post Type: post, page, newspack_lst_event, newspack_lst_generic, newspack_lst_mktplce, newspack_lst_place, govpack_profiles
  *
  * The template for displaying all single posts
  *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

An election profile could not be assigned a page template. One column and One column wide were offered on posts, pages, and listings, but not on profiles, so the Template control never appeared in the editor for them.

Both templates now list `govpack_profiles` among their supported post types.

This is half of the fix. Automattic/newspack-elections#91 stops the plugin discarding the chosen template. Until a site has both, the control appears but has no effect on the page.

Part of NPPM-3247.

### How to test the changes in this Pull Request:

1. Activate Newspack Elections with Automattic/newspack-elections#91, on a classic Newspack theme.
2. Create a profile with two or three paragraphs of body text. Publish it.
3. Open it in the editor. The Summary panel shows a Template row.
4. Set Template to One column. The published profile drops the sidebar.
5. Set Template to One column wide. Body text expands to the full container width.
6. Set it back to Default template. The profile uses the regular post layout.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

Targets `release` so it ships without promoting `main`. No automated test covers a theme template header; verified by hand across all three options.
