### PR TITLE
fix(content-gate): filter the metered excerpt once

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -1970,7 +1970,9 @@ class Content_Gate {
 	 *
 	 * @param \WP_Post $post Post object.
 	 *
-	 * @return string
+	 * @return string Rendered excerpt HTML. Already through the `newspack_gate_content`
+	 *                pipeline: callers must not apply that filter again, or blocks get
+	 *                re-rendered and shortcodes re-expanded over the rendered output.
 	 */
 	public static function get_restricted_post_excerpt( $post ) {
 		self::$is_gated = true;

--- a/plugins/newspack-plugin/includes/content-gate/class-metering.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-metering.php
@@ -472,7 +472,7 @@ class Metering {
 				'meter_key'          => self::get_meter_key( $gate_post_id, false ),
 				'post_id'            => get_the_ID(),
 				'article_view'       => self::$article_view,
-				'excerpt'            => apply_filters( 'newspack_gate_content', Content_Gate::get_restricted_post_excerpt( get_post() ) ),
+				'excerpt'            => Content_Gate::get_restricted_post_excerpt( get_post() ),
 				'other_settings'     => Content_Gate_Advanced_Settings::get_settings(),
 			]
 		);

--- a/plugins/newspack-plugin/includes/content-gate/class-metering.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-metering.php
@@ -452,7 +452,7 @@ class Metering {
 			$handle,
 			Newspack::plugin_url() . '/dist/content-gate-metering.js',
 			[],
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/content-gate-metering.js' ),
+			Newspack::asset_version( 'content-gate-metering' ),
 			[
 				'in_footer' => true,
 				'strategy'  => 'defer',

--- a/plugins/newspack-plugin/includes/content-gate/trait-content-gate-layout.php
+++ b/plugins/newspack-plugin/includes/content-gate/trait-content-gate-layout.php
@@ -257,7 +257,9 @@ trait Content_Gate_Layout {
 	 * @param \WP_Post $post         The post object to get excerpt from.
 	 * @param int      $gate_layout_id The gate layout ID.
 	 *
-	 * @return string The restricted post excerpt HTML.
+	 * @return string Rendered excerpt HTML. Already through the `newspack_gate_content`
+	 *                pipeline: callers must not apply that filter again, or blocks get
+	 *                re-rendered and shortcodes re-expanded over the rendered output.
 	 */
 	public static function get_restricted_post_excerpt_for_gate( $post, $gate_layout_id ) {
 		$content          = $post->post_content;

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/metering.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/metering.php
@@ -1014,6 +1014,63 @@ class Test_Metering extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * The excerpt localized for the frontend metering script leaves the gate content
+	 * pipeline already rendered. Running that pipeline over it again re-renders blocks and
+	 * re-expands shortcodes, and — do_blocks() suppresses wpautop only while block
+	 * delimiters are still there — reflows markup the first pass deliberately spared.
+	 */
+	public function test_metering_excerpt_applies_the_gate_content_filter_once() {
+		$gate_id = $this->create_gate_with_settings( [ 'metering_count' => 3 ] );
+
+		$post_id = $this->factory->post->create(
+			[
+				'post_content' => "<!-- wp:paragraph -->\n<p>First paragraph.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Second paragraph.</p>\n<!-- /wp:paragraph -->",
+			]
+		);
+		$this->post_ids[] = $post_id;
+
+		$layout_id = $this->factory->post->create( [ 'post_type' => Content_Gate::GATE_LAYOUT_CPT ] );
+		$this->post_ids[] = $layout_id;
+		update_post_meta( $layout_id, 'style', 'inline' );
+		update_post_meta( $layout_id, 'use_more_tag', false );
+		update_post_meta( $layout_id, 'visible_paragraphs', 2 );
+
+		$this->go_to( get_permalink( $post_id ) );
+		wp_set_current_user( 0 );
+		add_filter( 'newspack_is_post_restricted', '__return_true' );
+		add_filter(
+			'newspack_content_gate_post_id',
+			function() use ( $gate_id ) {
+				return $gate_id;
+			}
+		);
+		add_filter(
+			'newspack_content_gate_layout_id',
+			function() use ( $layout_id ) {
+				return $layout_id;
+			}
+		);
+
+		$applications        = 0;
+		$count_applications  = function( $content ) use ( &$applications ) {
+			++$applications;
+			return $content;
+		};
+		add_filter( 'newspack_gate_content', $count_applications, 1 );
+
+		try {
+			Metering::enqueue_scripts();
+		} finally {
+			remove_filter( 'newspack_gate_content', $count_applications, 1 );
+		}
+
+		$localized_settings = wp_scripts()->get_data( 'newspack-content-gate-metering', 'data' );
+
+		$this->assertStringContainsString( 'First paragraph.', (string) $localized_settings, 'The metering script should be localized with the restricted post excerpt' );
+		$this->assertSame( 1, $applications, 'The metering excerpt should pass through the newspack_gate_content pipeline exactly once' );
+	}
+
+	/**
 	 * Create a gate the way the wizard does - passing full settings to create_gate() so the
 	 * default layouts are generated against the gate's real metering, not empty defaults.
 	 *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`Metering::enqueue_scripts()` wrapped the excerpt it localizes into `newspack_metering_settings` in `apply_filters( 'newspack_gate_content', … )`, but `Content_Gate::get_restricted_post_excerpt()` already runs that pipeline. Every metered anonymous pageview built the excerpt twice.

The second pass is not a no-op. `Content_Gate::do_blocks()` suppresses `wpautop` only while the content still carries block delimiters, so on the second pass — over rendered HTML — `wpautop` runs and reflows markup the first pass deliberately spared:

```
once:  <figure class="wp-block-pullquote"><blockquote><p>A pulled quote.</p></blockquote></figure>
twice: <figure class="wp-block-pullquote">\n<blockquote>\n<p>A pulled quote.</p>\n</blockquote>\n</figure>
```

`do_shortcode` also re-expanded output the first pass produced.

The outer call is the redundant one: every other caller of the two excerpt helpers consumes their already-filtered return value as-is. Both `@return` docs now state that contract.

The same enqueue versioned its script with a raw `filemtime()` on `dist/`, which warns on an install where the plugin has not been built. It now uses `Newspack::asset_version()`, which falls back to the plugin version when the asset is absent.

### How to test the changes in this Pull Request:

1. Create a content gate with metering enabled for anonymous readers.
2. Publish a post with a pullquote block. Restrict the post with the gate.
3. Open the post in a logged-out browser.
4. View the page source. Find `newspack_metering_settings`.
5. Confirm the `excerpt` value matches the teaser a reader with no views left sees.
6. Run `n test-php --filter test_metering_excerpt_applies_the_gate_content_filter_once` in `plugins/newspack-plugin`. The test passes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

> [!NOTE]
> Conflicts with the in-flight hotfix for NPPD-2254, which moves this call site into a new `Metering::get_metered_excerpt()` on `release`. Whichever lands second should drop the `apply_filters( 'newspack_gate_content', … )` wrapper from `get_metered_excerpt()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUpYc3szRNMqbWQx4qxa8m
