### PR TITLE
fix(pricing-rules): new Custom rules start locked at purchase

### DIFF
--- a/plugins/newspack-plugin/src/wizards/audience/views/pricing-rules/rule-form-goal.test.jsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/pricing-rules/rule-form-goal.test.jsx
@@ -267,6 +267,17 @@ describe( 'choosing the goal from the form', () => {
 		expect( body.cycle_anchor ).toBe( cycleAnchor );
 	} );
 
+	// The engine's own default: a rule that pins at purchase can only touch new
+	// sign-ups, so a toggle left alone cannot reprice existing subscribers.
+	it( 'starts a Custom rule with pricing locked at purchase', async () => {
+		await renderForm( 'custom' );
+		fireEvent.change( field( 'Name' ), { target: { value: 'Intro deal' } } );
+		fireEvent.change( field( /^Value/ ), { target: { value: '5' } } );
+
+		expect( field( 'Lock pricing at purchase' ) ).toBeChecked();
+		expect( ( await save() ).application ).toBe( 'locked' );
+	} );
+
 	it( 'leaves the name empty on a cold load of the Custom URL', async () => {
 		await renderForm( 'custom' );
 		expect( field( 'Name' ) ).toHaveValue( '' );
@@ -461,6 +472,14 @@ describe( 'choosing the goal from the form', () => {
 
 			expect( screen.queryByRole( 'dialog' ) ).toBeNull();
 			expect( goals().getByRole( 'radio', { checked: true } ) ).toHaveAccessibleName( /^Retention/ );
+		} );
+
+		it( 'keeps a saved Custom rule on always-current pricing', async () => {
+			const rule = { ...savedRule( 'custom' ), id: 6, application: 'current' };
+			await renderSavedRule( rule );
+
+			expect( field( 'Lock pricing at purchase' ) ).not.toBeChecked();
+			expect( ( await save() ).application ).toBe( 'current' );
 		} );
 
 		it( 'falls back to Custom when the rule has no goal', async () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/pricing-rules/rule-form.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/pricing-rules/rule-form.tsx
@@ -214,7 +214,16 @@ export default function RuleForm( { isNew, initialPath = null, rule, vocab, onDo
 	// modes below. Hold whatever the server sent so a value this UI doesn't know
 	// round-trips on save instead of being rewritten to 'min'.
 	const [ composeMode, setComposeMode ] = useState< PricingRuleRow[ 'compose_mode' ] >( rule?.compose_mode ?? 'min' );
-	const [ application, setApplication ] = useState( rule?.application === 'locked' ? 'locked' : seedApplication ?? 'current' );
+	// A saved rule keeps its stored application. A new Custom rule starts locked,
+	// the engine's own default: a rule that pins at purchase can only touch new
+	// sign-ups, so a toggle left alone cannot reprice existing subscribers.
+	// Retention is the one goal that seeds `current`.
+	const [ application, setApplication ] = useState( () => {
+		if ( rule ) {
+			return rule.application === 'locked' ? 'locked' : 'current';
+		}
+		return seedApplication ?? 'locked';
+	} );
 	const [ cycleAnchor, setCycleAnchor ] = useState( rule?.cycle_anchor === 'rule_application' ? 'rule_application' : seedCycleAnchor );
 	const [ publicize, setPublicize ] = useState( Boolean( rule?.publicize ) );
 	const [ intentNote, setIntentNote ] = useState( rule?.intent_note ?? '' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A new rule with the **Custom** goal started with "Lock pricing at purchase" off. Every other layer defaults to locked: the engine's rule model, its own admin screen, and three of the four named goals. Only Retention seeds always-current, on purpose.

Off is the risky side. An always-current rule is re-evaluated at every renewal of every matching subscription, so a publisher who meant an intro offer and never touched the toggle could reprice existing subscribers, or reset a below-regular renewal to full price. A locked rule can only touch new sign-ups, and the impact preview shows that at once.

New Custom rules now start locked. Saved rules keep their stored value, so an always-current rule still opens with the toggle off. Switching goals is unchanged: Custom presets nothing, and each named goal keeps seeding its own value.

### How to test the changes in this Pull Request:

1. Go to **Audience → Pricing Rules**, press **Add Rule**, and pick **Custom**. "Lock pricing at purchase" is on.
2. Turn it off, name and price the rule, **Save**, and reopen it. The toggle is still off.
3. Open a Custom rule saved before this change with the toggle off. It opens with the toggle off.
4. Press **Add Rule**, pick **Retention**, then switch to **Custom**. The toggle stays off, as Retention set it.
5. Press **Add Rule**, pick **New Subscriptions**, then switch to **Custom**. The toggle stays on.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

The engine's REST controller still falls back to always-current when a create body carries no `application`. The wizard always sends one, so that path is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
