### PR TITLE
fix(pricing-rules): goal dialog no longer blocks saving a Custom rule

### DIFF
--- a/plugins/newspack-plugin/src/wizards/audience/views/pricing-rules/rule-form-goal.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/pricing-rules/rule-form-goal.test.jsx
@@ -62,8 +62,7 @@ jest.mock( '../../../../../packages/components/src', () => {
 	);
 	const AutocompleteTokenField = ( { label, onChange } ) => <button type="button" onClick={ () => onChange( [ 1 ] ) }>{ `Set ${ label }` }</button>;
 	const history = { push: jest.fn(), replace: jest.fn() };
-	// Mirrors the real hook: `when === false` skips the prompt and runs straight away.
-	const useConfirmDialog = ( { when, message, title, confirmButtonText } ) => {
+	const useConfirmDialog = ( { message, title, confirmButtonText } ) => {
 		const [ pending, setPending ] = useStateMock( null );
 		return {
 			confirmDialog: pending ? (
@@ -83,13 +82,7 @@ jest.mock( '../../../../../packages/components/src', () => {
 					</button>
 				</div>
 			) : null,
-			requestConfirm: callback => {
-				if ( when === false ) {
-					callback();
-				} else {
-					setPending( () => callback );
-				}
-			},
+			requestConfirm: callback => setPending( () => callback ),
 			cancelConfirm: () => setPending( null ),
 		};
 	};

--- a/plugins/newspack-plugin/src/wizards/audience/views/pricing-rules/rule-form-save-redirect.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/pricing-rules/rule-form-save-redirect.test.jsx
@@ -1,0 +1,79 @@
+/**
+ * Saving hands the publisher back to the list, through the real wizard and router.
+ * The "Change goal?" warning belongs to the goal cards alone: a Custom rule whose
+ * priority or compose mode differs from the defaults must not see it on Save.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent, act } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { Wizard } from '../../../../../packages/components/src';
+import { SECTIONS } from './index';
+import { RULES_API_PATH as API_PATH } from './constants';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+jest.mock( './list', () => () => <p>Rules list</p> );
+jest.mock( './scope-targets', () => () => null );
+jest.mock( './rule-preview', () => () => null );
+
+global.newspack_aux_data = { is_debug_mode: false };
+global.newspack_urls = { support: 'https://newspack.com/support/' };
+window.scrollTo = jest.fn();
+
+const VOCAB = {
+	strategies: [ { id: 'simple_price', label: 'Simple' } ],
+	scopes: [ { id: 'all_products', label: 'All products' } ],
+	calc_types: [ { value: 'fixed_price', label: 'Fixed' } ],
+	currency: { code: 'USD', symbol: '$', decimals: 2 },
+	conditions: [],
+};
+
+// A Custom rule with a priority of its own: the one kind of rule whose goal
+// change has something to warn about.
+const SAVED_RULE = {
+	id: 3,
+	title: 'Loyalty deal',
+	intent: 'custom',
+	status: 'publish',
+	priority: 5,
+	compose_mode: 'priority_exclusive',
+	application: 'current',
+	simple: { calc_type: 'fixed_price', value: 4, cycles_limit: 0, label: '' },
+};
+
+describe( 'saving a Custom rule with its own priority', () => {
+	beforeEach( async () => {
+		apiFetch.mockImplementation( ( { path, method } ) => {
+			if ( method ) {
+				return Promise.resolve( {} );
+			}
+			return Promise.resolve( path === `${ API_PATH }/${ SAVED_RULE.id }` ? SAVED_RULE : VOCAB );
+		} );
+		window.location.hash = `#/edit/${ SAVED_RULE.id }`;
+		await act( async () => {
+			render( <Wizard sections={ SECTIONS } /> );
+		} );
+	} );
+
+	it( 'returns to the list without asking about the goal', async () => {
+		expect( screen.getByLabelText( 'Priority' ) ).toHaveValue( 5 );
+
+		await act( async () => {
+			fireEvent.click( screen.getByRole( 'button', { name: 'Save' } ) );
+		} );
+
+		expect( screen.queryByRole( 'dialog' ) ).toBeNull();
+		expect( window.location.hash ).toBe( '#/' );
+		expect( screen.getByText( 'Rules list' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/audience/views/pricing-rules/rule-form.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/pricing-rules/rule-form.tsx
@@ -298,8 +298,11 @@ export default function RuleForm( { isNew, initialPath = null, rule, vocab, onDo
 		return lost;
 	}, [ recipe, priority, composeMode, dateModes, vocab.conditions ] );
 
+	// No `when`: the hook forwards it to ConfirmDialog, where it means "block
+	// navigation while true", so a Custom rule with its own priority would raise
+	// this dialog on Save's redirect and on the back crumb. requestGoal() decides
+	// whether there is anything to warn about.
 	const { confirmDialog: goalDialog, requestConfirm: requestGoalChange } = useConfirmDialog( {
-		when: goalChangeLosses.length > 0,
 		title: __( 'Change goal?', 'newspack-plugin' ),
 		confirmButtonText: __( 'Change Goal', 'newspack-plugin' ),
 		message: (
@@ -327,6 +330,10 @@ export default function RuleForm( { isNew, initialPath = null, rule, vocab, onDo
 
 	const requestGoal = ( next: PricingPath ) => {
 		if ( next === path ) {
+			return;
+		}
+		if ( ! goalChangeLosses.length ) {
+			choosePath( next );
 			return;
 		}
 		requestGoalChange( () => choosePath( next ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Saving a Custom pricing rule could open the **"Change goal?"** dialog. It appeared whenever the rule had a priority other than 100, "This rule only" as its compose mode, or an eligibility date set by hand. The same dialog opened on the Pricing Rules crumb and on browser back. On a saved rule the goal cards are disabled, so the dialog never had a reason to show there.

The form passed a `when` flag to the shared confirm-dialog hook to mean "only warn when a goal change would drop something". The hook forwards `when` to ConfirmDialog, where it installs a navigation guard, the unsaved-changes pattern. Every route change while the flag was true raised the goal dialog.

The dialog is now raised only from the goal cards. The form checks whether the switch would lose anything and applies the goal directly when it would not. Saving redirects to the list again, and the goal-change warning keeps its content.

A new test drives the whole wizard with the real router and confirm dialog: saving a Custom rule with its own priority lands on the list with no dialog.

### How to test the changes in this Pull Request:

1. Go to **Audience → Pricing Rules**, open a rule with the Custom goal, set **Priority** to 5, and press **Save**. The list opens with no dialog.
2. Open the rule again, set **When multiple rules match** to "This rule only", and click the **Pricing Rules** crumb. The list opens with no dialog.
3. Open the rule again, set the eligibility date selector to **Custom**, and use browser back. You return to the list with no dialog.
4. Press **Add Rule**, pick **Custom**, set Priority to 5, then pick **Win-Back**. A "Change goal?" dialog lists Priority; confirm it, and Priority is gone from the form.
5. Press **Add Rule**, pick **Custom**, change nothing, then pick **Retention**. The goal switches without a dialog.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
