### PR TITLE
fix(content-distribution): authorize the post on unlink and pull

### DIFF
--- a/plugins/newspack-network/includes/content-distribution/class-api.php
+++ b/plugins/newspack-network/includes/content-distribution/class-api.php
@@ -52,9 +52,7 @@ class API {
 						'default' => 'draft',
 					],
 				],
-				'permission_callback' => function ( $request ) {
-					return current_user_can( Admin::CAPABILITY ) && current_user_can( 'edit_post', $request['post_id'] );
-				},
+				'permission_callback' => [ __CLASS__, 'check_post_permission' ],
 			]
 		);
 
@@ -70,9 +68,7 @@ class API {
 						'type'     => 'boolean',
 					],
 				],
-				'permission_callback' => function () {
-					return current_user_can( Admin::CAPABILITY );
-				},
+				'permission_callback' => [ __CLASS__, 'check_post_permission' ],
 			]
 		);
 
@@ -93,9 +89,7 @@ class API {
 						'default' => 'draft',
 					],
 				],
-				'permission_callback' => function () {
-					return current_user_can( Admin::CAPABILITY );
-				},
+				'permission_callback' => [ __CLASS__, 'check_post_permission' ],
 			]
 		);
 
@@ -116,6 +110,21 @@ class API {
 				},
 			]
 		);
+	}
+
+	/**
+	 * Permission callback for the routes that act on the post named in the URL.
+	 *
+	 * The capability is granted to the 'author' role by default and only
+	 * authorizes the caller. The edit_post check is what holds an author to the
+	 * posts they can edit, and it refuses a post ID that resolves to nothing.
+	 *
+	 * @param WP_REST_Request $request The REST request object.
+	 *
+	 * @return bool
+	 */
+	public static function check_post_permission( $request ): bool {
+		return current_user_can( Admin::CAPABILITY ) && current_user_can( 'edit_post', $request['post_id'] );
 	}
 
 	/**

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
@@ -38,13 +38,6 @@ class TestApi extends \WP_UnitTestCase {
 	];
 
 	/**
-	 * The 'distribute' route's permission callback.
-	 *
-	 * @var callable
-	 */
-	private $permission_callback;
-
-	/**
 	 * Set up.
 	 */
 	public function set_up() {
@@ -57,11 +50,6 @@ class TestApi extends \WP_UnitTestCase {
 		rest_get_server();
 
 		API::register_routes();
-
-		$routes = rest_get_server()->get_routes();
-		$route  = $routes['/newspack-network/v1/content-distribution/distribute/(?P<post_id>\d+)'][0];
-
-		$this->permission_callback = $route['permission_callback'];
 	}
 
 	/**
@@ -112,59 +100,139 @@ class TestApi extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * An author cannot distribute a post authored by another user, even
-	 * though the 'author' role is granted the distribute capability by
-	 * default; the capability check alone doesn't guard against posting
-	 * someone else's post ID.
+	 * The routes that act on the post named in the URL, each with the body it
+	 * requires. The server validates the body before it consults the permission
+	 * callback, so a request missing a required field would be refused for the
+	 * wrong reason.
+	 *
+	 * @return array
 	 */
-	public function test_author_cannot_distribute_others_post() {
-		$author       = $this->factory->user->create( [ 'role' => 'author' ] );
-		$other_author = $this->factory->user->create( [ 'role' => 'author' ] );
-		$post         = $this->factory->post->create( [ 'post_author' => $other_author ] );
-
-		wp_set_current_user( $author );
-
-		$this->assertFalse( ( $this->permission_callback )( $this->make_request( $post ) ) );
+	public function post_routes() {
+		return [
+			'distribute' => [ 'distribute', [ 'urls' => [ 'https://node.test' ] ] ],
+			'unlink'     => [ 'unlink', [ 'unlinked' => true ] ],
+			'pull'       => [ 'pull', [ 'url' => 'https://node.test' ] ],
+		];
 	}
 
 	/**
-	 * An author can distribute their own post.
+	 * Create a post the given user authored, shaped so the route's handler
+	 * accepts it: unlink loads the post as an incoming one from its stored payload.
+	 *
+	 * @param string $route  The route slug.
+	 * @param int    $author The author's user ID.
+	 *
+	 * @return int The post ID.
 	 */
-	public function test_author_can_distribute_own_post() {
-		$author = $this->factory->user->create( [ 'role' => 'author' ] );
-		$post   = $this->factory->post->create( [ 'post_author' => $author ] );
+	private function make_post_for( $route, $author ) {
+		$post_id = $this->factory->post->create( [ 'post_author' => $author ] );
+
+		if ( 'unlink' === $route ) {
+			update_post_meta( $post_id, Incoming_Post::PAYLOAD_META, get_sample_payload( 'https://origin.test', get_bloginfo( 'url' ) ) );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * Dispatch a request for one of the post routes through the REST server.
+	 *
+	 * The post ID travels in the URL only, the way a real request carries it,
+	 * so a permission callback that cannot see the request fails these.
+	 *
+	 * @param string $route   The route slug.
+	 * @param int    $post_id The post ID.
+	 * @param array  $params  Body parameters.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	private function dispatch( $route, $post_id, array $params ) {
+		$request = new WP_REST_Request( 'POST', '/newspack-network/v1/content-distribution/' . $route . '/' . $post_id );
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * The 'author' role holds the distribute capability by default, and the
+	 * capability alone says nothing about the post: without the object check,
+	 * an author could read any post by ID through pull and toggle any post's
+	 * link through unlink.
+	 *
+	 * @dataProvider post_routes
+	 *
+	 * @param string $route  The route slug.
+	 * @param array  $params Body parameters the route requires.
+	 */
+	public function test_author_is_refused_another_users_post( $route, array $params ) {
+		$author       = $this->factory->user->create( [ 'role' => 'author' ] );
+		$other_author = $this->factory->user->create( [ 'role' => 'author' ] );
+		$post_id      = $this->make_post_for( $route, $other_author );
 
 		wp_set_current_user( $author );
 
-		$this->assertTrue( ( $this->permission_callback )( $this->make_request( $post ) ) );
+		$this->assertSame( 403, $this->dispatch( $route, $post_id, $params )->get_status() );
+	}
+
+	/**
+	 * The object check must not over-restrict: a caller who can edit the post
+	 * reaches the handler.
+	 *
+	 * @dataProvider post_routes
+	 *
+	 * @param string $route  The route slug.
+	 * @param array  $params Body parameters the route requires.
+	 */
+	public function test_author_can_act_on_their_own_post( $route, array $params ) {
+		$author  = $this->factory->user->create( [ 'role' => 'author' ] );
+		$post_id = $this->make_post_for( $route, $author );
+
+		wp_set_current_user( $author );
+
+		$response = $this->dispatch( $route, $post_id, $params );
+
+		$this->assertSame( 200, $response->get_status(), 'Expected the handler to run, got: ' . wp_json_encode( $response->get_data() ) );
 	}
 
 	/**
 	 * The other half of the '&&': edit rights on the post are not enough on
 	 * their own, the distribute capability is still required.
+	 *
+	 * @dataProvider post_routes
+	 *
+	 * @param string $route  The route slug.
+	 * @param array  $params Body parameters the route requires.
 	 */
-	public function test_edit_rights_without_capability_cannot_distribute() {
-		$author = $this->factory->user->create( [ 'role' => 'author' ] );
-		$post   = $this->factory->post->create( [ 'post_author' => $author ] );
+	public function test_edit_rights_without_the_capability_are_refused( $route, array $params ) {
+		$author  = $this->factory->user->create( [ 'role' => 'author' ] );
+		$post_id = $this->make_post_for( $route, $author );
 
 		// A user-level deny overrides the role grant.
 		get_userdata( $author )->add_cap( Admin::CAPABILITY, false );
 
 		wp_set_current_user( $author );
 
-		$this->assertTrue( current_user_can( 'edit_post', $post ) );
-		$this->assertFalse( ( $this->permission_callback )( $this->make_request( $post ) ) );
+		$this->assertTrue( current_user_can( 'edit_post', $post_id ) );
+		$this->assertSame( 403, $this->dispatch( $route, $post_id, $params )->get_status() );
 	}
 
 	/**
 	 * A post ID that resolves to no post is refused, so the handler is never
-	 * reached with nothing to distribute.
+	 * reached with nothing to act on.
+	 *
+	 * @dataProvider post_routes
+	 *
+	 * @param string $route  The route slug.
+	 * @param array  $params Body parameters the route requires.
 	 */
-	public function test_missing_post_cannot_be_distributed() {
+	public function test_a_missing_post_is_refused( $route, array $params ) {
 		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
 
-		$this->assertFalse( ( $this->permission_callback )( $this->make_request( 0 ) ) );
-		$this->assertFalse( ( $this->permission_callback )( $this->make_request( PHP_INT_MAX ) ) );
+		foreach ( [ 0, PHP_INT_MAX ] as $missing_post_id ) {
+			$this->assertSame( 403, $this->dispatch( $route, $missing_post_id, $params )->get_status(), "Post ID $missing_post_id must be refused." );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The content-distribution `unlink` and `pull` routes checked only that the caller holds `newspack_network_distribute`, granted to administrators, editors, and authors by default. Neither looked at the post named in the URL, so an author could pull any post by ID, drafts and private posts included, and unlink or re-link any post received from the network.

Both routes now also require the caller to be able to edit that post, as `distribute` already did.

**Who is affected.** An author can now pull, unlink, or re-link only posts they can edit. Editors and administrators are unchanged. Story Budget still offers Pull for every story on a networked site, so an author without edit rights on the origin post gets a permission error on use; hiding the action for them is a Story Budget change left for a follow-up.

Closes NPPM-3197.

### How to test the changes in this Pull Request:

Use two networked sites (a hub and a node) and an author account on the origin site with an application password.

1. As the author, request `POST /wp-json/newspack-network/v1/content-distribution/pull/<ID>` with `url` set to the other site, for a post someone else wrote. Expect a 403 `rest_forbidden` response.
2. Repeat for a post the author wrote. Expect a 200 response carrying the post payload.
3. On the receiving site, as an author who did not write a post received from the network, request `POST /wp-json/newspack-network/v1/content-distribution/unlink/<ID>` with `{"unlinked": true}`. Expect 403.
4. Repeat as an editor. Expect 200 with `"unlinked": true`.
5. Open a post received from the network in the editor as an editor. Expect the Unlink and Relink toggles to work as before.
6. In Story Budget on the node, pull a story from the hub as an editor. Expect the pull to succeed as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? The permission tests cover all three post routes through the REST server: refused for another user's post and for a missing post, allowed for the caller's own.
* [x] Have you successfully run tests with your changes locally? `test_toggle_jetpack_photon` fails locally with or without this change: it sideloads a real image and needs network access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
