### PR TITLE
fix(subscriptions): no renewal messaging for free subscriptions

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -942,12 +942,14 @@ class WooCommerce_Subscriptions {
 		include_once __DIR__ . '/class-subscriptions-confirmation.php';
 		include_once __DIR__ . '/class-subscriptions-tiers.php';
 		include_once __DIR__ . '/class-card-expiry-warning.php';
+		include_once __DIR__ . '/class-zero-total-renewals.php';
 
 		On_Hold_Duration::init();
 		Renewal::init();
 		Subscriptions_Meta::init();
 		Subscriptions_Confirmation::init();
 		Card_Expiry_Warning::init();
+		Zero_Total_Renewals::init();
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-zero-total-renewals.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-zero-total-renewals.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * WooCommerce Subscriptions zero-total renewal messaging.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Withholds renewal messaging that only makes sense for a subscription someone pays for.
+ *
+ * A free subscription still renews on every billing cycle: WooCommerce Subscriptions
+ * creates a renewal order and completes it on the spot, because nothing is owed. That
+ * keeps access from lapsing, which is the point — but it also mails the reader a receipt
+ * for $0.00. Readers holding complimentary access never bought anything and are never
+ * asked to pay, so the receipt is unexplainable to them.
+ *
+ * The upcoming-renewal reminder is stopped one step earlier, at scheduling. Subscriptions
+ * has refused to send that email for a zero-total subscription since 7.4.0, so what the
+ * notification filter removes is the scheduled action that would fire and do nothing.
+ */
+class Zero_Total_Renewals {
+	/**
+	 * Reader-facing renewal receipts withheld for a free renewal order.
+	 *
+	 * The completed-order receipt named in the report is one of several ways the same
+	 * $0.00 message reaches a reader. Subscriptions auto-completes a renewal whose
+	 * subtotal is zero, which is why a migrated complimentary subscription takes that
+	 * path; a renewal that misses the auto-complete rests in `processing` and mails the
+	 * receipt from there; and a gifted subscription mails its recipient under ids of its
+	 * own.
+	 */
+	const RENEWAL_RECEIPT_EMAIL_IDS = [
+		'customer_completed_renewal_order',
+		'customer_processing_renewal_order',
+		'recipient_completed_renewal_order',
+		'gift_recipient_processing_renewal_order',
+	];
+
+	/**
+	 * Initialize hooks and filters.
+	 */
+	public static function init() {
+		if ( ! WooCommerce_Subscriptions::is_active() ) {
+			return;
+		}
+
+		add_filter( 'woocommerce_subscription_valid_customer_notification_types', [ __CLASS__, 'skip_renewal_notification' ], 10, 2 );
+
+		foreach ( self::RENEWAL_RECEIPT_EMAIL_IDS as $email_id ) {
+			add_filter( 'woocommerce_email_enabled_' . $email_id, [ __CLASS__, 'is_renewal_receipt_enabled' ], 10, 2 );
+		}
+	}
+
+	/**
+	 * Whether an order or subscription costs the reader nothing.
+	 *
+	 * The recurring total on its own would also match a paying subscription carrying a
+	 * limited 100% recurring coupon, which Subscriptions removes once its payment count
+	 * runs out — withholding that reader's receipt would hide the renewal that starts
+	 * charging them. The pre-discount subtotal is immune to a coupon, and is 0 on every
+	 * subscription `migrate-manual-members` creates, so both have to be zero.
+	 * `Teams_Migration::subscription_is_paid()` draws the same line. A reader comped with
+	 * an unlimited recurring coupon rather than the CLI keeps their $0.00 receipts.
+	 *
+	 * @param \WC_Abstract_Order $order Order or subscription to test.
+	 *
+	 * @return bool
+	 */
+	private static function is_free( $order ) {
+		return 0.0 >= (float) $order->get_total() && 0.0 >= (float) $order->get_subtotal();
+	}
+
+	/**
+	 * Drop the upcoming-renewal reminder from the notifications scheduled for a free subscription.
+	 *
+	 * Trial-end and expiration notifications stay: those say the reader's access is
+	 * about to change, which is true whether or not they pay for it.
+	 *
+	 * @param array            $notifications Notification types WooCommerce Subscriptions is about to schedule.
+	 * @param \WC_Subscription $subscription  The subscription being scheduled.
+	 *
+	 * @return array
+	 */
+	public static function skip_renewal_notification( $notifications, $subscription ) {
+		if ( ! is_array( $notifications ) || ! is_a( $subscription, 'WC_Subscription' ) ) {
+			return $notifications;
+		}
+
+		if ( ! self::is_free( $subscription ) ) {
+			return $notifications;
+		}
+
+		return array_values( array_diff( $notifications, [ 'next_payment' ] ) );
+	}
+
+	/**
+	 * Whether a renewal receipt should reach the reader.
+	 *
+	 * @param bool           $enabled Whether the email is enabled.
+	 * @param \WC_Order|null $order   The renewal order. WooCommerce also evaluates this
+	 *                                filter with no order in hand — on the email settings
+	 *                                screen, for one — where the publisher's own setting
+	 *                                is the only honest answer.
+	 *
+	 * @return bool
+	 */
+	public static function is_renewal_receipt_enabled( $enabled, $order = null ) {
+		if ( ! $enabled || ! is_a( $order, 'WC_Order' ) ) {
+			return $enabled;
+		}
+
+		return ! self::is_free( $order );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-zero-total-renewals.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-zero-total-renewals.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Tests renewal messaging withheld for free subscriptions and renewal orders.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Zero_Total_Renewals;
+
+require_once __DIR__ . '/../../../mocks/wc-mocks.php';
+
+/**
+ * A free subscription still renews every cycle — WooCommerce Subscriptions creates a
+ * renewal order and completes it immediately, because nothing is owed. These tests pin
+ * the reader-facing messages that renewal must not produce, and the boundary that keeps
+ * a paying reader's messages intact: a 100% recurring coupon zeroes the total but not
+ * the pre-discount subtotal.
+ *
+ * @group WooCommerce_Subscriptions_Integration
+ */
+class Newspack_Test_Zero_Total_Renewals extends WP_UnitTestCase {
+	/**
+	 * Every notification type WooCommerce Subscriptions can schedule for a subscription.
+	 */
+	const ALL_NOTIFICATIONS = [ 'next_payment', 'trial_end', 'end' ];
+
+	/**
+	 * Build a subscription double carrying a total and a pre-discount subtotal.
+	 *
+	 * @param float $total    Recurring total.
+	 * @param float $subtotal Pre-discount subtotal.
+	 * @return WC_Subscription
+	 */
+	private function subscription( $total, $subtotal ) {
+		return new WC_Subscription(
+			[
+				'id'       => 1,
+				'total'    => $total,
+				'subtotal' => $subtotal,
+			]
+		);
+	}
+
+	/**
+	 * Build a renewal order double carrying a total and a pre-discount subtotal.
+	 *
+	 * The mock requires a status and writes customer meta on a completed one, which
+	 * this fixture has no use for — `get_total()` and `get_subtotal()` are all the filter
+	 * reads.
+	 *
+	 * @param float $total    Order total.
+	 * @param float $subtotal Pre-discount subtotal.
+	 * @return WC_Order
+	 */
+	private function renewal_order( $total, $subtotal ) {
+		return new WC_Order(
+			[
+				'status'   => 'pending',
+				'total'    => $total,
+				'subtotal' => $subtotal,
+			]
+		);
+	}
+
+	/**
+	 * A free subscription loses its upcoming-renewal reminder, and nothing else.
+	 *
+	 * Trial-end and expiration notices tell the reader their access is about to change,
+	 * which is true whether or not they pay for it.
+	 */
+	public function test_free_subscription_keeps_only_access_notifications() {
+		$this->assertSame(
+			[ 'trial_end', 'end' ],
+			Zero_Total_Renewals::skip_renewal_notification( self::ALL_NOTIFICATIONS, $this->subscription( 0, 0 ) )
+		);
+	}
+
+	/**
+	 * A subscription the publisher bills is left alone, whether it charges this period or
+	 * is fully discounted for it. Both callbacks read the same free/paid test, so pinning
+	 * the discounted case here pins it for the receipt too, where it decides the outcome.
+	 */
+	public function test_a_paying_subscription_keeps_the_renewal_reminder() {
+		$this->assertSame(
+			self::ALL_NOTIFICATIONS,
+			Zero_Total_Renewals::skip_renewal_notification( self::ALL_NOTIFICATIONS, $this->subscription( 10.00, 10.00 ) )
+		);
+		$this->assertSame(
+			self::ALL_NOTIFICATIONS,
+			Zero_Total_Renewals::skip_renewal_notification( self::ALL_NOTIFICATIONS, $this->subscription( 0, 10.00 ) )
+		);
+	}
+
+	/**
+	 * The $0.00 receipt is the message readers actually see today, so it is the one that
+	 * has to stop — and only for a renewal that was free rather than discounted.
+	 */
+	public function test_receipt_is_withheld_only_from_a_free_renewal_order() {
+		$this->assertFalse( Zero_Total_Renewals::is_renewal_receipt_enabled( true, $this->renewal_order( 0, 0 ) ) );
+		$this->assertTrue( Zero_Total_Renewals::is_renewal_receipt_enabled( true, $this->renewal_order( 25.00, 25.00 ) ) );
+		$this->assertTrue( Zero_Total_Renewals::is_renewal_receipt_enabled( true, $this->renewal_order( 0, 25.00 ) ) );
+	}
+
+	/**
+	 * A publisher who turned the receipt off keeps it off.
+	 */
+	public function test_the_filter_never_enables_a_disabled_receipt() {
+		$this->assertFalse( Zero_Total_Renewals::is_renewal_receipt_enabled( false, $this->renewal_order( 25.00, 25.00 ) ) );
+	}
+
+	/**
+	 * WooCommerce evaluates the filter with no order in hand every time a publisher opens
+	 * the email settings screen, so the guard that lets that through is a hot path, not a
+	 * defensive flourish: without it the screen fatals on a method call against null.
+	 */
+	public function test_the_publisher_setting_survives_an_evaluation_with_no_order() {
+		$this->assertTrue( Zero_Total_Renewals::is_renewal_receipt_enabled( true, null ) );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Readers on complimentary access get a `$0.00` renewal receipt every year, for a subscription they never bought. Publishers who moved off manual Memberships plans hold these as `$0` subscriptions, and Subscriptions renews them like any other: it creates a renewal order and completes it on the spot because nothing is owed. Access never lapses, which is the point, but the receipt goes out with it.

`Newspack\Zero_Total_Renewals` withholds that receipt and stops the upcoming-renewal reminder being scheduled. Trial-end and expiration notices still fire.

Free means the total **and** the pre-discount subtotal are zero, so a paying subscriber on a limited 100% recurring coupon still gets warned before the charges start. A reader comped with an *unlimited* 100% coupon reads as paid and keeps their receipts.

On Subscriptions 7.4.0+ the reminder half changes nothing a reader sees: a send-time zero-total break already stops that email, so this removes a scheduled action that fires and does nothing. The reporting site is on 9.1.0.

Closes NPPD-2253.

Today, on a `$0` complimentary subscription:

![The $0.00 renewal receipt a complimentary subscriber receives today](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/09/2az2xdko-step-1-zero-dollar-receipt-before-fix.png)

After this change the same renewal runs, access holds, and nothing is mailed:

![After the fix: the same subscription renews, stays active, and mails nothing](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/09/09/rc4s9h7j-step-2-comp-subscription-renewed-after-fix.png)

### How to test the changes in this Pull Request:

1. Set up a site with WooCommerce and WooCommerce Subscriptions.
2. Go to WooCommerce > Settings > Subscriptions. Turn on customer notification emails and set the reminder to 5 days.
3. Create a `$0` yearly subscription for a reader. Set it to manual renewal, with a next-payment date in the future.
4. Open the subscription in WooCommerce > Subscriptions. The status is Active and the total is `$0.00`.
5. Set the next-payment date to the past and run the renewal.
6. Open MailHog at http://localhost:8025. The reader has no new mail. Only the store admin gets the new-renewal-order notice.
7. Open the subscription again. The status is still Active, and the related renewal order is Completed at `$0.00`.
8. Repeat steps 3 to 7 with a `$25` yearly subscription. The reader gets the completed-renewal receipt as before.

A ready-made script for steps 3 to 7 is in the Linear issue.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<details>
<summary>For reviewers and agents: hooks, boundaries, and what was checked</summary>

**Hooks**

`woocommerce_subscription_valid_customer_notification_types` drops `next_payment`, which also unschedules an existing row on the subscription's next date or status change. `woocommerce_email_enabled_<id>` covers the completed, processing and gifting renewal receipts: Subscriptions auto-completes a renewal whose subtotal is zero, so a migrated comp takes the completed path and the others catch the rest.

Registration is gated on `is_active()` rather than `is_enabled()`, which adds Reader Activation — a site with it off gets the same receipts. `new_renewal_order` is merchant-facing, and `customer_renewal_invoice` only fires for a renewal awaiting payment, so both are out of scope.

**Verification**

Tests and PHPCS green; the new tests were mutation-checked. Exercised on an isolated env against Subscriptions 9.1.0 with mail captured: a `$0` comp renewal sent the reader nothing and stayed active, a `$25` control kept its reminder and receipt, and a renewal with total `0` and subtotal `25` kept its receipt. The hook strings are proven by that run rather than by the suite, since the test bootstrap has no `WC()` shim and `init()` returns early.

**One correction to the report**

The ticket says readers also get `customer_notification_manual_renewal`. On 9.1.0 they do not: Subscriptions breaks on a zero total before triggering it, added in 7.4.0. The reporting site was since confirmed to be on 9.1.0. The `$0.00` receipt reproduced exactly.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGecxhdfoPwUoqQqPTU6wC
