### PR TITLE
fix(newsletters): report a failed ActiveCampaign list read (NPPD-2255)

### DIFF
--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-contacts.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-contacts.php
@@ -332,7 +332,12 @@ class Newspack_Newsletters_Contacts {
 		$lists_to_remove = array_diff( array_keys( $lists_config ), $lists );
 
 		/** Clean up lists to add/remove from contact's existing data. */
-		$current_lists   = Newspack_Newsletters_Subscription::get_contact_lists( $email );
+		$current_lists = Newspack_Newsletters_Subscription::get_contact_lists( $email );
+		if ( is_wp_error( $current_lists ) ) {
+			// The change is worked out against the current lists. Computing it
+			// against an empty set instead would silently drop every removal.
+			return $current_lists;
+		}
 		$lists_to_add    = array_diff( $lists_to_add, $current_lists );
 		$lists_to_remove = array_intersect( $current_lists, $lists_to_remove );
 

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-subscription.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-subscription.php
@@ -1443,10 +1443,11 @@ class Newspack_Newsletters_Subscription {
 					</ul>
 				<?php endif; ?>
 				<?php
-				if ( is_wp_error( $user_lists ) ) :
+				if ( is_wp_error( $list_config ) || is_wp_error( $user_lists ) ) :
 					// The form pre-checks the lists the reader is on. With nothing to
 					// check it would read as "subscribed to nothing", which is not what
-					// a failed read means, so it is not shown.
+					// a failed read means, so it is not shown. The lists on offer come
+					// through a filter that may answer an error as well.
 					?>
 					<ul class="woocommerce-error" role="alert">
 						<li><?php esc_html_e( 'Newsletter subscriptions could not be loaded. Please try again later.', 'newspack-newsletters' ); ?></li>

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-subscription.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-subscription.php
@@ -1426,7 +1426,7 @@ class Newspack_Newsletters_Subscription {
 				 * @param array|WP_Error $lists_config Associative array with list configuration keyed by list ID or WP_Error.
 				 */
 				$list_config  = apply_filters( 'newspack_newsletters_manage_newsletters_available_lists', self::get_lists_config() );
-				$user_lists   = array_flip( self::get_contact_lists( $email ) );
+				$user_lists   = self::get_contact_lists( $email );
 				$intent_error = self::get_user_subscription_intent_error( $user_id );
 				if ( $intent_error ) :
 					?>
@@ -1442,43 +1442,57 @@ class Newspack_Newsletters_Subscription {
 						</li>
 					</ul>
 				<?php endif; ?>
-				<p>
-					<?php _e( 'Manage your newsletter preferences.', 'newspack-newsletters' ); ?>
-				</p>
-				<form method="post">
-					<?php wp_nonce_field( self::SUBSCRIPTION_UPDATE, self::SUBSCRIPTION_UPDATE ); ?>
-					<div class="newspack-newsletters__lists">
-						<ul>
-							<?php
-							foreach ( $list_config as $list_id => $list ) :
-								$checkbox_id = sprintf( 'newspack-newsletters-list-checkbox-%s', $list_id );
-								?>
-								<li>
-									<span class="newspack-newsletters__lists__checkbox">
-										<input
-											type="checkbox"
-											name="lists[]"
-											value="<?php echo \esc_attr( $list_id ); ?>"
-											id="<?php echo \esc_attr( $checkbox_id ); ?>"
-											<?php if ( isset( $user_lists[ $list_id ] ) ) : ?>
-												checked
-											<?php endif; ?>
-										/>
-									</span>
-									<span class="newspack-newsletters__lists__details">
-										<label class="newspack-newsletters__lists__label" for="<?php echo \esc_attr( $checkbox_id ); ?>">
-											<span class="newspack-newsletters__lists__title">
-												<?php echo \esc_html( $list['title'] ); ?>
-											</span>
-											<span class="newspack-newsletters__lists__description"><?php echo \esc_html( $list['description'] ); ?></span>
-										</label>
-									</span>
-								</li>
-							<?php endforeach; ?>
-						</ul>
-					</div>
-					<button class="newspack-ui__button newspack-ui__button--primary" type="submit"><?php _e( 'Update subscriptions', 'newspack-newsletters' ); ?></button>
-				</form>
+				<?php
+				if ( is_wp_error( $user_lists ) ) :
+					// The form pre-checks the lists the reader is on. With nothing to
+					// check it would read as "subscribed to nothing", which is not what
+					// a failed read means, so it is not shown.
+					?>
+					<ul class="woocommerce-error" role="alert">
+						<li><?php esc_html_e( 'Newsletter subscriptions could not be loaded. Please try again later.', 'newspack-newsletters' ); ?></li>
+					</ul>
+					<?php
+				else :
+					$user_lists = array_flip( $user_lists );
+					?>
+					<p>
+						<?php _e( 'Manage your newsletter preferences.', 'newspack-newsletters' ); ?>
+					</p>
+					<form method="post">
+						<?php wp_nonce_field( self::SUBSCRIPTION_UPDATE, self::SUBSCRIPTION_UPDATE ); ?>
+						<div class="newspack-newsletters__lists">
+							<ul>
+								<?php
+								foreach ( $list_config as $list_id => $list ) :
+									$checkbox_id = sprintf( 'newspack-newsletters-list-checkbox-%s', $list_id );
+									?>
+									<li>
+										<span class="newspack-newsletters__lists__checkbox">
+											<input
+												type="checkbox"
+												name="lists[]"
+												value="<?php echo \esc_attr( $list_id ); ?>"
+												id="<?php echo \esc_attr( $checkbox_id ); ?>"
+												<?php if ( isset( $user_lists[ $list_id ] ) ) : ?>
+													checked
+												<?php endif; ?>
+											/>
+										</span>
+										<span class="newspack-newsletters__lists__details">
+											<label class="newspack-newsletters__lists__label" for="<?php echo \esc_attr( $checkbox_id ); ?>">
+												<span class="newspack-newsletters__lists__title">
+													<?php echo \esc_html( $list['title'] ); ?>
+												</span>
+												<span class="newspack-newsletters__lists__description"><?php echo \esc_html( $list['description'] ); ?></span>
+											</label>
+										</span>
+									</li>
+								<?php endforeach; ?>
+							</ul>
+						</div>
+						<button class="newspack-ui__button newspack-ui__button--primary" type="submit"><?php _e( 'Update subscriptions', 'newspack-newsletters' ); ?></button>
+					</form>
+				<?php endif; ?>
 			<?php endif; ?>
 		</div>
 		<?php
@@ -1514,8 +1528,12 @@ class Newspack_Newsletters_Subscription {
 				$result = Newspack_Newsletters_Contacts::subscribe( [ 'email' => $email ], $lists, false, 'User subscribed on My Account page' );
 			} else {
 				$current_lists = self::get_contact_lists( $email );
-				$lists_to_add  = array_values( array_diff( $lists_to_add, $current_lists ) );
-				$result        = Newspack_Newsletters_Contacts::update_lists( $email, $lists, 'User updated their subscriptions on My Account page' );
+				if ( is_wp_error( $current_lists ) ) {
+					$result = $current_lists;
+				} else {
+					$lists_to_add = array_values( array_diff( $lists_to_add, $current_lists ) );
+					$result       = Newspack_Newsletters_Contacts::update_lists( $email, $lists, 'User updated their subscriptions on My Account page' );
+				}
 			}
 			if ( is_wp_error( $result ) ) {
 				// Get a reader-friendly error message to show to the user.

--- a/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -2160,9 +2160,16 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	/**
 	 * Get the lists a contact is subscribed to.
 	 *
+	 * The lists come from a request of their own after the contact lookup, and
+	 * that request's failure is reported rather than answered with an empty
+	 * array: callers store and sync the result, so a failure that read as "on
+	 * no lists" would blank the reader's selection. A contact that cannot be
+	 * read still answers an empty array, like the other providers, since the
+	 * subscribe paths treat that as a contact on no lists (NPPD-2255).
+	 *
 	 * @param string $email The contact email.
 	 *
-	 * @return string[] Contact subscribed lists IDs.
+	 * @return string[]|WP_Error Contact subscribed lists IDs, or an error when the lists could not be read.
 	 */
 	public function get_contact_lists( $email ) {
 		$contact = $this->get_contact_data( $email );
@@ -2170,8 +2177,14 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			return [];
 		}
 		$contact_lists = $this->api_v3_request( 'contacts/' . $contact['id'] . '/contactLists' );
-		if ( is_wp_error( $contact_lists ) || ! isset( $contact_lists['contactLists'] ) ) {
-			return [];
+		if ( is_wp_error( $contact_lists ) ) {
+			return $contact_lists;
+		}
+		if ( ! isset( $contact_lists['contactLists'] ) || ! is_array( $contact_lists['contactLists'] ) ) {
+			return new WP_Error(
+				'newspack_newsletters_active_campaign_contact_lists_malformed',
+				__( 'ActiveCampaign returned a response without the contact\'s lists.', 'newspack-newsletters' )
+			);
 		}
 		$lists = [];
 		foreach ( $contact_lists['contactLists'] as $list ) {

--- a/plugins/newspack-newsletters/includes/service-providers/interface-newspack-newsletters-esp-service.php
+++ b/plugins/newspack-newsletters/includes/service-providers/interface-newspack-newsletters-esp-service.php
@@ -149,7 +149,7 @@ interface Newspack_Newsletters_ESP_API_Interface {
 	 *
 	 * @param string $email The contact email.
 	 *
-	 * @return string[] Contact subscribed lists IDs.
+	 * @return string[]|WP_Error Contact subscribed lists IDs, or an error when the lists could not be read.
 	 */
 	public function get_contact_lists( $email );
 

--- a/plugins/newspack-newsletters/tests/test-active-campaign-contact-lists.php
+++ b/plugins/newspack-newsletters/tests/test-active-campaign-contact-lists.php
@@ -1,0 +1,200 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Tests for the ActiveCampaign contact-lists read.
+ *
+ * Background: ActiveCampaign reads a contact's lists in a second request,
+ * `contacts/<id>/contactLists`, after the contact lookup. Answering that
+ * request's failure with an empty array made "could not read the lists" look
+ * like "on no lists" to every caller, and the login refresh in newspack-plugin
+ * then stored an empty selection and synced it to the ESP. The read now
+ * reports its own failure as a WP_Error. A contact that cannot be read still
+ * answers an empty array: the login refresh tells that case apart with a
+ * contact read of its own, and the subscribe paths rely on it to treat a new
+ * reader as a contact on no lists.
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * Test the ActiveCampaign contact-lists read.
+ */
+class ActiveCampaignContactListsTest extends WP_UnitTestCase {
+
+	/**
+	 * Email of the mocked contact.
+	 *
+	 * @var string
+	 */
+	const CONTACT_EMAIL = 'listed@example.com';
+
+	/**
+	 * Canned result for the contactLists request: a decoded body array
+	 * (returned as a 200), an int HTTP status (returned with an empty body), or
+	 * a WP_Error (returned as a transport failure).
+	 *
+	 * @var array|int|WP_Error
+	 */
+	private $contact_lists_response;
+
+	/**
+	 * Whether the contact lookup resolves the contact.
+	 *
+	 * @var bool
+	 */
+	private $contact_found = true;
+
+	/**
+	 * Set up: select the provider, configure credentials and intercept all
+	 * outbound HTTP.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->contact_found          = true;
+		$this->contact_lists_response = [ 'contactLists' => [] ];
+		Newspack_Newsletters::set_service_provider( 'active_campaign' );
+		Newspack_Newsletters_Active_Campaign::instance()->set_api_credentials(
+			[
+				'url' => 'https://example.api-us1.com',
+				'key' => 'test-key',
+			]
+		);
+		Newspack_Newsletters_Active_Campaign::instance()->clear_contact_data( self::CONTACT_EMAIL );
+		add_filter( 'pre_http_request', [ $this, 'mock_http' ], 10, 3 );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		remove_filter( 'pre_http_request', [ $this, 'mock_http' ], 10 );
+		// The provider caches contact lookups per email on the (singleton)
+		// instance, so drop the entry rather than leak it across tests.
+		Newspack_Newsletters_Active_Campaign::instance()->clear_contact_data( self::CONTACT_EMAIL );
+		parent::tear_down();
+	}
+
+	/**
+	 * Intercept outbound requests and play an AC account with one contact.
+	 *
+	 * @param mixed  $preempt Short-circuit value.
+	 * @param array  $args    HTTP request arguments.
+	 * @param string $url     Request URL.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function mock_http( $preempt, $args, $url ) {
+		$respond = function ( $body, $code = 200 ) {
+			return [
+				'response' => [
+					'code'    => $code,
+					'message' => 200 === $code ? 'OK' : 'Internal Server Error',
+				],
+				'body'     => wp_json_encode( $body ),
+			];
+		};
+
+		if ( false !== strpos( $url, '/api/3/contacts/101/contactLists' ) ) {
+			if ( is_wp_error( $this->contact_lists_response ) ) {
+				return $this->contact_lists_response;
+			}
+			if ( is_int( $this->contact_lists_response ) ) {
+				return $respond( [], $this->contact_lists_response );
+			}
+			return $respond( $this->contact_lists_response );
+		}
+		// The local-lists read that follows a successful lists read.
+		if ( false !== strpos( $url, '/api/3/contacts/101/contactTags' ) ) {
+			return $respond( [ 'contactTags' => [] ] );
+		}
+		// The search by email resolving the contact id.
+		if ( false !== strpos( $url, '/api/3/contacts' ) ) {
+			return $respond(
+				[
+					'contacts' => $this->contact_found ? [
+						[
+							'id'    => '101',
+							'email' => self::CONTACT_EMAIL,
+						],
+					] : [],
+				]
+			);
+		}
+		return $respond( [] );
+	}
+
+	/**
+	 * The lists a contact is subscribed to are the ones the ESP marks active.
+	 */
+	public function test_returns_the_lists_the_contact_is_subscribed_to() {
+		$this->contact_lists_response = [
+			'contactLists' => [
+				[
+					'list'   => '3',
+					'status' => '1',
+				],
+				[
+					'list'   => '4',
+					'status' => '2',
+				],
+				[
+					'list'   => '5',
+					'status' => 1,
+				],
+			],
+		];
+
+		$this->assertSame( [ '3', '5' ], Newspack_Newsletters_Active_Campaign::instance()->get_contact_lists( self::CONTACT_EMAIL ) );
+	}
+
+	/**
+	 * A contactLists request that fails in transport is an error, not a
+	 * contact on no lists.
+	 */
+	public function test_a_failed_contact_lists_request_is_an_error() {
+		$this->contact_lists_response = new WP_Error( 'http_request_failed', 'cURL error 28: Operation timed out' );
+
+		$this->assertWPError( Newspack_Newsletters_Active_Campaign::instance()->get_contact_lists( self::CONTACT_EMAIL ) );
+	}
+
+	/**
+	 * A contactLists request the ESP rejects is an error too.
+	 */
+	public function test_a_rejected_contact_lists_request_is_an_error() {
+		$this->contact_lists_response = 500;
+
+		$this->assertWPError( Newspack_Newsletters_Active_Campaign::instance()->get_contact_lists( self::CONTACT_EMAIL ) );
+	}
+
+	/**
+	 * A response without the lists in it says nothing about the contact's
+	 * lists, so it is an error rather than an empty set.
+	 */
+	public function test_a_malformed_contact_lists_response_is_an_error() {
+		$this->contact_lists_response = [ 'unexpected' => true ];
+
+		$this->assertWPError( Newspack_Newsletters_Active_Campaign::instance()->get_contact_lists( self::CONTACT_EMAIL ) );
+	}
+
+	/**
+	 * A contact that cannot be read keeps answering an empty array, like the
+	 * other providers: the login refresh tells that case apart with its own
+	 * contact read, and the subscribe paths treat a new reader as a contact on
+	 * no lists.
+	 */
+	public function test_an_unreadable_contact_still_answers_an_empty_array() {
+		$this->contact_found = false;
+
+		$this->assertSame( [], Newspack_Newsletters_Active_Campaign::instance()->get_contact_lists( self::CONTACT_EMAIL ) );
+	}
+
+	/**
+	 * What to add and remove is worked out against the contact's current
+	 * lists, so an update over a failed read reports the failure instead of
+	 * computing the change against an empty set.
+	 */
+	public function test_update_lists_reports_a_failed_list_read() {
+		$this->contact_lists_response = new WP_Error( 'http_request_failed', 'cURL error 28: Operation timed out' );
+
+		$this->assertWPError( Newspack_Newsletters_Contacts::update_lists( self::CONTACT_EMAIL, [ '3' ], 'Test' ) );
+	}
+}

--- a/plugins/newspack-newsletters/tests/test-active-campaign-contact-lists.php
+++ b/plugins/newspack-newsletters/tests/test-active-campaign-contact-lists.php
@@ -197,4 +197,29 @@ class ActiveCampaignContactListsTest extends WP_UnitTestCase {
 
 		$this->assertWPError( Newspack_Newsletters_Contacts::update_lists( self::CONTACT_EMAIL, [ '3' ], 'Test' ) );
 	}
+
+	/**
+	 * The lists the My Account page offers pass through a filter documented as
+	 * answering an error as well, and an error there is a failed load like a
+	 * failed lists read: the notice is shown and the form is not.
+	 */
+	public function test_my_account_treats_an_unreadable_lists_config_as_a_failed_load() {
+		$user_id = self::factory()->user->create( [ 'user_email' => self::CONTACT_EMAIL ] );
+		update_user_meta( $user_id, Newspack_Newsletters_Subscription::EMAIL_VERIFIED_META, [ self::CONTACT_EMAIL ] );
+		wp_set_current_user( $user_id );
+		$fail = function () {
+			return new WP_Error( 'blocked', 'blocked' );
+		};
+		add_filter( 'newspack_newsletters_manage_newsletters_available_lists', $fail );
+
+		ob_start();
+		Newspack_Newsletters_Subscription::endpoint_content();
+		$output = ob_get_clean();
+
+		remove_filter( 'newspack_newsletters_manage_newsletters_available_lists', $fail );
+		wp_set_current_user( 0 );
+
+		$this->assertStringContainsString( 'could not be loaded', $output );
+		$this->assertStringNotContainsString( 'newspack-newsletters__lists', $output );
+	}
 }

--- a/plugins/newspack-plugin/includes/cli/class-premium-newsletters-verify.php
+++ b/plugins/newspack-plugin/includes/cli/class-premium-newsletters-verify.php
@@ -482,29 +482,29 @@ class Premium_Newsletters_Verify {
 	/**
 	 * One reader's ESP list membership, and whether it can be trusted.
 	 *
-	 * Every shipped provider's get_contact_lists() swallows a failed API call into an
-	 * empty array rather than a WP_Error, so it cannot tell "no contact" from "could
-	 * not ask". Reading get_contact_data() first recovers part of that distinction:
+	 * Every shipped provider's get_contact_lists() answers a failed contact read with
+	 * an empty array rather than a WP_Error, so it cannot tell "no contact" from
+	 * "could not ask". Reading get_contact_data() first recovers part of that distinction:
 	 * its WP_Error code names a genuine miss on all three providers, so a reader with
 	 * no contact counts as "on no lists" rather than failing.
 	 *
 	 * That pre-read does not cover the remaining ambiguity — an empty list set from a
 	 * contact that exists is both what a reader on no lists looks like and what a
 	 * failed list read returns. On Mailchimp and Constant Contact the list read is a
-	 * second, un-memoized request that can fail on its own; on ActiveCampaign it is a
-	 * different endpoint entirely. So an empty set is corroborated by a further
-	 * contact read before it is believed, which costs one call on that path only and
-	 * turns a flaking provider into unresolved rows rather than a clean run.
+	 * second, un-memoized request that can fail on its own. (ActiveCampaign reads the
+	 * lists from an endpoint of their own and reports that request's failure as a
+	 * WP_Error, which the check above already turns into an unresolved row.) So an
+	 * empty set is corroborated by a further contact read before it is believed,
+	 * which costs one call on that path only and turns a flaking provider into
+	 * unresolved rows rather than a clean run.
 	 *
 	 * What this closes, precisely: a failure that persists across two reads. It does
-	 * not close a single transient one, on any provider. Mailchimp's and Constant
-	 * Contact's get_contact_lists() are get_contact_data() plus a filter, so the
-	 * corroborating call re-issues the request that just failed and a blip clearing
-	 * in between reads as "no lists"; ActiveCampaign's list read is a separate
-	 * endpoint the corroborating call never touches at all. Deciding this from the
-	 * contact payload already in hand would be stronger, but it means mirroring each
-	 * provider's own membership filter — Mailchimp counts only `subscribed` entries —
-	 * and ActiveCampaign's payload carries no membership to read.
+	 * not close a single transient one on Mailchimp or Constant Contact: their
+	 * get_contact_lists() are get_contact_data() plus a filter, so the corroborating
+	 * call re-issues the request that just failed and a blip clearing in between
+	 * reads as "no lists". Deciding this from the contact payload already in hand
+	 * would be stronger, but it means mirroring each provider's own membership
+	 * filter — Mailchimp counts only `subscribed` entries.
 	 *
 	 * @param array  $esp   The ESP gateway.
 	 * @param string $email The reader's email address.

--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-data.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-data.php
@@ -692,9 +692,10 @@ final class Reader_Data {
 		// second lookup only happens for readers on no lists. A contact that
 		// does not exist is treated like one that could not be read, so a reader
 		// deleted at the ESP keeps their stored lists: the conservative side,
-		// since a blank pushed by mistake cannot be recovered. Known gap:
-		// ActiveCampaign fetches the lists in a second request and answers []
-		// when that one fails, which this check cannot tell from a real empty.
+		// since a blank pushed by mistake cannot be recovered. ActiveCampaign
+		// reads the lists in a second request and reports that one's failure
+		// as a WP_Error, which the check above returns on, so this re-read is
+		// only about the contact lookup.
 		if ( empty( $subscribed_lists ) && is_wp_error( \Newspack_Newsletters_Subscription::get_contact_data( $data['email'] ) ) ) {
 			return;
 		}

--- a/plugins/newspack-plugin/tests/unit-tests/reader-data-newsletter-lists.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-data-newsletter-lists.php
@@ -219,6 +219,27 @@ class Newspack_Test_Reader_Data_Newsletter_Lists extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A list lookup that fails on its own is an error, not a reader on no
+	 * lists, even though the contact reads fine. ActiveCampaign reads the lists
+	 * in a request of its own and reports that request's failure this way.
+	 * Nothing is stored, so the selection the ESP holds is left alone.
+	 */
+	public function test_login_refresh_keeps_the_stored_lists_when_the_list_lookup_fails() {
+		Reader_Data::update_item( $this->user_id, 'newsletter_subscribed_lists', [ 'list-1' ] );
+		Newspack_Newsletters_Subscription::$contact_data[ $this->email ]  = [ 'email' => $this->email ];
+		Newspack_Newsletters_Subscription::$contact_lists[ $this->email ] = new \WP_Error( 'http_request_failed', 'cURL error 28: Operation timed out' );
+		Reader_Data::check_newsletter_subscription(
+			time(),
+			[
+				'user_id' => $this->user_id,
+				'email'   => $this->email,
+			]
+		);
+		$this->assertSame( '["list-1"]', $this->stored_lists() );
+		$this->assertFalse( Reader_Data::get_data( $this->user_id, 'is_newsletter_subscriber' ) );
+	}
+
+	/**
 	 * The typed accessor returns the stored list as strings.
 	 */
 	public function test_get_newsletter_subscribed_lists_returns_the_stored_ids() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When ActiveCampaign's contact-lists request fails or comes back without lists, the provider now answers with an error instead of an empty list. Before, the login refresh took that empty list as "on no lists", stored it, and the next sync blanked the reader's **Newsletter Selection** at the ESP. #1018 named this gap when it restored the field. A contact that cannot be read still answers an empty list, like the other providers, so new readers keep subscribing as before.

Every caller of the list lookup now handles an error: the My Account newsletters page shows a notice instead of an all-unchecked form, saving from that page reports the error, and list updates stop rather than computing the change against an empty set, which dropped removals silently. The login refresh keeps its contact re-read, since Mailchimp and Constant Contact still answer an empty list when the contact read itself fails.

Closes NPPD-2255.

### How to test the changes in this Pull Request:

1. On a site with ActiveCampaign as the newsletter provider, log in as a reader who is on at least one list, then run `wp action-scheduler run`. The reader's `newspack_reader_data_item_newsletter_subscribed_lists` user meta holds that list.
2. Add an mu-plugin that fails the lists request: `add_filter( 'pre_http_request', fn( $pre, $args, $url ) => str_contains( $url, '/contactLists' ) ? new WP_Error( 'blocked', 'blocked' ) : $pre, 10, 3 );`
3. Log out, log in again as the reader, and run `wp action-scheduler run`. The stored meta is unchanged; without this PR it becomes `[]`.
4. Open My Account > Newsletters. A notice says the subscriptions could not be loaded, and no checkbox form is shown.
5. Remove the mu-plugin and reload the page. The form renders with the reader's list checked.
6. Re-add the mu-plugin without reloading, change a checkbox, and submit. An error notice is shown and the reader's lists at ActiveCampaign are unchanged.
7. Remove the mu-plugin, submit the form again. The change reaches ActiveCampaign and the success notice appears.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Left out on purpose: the shared provider code still answers an empty list when a local-lists (tag) read fails, the same shape one level up. Separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
