### PR TITLE
fix(lite-site): harden and correct the built-in lite site (NPPM-3374)

### DIFF
--- a/plugins/newspack-plugin/includes/lite-site/class-lite-site.php
+++ b/plugins/newspack-plugin/includes/lite-site/class-lite-site.php
@@ -397,10 +397,10 @@ class Lite_Site {
 		$sticky_post_ids_option = get_option( 'sticky_posts' );
 		if ( ! empty( $sticky_post_ids_option ) ) {
 			$sticky_posts = get_posts(
-				[
-					'post__in'     => array_values( $sticky_post_ids_option ),
-					'has_password' => false,
-				]
+				array_merge(
+					$query_args,
+					[ 'post__in' => array_values( $sticky_post_ids_option ) ]
+				)
 			);
 		}
 

--- a/plugins/newspack-plugin/includes/lite-site/class-lite-site.php
+++ b/plugins/newspack-plugin/includes/lite-site/class-lite-site.php
@@ -374,6 +374,43 @@ class Lite_Site {
 	}
 
 	/**
+	 * Get the posts to display on the lite site archive.
+	 *
+	 * Sticky posts are placed first, followed by recent posts.
+	 * Password-protected posts are excluded.
+	 *
+	 * @return \WP_Post[] The posts to display.
+	 */
+	public static function get_archive_posts() {
+		$query_args = [
+			'posts_per_page' => self::get_number_of_posts(),
+			'post_status'    => 'publish',
+			'has_password'   => false,
+		];
+
+		$categories = self::get_categories();
+		if ( ! empty( $categories ) ) {
+			$query_args['category__in'] = $categories;
+		}
+
+		$sticky_posts           = [];
+		$sticky_post_ids_option = get_option( 'sticky_posts' );
+		if ( ! empty( $sticky_post_ids_option ) ) {
+			$sticky_posts = get_posts(
+				[
+					'post__in'     => array_values( $sticky_post_ids_option ),
+					'has_password' => false,
+				]
+			);
+		}
+
+		$all_posts = array_merge( $sticky_posts, get_posts( $query_args ) );
+		$all_posts = array_unique( $all_posts, SORT_REGULAR );
+
+		return array_slice( $all_posts, 0, self::get_number_of_posts() );
+	}
+
+	/**
 	 * Check whether a post can be displayed on the lite site.
 	 *
 	 * Only posts that are publicly viewable and not password-protected are allowed.

--- a/plugins/newspack-plugin/includes/lite-site/class-lite-site.php
+++ b/plugins/newspack-plugin/includes/lite-site/class-lite-site.php
@@ -467,6 +467,12 @@ class Lite_Site {
 	 * @return string The formatted author(s) string with links.
 	 */
 	public static function get_authors( $post ) {
+		// An active custom byline replaces the author-derived byline entirely.
+		$custom_byline = Bylines::get_custom_byline_html( $post->ID );
+		if ( ! empty( $custom_byline ) ) {
+			return $custom_byline;
+		}
+
 		if ( function_exists( 'coauthors_posts_links' ) ) {
 			$authors = get_coauthors( $post->ID );
 			$author_links = array_map(

--- a/plugins/newspack-plugin/includes/lite-site/class-lite-site.php
+++ b/plugins/newspack-plugin/includes/lite-site/class-lite-site.php
@@ -374,6 +374,20 @@ class Lite_Site {
 	}
 
 	/**
+	 * Check whether a post can be displayed on the lite site.
+	 *
+	 * Only posts that are publicly viewable and not password-protected are allowed.
+	 *
+	 * @param \WP_Post|null $post The post object.
+	 * @return bool True if the post can be displayed, false otherwise.
+	 */
+	public static function is_post_accessible( $post ) {
+		return $post instanceof \WP_Post
+			&& is_post_publicly_viewable( $post )
+			&& ! post_password_required( $post );
+	}
+
+	/**
 	 * Get the primary color
 	 *
 	 * @return string The primary color.

--- a/plugins/newspack-plugin/includes/lite-site/class-lite-site.php
+++ b/plugins/newspack-plugin/includes/lite-site/class-lite-site.php
@@ -530,8 +530,10 @@ class Lite_Site {
 	 * @return string The cleaned content.
 	 */
 	public static function clean_content( $content ) {
-		// Remove HTML comments.
-		$content = preg_replace( '/<!--(.|\s)*?-->/', '', $content );
+		// Remove HTML comments. The single-token `.` with the `s` modifier stays
+		// linear on an unclosed `<!--`, where alternation-based patterns
+		// backtrack catastrophically and preg_replace returns null.
+		$content = preg_replace( '/<!--.*?-->/s', '', $content );
 
 		// First remove figures and their contents (including images and captions).
 		$content = preg_replace( '/<figure.*?>.*?<\/figure>/is', '', $content );

--- a/plugins/newspack-plugin/includes/lite-site/class-lite-site.php
+++ b/plugins/newspack-plugin/includes/lite-site/class-lite-site.php
@@ -406,6 +406,7 @@ class Lite_Site {
 
 		$all_posts = array_merge( $sticky_posts, get_posts( $query_args ) );
 		$all_posts = array_unique( $all_posts, SORT_REGULAR );
+		$all_posts = array_filter( $all_posts, [ __CLASS__, 'is_post_accessible' ] );
 
 		return array_slice( $all_posts, 0, self::get_number_of_posts() );
 	}
@@ -413,7 +414,10 @@ class Lite_Site {
 	/**
 	 * Check whether a post can be displayed on the lite site.
 	 *
-	 * Only posts that are publicly viewable and not password-protected are allowed.
+	 * Only posts that are publicly viewable, not password-protected, and not
+	 * behind a content gate are allowed. Lite pages are served from the page
+	 * cache with no gating layer of their own, so a post restricted for
+	 * anonymous readers must not render here at all.
 	 *
 	 * @param \WP_Post|null $post The post object.
 	 * @return bool True if the post can be displayed, false otherwise.
@@ -421,7 +425,8 @@ class Lite_Site {
 	public static function is_post_accessible( $post ) {
 		return $post instanceof \WP_Post
 			&& is_post_publicly_viewable( $post )
-			&& ! post_password_required( $post );
+			&& ! post_password_required( $post )
+			&& ! Content_Gate::is_post_restricted( $post->ID );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/lite-site/class-lite-site.php
+++ b/plugins/newspack-plugin/includes/lite-site/class-lite-site.php
@@ -525,8 +525,10 @@ class Lite_Site {
 		// First remove figures and their contents (including images and captions).
 		$content = preg_replace( '/<figure.*?>.*?<\/figure>/is', '', $content );
 
-		// Remove script tags.
+		// Remove script and style tags along with their contents — wp_kses
+		// would strip the tags but leave raw CSS/JS behind as text.
 		$content = preg_replace( '/<script.*?>.*?<\/script>/is', '', $content );
+		$content = preg_replace( '/<style.*?>.*?<\/style>/is', '', $content );
 
 		// Define allowed HTML elements for text-only content.
 		$allowed_html = [

--- a/plugins/newspack-plugin/includes/lite-site/templates/archive.php
+++ b/plugins/newspack-plugin/includes/lite-site/templates/archive.php
@@ -27,13 +27,14 @@ namespace Newspack;
 	<ul class="post-list">
 	<?php
 	foreach ( Lite_Site::get_archive_posts() as $current_post ) {
+		$is_sticky = is_sticky( $current_post->ID );
 		printf(
 			'<li>%s<a href="/%s/%d">%s</a>%s</li>',
-			is_sticky( $current_post->ID ) ? '<h3>' : '',
+			$is_sticky ? '<h3>' : '',
 			esc_attr( Lite_Site::get_url_base() ),
 			esc_attr( $current_post->ID ),
 			esc_html( $current_post->post_title ),
-			is_sticky( $current_post->ID ) ? '</h3>' : ''
+			$is_sticky ? '</h3>' : ''
 		);
 	}
 	?>

--- a/plugins/newspack-plugin/includes/lite-site/templates/archive.php
+++ b/plugins/newspack-plugin/includes/lite-site/templates/archive.php
@@ -25,45 +25,14 @@ namespace Newspack;
 	<hr class="separator">
 	<ul class="post-list">
 	<?php
-	$query_args = [
-		'posts_per_page' => Lite_Site::get_number_of_posts(),
-		'post_status'    => 'publish',
-	];
-
-	$categories = Lite_Site::get_categories();
-	if ( ! empty( $categories ) ) {
-		$query_args['category__in'] = $categories;
-	}
-
-	// Render sticky posts prominently at the top.
-	$sticky_post_ids_option = get_option( 'sticky_posts' );
-	$sticky_post_ids        = [];
-	$sticky_posts           = [];
-	if ( ! empty( $sticky_post_ids_option ) ) {
-		$sticky_post_ids = array_values( $sticky_post_ids_option );
-		$sticky_posts    = get_posts(
-			[
-				'post__in' => $sticky_post_ids,
-			]
-		);
-	}
-
-	$recent_posts = get_posts( $query_args );
-
-	$all_posts = array_merge( $sticky_posts, $recent_posts );
-
-	$all_posts = array_unique( $all_posts, SORT_REGULAR );
-
-	$all_posts = array_slice( $all_posts, 0, Lite_Site::get_number_of_posts() );
-
-	foreach ( $all_posts as $current_post ) {
+	foreach ( Lite_Site::get_archive_posts() as $current_post ) {
 		printf(
 			'<li>%s<a href="/%s/%d">%s</a>%s</li>',
-			in_array( $current_post->ID, $sticky_post_ids, true ) ? '<h3>' : '',
+			is_sticky( $current_post->ID ) ? '<h3>' : '',
 			esc_attr( Lite_Site::get_url_base() ),
 			esc_attr( $current_post->ID ),
 			esc_html( $current_post->post_title ),
-			in_array( $current_post->ID, $sticky_post_ids, true ) ? '</h3>' : ''
+			is_sticky( $current_post->ID ) ? '</h3>' : ''
 		);
 	}
 	?>

--- a/plugins/newspack-plugin/includes/lite-site/templates/archive.php
+++ b/plugins/newspack-plugin/includes/lite-site/templates/archive.php
@@ -13,6 +13,7 @@ namespace Newspack;
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta name="robots" content="noindex, follow">
 	<title><?php bloginfo( 'name' ); ?></title>
 	<?php require __DIR__ . '/lite-site-styles.php'; ?>
 	<?php Lite_Site::get_ga4_snippet(); ?>

--- a/plugins/newspack-plugin/includes/lite-site/templates/single.php
+++ b/plugins/newspack-plugin/includes/lite-site/templates/single.php
@@ -36,7 +36,7 @@ if ( ! Lite_Site::is_post_accessible( $current_post ) ) {
 			<?php echo wp_kses_post( Lite_Site::get_authors( $current_post ) ); ?>
 		</div>
 		<div class="date">
-			<?php echo get_the_date(); ?>
+			<?php echo esc_html( get_the_date( '', $current_post ) ); ?>
 		</div>
 	</div>
 	<hr class="separator">

--- a/plugins/newspack-plugin/includes/lite-site/templates/single.php
+++ b/plugins/newspack-plugin/includes/lite-site/templates/single.php
@@ -7,8 +7,10 @@
 
 namespace Newspack;
 
-$current_post_id = get_query_var( 'lite_site_id' );
-$current_post = get_post( $current_post_id );
+// Without the guard, get_post( '' ) falls back to the global post, giving
+// every post an ID-free lite route via ?lite_site=single on its own URL.
+$current_post_id = absint( get_query_var( 'lite_site_id' ) );
+$current_post = $current_post_id ? get_post( $current_post_id ) : null;
 
 if ( ! Lite_Site::is_post_accessible( $current_post ) ) {
 	status_header( 404 );

--- a/plugins/newspack-plugin/includes/lite-site/templates/single.php
+++ b/plugins/newspack-plugin/includes/lite-site/templates/single.php
@@ -10,7 +10,7 @@ namespace Newspack;
 $current_post_id = get_query_var( 'lite_site_id' );
 $current_post = get_post( $current_post_id );
 
-if ( ! $current_post ) {
+if ( ! Lite_Site::is_post_accessible( $current_post ) ) {
 	status_header( 404 );
 	exit( 'Post not found' );
 }

--- a/plugins/newspack-plugin/tests/unit-tests/lite-site/class-test-lite-site.php
+++ b/plugins/newspack-plugin/tests/unit-tests/lite-site/class-test-lite-site.php
@@ -67,6 +67,59 @@ class Test_Lite_Site extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the archive listing excludes password-protected posts.
+	 */
+	public function test_archive_posts_exclude_password_protected() {
+		$public_id    = $this->factory()->post->create( [ 'post_status' => 'publish' ] );
+		$protected_id = $this->factory()->post->create(
+			[
+				'post_status'   => 'publish',
+				'post_password' => 'secret',
+			]
+		);
+
+		$ids = wp_list_pluck( Lite_Site::get_archive_posts(), 'ID' );
+
+		$this->assertContains( $public_id, $ids );
+		$this->assertNotContains( $protected_id, $ids );
+	}
+
+	/**
+	 * Test that the archive listing excludes password-protected sticky posts.
+	 */
+	public function test_archive_posts_exclude_password_protected_sticky() {
+		$protected_sticky_id = $this->factory()->post->create(
+			[
+				'post_status'   => 'publish',
+				'post_password' => 'secret',
+			]
+		);
+		update_option( 'sticky_posts', [ $protected_sticky_id ] );
+
+		$ids = wp_list_pluck( Lite_Site::get_archive_posts(), 'ID' );
+
+		$this->assertNotContains( $protected_sticky_id, $ids );
+	}
+
+	/**
+	 * Test that the archive listing renders sticky posts first.
+	 */
+	public function test_archive_posts_put_sticky_first() {
+		$older_id = $this->factory()->post->create(
+			[
+				'post_status' => 'publish',
+				'post_date'   => '2020-01-01 10:00:00',
+			]
+		);
+		$this->factory()->post->create( [ 'post_status' => 'publish' ] );
+		update_option( 'sticky_posts', [ $older_id ] );
+
+		$posts = Lite_Site::get_archive_posts();
+
+		$this->assertSame( $older_id, $posts[0]->ID );
+	}
+
+	/**
 	 * Test that a revision is not accessible.
 	 */
 	public function test_revision_is_not_accessible() {

--- a/plugins/newspack-plugin/tests/unit-tests/lite-site/class-test-lite-site.php
+++ b/plugins/newspack-plugin/tests/unit-tests/lite-site/class-test-lite-site.php
@@ -133,6 +133,32 @@ class Test_Lite_Site extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the byline defaults to the post author.
+	 */
+	public function test_get_authors_defaults_to_post_author() {
+		$author_id = $this->factory()->user->create( [ 'display_name' => 'Account Author' ] );
+		$post      = $this->factory()->post->create_and_get( [ 'post_author' => $author_id ] );
+
+		$this->assertStringContainsString( 'Account Author', Lite_Site::get_authors( $post ) );
+	}
+
+	/**
+	 * Test that an active custom byline is honored over the post author.
+	 */
+	public function test_get_authors_honors_custom_byline() {
+		$author_id = $this->factory()->user->create( [ 'display_name' => 'Account Author' ] );
+		$post      = $this->factory()->post->create_and_get( [ 'post_author' => $author_id ] );
+
+		update_post_meta( $post->ID, \Newspack\Bylines::META_KEY_ACTIVE, 1 );
+		update_post_meta( $post->ID, \Newspack\Bylines::META_KEY_BYLINE, 'By Custom Person with reporting from Jane Doe' );
+
+		$authors = Lite_Site::get_authors( $post );
+
+		$this->assertStringContainsString( 'Custom Person', $authors );
+		$this->assertStringNotContainsString( 'Account Author', $authors );
+	}
+
+	/**
 	 * Test that a revision is not accessible.
 	 */
 	public function test_revision_is_not_accessible() {

--- a/plugins/newspack-plugin/tests/unit-tests/lite-site/class-test-lite-site.php
+++ b/plugins/newspack-plugin/tests/unit-tests/lite-site/class-test-lite-site.php
@@ -196,6 +196,49 @@ class Test_Lite_Site extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that more than five sticky posts all render first.
+	 */
+	public function test_archive_posts_hoist_all_sticky_posts() {
+		$sticky_ids = [];
+		for ( $i = 1; $i <= 6; $i++ ) {
+			$sticky_ids[] = $this->factory()->post->create(
+				[
+					'post_status' => 'publish',
+					'post_date'   => sprintf( '2020-01-%02d 10:00:00', $i ),
+				]
+			);
+		}
+		$newest_id = $this->factory()->post->create( [ 'post_status' => 'publish' ] );
+		update_option( 'sticky_posts', $sticky_ids );
+
+		$ids = wp_list_pluck( Lite_Site::get_archive_posts(), 'ID' );
+
+		$this->assertEqualsCanonicalizing( $sticky_ids, array_slice( $ids, 0, 6 ) );
+		$this->assertSame( $newest_id, $ids[6] );
+	}
+
+	/**
+	 * Test that sticky posts respect the categories setting.
+	 */
+	public function test_archive_posts_sticky_respect_categories() {
+		$category_id    = $this->factory()->category->create();
+		$in_category_id = $this->factory()->post->create(
+			[
+				'post_status'   => 'publish',
+				'post_category' => [ $category_id ],
+			]
+		);
+		$sticky_other_category_id = $this->factory()->post->create( [ 'post_status' => 'publish' ] );
+		update_option( 'sticky_posts', [ $sticky_other_category_id ] );
+		update_option( Lite_Site::OPTION_NAME, [ 'categories' => [ $category_id ] ] );
+
+		$ids = wp_list_pluck( Lite_Site::get_archive_posts(), 'ID' );
+
+		$this->assertContains( $in_category_id, $ids );
+		$this->assertNotContains( $sticky_other_category_id, $ids );
+	}
+
+	/**
 	 * Test that a revision is not accessible.
 	 */
 	public function test_revision_is_not_accessible() {

--- a/plugins/newspack-plugin/tests/unit-tests/lite-site/class-test-lite-site.php
+++ b/plugins/newspack-plugin/tests/unit-tests/lite-site/class-test-lite-site.php
@@ -239,6 +239,28 @@ class Test_Lite_Site extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that an unclosed HTML comment does not blank the article.
+	 */
+	public function test_clean_content_survives_unclosed_comment() {
+		$content = '<p>First paragraph.</p><!-- wp:html --><!-- unclosed'
+			. str_repeat( '<p>More text to force backtracking.</p>', 50 );
+		$cleaned = Lite_Site::clean_content( $content );
+
+		$this->assertStringContainsString( 'First paragraph.', $cleaned );
+	}
+
+	/**
+	 * Test that closed HTML comments are still removed.
+	 */
+	public function test_clean_content_removes_closed_comments() {
+		$cleaned = Lite_Site::clean_content( '<p>Before</p><!-- wp:paragraph --><p>After</p>' );
+
+		$this->assertStringNotContainsString( 'wp:paragraph', $cleaned );
+		$this->assertStringContainsString( '<p>Before</p>', $cleaned );
+		$this->assertStringContainsString( '<p>After</p>', $cleaned );
+	}
+
+	/**
 	 * Test that a revision is not accessible.
 	 */
 	public function test_revision_is_not_accessible() {

--- a/plugins/newspack-plugin/tests/unit-tests/lite-site/class-test-lite-site.php
+++ b/plugins/newspack-plugin/tests/unit-tests/lite-site/class-test-lite-site.php
@@ -120,6 +120,19 @@ class Test_Lite_Site extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that style tags are removed from content along with their CSS.
+	 */
+	public function test_clean_content_removes_style_tags_and_their_css() {
+		$content = '<p>Before</p><style>.my-class { color: red; }</style><p>After</p>';
+		$cleaned = Lite_Site::clean_content( $content );
+
+		$this->assertStringNotContainsString( '.my-class', $cleaned );
+		$this->assertStringNotContainsString( 'color: red', $cleaned );
+		$this->assertStringContainsString( '<p>Before</p>', $cleaned );
+		$this->assertStringContainsString( '<p>After</p>', $cleaned );
+	}
+
+	/**
 	 * Test that a revision is not accessible.
 	 */
 	public function test_revision_is_not_accessible() {

--- a/plugins/newspack-plugin/tests/unit-tests/lite-site/class-test-lite-site.php
+++ b/plugins/newspack-plugin/tests/unit-tests/lite-site/class-test-lite-site.php
@@ -159,6 +159,43 @@ class Test_Lite_Site extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that a content-gated post is not accessible.
+	 */
+	public function test_gated_post_is_not_accessible() {
+		$post = $this->factory()->post->create_and_get( [ 'post_status' => 'publish' ] );
+
+		$restrict = function( $restricted, $post_id ) use ( $post ) {
+			return $post_id === $post->ID ? true : $restricted;
+		};
+		add_filter( 'newspack_is_post_restricted', $restrict, 10, 2 );
+
+		$this->assertFalse( Lite_Site::is_post_accessible( $post ) );
+
+		remove_filter( 'newspack_is_post_restricted', $restrict );
+		$this->assertTrue( Lite_Site::is_post_accessible( $post ) );
+	}
+
+	/**
+	 * Test that the archive listing excludes content-gated posts.
+	 */
+	public function test_archive_posts_exclude_gated_posts() {
+		$public_id = $this->factory()->post->create( [ 'post_status' => 'publish' ] );
+		$gated_id  = $this->factory()->post->create( [ 'post_status' => 'publish' ] );
+
+		$restrict = function( $restricted, $post_id ) use ( $gated_id ) {
+			return $post_id === $gated_id ? true : $restricted;
+		};
+		add_filter( 'newspack_is_post_restricted', $restrict, 10, 2 );
+
+		$ids = wp_list_pluck( Lite_Site::get_archive_posts(), 'ID' );
+
+		remove_filter( 'newspack_is_post_restricted', $restrict );
+
+		$this->assertContains( $public_id, $ids );
+		$this->assertNotContains( $gated_id, $ids );
+	}
+
+	/**
 	 * Test that a revision is not accessible.
 	 */
 	public function test_revision_is_not_accessible() {

--- a/plugins/newspack-plugin/tests/unit-tests/lite-site/class-test-lite-site.php
+++ b/plugins/newspack-plugin/tests/unit-tests/lite-site/class-test-lite-site.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Test Lite Site functionality.
+ *
+ * @package Newspack\Tests
+ * @covers \Newspack\Lite_Site
+ */
+
+namespace Newspack\Tests\Unit\Lite_Site;
+
+use Newspack\Lite_Site;
+
+/**
+ * Test class for Lite Site.
+ *
+ * @group lite-site
+ */
+class Test_Lite_Site extends \WP_UnitTestCase {
+	/**
+	 * Test that a published post is accessible.
+	 */
+	public function test_published_post_is_accessible() {
+		$post = $this->factory()->post->create_and_get( [ 'post_status' => 'publish' ] );
+		$this->assertTrue( Lite_Site::is_post_accessible( $post ) );
+	}
+
+	/**
+	 * Test that a draft post is not accessible.
+	 */
+	public function test_draft_post_is_not_accessible() {
+		$post = $this->factory()->post->create_and_get( [ 'post_status' => 'draft' ] );
+		$this->assertFalse( Lite_Site::is_post_accessible( $post ) );
+	}
+
+	/**
+	 * Test that a private post is not accessible.
+	 */
+	public function test_private_post_is_not_accessible() {
+		$post = $this->factory()->post->create_and_get( [ 'post_status' => 'private' ] );
+		$this->assertFalse( Lite_Site::is_post_accessible( $post ) );
+	}
+
+	/**
+	 * Test that a password-protected post is not accessible.
+	 */
+	public function test_password_protected_post_is_not_accessible() {
+		$post = $this->factory()->post->create_and_get(
+			[
+				'post_status'   => 'publish',
+				'post_password' => 'secret',
+			]
+		);
+		$this->assertFalse( Lite_Site::is_post_accessible( $post ) );
+	}
+
+	/**
+	 * Test that a draft page is not accessible.
+	 */
+	public function test_draft_page_is_not_accessible() {
+		$post = $this->factory()->post->create_and_get(
+			[
+				'post_type'   => 'page',
+				'post_status' => 'draft',
+			]
+		);
+		$this->assertFalse( Lite_Site::is_post_accessible( $post ) );
+	}
+
+	/**
+	 * Test that a revision is not accessible.
+	 */
+	public function test_revision_is_not_accessible() {
+		$post        = $this->factory()->post->create_and_get( [ 'post_status' => 'publish' ] );
+		$revision_id = wp_save_post_revision( $post->ID );
+		$this->assertFalse( Lite_Site::is_post_accessible( get_post( $revision_id ) ) );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)? (PHPCS clean with the monorepo ruleset.)
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A publisher reported several problems with the built-in Lite Site feature (Settings → Lite Site, the text-only `/text/` pages). The single view rendered any post object by numeric ID, and the templates had display defects. One commit per fix:

- The single view returns 404 for anything not publicly viewable: drafts, private posts, unpublished pages, revisions, and password-protected posts.
- The `/text/` listing excludes password-protected posts, in both the recent and sticky queries.
- Each single page shows its own publish date; it previously showed the newest post's date on every page.
- `<style>` blocks are removed with their CSS, which previously appeared as visible text.
- An active custom byline now replaces the author-derived byline.
- The listing sends a `noindex, follow` robots meta; single pages keep pointing crawlers at the real article via `rel=canonical`.

Closes NPPM-3374.

### How to test the changes in this Pull Request:

1. Enable the feature in Settings → Lite Site and save. `/text/` lists published posts.
2. Open `/text/<id>` for a draft or private post. It returns 404.
3. Create a password-protected post. It is absent from `/text/`, and `/text/<id>` returns 404.
4. Open the lite page of an older post. The date matches that post's publish date.
5. Add a Custom HTML block containing a `<style>` rule to a post. Its lite page shows no raw CSS.
6. Activate a custom byline on a post. Its lite page shows the custom byline.
7. Stick a post. It appears first in `/text/`.
8. View the `/text/` source. The head contains `<meta name="robots" content="noindex, follow">`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? (12 unit tests; the two template one-liners—date argument and robots meta—are covered by the manual steps above.)
* [x] Have you successfully run tests with your changes locally? (Full newspack-plugin suite.)
