### PR TITLE
fix(story-budget): stop contributors from altering budgets (NPPM-3199)

### DIFF
--- a/plugins/newspack-story-budget/includes/class-api.php
+++ b/plugins/newspack-story-budget/includes/class-api.php
@@ -997,7 +997,7 @@ class API {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public static function update_budget( $request ) {
-		$budget = new Budget( $request->get_param( 'id' ) );
+		$budget = new Budget( $request->get_url_params()['id'] );
 		if ( ! $budget->is_valid() ) {
 			return new \WP_Error(
 				'budget_not_found',

--- a/plugins/newspack-story-budget/includes/class-api.php
+++ b/plugins/newspack-story-budget/includes/class-api.php
@@ -550,7 +550,8 @@ class API {
 	public static function get_stories_meta( $request ) {
 		return rest_ensure_response(
 			[
-				'can_edit' => current_user_can( 'edit_others_posts' ),
+				'can_edit'           => current_user_can( 'edit_others_posts' ),
+				'can_manage_budgets' => Budgets::current_user_can_manage(),
 			]
 		);
 	}

--- a/plugins/newspack-story-budget/includes/class-api.php
+++ b/plugins/newspack-story-budget/includes/class-api.php
@@ -246,7 +246,7 @@ class API {
 			[
 				'methods'             => 'PUT',
 				'callback'            => [ __CLASS__, 'update_budget' ],
-				'permission_callback' => [ __CLASS__, 'permission_callback' ],
+				'permission_callback' => [ __CLASS__, 'manage_budgets_permission_callback' ],
 				'args'                => [
 					'id'       => [
 						'description' => __( 'The ID of the budget to update.', 'newspack-story-budget' ),
@@ -313,7 +313,7 @@ class API {
 			[
 				'methods'             => 'POST',
 				'callback'            => [ __CLASS__, 'set_active_budget_order' ],
-				'permission_callback' => [ __CLASS__, 'permission_callback' ],
+				'permission_callback' => [ __CLASS__, 'manage_budgets_permission_callback' ],
 				'args'                => [
 					'ids' => [
 						'description' => __( 'Array of budget IDs to set as active.', 'newspack-story-budget' ),
@@ -332,7 +332,7 @@ class API {
 			[
 				'methods'             => 'POST',
 				'callback'            => [ __CLASS__, 'create_budget' ],
-				'permission_callback' => [ __CLASS__, 'permission_callback' ],
+				'permission_callback' => [ __CLASS__, 'manage_budgets_permission_callback' ],
 				'args'                => [
 					'name' => [
 						'description' => __( 'Name of the budget.', 'newspack-story-budget' ),
@@ -370,12 +370,28 @@ class API {
 	}
 
 	/**
-	 * Permission callback for non-story entities.
+	 * Permission callback for reading budgets and fields.
+	 *
+	 * The floor is `edit_posts`: anyone who can assign a budget to a story may
+	 * list and search budgets. Routes that alter budgets use
+	 * `manage_budgets_permission_callback()` instead.
 	 *
 	 * @return bool
 	 */
 	public static function permission_callback() {
 		return current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Permission callback for the routes that create or alter budgets.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @return bool
+	 */
+	public static function manage_budgets_permission_callback( $request ) {
+		// Only the route's URL segment names the budget; a body-supplied `id` must not steer the object check.
+		return Budgets::current_user_can_manage( $request->get_url_params()['id'] ?? null );
 	}
 
 	/**

--- a/plugins/newspack-story-budget/includes/class-api.php
+++ b/plugins/newspack-story-budget/includes/class-api.php
@@ -998,14 +998,15 @@ class API {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public static function update_budget( $request ) {
-		$budget = new Budget( $request->get_url_params()['id'] );
+		$id     = $request->get_url_params()['id'] ?? null;
+		$budget = new Budget( $id );
 		if ( ! $budget->is_valid() ) {
 			return new \WP_Error(
 				'budget_not_found',
 				sprintf(
 					// translators: %d is the budget ID.
 					__( 'Budget with ID "%d" not found.', 'newspack-story-budget' ),
-					$request->get_param( 'id' )
+					$id
 				),
 				[ 'status' => 404 ]
 			);

--- a/plugins/newspack-story-budget/includes/class-budgets.php
+++ b/plugins/newspack-story-budget/includes/class-budgets.php
@@ -204,9 +204,18 @@ class Budgets {
 	/**
 	 * Update the order of active budgets.
 	 *
+	 * IDs that are not budgets are skipped, so a stray ID cannot write order
+	 * meta onto a term from another taxonomy.
+	 *
 	 * @param int[] $budget_ids Ordered list of budget IDs.
 	 */
 	public static function update_budgets_order( $budget_ids ) {
+		$budget_ids = array_values(
+			array_filter(
+				$budget_ids,
+				fn( $budget_id ) => get_term( $budget_id, self::TAXONOMY ) instanceof \WP_Term
+			)
+		);
 		foreach ( $budget_ids as $index => $budget_id ) {
 			$order = $index + 1;
 			update_term_meta( $budget_id, Budget::ORDER_META_KEY, $order );
@@ -219,11 +228,9 @@ class Budgets {
 	/**
 	 * Whether the current user may create, rename, archive or reorder budgets.
 	 *
-	 * Resolved from the taxonomy's own capabilities so the REST routes and the
-	 * app's UI flag share one floor with wp-admin's term screens
-	 * (`manage_categories` by default) instead of the `edit_posts` floor that
-	 * let contributors alter anyone's budgets (NPPM-3199). A budget ID switches
-	 * to the object-level `edit_term` check; an ID that is not a budget falls
+	 * Resolved from the taxonomy's own capabilities (`manage_categories` by
+	 * default) so the REST routes, the app's UI flag and wp-admin's term
+	 * screens share one floor (NPPM-3199). An ID that is not a budget falls
 	 * back to the floor so managers still reach the route's own 404.
 	 *
 	 * @param int|null $budget_id Optional budget (term) ID.

--- a/plugins/newspack-story-budget/includes/class-budgets.php
+++ b/plugins/newspack-story-budget/includes/class-budgets.php
@@ -217,6 +217,28 @@ class Budgets {
 	}
 
 	/**
+	 * Whether the current user may create, rename, archive or reorder budgets.
+	 *
+	 * Resolved from the taxonomy's own capabilities so the REST routes and the
+	 * app's UI flag share one floor with wp-admin's term screens
+	 * (`manage_categories` by default) instead of the `edit_posts` floor that
+	 * let contributors alter anyone's budgets (NPPM-3199). A budget ID switches
+	 * to the object-level `edit_term` check; an ID that is not a budget falls
+	 * back to the floor so managers still reach the route's own 404.
+	 *
+	 * @param int|null $budget_id Optional budget (term) ID.
+	 *
+	 * @return bool
+	 */
+	public static function current_user_can_manage( $budget_id = null ) {
+		if ( $budget_id && get_term( $budget_id, self::TAXONOMY ) instanceof \WP_Term ) {
+			return current_user_can( 'edit_term', $budget_id );
+		}
+		$taxonomy = get_taxonomy( self::TAXONOMY );
+		return $taxonomy && current_user_can( $taxonomy->cap->edit_terms );
+	}
+
+	/**
 	 * Register the daily cron job for auto-archiving budgets.
 	 */
 	public static function register_cron_jobs() {

--- a/plugins/newspack-story-budget/src/app/index.js
+++ b/plugins/newspack-story-budget/src/app/index.js
@@ -67,6 +67,7 @@ const StoryBudget = () => {
 	} ) );
 
 	const canManage = useSelect( select => select( storeNamespace ).canManage() );
+	const canManageBudgets = useSelect( select => select( storeNamespace ).canManageBudgets() );
 
 	const navigationItems = [ { label: __( 'Stories', 'newspack-story-budget' ), path: '/stories' } ];
 
@@ -136,9 +137,11 @@ const StoryBudget = () => {
 						</Route>
 						<Route path="/budgets">
 							<AppHeaderActions>
-								<Button variant="primary" href="#/budgets/new">
-									{ __( 'Add Budget', 'newspack-story-budget' ) }
-								</Button>
+								{ canManageBudgets && (
+									<Button variant="primary" href="#/budgets/new">
+										{ __( 'Add Budget', 'newspack-story-budget' ) }
+									</Button>
+								) }
 								<SitesNav />
 							</AppHeaderActions>
 							<Budgets />

--- a/plugins/newspack-story-budget/src/app/index.js
+++ b/plugins/newspack-story-budget/src/app/index.js
@@ -146,11 +146,17 @@ const StoryBudget = () => {
 							</AppHeaderActions>
 							<Budgets />
 							<Switch>
-								<Route path="/budgets/new">
-									<ModalPage title={ __( 'Add Budget', 'newspack-story-budget' ) } closeHref="#/budgets" name={ 'create-budget' }>
-										<CreateBudgetModal onClose={ () => ( window.location.href = '#/budgets' ) } />
-									</ModalPage>
-								</Route>
+								{ canManageBudgets && (
+									<Route path="/budgets/new">
+										<ModalPage
+											title={ __( 'Add Budget', 'newspack-story-budget' ) }
+											closeHref="#/budgets"
+											name={ 'create-budget' }
+										>
+											<CreateBudgetModal onClose={ () => ( window.location.href = '#/budgets' ) } />
+										</ModalPage>
+									</Route>
+								) }
 							</Switch>
 						</Route>
 						<Redirect to="/stories" />

--- a/plugins/newspack-story-budget/src/components/budget-rows.js
+++ b/plugins/newspack-story-budget/src/components/budget-rows.js
@@ -30,9 +30,10 @@ const BudgetRows = ( { allowEdit, budgetStatus, isSearching } ) => {
 
 	const { updateBudget, saveActiveBudgetOrder } = useDispatch( storeNamespace );
 
-	const { budgets } = useSelect(
+	const { budgets, canManageBudgets } = useSelect(
 		select => ( {
 			budgets: select( storeNamespace ).getBudgets(),
+			canManageBudgets: select( storeNamespace ).canManageBudgets(),
 		} ),
 		[ budgetStatus ]
 	);
@@ -154,29 +155,34 @@ const BudgetRows = ( { allowEdit, budgetStatus, isSearching } ) => {
 	/**
 	 * Budget actions.
 	 */
-	const getBudgetControls = budget => [
-		{
-			title: __( 'View Stories', 'newspack-story-budget' ),
-			onClick: () => {
-				const url = new URL( window.location.href );
-				url.hash = '#/stories';
-				url.searchParams.set( 'budget_id', budget.id );
+	const getBudgetControls = budget => {
+		const controls = [
+			{
+				title: __( 'View Stories', 'newspack-story-budget' ),
+				onClick: () => {
+					const url = new URL( window.location.href );
+					url.hash = '#/stories';
+					url.searchParams.set( 'budget_id', budget.id );
 
-				window.location.assign( url.toString() );
+					window.location.assign( url.toString() );
+				},
 			},
-		},
-		{
-			title: budget.archived ? __( 'Unarchive', 'newspack-story-budget' ) : __( 'Archive', 'newspack-story-budget' ),
-			onClick: async () => {
-				await onUpdateBudget( budget.id, {
-					...budget,
-					archived: ! budget.archived,
-					order: 0,
-				} );
-			},
-			label: budget.archived ? 'budget-unarchive' : 'budget-archive',
-		},
-	];
+		];
+		if ( canManageBudgets ) {
+			controls.push( {
+				title: budget.archived ? __( 'Unarchive', 'newspack-story-budget' ) : __( 'Archive', 'newspack-story-budget' ),
+				onClick: async () => {
+					await onUpdateBudget( budget.id, {
+						...budget,
+						archived: ! budget.archived,
+						order: 0,
+					} );
+				},
+				label: budget.archived ? 'budget-unarchive' : 'budget-archive',
+			} );
+		}
+		return controls;
+	};
 
 	return (
 		<>

--- a/plugins/newspack-story-budget/src/components/budgets.js
+++ b/plugins/newspack-story-budget/src/components/budgets.js
@@ -49,10 +49,11 @@ const LoadingSpinner = () => (
 );
 
 export default () => {
-	const { view, totalBudgets, isLoading } = useSelect( select => ( {
+	const { view, totalBudgets, isLoading, canManageBudgets } = useSelect( select => ( {
 		view: select( storeNamespace ).getBudgetsView(),
 		totalBudgets: select( storeNamespace ).getBudgetsCount(),
 		isLoading: select( storeNamespace ).isBudgetsLoading(),
+		canManageBudgets: select( storeNamespace ).canManageBudgets(),
 	} ) );
 
 	const { setBudgetsView, setSearching, searchBudgets } = useDispatch( storeNamespace );
@@ -127,20 +128,22 @@ export default () => {
 						__nextHasNoMarginBottom
 					/>
 				</HStack>
-				<div className="newspack-story-budget__budgets-actions__secondary">
-					<ToggleControl
-						label={ __( 'Edit Mode', 'newspack-story-budget' ) }
-						checked={ editMode }
-						onChange={ () => setEditMode( ! editMode ) }
-						__nextHasNoMarginBottom
-					/>
-				</div>
+				{ canManageBudgets && (
+					<div className="newspack-story-budget__budgets-actions__secondary">
+						<ToggleControl
+							label={ __( 'Edit Mode', 'newspack-story-budget' ) }
+							checked={ editMode }
+							onChange={ () => setEditMode( ! editMode ) }
+							__nextHasNoMarginBottom
+						/>
+					</div>
+				) }
 			</HStack>
 			{ isLoading ? (
 				<LoadingSpinner />
 			) : (
 				<VStack className="newspack-story-budget__budgets-list" spacing={ 2 } align="stretch">
-					<BudgetRows allowEdit={ editMode } budgetStatus={ budgetStatus } isSearching={ searchTerm.length > 0 } />
+					<BudgetRows allowEdit={ editMode && canManageBudgets } budgetStatus={ budgetStatus } isSearching={ searchTerm.length > 0 } />
 					{ BUDGET_STATUS.ARCHIVED === budgetStatus && 0 === searchTerm.length && (
 						<Pagination currentPage={ page } totalPages={ totalPages } onPageChange={ setPage } />
 					) }

--- a/plugins/newspack-story-budget/src/components/create-new-story.js
+++ b/plugins/newspack-story-budget/src/components/create-new-story.js
@@ -27,6 +27,8 @@ const CreateStoryModal = ( { onClose } ) => {
 		isCreatingBudget: select( storeNamespace ).isCreatingBudget(),
 	} ) );
 
+	const canManageBudgets = useSelect( select => select( storeNamespace ).canManageBudgets() );
+
 	const budgets = useField( 'budgets' );
 	const fields = useFields();
 
@@ -41,13 +43,17 @@ const CreateStoryModal = ( { onClose } ) => {
 				value: '',
 				label: __( 'Select a budget', 'newspack-story-budget' ),
 			},
-			{
-				value: 'new',
-				label: __( 'Add new budget', 'newspack-story-budget' ),
-			},
+			...( canManageBudgets
+				? [
+						{
+							value: 'new',
+							label: __( 'Add new budget', 'newspack-story-budget' ),
+						},
+				  ]
+				: [] ),
 			...( budgets?.options || [] ),
 		],
-		[ budgets ]
+		[ budgets, canManageBudgets ]
 	);
 
 	const handleFieldChange = ( fieldSlug, newValue ) => {

--- a/plugins/newspack-story-budget/src/store/constants.js
+++ b/plugins/newspack-story-budget/src/store/constants.js
@@ -16,6 +16,7 @@ export const INITIAL_STATE = {
 		storyMetaFetchQueue: {},
 		stories: {
 			can_edit: false,
+			can_manage_budgets: false,
 		},
 		isCreatingStory: false,
 		isCreatingBudget: false,

--- a/plugins/newspack-story-budget/src/store/selectors.js
+++ b/plugins/newspack-story-budget/src/store/selectors.js
@@ -123,6 +123,8 @@ export const canManage = () => ! utils.sites.isRemoteSite();
 
 export const canEditStory = ( state, id ) => canManage() && ( state.meta.stories.can_edit || state.stories[ id ]?.metadata?.can_edit );
 
+export const canManageBudgets = state => canManage() && !! state.meta.stories?.can_manage_budgets;
+
 export const getStoriesMeta = state => state.meta.stories;
 
 export const getStoryMeta = ( state, id, key ) => ( key ? state.stories[ id ]?.metadata?.[ key ] : state.stories[ id ]?.metadata );

--- a/plugins/newspack-story-budget/tests/unit-tests/test-api-permissions.php
+++ b/plugins/newspack-story-budget/tests/unit-tests/test-api-permissions.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Test API permissions.
+ *
+ * @package Newspack_Story_Budget
+ */
+
+//phpcs:disable Squiz.Commenting.VariableComment.Missing
+
+namespace Newspack_Story_Budget;
+
+/**
+ * Budget routes dispatched through the REST server, so the permission
+ * callbacks run. The handler-level tests in test-api.php never reach them.
+ */
+class Test_API_Permissions extends \WP_UnitTestCase {
+
+	protected static $budgets = [];
+
+	/**
+	 * WP setup before class.
+	 */
+	public static function wpSetUpBeforeClass() {
+		self::$budgets = self::factory()->term->create_many(
+			2,
+			[
+				'taxonomy' => Budgets::TAXONOMY,
+			]
+		);
+	}
+
+	/**
+	 * Teardown.
+	 */
+	public function tear_down() {
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Dispatch a request through the REST server as a fresh user with the given role.
+	 *
+	 * @param string $role   Role slug.
+	 * @param string $method HTTP method.
+	 * @param string $route  Route, relative to the API namespace.
+	 * @param array  $params Request parameters.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	private function dispatch_as( $role, $method, $route, $params = [] ) {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => $role ] ) );
+		$request = new \WP_REST_Request( $method, '/' . API::NAMESPACE . $route );
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * Roles that hold edit_posts but not manage_categories.
+	 *
+	 * @return array
+	 */
+	public function roles_without_manage_categories() {
+		return [
+			'contributor' => [ 'contributor' ],
+			'author'      => [ 'author' ],
+		];
+	}
+
+	/**
+	 * Creating a budget needs the taxonomy capability, not edit_posts.
+	 *
+	 * @dataProvider roles_without_manage_categories
+	 *
+	 * @param string $role Role slug.
+	 */
+	public function test_create_budget_is_forbidden_without_manage_categories( $role ) {
+		$response = $this->dispatch_as( $role, 'POST', '/budgets', [ 'name' => 'Unauthorized budget' ] );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 'rest_forbidden', $response->get_data()['code'] );
+		$this->assertEmpty( term_exists( 'Unauthorized budget', Budgets::TAXONOMY ) );
+	}
+
+	/**
+	 * Renaming or archiving a budget needs the taxonomy capability on that budget.
+	 *
+	 * @dataProvider roles_without_manage_categories
+	 *
+	 * @param string $role Role slug.
+	 */
+	public function test_update_budget_is_forbidden_without_manage_categories( $role ) {
+		$budget_id = self::$budgets[0];
+		$name      = get_term( $budget_id, Budgets::TAXONOMY )->name;
+
+		$response = $this->dispatch_as(
+			$role,
+			'PUT',
+			'/budgets/' . $budget_id,
+			[
+				'name'     => 'Renamed by ' . $role,
+				'archived' => true,
+			]
+		);
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( $name, get_term( $budget_id, Budgets::TAXONOMY )->name );
+		$this->assertEmpty( get_term_meta( $budget_id, Budget::ARCHIVE_META_KEY, true ) );
+	}
+
+	/**
+	 * Reordering budgets needs the taxonomy capability.
+	 *
+	 * @dataProvider roles_without_manage_categories
+	 *
+	 * @param string $role Role slug.
+	 */
+	public function test_reorder_budgets_is_forbidden_without_manage_categories( $role ) {
+		$response = $this->dispatch_as( $role, 'POST', '/budgets/order', [ 'ids' => array_reverse( self::$budgets ) ] );
+
+		$this->assertSame( 403, $response->get_status() );
+		foreach ( self::$budgets as $budget_id ) {
+			$this->assertEmpty( get_term_meta( $budget_id, Budget::ORDER_META_KEY, true ) );
+		}
+	}
+
+	/**
+	 * An editor holds manage_categories and keeps every budget write.
+	 */
+	public function test_editor_can_create_update_and_reorder_budgets() {
+		$response = $this->dispatch_as( 'editor', 'POST', '/budgets', [ 'name' => 'Editor budget' ] );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'Editor budget', $response->get_data()['name'] );
+		$this->assertNotEmpty( term_exists( 'Editor budget', Budgets::TAXONOMY ) );
+
+		$budget_id = self::$budgets[0];
+		$response  = $this->dispatch_as( 'editor', 'PUT', '/budgets/' . $budget_id, [ 'name' => 'Renamed by editor' ] );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'Renamed by editor', get_term( $budget_id, Budgets::TAXONOMY )->name );
+
+		$ordered  = array_reverse( self::$budgets );
+		$response = $this->dispatch_as( 'editor', 'POST', '/budgets/order', [ 'ids' => $ordered ] );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 1, (int) get_term_meta( $ordered[0], Budget::ORDER_META_KEY, true ) );
+		$this->assertSame( 2, (int) get_term_meta( $ordered[1], Budget::ORDER_META_KEY, true ) );
+	}
+
+	/**
+	 * An ID that is not a budget falls back to the floor: managers still get the
+	 * handler's 404, non-managers get 403.
+	 */
+	public function test_update_unknown_budget_keeps_404_for_managers() {
+		$response = $this->dispatch_as( 'editor', 'PUT', '/budgets/999999', [ 'name' => 'Ghost' ] );
+		$this->assertSame( 404, $response->get_status() );
+		$this->assertSame( 'budget_not_found', $response->get_data()['code'] );
+
+		$response = $this->dispatch_as( 'contributor', 'PUT', '/budgets/999999', [ 'name' => 'Ghost' ] );
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * Read routes keep the edit_posts floor.
+	 */
+	public function test_contributor_can_read_budgets_and_fields() {
+		$budget_id = self::$budgets[0];
+		$routes    = [
+			[ 'GET', '/budgets', [] ],
+			[ 'GET', '/fields', [] ],
+			[ 'POST', '/budgets/search', [ 's' => 'budget' ] ],
+			[ 'GET', '/budgets/' . $budget_id . '/stories', [] ],
+		];
+		foreach ( $routes as list( $method, $route, $params ) ) {
+			$response = $this->dispatch_as( 'contributor', $method, $route, $params );
+			$this->assertSame( 200, $response->get_status(), "$method $route should stay readable for contributors." );
+		}
+	}
+}

--- a/plugins/newspack-story-budget/tests/unit-tests/test-api-permissions.php
+++ b/plugins/newspack-story-budget/tests/unit-tests/test-api-permissions.php
@@ -40,7 +40,7 @@ class Test_API_Permissions extends \WP_UnitTestCase {
 	/**
 	 * Dispatch a request through the REST server as a fresh user with the given role.
 	 *
-	 * @param string|null $role Role slug, or null for a logged-out request.
+	 * @param string|null $role   Role slug, or null for a logged-out request.
 	 * @param string      $method HTTP method.
 	 * @param string      $route  Route, relative to the API namespace.
 	 * @param array       $params Request parameters.
@@ -151,9 +151,18 @@ class Test_API_Permissions extends \WP_UnitTestCase {
 	 * handler's 404, non-managers get 403.
 	 */
 	public function test_update_unknown_budget_keeps_404_for_managers() {
-		$response = $this->dispatch_as( 'editor', 'PUT', '/budgets/999999', [ 'name' => 'Ghost' ] );
+		$response = $this->dispatch_as(
+			'editor',
+			'PUT',
+			'/budgets/999999',
+			[
+				'id'   => self::$budgets[1],
+				'name' => 'Ghost',
+			]
+		);
 		$this->assertSame( 404, $response->get_status() );
 		$this->assertSame( 'budget_not_found', $response->get_data()['code'] );
+		$this->assertStringContainsString( '999999', $response->get_data()['message'] );
 
 		$response = $this->dispatch_as( 'contributor', 'PUT', '/budgets/999999', [ 'name' => 'Ghost' ] );
 		$this->assertSame( 403, $response->get_status() );
@@ -225,5 +234,20 @@ class Test_API_Permissions extends \WP_UnitTestCase {
 
 		$response = $this->dispatch_as( 'editor', 'GET', '/stories/meta' );
 		$this->assertTrue( $response->get_data()['can_manage_budgets'] );
+	}
+
+	/**
+	 * A term from another taxonomy is not a budget: managers get the 404, others the 403.
+	 */
+	public function test_update_budget_rejects_a_term_from_another_taxonomy() {
+		$category_id = self::factory()->category->create();
+
+		$response = $this->dispatch_as( 'editor', 'PUT', '/budgets/' . $category_id, [ 'name' => 'Not a budget' ] );
+		$this->assertSame( 404, $response->get_status() );
+		$this->assertSame( 'budget_not_found', $response->get_data()['code'] );
+		$this->assertNotSame( 'Not a budget', get_term( $category_id, 'category' )->name );
+
+		$response = $this->dispatch_as( 'contributor', 'PUT', '/budgets/' . $category_id, [ 'name' => 'Not a budget' ] );
+		$this->assertSame( 403, $response->get_status() );
 	}
 }

--- a/plugins/newspack-story-budget/tests/unit-tests/test-api-permissions.php
+++ b/plugins/newspack-story-budget/tests/unit-tests/test-api-permissions.php
@@ -147,25 +147,52 @@ class Test_API_Permissions extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * An ID that is not a budget falls back to the floor: managers still get the
-	 * handler's 404, non-managers get 403.
+	 * IDs that are not budgets: one with no term row, one that is a term in another taxonomy.
+	 *
+	 * @return array
 	 */
-	public function test_update_unknown_budget_keeps_404_for_managers() {
-		$response = $this->dispatch_as(
-			'editor',
-			'PUT',
-			'/budgets/999999',
-			[
-				'id'   => self::$budgets[1],
-				'name' => 'Ghost',
-			]
-		);
+	public function non_budget_ids() {
+		return [
+			'unknown ID'               => [ 'unknown' ],
+			'term in another taxonomy' => [ 'category' ],
+		];
+	}
+
+	/**
+	 * An ID that is not a budget falls back to the floor: managers still get the
+	 * handler's 404, non-managers get 403, and no term is renamed.
+	 *
+	 * @dataProvider non_budget_ids
+	 *
+	 * @param string $kind Which kind of non-budget ID to send.
+	 */
+	public function test_update_non_budget_id_keeps_404_for_managers( $kind ) {
+		$id = 'category' === $kind ? self::factory()->category->create() : 999999;
+
+		$response = $this->dispatch_as( 'editor', 'PUT', '/budgets/' . $id, [ 'name' => 'Ghost' ] );
 		$this->assertSame( 404, $response->get_status() );
 		$this->assertSame( 'budget_not_found', $response->get_data()['code'] );
-		$this->assertStringContainsString( '999999', $response->get_data()['message'] );
+		$this->assertStringContainsString( (string) $id, $response->get_data()['message'] );
+		$this->assertNotSame( 'Ghost', get_term( $id )->name ?? null );
 
-		$response = $this->dispatch_as( 'contributor', 'PUT', '/budgets/999999', [ 'name' => 'Ghost' ] );
+		$response = $this->dispatch_as( 'contributor', 'PUT', '/budgets/' . $id, [ 'name' => 'Ghost' ] );
 		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * Reordering skips IDs that are not budgets instead of writing order meta onto them.
+	 */
+	public function test_reorder_skips_ids_that_are_not_budgets() {
+		$category_id = self::factory()->category->create();
+		$ordered     = array_reverse( self::$budgets );
+
+		$response = $this->dispatch_as( 'editor', 'POST', '/budgets/order', [ 'ids' => [ $category_id, $ordered[0], 999999, $ordered[1] ] ] );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEmpty( get_term_meta( $category_id, Budget::ORDER_META_KEY, true ) );
+		$this->assertEmpty( get_term_meta( 999999, Budget::ORDER_META_KEY, true ) );
+		$this->assertSame( 1, (int) get_term_meta( $ordered[0], Budget::ORDER_META_KEY, true ) );
+		$this->assertSame( 2, (int) get_term_meta( $ordered[1], Budget::ORDER_META_KEY, true ) );
 	}
 
 	/**
@@ -210,22 +237,6 @@ class Test_API_Permissions extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Anonymous requests never reach the write routes.
-	 */
-	public function test_budget_writes_require_a_logged_in_user() {
-		$budget_id = self::$budgets[0];
-		$writes    = [
-			[ 'POST', '/budgets', [ 'name' => 'Anonymous budget' ] ],
-			[ 'PUT', '/budgets/' . $budget_id, [ 'name' => 'Anonymous rename' ] ],
-			[ 'POST', '/budgets/order', [ 'ids' => array_reverse( self::$budgets ) ] ],
-		];
-		foreach ( $writes as list( $method, $route, $params ) ) {
-			$response = $this->dispatch_as( null, $method, $route, $params );
-			$this->assertSame( 401, $response->get_status(), "$method $route should require a logged-in user." );
-		}
-	}
-
-	/**
 	 * The app reads the same floor from the stories meta, so its controls and the routes agree.
 	 */
 	public function test_stories_meta_reports_budget_management_capability() {
@@ -234,20 +245,5 @@ class Test_API_Permissions extends \WP_UnitTestCase {
 
 		$response = $this->dispatch_as( 'editor', 'GET', '/stories/meta' );
 		$this->assertTrue( $response->get_data()['can_manage_budgets'] );
-	}
-
-	/**
-	 * A term from another taxonomy is not a budget: managers get the 404, others the 403.
-	 */
-	public function test_update_budget_rejects_a_term_from_another_taxonomy() {
-		$category_id = self::factory()->category->create();
-
-		$response = $this->dispatch_as( 'editor', 'PUT', '/budgets/' . $category_id, [ 'name' => 'Not a budget' ] );
-		$this->assertSame( 404, $response->get_status() );
-		$this->assertSame( 'budget_not_found', $response->get_data()['code'] );
-		$this->assertNotSame( 'Not a budget', get_term( $category_id, 'category' )->name );
-
-		$response = $this->dispatch_as( 'contributor', 'PUT', '/budgets/' . $category_id, [ 'name' => 'Not a budget' ] );
-		$this->assertSame( 403, $response->get_status() );
 	}
 }

--- a/plugins/newspack-story-budget/tests/unit-tests/test-api-permissions.php
+++ b/plugins/newspack-story-budget/tests/unit-tests/test-api-permissions.php
@@ -215,4 +215,15 @@ class Test_API_Permissions extends \WP_UnitTestCase {
 			$this->assertSame( 401, $response->get_status(), "$method $route should require a logged-in user." );
 		}
 	}
+
+	/**
+	 * The app reads the same floor from the stories meta, so its controls and the routes agree.
+	 */
+	public function test_stories_meta_reports_budget_management_capability() {
+		$response = $this->dispatch_as( 'contributor', 'GET', '/stories/meta' );
+		$this->assertFalse( $response->get_data()['can_manage_budgets'] );
+
+		$response = $this->dispatch_as( 'editor', 'GET', '/stories/meta' );
+		$this->assertTrue( $response->get_data()['can_manage_budgets'] );
+	}
 }

--- a/plugins/newspack-story-budget/tests/unit-tests/test-api-permissions.php
+++ b/plugins/newspack-story-budget/tests/unit-tests/test-api-permissions.php
@@ -40,15 +40,15 @@ class Test_API_Permissions extends \WP_UnitTestCase {
 	/**
 	 * Dispatch a request through the REST server as a fresh user with the given role.
 	 *
-	 * @param string $role   Role slug.
-	 * @param string $method HTTP method.
-	 * @param string $route  Route, relative to the API namespace.
-	 * @param array  $params Request parameters.
+	 * @param string|null $role Role slug, or null for a logged-out request.
+	 * @param string      $method HTTP method.
+	 * @param string      $route  Route, relative to the API namespace.
+	 * @param array       $params Request parameters.
 	 *
 	 * @return \WP_REST_Response
 	 */
 	private function dispatch_as( $role, $method, $route, $params = [] ) {
-		wp_set_current_user( self::factory()->user->create( [ 'role' => $role ] ) );
+		wp_set_current_user( $role ? self::factory()->user->create( [ 'role' => $role ] ) : 0 );
 		$request = new \WP_REST_Request( $method, '/' . API::NAMESPACE . $route );
 		foreach ( $params as $key => $value ) {
 			$request->set_param( $key, $value );
@@ -169,10 +169,50 @@ class Test_API_Permissions extends \WP_UnitTestCase {
 			[ 'GET', '/fields', [] ],
 			[ 'POST', '/budgets/search', [ 's' => 'budget' ] ],
 			[ 'GET', '/budgets/' . $budget_id . '/stories', [] ],
+			[ 'POST', '/budgets/' . $budget_id . '/stories/search', [ 's' => 'story' ] ],
 		];
 		foreach ( $routes as list( $method, $route, $params ) ) {
 			$response = $this->dispatch_as( 'contributor', $method, $route, $params );
 			$this->assertSame( 200, $response->get_status(), "$method $route should stay readable for contributors." );
+		}
+	}
+
+	/**
+	 * The budget a write is authorized against is the one the write alters.
+	 */
+	public function test_update_budget_ignores_a_body_supplied_id() {
+		list( $target, $other ) = self::$budgets;
+		$other_name             = get_term( $other, Budgets::TAXONOMY )->name;
+
+		$response = $this->dispatch_as(
+			'editor',
+			'PUT',
+			'/budgets/' . $target,
+			[
+				'id'   => $other,
+				'name' => 'Renamed through the URL',
+			]
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $target, $response->get_data()['id'] );
+		$this->assertSame( 'Renamed through the URL', get_term( $target, Budgets::TAXONOMY )->name );
+		$this->assertSame( $other_name, get_term( $other, Budgets::TAXONOMY )->name );
+	}
+
+	/**
+	 * Anonymous requests never reach the write routes.
+	 */
+	public function test_budget_writes_require_a_logged_in_user() {
+		$budget_id = self::$budgets[0];
+		$writes    = [
+			[ 'POST', '/budgets', [ 'name' => 'Anonymous budget' ] ],
+			[ 'PUT', '/budgets/' . $budget_id, [ 'name' => 'Anonymous rename' ] ],
+			[ 'POST', '/budgets/order', [ 'ids' => array_reverse( self::$budgets ) ] ],
+		];
+		foreach ( $writes as list( $method, $route, $params ) ) {
+			$response = $this->dispatch_as( null, $method, $route, $params );
+			$this->assertSame( 401, $response->get_status(), "$method $route should require a logged-in user." );
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Story Budget REST routes that create, rename, archive, and reorder budgets shared one `edit_posts` check, so a contributor could create budgets and change anyone's, including an administrator's. Budgets are terms, and WordPress asks for `manage_categories` to create or edit a term through any of its own screens.

Those three routes now require the budget taxonomy's own capability, read from the taxonomy object (`manage_categories` by default) and checked against the specific budget on the update route. Read routes are unchanged: contributors still list budgets and open a budget's stories.

The app hides what the server now refuses. Without the capability there is no Add Budget button, no Edit Mode, no Archive action, and no "Add new budget" option in Add Story. The Budgets tab stays visible read-only.

Closes NPPM-3199.

### How to test the changes in this Pull Request:

1. As an administrator, create two budgets. Edit Mode, drag reorder, Archive, and Add Budget work as before.
2. Log in as a contributor and open Story Budget → Budgets. The list shows with no Add Budget button, no Edit Mode toggle, and only View Stories in a row's menu.
3. Still as the contributor, open Add Story. The Budget dropdown offers "Select a budget", then the existing budgets, and no "Add new budget" option. An editor sees "Add new budget" as the second option.
4. As the contributor, send `POST /wp-json/newspack-story-budget/v1/budgets` with `{"name":"x"}` (browser console with the REST nonce, or an application password). The response is 403 `rest_forbidden` and no budget appears.
5. Repeat step 4 with `PUT .../budgets/<id>` and `{"name":"y"}`, then `POST .../budgets/order` and `{"ids":[<id>,<id>]}`. Both return 403 and nothing changes.
6. Log in as an editor. Every control from step 1 is present and the three requests from steps 4 and 5 succeed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Deliberately out of scope: the wider check for other places that re-implement taxonomy operations behind `edit_posts` (noted on NPPM-3199). There is no delete route, and the reorder route keeps its whole-list write for managers.

The four hidden controls have no automated coverage; verified manually as contributor and editor.

Also out of scope: WordPress core's post-save path still creates a budget term for any role that can assign one. Follow-up noted on NPPM-3199.
