### PR TITLE
fix(my-account): tweak subscription header component styles

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group.php
@@ -14,7 +14,6 @@
 
 use Newspack\Group_Subscription;
 use Newspack\Group_Subscription_MyAccount;
-use Newspack\Group_Subscription_Seats;
 use Newspack\Group_Subscription_Settings;
 use Newspack\Newspack_UI_Icons;
 use Newspack\Subscriptions_Tiers;
@@ -68,59 +67,52 @@ if ( in_array( $subscription_status, [ 'cancelled', 'expired' ], true ) ) {
 			<div class="newspack-my-account__subscription--actions-container">
 				<?php
 				/* translators: %s: lowercase singular group label (e.g. "group", "team"). */
-				$rename_label = sprintf( __( 'Rename %s', 'newspack-plugin' ), $group_label_lower );
+				$rename_label          = sprintf( __( 'Rename %s', 'newspack-plugin' ), $group_label_lower );
+				$is_owner              = $user_id === (int) $subscription->get_user_id(); // Billing is the owner's surface; a manager never sees it.
+				$view_subscription_url = wc_get_endpoint_url( 'view-subscription', $subscription->get_id(), wc_get_page_permalink( 'myaccount' ) );
+				$seat_item             = $is_owner && Group_Subscription_MyAccount::can_change_seats( $subscription, $user_id )
+					? Group_Subscription_Settings::get_seat_line_item( $subscription )
+					: null;
+				$change_seats_url      = null;
+				if ( $seat_item ) {
+					// Only line items registered here get a modal printed on wp_footer, so
+					// register before the link that opens it. The href is the no-JS
+					// fallback; switch-subscription.js intercepts the click and opens the
+					// modal keyed by this subscription's ID.
+					Subscriptions_Tiers::register_switch_modal( $seat_item->get_id(), $seat_item, $subscription );
+					// WooCommerce Subscriptions' own helper, because its switch handler
+					// refuses a URL without the `_wcsnonce` it appends -- a hand-built
+					// link would send a reader without JavaScript back to My Account
+					// with nothing changed and nothing said.
+					$change_seats_url = \WC_Subscriptions_Switcher::get_switch_url( $seat_item->get_id(), $seat_item, $subscription );
+				}
+				// Rename and View subscription stay available whatever the subscription's status;
+				// only inviting is tied to an active group that still has room.
+				$show_invite_actions = $is_active && ! $is_completely_empty;
 
-				/**
-				 * Dropdown menus are only shown at large viewports.
-				 */
+				// Dropdown menu, shown at large viewports only.
 				?>
-				<?php if ( $is_active ) : ?>
-					<div class="newspack-ui__dropdown newspack-my-account__subscription--actions-dropdown">
-						<button class="newspack-ui__button newspack-ui__button--ghost newspack-ui__dropdown__toggle">
-							<span class="screen-reader-text"><?php esc_html_e( 'More', 'newspack-plugin' ); ?></span>
-							<?php Newspack_UI_Icons::print_svg( 'more' ); ?>
-						</button>
-						<div class="newspack-ui__dropdown__content">
-							<ul>
+				<div class="newspack-ui__dropdown newspack-my-account__subscription--actions-dropdown">
+					<button class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--small newspack-ui__dropdown__toggle">
+						<span class="screen-reader-text"><?php esc_html_e( 'More', 'newspack-plugin' ); ?></span>
+						<?php Newspack_UI_Icons::print_svg( 'more' ); ?>
+					</button>
+					<div class="newspack-ui__dropdown__content">
+						<ul>
 							<li>
-								<button
-									type="button"
-									class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide newspack-my-account__group--rename"
-									title="<?php echo esc_attr( $rename_label ); ?>"
-								>
-									<?php echo esc_html( $rename_label ); ?>
-								</button>
+								<button type="button" class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide newspack-my-account__group--rename"><?php echo esc_html( $rename_label ); ?></button>
 							</li>
-							<?php if ( $user_id === (int) $subscription->get_user_id() ) : // Billing is the owner's surface; a manager never sees it. ?>
+							<?php if ( $is_owner ) : ?>
 								<li>
-									<a href="<?php echo esc_url( wc_get_endpoint_url( 'view-subscription', $subscription->get_id(), wc_get_page_permalink( 'myaccount' ) ) ); ?>" class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide">
-										<?php esc_html_e( 'View subscription', 'newspack-plugin' ); ?>
-									</a>
+									<a href="<?php echo esc_url( $view_subscription_url ); ?>" class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide"><?php esc_html_e( 'View subscription', 'newspack-plugin' ); ?></a>
 								</li>
-								<?php
-								$seat_item = Group_Subscription_MyAccount::can_change_seats( $subscription, $user_id )
-									? Group_Subscription_Settings::get_seat_line_item( $subscription )
-									: null;
-								if ( $seat_item ) :
-									// Only line items registered here get a modal printed on wp_footer, so
-									// register before the link that opens it. The href is the no-JS
-									// fallback; switch-subscription.js intercepts the click and opens the
-									// modal keyed by this subscription's ID.
-									Subscriptions_Tiers::register_switch_modal( $seat_item->get_id(), $seat_item, $subscription );
-									// WooCommerce Subscriptions' own helper, because its switch handler
-									// refuses a URL without the `_wcsnonce` it appends -- a hand-built
-									// link would send a reader without JavaScript back to My Account
-									// with nothing changed and nothing said.
-									$change_seats_url = \WC_Subscriptions_Switcher::get_switch_url( $seat_item->get_id(), $seat_item, $subscription );
-									?>
+								<?php if ( $change_seats_url ) : ?>
 									<li>
-										<a href="<?php echo esc_url( $change_seats_url ); ?>" class="wcs-switch-link newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide">
-											<?php esc_html_e( 'Change seats', 'newspack-plugin' ); ?>
-										</a>
+										<a href="<?php echo esc_url( $change_seats_url ); ?>" class="wcs-switch-link newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide"><?php esc_html_e( 'Change seats', 'newspack-plugin' ); ?></a>
 									</li>
 								<?php endif; ?>
 							<?php endif; ?>
-							<?php if ( ! $is_completely_empty ) : ?>
+							<?php if ( $show_invite_actions ) : ?>
 								<li>
 									<button type="button" class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide newspack-my-account__subscription--invite-member"><?php esc_html_e( 'Invite by email', 'newspack-plugin' ); ?></button>
 								</li>
@@ -134,50 +126,23 @@ if ( in_array( $subscription_status, [ 'cancelled', 'expired' ], true ) ) {
 									<button type="button" class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide newspack-ui__button--destructive newspack-my-account__group_subscription__invite-link__confirm-disable"><?php esc_html_e( 'Disable invite link', 'newspack-plugin' ); ?></button>
 								</li>
 							<?php endif; ?>
-							</ul>
-						</div>
+						</ul>
 					</div>
-				<?php endif; ?>
+				</div>
 
-				<?php
-				/**
-				 * Actions repeated outside of dropdown menus, for smaller viewports.
-				 */
-				if ( $is_active ) :
-					?>
-					<button
-						type="button"
-						class="newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary newspack-my-account__group--rename"
-						title="<?php echo esc_attr( $rename_label ); ?>"
-					>
-						<?php
-						printf(
-							/* translators: %s: lowercase singular group label (e.g. "group", "team"). */
-							esc_html__( 'Rename %s', 'newspack-plugin' ),
-							esc_html( $group_label_lower )
-						);
-						?>
-					</button>
-					<?php
-					if ( $user_id === (int) $subscription->get_user_id() ) : // Billing is the owner's surface; a manager never sees it.
-						?>
-						<a href="<?php echo esc_url( wc_get_endpoint_url( 'view-subscription', $subscription->get_id(), wc_get_page_permalink( 'myaccount' ) ) ); ?>" class="newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary">
-							<?php esc_html_e( 'View subscription', 'newspack-plugin' ); ?>
-						</a>
-						<?php
-						if ( $seat_item && $change_seats_url ) :
-							?>
-							<a href="<?php echo esc_url( $change_seats_url ); ?>" class="wcs-switch-link newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary">
-								<?php esc_html_e( 'Change seats', 'newspack-plugin' ); ?>
-							</a>
-						<?php endif; ?>
+				<?php // The same actions as plain buttons, shown at small viewports only. ?>
+				<button type="button" class="newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary newspack-my-account__group--rename"><?php echo esc_html( $rename_label ); ?></button>
+				<?php if ( $is_owner ) : ?>
+					<a href="<?php echo esc_url( $view_subscription_url ); ?>" class="newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary"><?php esc_html_e( 'View subscription', 'newspack-plugin' ); ?></a>
+					<?php if ( $change_seats_url ) : ?>
+						<a href="<?php echo esc_url( $change_seats_url ); ?>" class="wcs-switch-link newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary"><?php esc_html_e( 'Change seats', 'newspack-plugin' ); ?></a>
 					<?php endif; ?>
-					<?php if ( ! $is_completely_empty ) : ?>
-						<button type="button" class="newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary newspack-my-account__subscription--invite-member"><?php esc_html_e( 'Invite by email', 'newspack-plugin' ); ?></button>
-						<button type="button" class="newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary newspack-my-account__group_subscription__invite-link__copy" data-error-text="<?php echo esc_attr( __( 'Could not copy. Please try again.', 'newspack-plugin' ) ); ?>"><span><?php esc_html_e( 'Copy invite link', 'newspack-plugin' ); ?></span></button>
-						<button type="button" class="<?php echo esc_attr( ! $invite_link ? 'hidden' : '' ); ?> newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary newspack-my-account__group_subscription__invite-link__confirm-regenerate"><?php esc_html_e( 'Regenerate invite link', 'newspack-plugin' ); ?></button>
-						<button type="button" class="<?php echo esc_attr( ! $invite_link ? 'hidden' : '' ); ?> newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary newspack-ui__button--destructive newspack-my-account__group_subscription__invite-link__confirm-disable"><?php esc_html_e( 'Disable invite link', 'newspack-plugin' ); ?></button>
-					<?php endif; ?>
+				<?php endif; ?>
+				<?php if ( $show_invite_actions ) : ?>
+					<button type="button" class="newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary newspack-my-account__subscription--invite-member"><?php esc_html_e( 'Invite by email', 'newspack-plugin' ); ?></button>
+					<button type="button" class="newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary newspack-my-account__group_subscription__invite-link__copy" data-error-text="<?php echo esc_attr( __( 'Could not copy. Please try again.', 'newspack-plugin' ) ); ?>"><span><?php esc_html_e( 'Copy invite link', 'newspack-plugin' ); ?></span></button>
+					<button type="button" class="<?php echo esc_attr( ! $invite_link ? 'hidden' : '' ); ?> newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary newspack-my-account__group_subscription__invite-link__confirm-regenerate"><?php esc_html_e( 'Regenerate invite link', 'newspack-plugin' ); ?></button>
+					<button type="button" class="<?php echo esc_attr( ! $invite_link ? 'hidden' : '' ); ?> newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary newspack-ui__button--destructive newspack-my-account__group_subscription__invite-link__confirm-disable"><?php esc_html_e( 'Disable invite link', 'newspack-plugin' ); ?></button>
 				<?php endif; ?>
 			</div>
 		</div>

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group.php
@@ -67,6 +67,9 @@ if ( in_array( $subscription_status, [ 'cancelled', 'expired' ], true ) ) {
 		<div class="newspack-my-account__subscription--actions">
 			<div class="newspack-my-account__subscription--actions-container">
 				<?php
+				/* translators: %s: lowercase singular group label (e.g. "group", "team"). */
+				$rename_label = sprintf( __( 'Rename %s', 'newspack-plugin' ), $group_label_lower );
+
 				/**
 				 * Dropdown menus are only shown at large viewports.
 				 */
@@ -80,10 +83,6 @@ if ( in_array( $subscription_status, [ 'cancelled', 'expired' ], true ) ) {
 						<div class="newspack-ui__dropdown__content">
 							<ul>
 							<li>
-								<?php
-								/* translators: %s: lowercase singular group label (e.g. "group", "team"). */
-								$rename_label = sprintf( __( 'Rename %s', 'newspack-plugin' ), $group_label_lower );
-								?>
 								<button
 									type="button"
 									class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide newspack-my-account__group--rename"

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group.php
@@ -60,83 +60,68 @@ if ( in_array( $subscription_status, [ 'cancelled', 'expired' ], true ) ) {
 				</a>
 			<?php endif; ?>
 			<h2 class="newspack-ui__font--m" data-group-name><?php echo esc_html( $settings['name'] ); ?></h2>
-			<?php
-			/* translators: %s: lowercase singular group label (e.g. "group", "team"). */
-			$rename_label = sprintf( __( 'Rename %s', 'newspack-plugin' ), $group_label_lower );
-			?>
-			<button
-				type="button"
-				class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--icon newspack-ui__button--small newspack-my-account__group--rename"
-				title="<?php echo esc_attr( $rename_label ); ?>"
-				aria-label="<?php echo esc_attr( $rename_label ); ?>"
-			>
-				<?php Newspack_UI_Icons::print_svg( 'edit' ); ?>
-			</button>
 			<span class="<?php echo esc_attr( implode( ' ', $status_badge_classes ) ); ?>">
 				<?php echo esc_html( wcs_get_subscription_status_name( $subscription_status ) ); ?>
 			</span>
-			<?php
-			// Only a per-seat group has seats the owner pays for and can change, so it
-			// is the only one told how many are in use. Both numbers include the owner
-			// and every invitation still waiting to be accepted, which is what the
-			// "Change seats" control is measured against.
-			if ( Group_Subscription_Settings::is_per_seat( $subscription ) ) :
-				$seats_in_use  = Group_Subscription_Seats::get_occupancy( $subscription );
-				$seats_bought  = Group_Subscription::get_member_capacity( $subscription );
-				if ( null !== $seats_bought ) :
-					?>
-					<span class="newspack-my-account__group--seats newspack-ui__font--xs">
-						<?php
-						echo esc_html(
-							sprintf(
-								/* translators: 1: seats in use, 2: seats bought. */
-								__( '%1$d of %2$d seats', 'newspack-plugin' ),
-								$seats_in_use,
-								$seats_bought
-							)
-						);
-						?>
-					</span>
-					<?php
-				endif;
-			endif;
-			?>
 		</div>
 		<div class="newspack-my-account__subscription--actions">
 			<div class="newspack-my-account__subscription--actions-container">
-				<?php if ( $user_id === (int) $subscription->get_user_id() ) : // Billing is the owner's surface; a manager never sees it. ?>
-					<a href="<?php echo esc_url( wc_get_endpoint_url( 'view-subscription', $subscription->get_id(), wc_get_page_permalink( 'myaccount' ) ) ); ?>" class="newspack-ui__button newspack-ui__button--secondary">
-						<?php esc_html_e( 'View subscription', 'newspack-plugin' ); ?>
-					</a>
-					<?php
-					$seat_item = Group_Subscription_MyAccount::can_change_seats( $subscription, $user_id )
-						? Group_Subscription_Settings::get_seat_line_item( $subscription )
-						: null;
-					if ( $seat_item ) :
-						// Only line items registered here get a modal printed on wp_footer, so
-						// register before the link that opens it. The href is the no-JS
-						// fallback; switch-subscription.js intercepts the click and opens the
-						// modal keyed by this subscription's ID.
-						Subscriptions_Tiers::register_switch_modal( $seat_item->get_id(), $seat_item, $subscription );
-						// WooCommerce Subscriptions' own helper, because its switch handler
-						// refuses a URL without the `_wcsnonce` it appends -- a hand-built
-						// link would send a reader without JavaScript back to My Account
-						// with nothing changed and nothing said.
-						$change_seats_url = \WC_Subscriptions_Switcher::get_switch_url( $seat_item->get_id(), $seat_item, $subscription );
-						?>
-						<a href="<?php echo esc_url( $change_seats_url ); ?>" class="wcs-switch-link newspack-ui__button newspack-ui__button--secondary">
-							<?php esc_html_e( 'Change seats', 'newspack-plugin' ); ?>
-						</a>
-					<?php endif; ?>
-				<?php endif; ?>
-				<?php if ( $is_active && ! $is_completely_empty ) : ?>
+				<?php
+				/**
+				 * Dropdown menus are only shown at large viewports.
+				 */
+				?>
+				<?php if ( $is_active ) : ?>
 					<div class="newspack-ui__dropdown newspack-my-account__subscription--actions-dropdown">
-						<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__dropdown__toggle">
-							<?php esc_html_e( 'Invite members', 'newspack-plugin' ); ?>
+						<button class="newspack-ui__button newspack-ui__button--ghost newspack-ui__dropdown__toggle">
+							<span class="screen-reader-text"><?php esc_html_e( 'More', 'newspack-plugin' ); ?></span>
 							<?php Newspack_UI_Icons::print_svg( 'more' ); ?>
 						</button>
 						<div class="newspack-ui__dropdown__content">
 							<ul>
+							<li>
+								<?php
+								/* translators: %s: lowercase singular group label (e.g. "group", "team"). */
+								$rename_label = sprintf( __( 'Rename %s', 'newspack-plugin' ), $group_label_lower );
+								?>
+								<button
+									type="button"
+									class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide newspack-my-account__group--rename"
+									title="<?php echo esc_attr( $rename_label ); ?>"
+								>
+									<?php echo esc_html( $rename_label ); ?>
+								</button>
+							</li>
+							<?php if ( $user_id === (int) $subscription->get_user_id() ) : // Billing is the owner's surface; a manager never sees it. ?>
+								<li>
+									<a href="<?php echo esc_url( wc_get_endpoint_url( 'view-subscription', $subscription->get_id(), wc_get_page_permalink( 'myaccount' ) ) ); ?>" class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide">
+										<?php esc_html_e( 'View subscription', 'newspack-plugin' ); ?>
+									</a>
+								</li>
+								<?php
+								$seat_item = Group_Subscription_MyAccount::can_change_seats( $subscription, $user_id )
+									? Group_Subscription_Settings::get_seat_line_item( $subscription )
+									: null;
+								if ( $seat_item ) :
+									// Only line items registered here get a modal printed on wp_footer, so
+									// register before the link that opens it. The href is the no-JS
+									// fallback; switch-subscription.js intercepts the click and opens the
+									// modal keyed by this subscription's ID.
+									Subscriptions_Tiers::register_switch_modal( $seat_item->get_id(), $seat_item, $subscription );
+									// WooCommerce Subscriptions' own helper, because its switch handler
+									// refuses a URL without the `_wcsnonce` it appends -- a hand-built
+									// link would send a reader without JavaScript back to My Account
+									// with nothing changed and nothing said.
+									$change_seats_url = \WC_Subscriptions_Switcher::get_switch_url( $seat_item->get_id(), $seat_item, $subscription );
+									?>
+									<li>
+										<a href="<?php echo esc_url( $change_seats_url ); ?>" class="wcs-switch-link newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide">
+											<?php esc_html_e( 'Change seats', 'newspack-plugin' ); ?>
+										</a>
+									</li>
+								<?php endif; ?>
+							<?php endif; ?>
+							<?php if ( ! $is_completely_empty ) : ?>
 								<li>
 									<button type="button" class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide newspack-my-account__subscription--invite-member"><?php esc_html_e( 'Invite by email', 'newspack-plugin' ); ?></button>
 								</li>
@@ -149,9 +134,51 @@ if ( in_array( $subscription_status, [ 'cancelled', 'expired' ], true ) ) {
 								<li class="<?php echo esc_attr( ! $invite_link ? 'hidden' : '' ); ?>">
 									<button type="button" class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide newspack-ui__button--destructive newspack-my-account__group_subscription__invite-link__confirm-disable"><?php esc_html_e( 'Disable invite link', 'newspack-plugin' ); ?></button>
 								</li>
+							<?php endif; ?>
 							</ul>
 						</div>
 					</div>
+				<?php endif; ?>
+
+				<?php
+				/**
+				 * Actions repeated outside of dropdown menus, for smaller viewports.
+				 */
+				if ( $is_active ) :
+					?>
+					<button
+						type="button"
+						class="newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary newspack-my-account__group--rename"
+						title="<?php echo esc_attr( $rename_label ); ?>"
+					>
+						<?php
+						printf(
+							/* translators: %s: lowercase singular group label (e.g. "group", "team"). */
+							esc_html__( 'Rename %s', 'newspack-plugin' ),
+							esc_html( $group_label_lower )
+						);
+						?>
+					</button>
+					<?php
+					if ( $user_id === (int) $subscription->get_user_id() ) : // Billing is the owner's surface; a manager never sees it.
+						?>
+						<a href="<?php echo esc_url( wc_get_endpoint_url( 'view-subscription', $subscription->get_id(), wc_get_page_permalink( 'myaccount' ) ) ); ?>" class="newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary">
+							<?php esc_html_e( 'View subscription', 'newspack-plugin' ); ?>
+						</a>
+						<?php
+						if ( $seat_item && $change_seats_url ) :
+							?>
+							<a href="<?php echo esc_url( $change_seats_url ); ?>" class="wcs-switch-link newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary">
+								<?php esc_html_e( 'Change seats', 'newspack-plugin' ); ?>
+							</a>
+						<?php endif; ?>
+					<?php endif; ?>
+					<?php if ( ! $is_completely_empty ) : ?>
+						<button type="button" class="newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary newspack-my-account__subscription--invite-member"><?php esc_html_e( 'Invite by email', 'newspack-plugin' ); ?></button>
+						<button type="button" class="newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary newspack-my-account__group_subscription__invite-link__copy" data-error-text="<?php echo esc_attr( __( 'Could not copy. Please try again.', 'newspack-plugin' ) ); ?>"><span><?php esc_html_e( 'Copy invite link', 'newspack-plugin' ); ?></span></button>
+						<button type="button" class="<?php echo esc_attr( ! $invite_link ? 'hidden' : '' ); ?> newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary newspack-my-account__group_subscription__invite-link__confirm-regenerate"><?php esc_html_e( 'Regenerate invite link', 'newspack-plugin' ); ?></button>
+						<button type="button" class="<?php echo esc_attr( ! $invite_link ? 'hidden' : '' ); ?> newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary newspack-ui__button--destructive newspack-my-account__group_subscription__invite-link__confirm-disable"><?php esc_html_e( 'Disable invite link', 'newspack-plugin' ); ?></button>
+					<?php endif; ?>
 				<?php endif; ?>
 			</div>
 		</div>

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/subscription-header.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/subscription-header.php
@@ -119,11 +119,7 @@ if ( ! empty( $actions['change_payment_method']['name'] ) ) {
 				3
 			);
 			?>
-			<?php
-			/**
-			 * Dropdown menus are only shown at large viewports.
-			 */
-			?>
+			<?php // Dropdown menu, shown at large viewports only. ?>
 			<div class="newspack-ui__dropdown newspack-my-account__subscription--change-subscription-dropdown">
 				<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__dropdown__toggle">
 					<span><?php esc_html_e( 'Change subscription', 'newspack-plugin' ); ?></span>
@@ -160,16 +156,12 @@ if ( ! empty( $actions['change_payment_method']['name'] ) ) {
 			\woocommerce_order_again_button( $parent_order[0] );
 		}
 		?>
-		<?php
-		/**
-		 * Actions repeated outside of dropdown menus, for smaller viewports.
-		 */
-		?>
+		<?php // The same actions as plain buttons, shown at small viewports only. ?>
 		<?php if ( $is_group_owner_subscription ) : ?>
 			<a href="<?php echo esc_url( Group_Subscription_MyAccount::get_group_url( $subscription ) ); ?>" class="newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary">
 				<?php
 				printf(
-					/* translators: %s is the singular group label (e.g. "Group", "Team", or a publisher override). */
+					/* translators: %s is the lowercase singular group label (e.g. "group", "team", or a publisher override). */
 					esc_html__( 'View %s', 'newspack-plugin' ),
 					esc_html( Group_Subscription::get_label_lower( 'singular' ) )
 				);
@@ -210,7 +202,8 @@ if ( ! empty( $actions['change_payment_method']['name'] ) ) {
 			<?php endforeach; ?>
 		<?php endif; ?>
 		</div>
-		<?php if ( ! empty( $actions ) ) : ?>
+		<?php // Group owners always get "View group" here, even when WooCommerce has no actions of its own. ?>
+		<?php if ( ! empty( $actions ) || $is_group_owner_subscription ) : ?>
 		<div class="newspack-ui__dropdown newspack-my-account__subscription--actions-dropdown">
 			<button class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--small newspack-ui__dropdown__toggle">
 				<span class="screen-reader-text"><?php \esc_html_e( 'More', 'newspack-plugin' ); ?></span>
@@ -223,7 +216,7 @@ if ( ! empty( $actions['change_payment_method']['name'] ) ) {
 							<a href="<?php echo esc_url( Group_Subscription_MyAccount::get_group_url( $subscription ) ); ?>" class="newspack-ui__button newspack-ui__button--ghost">
 								<?php
 								printf(
-									/* translators: %s is the singular group label (e.g. "Group", "Team", or a publisher override). */
+									/* translators: %s is the lowercase singular group label (e.g. "group", "team", or a publisher override). */
 									esc_html__( 'View %s', 'newspack-plugin' ),
 									esc_html( Group_Subscription::get_label_lower( 'singular' ) )
 								);

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/subscription-header.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/subscription-header.php
@@ -91,17 +91,6 @@ if ( ! empty( $actions['change_payment_method']['name'] ) ) {
 	?>
 	<div class="newspack-my-account__subscription--actions">
 		<div class="newspack-my-account__subscription--actions-container">
-		<?php if ( $is_group_owner_subscription ) : ?>
-			<a href="<?php echo esc_url( Group_Subscription_MyAccount::get_group_url( $subscription ) ); ?>" class="newspack-ui__button newspack-ui__button--secondary">
-				<?php
-				printf(
-					/* translators: %s is the singular group label (e.g. "Group", "Team", or a publisher override). */
-					esc_html__( 'View %s', 'newspack-plugin' ),
-					esc_html( Group_Subscription::get_label_lower( 'singular' ) )
-				);
-				?>
-			</a>
-		<?php endif; ?>
 		<?php
 		// Members get a view-only experience: no owner-only management controls.
 		$items = $is_group_member_subscription ? [] : $subscription->get_items();
@@ -129,6 +118,11 @@ if ( ! empty( $actions['change_payment_method']['name'] ) ) {
 				13,
 				3
 			);
+			?>
+			<?php
+			/**
+			 * Dropdown menus are only shown at large viewports.
+			 */
 			?>
 			<div class="newspack-ui__dropdown newspack-my-account__subscription--change-subscription-dropdown">
 				<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__dropdown__toggle">
@@ -167,6 +161,22 @@ if ( ! empty( $actions['change_payment_method']['name'] ) ) {
 		}
 		?>
 		<?php
+		/**
+		 * Actions repeated outside of dropdown menus, for smaller viewports.
+		 */
+		?>
+		<?php if ( $is_group_owner_subscription ) : ?>
+			<a href="<?php echo esc_url( Group_Subscription_MyAccount::get_group_url( $subscription ) ); ?>" class="newspack-my-account__subscription--action-link newspack-ui__button newspack-ui__button--secondary">
+				<?php
+				printf(
+					/* translators: %s is the singular group label (e.g. "Group", "Team", or a publisher override). */
+					esc_html__( 'View %s', 'newspack-plugin' ),
+					esc_html( Group_Subscription::get_label_lower( 'singular' ) )
+				);
+				?>
+			</a>
+		<?php endif; ?>
+		<?php
 		if ( $is_group_member_subscription ) :
 			$group_label_lower  = Group_Subscription::get_label_lower( 'singular' );
 			$leave_button_label = sprintf(
@@ -202,12 +212,25 @@ if ( ! empty( $actions['change_payment_method']['name'] ) ) {
 		</div>
 		<?php if ( ! empty( $actions ) ) : ?>
 		<div class="newspack-ui__dropdown newspack-my-account__subscription--actions-dropdown">
-			<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__button--small newspack-ui__dropdown__toggle">
-				<span><?php \esc_html_e( 'More', 'newspack-plugin' ); ?></span>
+			<button class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--small newspack-ui__dropdown__toggle">
+				<span class="screen-reader-text"><?php \esc_html_e( 'More', 'newspack-plugin' ); ?></span>
 				<?php Newspack_UI_Icons::print_svg( 'more' ); ?>
 			</button>
 			<div class="newspack-ui__dropdown__content">
 				<ul>
+					<?php if ( $is_group_owner_subscription ) : ?>
+						<li>
+							<a href="<?php echo esc_url( Group_Subscription_MyAccount::get_group_url( $subscription ) ); ?>" class="newspack-ui__button newspack-ui__button--ghost">
+								<?php
+								printf(
+									/* translators: %s is the singular group label (e.g. "Group", "Team", or a publisher override). */
+									esc_html__( 'View %s', 'newspack-plugin' ),
+									esc_html( Group_Subscription::get_label_lower( 'singular' ) )
+								);
+								?>
+							</a>
+						</li>
+					<?php endif; ?>
 					<?php foreach ( $actions as $key => $action_link ) : ?>
 						<?php
 						$classes = [

--- a/plugins/newspack-plugin/src/my-account/v1/_subscriptions.scss
+++ b/plugins/newspack-plugin/src/my-account/v1/_subscriptions.scss
@@ -122,7 +122,7 @@
 			width: 100%;
 			// Compact buttons for the subscription header — modal buttons (which always carry --wide) keep the default medium size.
 			.newspack-ui__button:not(.newspack-ui__button--wide) {
-				width: auto;
+				margin-bottom: 0;
 				@media ( min-width: 768px ) {
 					font-size: var(--newspack-ui-font-size-xs);
 					line-height: var(--newspack-ui-line-height-xs);
@@ -156,5 +156,8 @@
 				background: var(--newspack-ui-color-error-50);
 			}
 		}
+	}
+	.newspack__subscription-tiers__seats {
+		margin-top: var(--newspack-ui-spacer-4);
 	}
 }

--- a/plugins/newspack-plugin/src/my-account/v1/group-subscriptions.js
+++ b/plugins/newspack-plugin/src/my-account/v1/group-subscriptions.js
@@ -256,7 +256,7 @@ domReady( function () {
 		} );
 	} );
 
-	// Rename group: the pencil button in the header opens a modal; saving POSTs the new name and
+	// Rename group: the "Rename" action in the header (More menu at large viewports, plain button at small ones) opens a modal; saving POSTs the new name and
 	// updates the header (and any other) group-name element in place.
 	const renameModal = document.getElementById( 'newspack-my-account__group_subscription--rename' );
 	const renameForm = renameModal?.querySelector( '.newspack-my-account__group--rename-form' );

--- a/plugins/newspack-plugin/src/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/plugins/newspack-plugin/src/newspack-ui/scss/elements/forms/_buttons.scss
@@ -32,6 +32,10 @@
 			margin-bottom: 0;
 		}
 
+		&[role="tab"] {
+			margin-bottom: 0;
+		}
+
 		@media only screen and ( min-width: breakpoints.$tablet_width ) {
 			&:not(.newspack-ui__button--wide) {
 				margin-bottom: 0;

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-myaccount.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-myaccount.php
@@ -877,33 +877,22 @@ class Test_Group_Subscription_MyAccount extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A per-seat group's owner is paying per seat, so the page says how many of the
-	 * seats they bought are in use. Both numbers count the owner and every invitation
-	 * still holding a seat -- the same measure "Change seats" is judged against.
+	 * Rename and "View subscription" are how an owner gets back to a group whose
+	 * subscription has lapsed, so they render whatever the status; only inviting is
+	 * tied to an active group.
 	 */
-	public function test_group_page_shows_the_seat_count_for_a_per_seat_group() {
+	public function test_group_page_keeps_rename_and_view_subscription_when_on_hold() {
 		$owner_id = $this->create_reader_user();
-		$sub      = $this->create_priced_group_subscription( $owner_id, Group_Subscription_Settings::PRICING_MODE_PER_SEAT );
+		$sub      = $this->create_group_subscription( $owner_id );
+		$sub->update_status( 'on-hold' );
+		$sub->save();
 		wp_set_current_user( $owner_id );
 
 		$html = $this->render_group_page( $sub );
 
-		// The fixture's line item holds 4 seats, and the owner alone occupies one.
-		$this->assertStringContainsString( '1 of 4 seats', $html );
-	}
-
-	/**
-	 * A flat group's price covers the whole group however many people are in it, so
-	 * there are no seats to report and the page is left as it was.
-	 */
-	public function test_group_page_shows_no_seat_count_for_a_flat_group() {
-		$owner_id = $this->create_reader_user();
-		$sub      = $this->create_priced_group_subscription( $owner_id, Group_Subscription_Settings::PRICING_MODE_PER_TEAM );
-		wp_set_current_user( $owner_id );
-
-		$html = $this->render_group_page( $sub );
-
-		$this->assertStringNotContainsString( 'newspack-my-account__group--seats', $html );
+		$this->assertStringContainsString( 'newspack-my-account__group--rename', $html );
+		$this->assertStringContainsString( 'View subscription', $html );
+		$this->assertStringNotContainsString( 'newspack-my-account__subscription--invite-member', $html );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Tweaks component styles for My Account. #955 added several actions for group subscriptions to subscription and group page headers, making them look extremely crowded. Additionally some actions available via dropdown menus at larger viewports were invisible to mobile-sized viewports, and those that were visible at mobile viewports were showing with improper sizing and spacing.

**Before:**
<img width="1511" height="198" alt="Screenshot 2026-09-08 at 3 28 02 PM" src="https://github.com/user-attachments/assets/bf0bab3b-8261-42d1-9cb6-547d70efed35" />
<img width="373" height="410" alt="Screenshot 2026-09-08 at 3 28 08 PM" src="https://github.com/user-attachments/assets/15f02190-7338-416d-993c-01c1d60ee3a6" />
<img width="1510" height="201" alt="Screenshot 2026-09-08 at 3 28 40 PM" src="https://github.com/user-attachments/assets/1ba84915-b776-4161-a3bd-9672a11beb7e" />
<img width="373" height="416" alt="Screenshot 2026-09-08 at 3 28 49 PM" src="https://github.com/user-attachments/assets/3a1997ea-c4f6-4480-bb6b-1289a076c474" />


**After:**
<img width="1510" height="232" alt="Screenshot 2026-09-08 at 2 43 44 PM" src="https://github.com/user-attachments/assets/71427ce0-47e5-4deb-aa0e-1784c118efec" />
<img width="372" height="337" alt="Screenshot 2026-09-08 at 2 43 54 PM" src="https://github.com/user-attachments/assets/e4b28068-5608-429a-9df0-ef83991e1b85" />
<img width="1508" height="446" alt="Screenshot 2026-09-08 at 3 16 52 PM" src="https://github.com/user-attachments/assets/9169de77-d7e1-4e01-b99d-5487631bd1a7" />
<img width="373" height="665" alt="Screenshot 2026-09-08 at 3 20 14 PM" src="https://github.com/user-attachments/assets/20f7513d-da20-46d0-8886-019039c90151" />

#### Changes

**Subscription page:**

- Moved group-related actions into the "More" dropdown at larger viewports
- Made group-related actions visible at mobile-size viewports

**Group page:**

- Renamed "Invite members" dropdown menu to "More"
- Moved all actions into "More" dropdown menu at larger viewports (including the "Rename group" button which previously had a separate "Edit" icon button next to the group name)
- Made all actions visible at mobile-size viewports
- Removed the "# of # seats" label from the header component—this was far too prominent in the header, and repeats info already shown in the "Change seats" modal
- Removed bottom-margin for buttons with with the `role="tab"` attribute. On large viewports, the tabs looked correct coincidentally because an unrelated rule was capturing the tabs and setting them to `margin: 0`. On mobile viewports, the active tab was floating higher than it should.

**Both pages:**

- Made the "More" dropdown menu label invisible (now visible to screen readers only)
- Added missing margin to the "Number of group seats" field section in the "Change subscription" modal

### How to test the changes in this Pull Request:

1. Test on a site with WooCommerce Subscriptions, `NEWSPACK_CONTENT_GATES`, and at two group subscription products: one set to "per group" pricing and the other set to "per seat".
2. As a reader, purchase a group subscription for both products.
3. Visit each subscription in My Account > Subscriptions and confirm that all subscription and group actions in the header behave correctly and appear as in the screenshots above. Test at both large and small viewports. Note that changing seats can only be done for "per-seat" subscriptions, not "per-group".
4. Visit the group pages associated with each subscription and confirm that all actions behave correctly and appear as in the screenshots above. Test at both large and small viewports.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
