### PR TITLE
fix(newsletters): report a failed local-lists read (NPPD-2255)

### DIFF
--- a/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -769,6 +769,12 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
+		if ( ! isset( $result['contactTags'] ) || ! is_array( $result['contactTags'] ) ) {
+			return new WP_Error(
+				'newspack_newsletters_active_campaign_contact_tags_malformed',
+				__( 'ActiveCampaign returned a response without the contact\'s tags.', 'newspack-newsletters' )
+			);
+		}
 
 		return array_values(
 			array_map(

--- a/plugins/newspack-newsletters/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/plugins/newspack-newsletters/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -838,17 +838,40 @@ Error message(s) received:
 	}
 
 	/**
+	 * Whether an error from a contact read means the contact does not exist,
+	 * rather than that the read failed.
+	 *
+	 * Each provider's get_contact_data() answers a miss with a code of its own,
+	 * and all of them end in `_contact_not_found`. newspack-plugin matches the
+	 * same convention in the premium newsletters verify command and the ESP
+	 * reader-activation integration.
+	 *
+	 * @param WP_Error $error The error a contact read returned.
+	 * @return bool
+	 */
+	protected function is_contact_not_found_error( $error ) {
+		return str_ends_with( (string) $error->get_error_code(), '_contact_not_found' );
+	}
+
+	/**
 	 * Get the contact local lists IDs
+	 *
+	 * A failed read is reported rather than answered with an empty array: the
+	 * combined read merges this into what callers store and sync, so a failure
+	 * that read as "on no local lists" dropped the reader's local lists from
+	 * their selection. A contact that does not exist has no local lists, the
+	 * way it has no lists, since the subscribe paths treat a new reader as a
+	 * contact on no lists (NPPD-2255).
 	 *
 	 * Note: Mailchimp overrides this method.
 	 *
 	 * @param string $email The contact email.
-	 * @return string[] Array of local lists IDs or error.
+	 * @return string[]|WP_Error Array of local lists IDs, or an error when they could not be read.
 	 */
 	public function get_contact_local_lists( $email ) {
 		$tags = $this->get_contact_esp_local_lists_ids( $email );
 		if ( is_wp_error( $tags ) ) {
-			return [];
+			return $this->is_contact_not_found_error( $tags ) ? [] : $tags;
 		}
 		$lists = Subscription_Lists::get_configured_for_provider( $this->service );
 		$ids   = [];

--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -2407,12 +2407,13 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 * In other providers, get_contact_esp_local_lists_ids returns a simple array with IDs, but in Mailchimp it returns IDs grouped by lists.
 	 *
 	 * @param string $email The contact email.
-	 * @return string[] Array of local lists IDs or error.
+	 * @return string[]|WP_Error Array of local lists IDs, or an error when they could not be read.
 	 */
 	public function get_contact_local_lists( $email ) {
 		$tags = $this->get_contact_esp_local_lists_ids( $email );
 		if ( is_wp_error( $tags ) ) {
-			return [];
+			// Same contract as the parent method: a failed read is reported, a missing contact has none.
+			return $this->is_contact_not_found_error( $tags ) ? [] : $tags;
 		}
 		$lists = Subscription_Lists::get_configured_for_provider( $this->service );
 		$ids   = [];

--- a/plugins/newspack-newsletters/tests/test-active-campaign-contact-lists.php
+++ b/plugins/newspack-newsletters/tests/test-active-campaign-contact-lists.php
@@ -1,6 +1,6 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 /**
- * Tests for the ActiveCampaign contact-lists read.
+ * Tests for the ActiveCampaign contact-lists and local-lists reads.
  *
  * Background: ActiveCampaign reads a contact's lists in a second request,
  * `contacts/<id>/contactLists`, after the contact lookup. Answering that
@@ -12,11 +12,20 @@
  * contact read of its own, and the subscribe paths rely on it to treat a new
  * reader as a contact on no lists.
  *
+ * The local lists (tags) are read the same way, in a `contacts/<id>/contactTags`
+ * request, and that read's failure is reported as well: answered with an empty
+ * array, it dropped the reader's local lists from the combined read the login
+ * refresh stores and syncs. A contact that does not exist has no local lists,
+ * for the reason above.
+ *
  * @package Newspack_Newsletters
  */
 
+use Newspack\Newsletters\Subscription_List;
+use Newspack\Newsletters\Subscription_Lists;
+
 /**
- * Test the ActiveCampaign contact-lists read.
+ * Test the ActiveCampaign contact-lists and local-lists reads.
  */
 class ActiveCampaignContactListsTest extends WP_UnitTestCase {
 
@@ -37,6 +46,14 @@ class ActiveCampaignContactListsTest extends WP_UnitTestCase {
 	private $contact_lists_response;
 
 	/**
+	 * Canned result for the contactTags request, in the same shapes as
+	 * $contact_lists_response.
+	 *
+	 * @var array|int|WP_Error
+	 */
+	private $contact_tags_response;
+
+	/**
 	 * Whether the contact lookup resolves the contact.
 	 *
 	 * @var bool
@@ -51,6 +68,7 @@ class ActiveCampaignContactListsTest extends WP_UnitTestCase {
 		parent::set_up();
 		$this->contact_found          = true;
 		$this->contact_lists_response = [ 'contactLists' => [] ];
+		$this->contact_tags_response  = [ 'contactTags' => [] ];
 		Newspack_Newsletters::set_service_provider( 'active_campaign' );
 		Newspack_Newsletters_Active_Campaign::instance()->set_api_credentials(
 			[
@@ -93,18 +111,22 @@ class ActiveCampaignContactListsTest extends WP_UnitTestCase {
 			];
 		};
 
+		$canned = function ( $response ) use ( $respond ) {
+			if ( is_wp_error( $response ) ) {
+				return $response;
+			}
+			if ( is_int( $response ) ) {
+				return $respond( [], $response );
+			}
+			return $respond( $response );
+		};
+
 		if ( false !== strpos( $url, '/api/3/contacts/101/contactLists' ) ) {
-			if ( is_wp_error( $this->contact_lists_response ) ) {
-				return $this->contact_lists_response;
-			}
-			if ( is_int( $this->contact_lists_response ) ) {
-				return $respond( [], $this->contact_lists_response );
-			}
-			return $respond( $this->contact_lists_response );
+			return $canned( $this->contact_lists_response );
 		}
-		// The local-lists read that follows a successful lists read.
+		// The local-lists read that follows the lists read.
 		if ( false !== strpos( $url, '/api/3/contacts/101/contactTags' ) ) {
-			return $respond( [ 'contactTags' => [] ] );
+			return $canned( $this->contact_tags_response );
 		}
 		// The search by email resolving the contact id.
 		if ( false !== strpos( $url, '/api/3/contacts' ) ) {
@@ -185,6 +207,104 @@ class ActiveCampaignContactListsTest extends WP_UnitTestCase {
 		$this->contact_found = false;
 
 		$this->assertSame( [], Newspack_Newsletters_Active_Campaign::instance()->get_contact_lists( self::CONTACT_EMAIL ) );
+	}
+
+	/**
+	 * Create a local list configured for ActiveCampaign under the given tag.
+	 *
+	 * @param int $tag_id The ActiveCampaign tag ID.
+	 *
+	 * @return string The list's public ID.
+	 */
+	private function create_local_list( $tag_id ) {
+		$post_id = wp_insert_post(
+			[
+				'post_title'  => 'Local list ' . $tag_id,
+				'post_type'   => Subscription_Lists::CPT,
+				'post_status' => 'publish',
+			]
+		);
+		update_post_meta(
+			$post_id,
+			Subscription_List::META_KEY,
+			[
+				'active_campaign' => [
+					'list'     => 'ac_list',
+					'tag_id'   => $tag_id,
+					'tag_name' => 'AC Tag ' . $tag_id,
+				],
+			]
+		);
+		Subscription_Lists::flush_cache();
+		return ( new Subscription_List( $post_id ) )->get_public_id();
+	}
+
+	/**
+	 * A local list the contact carries as a tag is part of the combined read,
+	 * next to the ESP's own lists.
+	 */
+	public function test_the_local_lists_the_contact_carries_are_part_of_its_combined_lists() {
+		$public_id                    = $this->create_local_list( 13 );
+		$this->contact_lists_response = [
+			'contactLists' => [
+				[
+					'list'   => '3',
+					'status' => '1',
+				],
+			],
+		];
+		$this->contact_tags_response  = [ 'contactTags' => [ [ 'tag' => '13' ] ] ];
+
+		$this->assertSame( [ '3', $public_id ], Newspack_Newsletters_Active_Campaign::instance()->get_contact_combined_lists( self::CONTACT_EMAIL ) );
+	}
+
+	/**
+	 * A contactTags request that fails in transport is an error, not a
+	 * contact on no local lists.
+	 */
+	public function test_a_failed_contact_tags_request_is_an_error() {
+		$this->contact_tags_response = new WP_Error( 'http_request_failed', 'cURL error 28: Operation timed out' );
+
+		$this->assertWPError( Newspack_Newsletters_Active_Campaign::instance()->get_contact_local_lists( self::CONTACT_EMAIL ) );
+	}
+
+	/**
+	 * A response without the tags in it says nothing about the contact's
+	 * local lists, so it is an error rather than an empty set.
+	 */
+	public function test_a_malformed_contact_tags_response_is_an_error() {
+		$this->contact_tags_response = [ 'unexpected' => true ];
+
+		$this->assertWPError( Newspack_Newsletters_Active_Campaign::instance()->get_contact_local_lists( self::CONTACT_EMAIL ) );
+	}
+
+	/**
+	 * A contact that does not exist has no local lists, the way it has no
+	 * lists: the subscribe paths treat a new reader as a contact on no lists.
+	 */
+	public function test_a_missing_contact_has_no_local_lists() {
+		$this->contact_found = false;
+
+		$this->assertSame( [], Newspack_Newsletters_Active_Campaign::instance()->get_contact_local_lists( self::CONTACT_EMAIL ) );
+	}
+
+	/**
+	 * The combined read is what callers store and sync, so a failed local-lists
+	 * read makes it an error rather than a set with the local lists missing.
+	 */
+	public function test_combined_lists_report_a_failed_local_lists_read() {
+		$this->create_local_list( 13 );
+		$this->contact_lists_response = [
+			'contactLists' => [
+				[
+					'list'   => '3',
+					'status' => '1',
+				],
+			],
+		];
+		$this->contact_tags_response  = new WP_Error( 'http_request_failed', 'cURL error 28: Operation timed out' );
+
+		$this->assertWPError( Newspack_Newsletters_Active_Campaign::instance()->get_contact_combined_lists( self::CONTACT_EMAIL ) );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/cli/class-premium-newsletters-verify.php
+++ b/plugins/newspack-plugin/includes/cli/class-premium-newsletters-verify.php
@@ -493,7 +493,12 @@ class Premium_Newsletters_Verify {
 	 * failed list read returns. On Mailchimp and Constant Contact the list read is a
 	 * second, un-memoized request that can fail on its own. (ActiveCampaign reads the
 	 * lists from an endpoint of their own and reports that request's failure as a
-	 * WP_Error, which the check above already turns into an unresolved row.) So an
+	 * WP_Error, which the check above already turns into an unresolved row. The local
+	 * lists in the same combined set, the tags or groups a site's local lists map to,
+	 * come from a further read that every provider reports the same way, so a
+	 * restricted local list only goes missing from an otherwise-believed set when that
+	 * read answers the provider's not-found code, which on Mailchimp is also what a
+	 * flake looks like.) So an
 	 * empty set is corroborated by a further contact read before it is believed,
 	 * which costs one call on that path only and turns a flaking provider into
 	 * unresolved rows rather than a clean run.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When a provider's local-lists read fails (ActiveCampaign and Constant Contact tags, Mailchimp groups), the shared provider code now answers with an error instead of an empty list. Before, the combined read every caller uses came back without the reader's local lists, the login refresh stored that partial set, and the next sync dropped those lists from the reader's **Newsletter Selection** at the ESP. #1047 fixed the same shape in ActiveCampaign's lists read and left this one out on purpose. A contact that does not exist still answers an empty list, so new readers keep subscribing as before. An ActiveCampaign tags response without tags in it is an error too; before, it ended in a fatal error.

The premium newsletters verify command gets the same benefit without changes of its own: a failed read of a restricted local list is now an unresolved row rather than a reader who reads as not on the list.

Follow-up to #1047 for NPPD-2255.

### How to test the changes in this Pull Request:

1. With ActiveCampaign as the newsletter provider and a local subscription list, log in as a reader on that list and on one ActiveCampaign list, then run `wp action-scheduler run`. The `newspack_reader_data_item_newsletter_subscribed_lists` user meta holds both lists.
2. Add an mu-plugin that fails the tags request: `add_filter( 'pre_http_request', fn( $pre, $args, $url ) => str_contains( $url, '/contactTags' ) ? new WP_Error( 'blocked', 'blocked' ) : $pre, 10, 3 );`
3. Log out, log in again as the reader, and run `wp action-scheduler run`. The stored meta is unchanged; without this PR it holds only the ActiveCampaign list.
4. Open My Account > Newsletters. A notice says the subscriptions could not be loaded, and no checkbox form is shown.
5. Remove the mu-plugin and reload the page. The form renders with both lists checked.
6. Re-add the mu-plugin without reloading, change a checkbox, and submit. An error notice is shown and the reader's lists at ActiveCampaign are unchanged.
7. Change the mu-plugin to answer the tags request with an empty JSON object: replace the `WP_Error` with `[ 'response' => [ 'code' => 200, 'message' => 'OK' ], 'body' => '{}' ]`. Log in again and run `wp action-scheduler run`. The stored meta is unchanged; without this PR the job ends in a fatal error.
8. On a site with a premium newsletter gate whose restricted list is a local list, keep the failing mu-plugin and run `wp newspack verify-premium-newsletters`. Readers on that list are reported as unresolved; without this PR they read as not on the list.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Stacked on #1047: the base is that branch until it merges, and the diff here is the follow-up commit only.

Left out on purpose: a Mailchimp contact read that flakes into its not-found code during the groups step still reads as no local lists, since not-found has to keep meaning "new reader". Closing that means reading the groups from the contact record the lists read already holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
