### PR TITLE
fix(newspack-plugin): flag gates built from the newsletter block for Insights

### DIFF
--- a/plugins/newspack-newsletters/src/blocks/subscribe/index.php
+++ b/plugins/newspack-newsletters/src/blocks/subscribe/index.php
@@ -565,11 +565,7 @@ function process_form() {
 	$email     = \sanitize_email( $_REQUEST['npe'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	$lists     = array_map( 'sanitize_text_field', $_REQUEST['lists'] ); // phpcs:ignore
 	$popup_id  = isset( $_REQUEST['newspack_popup_id'] ) ? (int) $_REQUEST['newspack_popup_id'] : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	// Set by newspack-plugin's content gate (gate.js adds it as a hidden input to
-	// every form inside a gate). Carried into the registration metadata and back
-	// out in the response so the reader_registered / newsletter_signup events
-	// name the gate that produced them.
-	$gate_post_id = isset( $_REQUEST['gate_post_id'] ) ? (int) $_REQUEST['gate_post_id'] : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$gate_post_id = isset( $_REQUEST['gate_post_id'] ) ? (int) $_REQUEST['gate_post_id'] : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- See METADATA_KEYS.
 	$current_page_url = \wp_get_raw_referer();
 	if ( strpos( $current_page_url, 'http' ) !== 0 ) {
 		$current_page_url = \home_url( $current_page_url );

--- a/plugins/newspack-newsletters/src/blocks/subscribe/index.php
+++ b/plugins/newspack-newsletters/src/blocks/subscribe/index.php
@@ -53,12 +53,10 @@ const RESPONSE_KEYS = [
  * This list is what the block itself may emit, not what view.js reads — the two
  * differ, and applying the narrower rule would wrongly delete entries.
  * `current_page_url` and `status` are built here (see the $metadata literal
- * below) and read by no front-end code. `gate_post_id` is the reverse: nothing
- * here ever sets it, because $metadata is built from a literal that omits it.
- * newspack-plugin's content gate does produce the value — `src/content-gate/
- * gate.js` adds it as a hidden input to every form inside a gate — but this
- * handler never copies that input into $metadata, so view.js's read of it
- * (`view.js:161`) is defensive rather than live.
+ * below) and read by no front-end code. `gate_post_id` arrives as a hidden
+ * input that newspack-plugin's content gate (`src/content-gate/gate.js`) adds
+ * to every form inside a gate; the handler copies it into $metadata so
+ * view.js can put it on the reader_registered / newsletter_signup events.
  */
 const METADATA_KEYS = [
 	'current_page_url',
@@ -567,6 +565,11 @@ function process_form() {
 	$email     = \sanitize_email( $_REQUEST['npe'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	$lists     = array_map( 'sanitize_text_field', $_REQUEST['lists'] ); // phpcs:ignore
 	$popup_id  = isset( $_REQUEST['newspack_popup_id'] ) ? (int) $_REQUEST['newspack_popup_id'] : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	// Set by newspack-plugin's content gate (gate.js adds it as a hidden input to
+	// every form inside a gate). Carried into the registration metadata and back
+	// out in the response so the reader_registered / newsletter_signup events
+	// name the gate that produced them.
+	$gate_post_id = isset( $_REQUEST['gate_post_id'] ) ? (int) $_REQUEST['gate_post_id'] : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	$current_page_url = \wp_get_raw_referer();
 	if ( strpos( $current_page_url, 'http' ) !== 0 ) {
 		$current_page_url = \home_url( $current_page_url );
@@ -576,6 +579,9 @@ function process_form() {
 		'newspack_popup_id'               => $popup_id,
 		'newsletters_subscription_method' => 'newsletters-subscription-block',
 	];
+	if ( $gate_post_id > 0 ) {
+		$metadata['gate_post_id'] = $gate_post_id;
+	}
 
 	// Handle Mailchimp double opt-in option.
 	$provider = \Newspack_Newsletters::get_service_provider();

--- a/plugins/newspack-newsletters/tests/test-subscribe-block-response.php
+++ b/plugins/newspack-newsletters/tests/test-subscribe-block-response.php
@@ -312,9 +312,10 @@ class Subscribe_Block_Response_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * `gate_post_id` is never set by this block — it originates in
-	 * newspack-plugin's content gate — but `view.js` reads it defensively when
-	 * present, so a gated subscription must still carry it through.
+	 * `gate_post_id` originates in newspack-plugin's content gate, which adds it
+	 * as a hidden input to the block's form; the handler copies it into
+	 * $metadata and `view.js` puts it on the reader_registered event, so a gated
+	 * subscription must carry it through the response.
 	 */
 	public function test_gate_post_id_survives() {
 		$response = $this->capture_response(

--- a/plugins/newspack-newsletters/tests/test-subscribe-block-response.php
+++ b/plugins/newspack-newsletters/tests/test-subscribe-block-response.php
@@ -314,8 +314,9 @@ class Subscribe_Block_Response_Test extends WP_UnitTestCase {
 	/**
 	 * `gate_post_id` originates in newspack-plugin's content gate, which adds it
 	 * as a hidden input to the block's form; the handler copies it into
-	 * $metadata and `view.js` puts it on the reader_registered event, so a gated
-	 * subscription must carry it through the response.
+	 * $metadata and `view.js` puts it on the newsletter_signup and
+	 * reader_registered activities, so a gated subscription must carry it
+	 * through the response.
 	 */
 	public function test_gate_post_id_survives() {
 		$response = $this->capture_response(

--- a/plugins/newspack-plugin/includes/data-events/class-memberships.php
+++ b/plugins/newspack-plugin/includes/data-events/class-memberships.php
@@ -89,6 +89,19 @@ final class Memberships {
 	}
 
 	/**
+	 * The page a registration came from. Producers disagree on the key: the
+	 * Reader Registration block and the auth modal set `referer`, the Newsletter
+	 * Subscription Form block sets `current_page_url` (its form carries the gate
+	 * id since it was added to the content gate's stamped forms).
+	 *
+	 * @param array $metadata Registration metadata.
+	 * @return string URL, or '' when neither key is present.
+	 */
+	private static function referer( array $metadata ): string {
+		return (string) ( $metadata['referer'] ?? $metadata['current_page_url'] ?? '' );
+	}
+
+	/**
 	 * Add content gate metadata to the cart item.
 	 *
 	 * @param array $cart_item_data The cart item data.
@@ -130,8 +143,10 @@ final class Memberships {
 	 * @return array
 	 */
 	public static function register_reader_metadata( $metadata ) {
-		$gate_post_id = filter_input( INPUT_POST, self::METADATA_NAME, FILTER_SANITIZE_NUMBER_INT );
-		if ( ! empty( $gate_post_id ) && ( isset( $metadata['registration_method'] ) || isset( $metadata['login_method'] ) ) ) {
+		// Validated like the order path: the value is a client-supplied integer, and
+		// an arbitrary one would land in the per-gate attribution Insights groups by.
+		$gate_post_id = self::get_valid_gate_post_id( filter_input( INPUT_POST, self::METADATA_NAME, FILTER_SANITIZE_NUMBER_INT ) );
+		if ( false !== $gate_post_id && ( isset( $metadata['registration_method'] ) || isset( $metadata['login_method'] ) ) ) {
 			$metadata['gate_post_id'] = $gate_post_id;
 		}
 		return $metadata;
@@ -197,7 +212,7 @@ final class Memberships {
 			[
 				'action'      => self::FORM_SUBMISSION,
 				'action_type' => 'registration',
-				'referer'     => $metadata['referer'],
+				'referer'     => self::referer( $metadata ),
 			]
 		);
 		$data['interaction_data']['registration_method'] = $metadata['registration_method'];
@@ -230,7 +245,7 @@ final class Memberships {
 			[
 				'action'      => $action,
 				'action_type' => 'registration',
-				'referer'     => $metadata['referer'],
+				'referer'     => self::referer( $metadata ),
 			]
 		);
 		$data['interaction_data']['registration_method'] = $metadata['registration_method'];

--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
@@ -230,6 +230,7 @@ final class GA4_Custom_Dimensions {
 			'prompt_title'                => 'Prompt Title',
 			'gate_has_donation_block'     => 'Gate Has Donation Block',
 			'gate_has_registration_block' => 'Gate Has Registration Block',
+			'gate_has_newsletter_block'   => 'Gate Has Newsletter Block',
 			'gate_has_checkout_button'    => 'Gate Has Checkout Button',
 			'gate_has_registration_link'  => 'Gate Has Registration Link',
 			'gate_has_signin_link'        => 'Gate Has Signin Link',

--- a/plugins/newspack-plugin/src/content-gate/gate-newsletter-flag.test.js
+++ b/plugins/newspack-plugin/src/content-gate/gate-newsletter-flag.test.js
@@ -20,7 +20,7 @@ jest.mock( '../shared/js/cta-attribution', () => ( { persistCtaAttribution: jest
 jest.mock( './gate.scss', () => ( {} ), { virtual: true } );
 
 /**
- * Render an inline gate and let gate.js fire its `seen` event.
+ * Render an inline gate, let gate.js initialise it and fire its `seen` event.
  *
  * jsdom lays nothing out, so every element reports a 0×0 box and gate.js's
  * isVisible() would call every block hidden. Give elements a box so the flags
@@ -29,7 +29,7 @@ jest.mock( './gate.scss', () => ( {} ), { virtual: true } );
  * @param {string} innerHtml Gate contents.
  * @return {Object} The payload gate.js sent for the `seen` event.
  */
-function seenPayloadFor( innerHtml ) {
+function renderGate( innerHtml ) {
 	jest.resetModules();
 	mockSendEvent.mockReset();
 	global.newspack_content_gate = { metadata: { gate_post_id: 123 } };
@@ -47,16 +47,16 @@ function seenPayloadFor( innerHtml ) {
 	return seen[ 0 ];
 }
 
-describe( 'gate.js seen-event capability flags', () => {
+describe( 'gate.js and the Newsletter Subscription Form block', () => {
 	it( 'flags a gate built from the Newsletter Subscription Form block', () => {
-		const payload = seenPayloadFor( '<div class="wp-block-newspack-newsletters-subscribe newspack-newsletters-subscribe"><form></form></div>' );
+		const payload = renderGate( '<div class="wp-block-newspack-newsletters-subscribe newspack-newsletters-subscribe"><form></form></div>' );
 
 		expect( payload.gate_has_newsletter_block ).toBe( 'yes' );
 		expect( payload.gate_has_registration_block ).toBe( 'no' );
 	} );
 
 	it( 'stamps the gate id onto the newsletter form and labels its submission', () => {
-		seenPayloadFor(
+		renderGate(
 			'<div class="newspack-newsletters-subscribe"><form><input type="hidden" name="newspack_newsletters_subscribe" value="1" /><input type="email" name="npe" value="reader@example.test" /></form></div>'
 		);
 
@@ -71,7 +71,7 @@ describe( 'gate.js seen-event capability flags', () => {
 	} );
 
 	it( 'keeps a registration-block submission labelled registration even though it also posts npe', () => {
-		seenPayloadFor(
+		renderGate(
 			'<div class="newspack-registration"><form><input type="hidden" name="newspack_reader_registration" value="1" /><input type="email" name="npe" value="reader@example.test" /></form></div>'
 		);
 
@@ -83,7 +83,7 @@ describe( 'gate.js seen-event capability flags', () => {
 	} );
 
 	it( 'reports no newsletter block on a registration-block gate', () => {
-		const payload = seenPayloadFor( '<div class="newspack-registration"><form></form></div>' );
+		const payload = renderGate( '<div class="newspack-registration"><form></form></div>' );
 
 		expect( payload.gate_has_newsletter_block ).toBe( 'no' );
 		expect( payload.gate_has_registration_block ).toBe( 'yes' );

--- a/plugins/newspack-plugin/src/content-gate/gate-newsletter-flag.test.js
+++ b/plugins/newspack-plugin/src/content-gate/gate-newsletter-flag.test.js
@@ -57,7 +57,7 @@ describe( 'gate.js seen-event capability flags', () => {
 
 	it( 'stamps the gate id onto the newsletter form and labels its submission', () => {
 		seenPayloadFor(
-			'<div class="newspack-newsletters-subscribe"><form><input type="email" name="npe" value="reader@example.test" /></form></div>'
+			'<div class="newspack-newsletters-subscribe"><form><input type="hidden" name="newspack_newsletters_subscribe" value="1" /><input type="email" name="npe" value="reader@example.test" /></form></div>'
 		);
 
 		const form = document.querySelector( '.newspack-newsletters-subscribe form' );

--- a/plugins/newspack-plugin/src/content-gate/gate-newsletter-flag.test.js
+++ b/plugins/newspack-plugin/src/content-gate/gate-newsletter-flag.test.js
@@ -70,6 +70,17 @@ describe( 'gate.js seen-event capability flags', () => {
 		expect( submission[ 0 ].action_type ).toBe( 'newsletter_signup' );
 	} );
 
+	it( 'keeps a registration-block submission labelled registration even though it also posts npe', () => {
+		seenPayloadFor(
+			'<div class="newspack-registration"><form><input type="hidden" name="newspack_reader_registration" value="1" /><input type="email" name="npe" value="reader@example.test" /></form></div>'
+		);
+
+		mockSendEvent.mockReset();
+		document.querySelector( '.newspack-registration form' ).dispatchEvent( new Event( 'submit', { bubbles: true, cancelable: true } ) );
+		const submission = mockSendEvent.mock.calls.find( ( [ payload ] ) => payload?.action === 'form_submission' );
+		expect( submission[ 0 ].action_type ).toBe( 'registration' );
+	} );
+
 	it( 'reports no newsletter block on a registration-block gate', () => {
 		const payload = seenPayloadFor( '<div class="newspack-registration"><form></form></div>' );
 

--- a/plugins/newspack-plugin/src/content-gate/gate-newsletter-flag.test.js
+++ b/plugins/newspack-plugin/src/content-gate/gate-newsletter-flag.test.js
@@ -1,9 +1,8 @@
 /**
- * The gate's `seen` event stamps a capability flag per surface-bearing block.
- * `gate_has_newsletter_block` is what lets Insights on the hub count a gate
- * built from the Newsletter Subscription Form block as a registration- and
- * newsletter-intent surface; before it existed such a gate looked like no
- * surface at all.
+ * A gate built from the Newsletter Subscription Form block is a registration
+ * and newsletter surface: the `seen` event stamps `gate_has_newsletter_block`
+ * so Insights on the hub can count it, and the block's form carries the
+ * gate's id so the registration it produces can be attributed to the gate.
  *
  * gate.js is imported for its side effects, so the mocks below have to be in
  * place before the import is evaluated.
@@ -54,7 +53,21 @@ describe( 'gate.js seen-event capability flags', () => {
 
 		expect( payload.gate_has_newsletter_block ).toBe( 'yes' );
 		expect( payload.gate_has_registration_block ).toBe( 'no' );
-		expect( payload.gate_has_registration_link ).toBe( 'no' );
+	} );
+
+	it( 'stamps the gate id onto the newsletter form and labels its submission', () => {
+		seenPayloadFor(
+			'<div class="newspack-newsletters-subscribe"><form><input type="email" name="npe" value="reader@example.test" /></form></div>'
+		);
+
+		const form = document.querySelector( '.newspack-newsletters-subscribe form' );
+		expect( form.querySelector( 'input[name="gate_post_id"]' ).value ).toBe( '123' );
+
+		mockSendEvent.mockReset();
+		form.dispatchEvent( new Event( 'submit', { bubbles: true, cancelable: true } ) );
+		const submission = mockSendEvent.mock.calls.find( ( [ payload ] ) => payload?.action === 'form_submission' );
+		expect( submission ).toBeDefined();
+		expect( submission[ 0 ].action_type ).toBe( 'newsletter_signup' );
 	} );
 
 	it( 'reports no newsletter block on a registration-block gate', () => {

--- a/plugins/newspack-plugin/src/content-gate/gate-newsletter-flag.test.js
+++ b/plugins/newspack-plugin/src/content-gate/gate-newsletter-flag.test.js
@@ -67,7 +67,7 @@ describe( 'gate.js and the Newsletter Subscription Form block', () => {
 		form.dispatchEvent( new Event( 'submit', { bubbles: true, cancelable: true } ) );
 		const submission = mockSendEvent.mock.calls.find( ( [ payload ] ) => payload?.action === 'form_submission' );
 		expect( submission ).toBeDefined();
-		expect( submission[ 0 ].action_type ).toBe( 'newsletter_signup' );
+		expect( submission[ 0 ].action_type ).toBe( 'newsletters_subscription' );
 	} );
 
 	it( 'keeps a registration-block submission labelled registration even though it also posts npe', () => {

--- a/plugins/newspack-plugin/src/content-gate/gate-newsletter-flag.test.js
+++ b/plugins/newspack-plugin/src/content-gate/gate-newsletter-flag.test.js
@@ -1,0 +1,66 @@
+/**
+ * The gate's `seen` event stamps a capability flag per surface-bearing block.
+ * `gate_has_newsletter_block` is what lets Insights on the hub count a gate
+ * built from the Newsletter Subscription Form block as a registration- and
+ * newsletter-intent surface; before it existed such a gate looked like no
+ * surface at all.
+ *
+ * gate.js is imported for its side effects, so the mocks below have to be in
+ * place before the import is evaluated.
+ */
+
+const mockSendEvent = jest.fn();
+
+jest.mock( './preview-links', () => ( { propagateGatePreviewParams: jest.fn() } ) );
+jest.mock( '../reader-activation/analytics', () => ( {
+	getEventPayload: payload => payload,
+	sendEvent: ( ...args ) => mockSendEvent( ...args ),
+} ) );
+jest.mock( '../reader-activation/utils', () => ( { debugLog: jest.fn() } ) );
+jest.mock( '../shared/js/cta-attribution', () => ( { persistCtaAttribution: jest.fn() } ) );
+jest.mock( './gate.scss', () => ( {} ), { virtual: true } );
+
+/**
+ * Render an inline gate and let gate.js fire its `seen` event.
+ *
+ * jsdom lays nothing out, so every element reports a 0×0 box and gate.js's
+ * isVisible() would call every block hidden. Give elements a box so the flags
+ * reflect what is in the gate rather than jsdom's lack of layout.
+ *
+ * @param {string} innerHtml Gate contents.
+ * @return {Object} The payload gate.js sent for the `seen` event.
+ */
+function seenPayloadFor( innerHtml ) {
+	jest.resetModules();
+	mockSendEvent.mockReset();
+	global.newspack_content_gate = { metadata: { gate_post_id: 123 } };
+	window.newspackRAS = [];
+	window.gtag = jest.fn();
+	Object.defineProperty( document, 'readyState', { value: 'interactive', configurable: true } );
+	Object.defineProperty( HTMLElement.prototype, 'offsetWidth', { configurable: true, get: () => 100 } );
+	Object.defineProperty( HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => 100 } );
+	document.body.innerHTML = `<div class="newspack-content-gate__gate">${ innerHtml }</div>`;
+
+	require( './gate' );
+
+	const seen = mockSendEvent.mock.calls.find( ( [ payload ] ) => payload?.action === 'seen' );
+	expect( seen ).toBeDefined();
+	return seen[ 0 ];
+}
+
+describe( 'gate.js seen-event capability flags', () => {
+	it( 'flags a gate built from the Newsletter Subscription Form block', () => {
+		const payload = seenPayloadFor( '<div class="wp-block-newspack-newsletters-subscribe newspack-newsletters-subscribe"><form></form></div>' );
+
+		expect( payload.gate_has_newsletter_block ).toBe( 'yes' );
+		expect( payload.gate_has_registration_block ).toBe( 'no' );
+		expect( payload.gate_has_registration_link ).toBe( 'no' );
+	} );
+
+	it( 'reports no newsletter block on a registration-block gate', () => {
+		const payload = seenPayloadFor( '<div class="newspack-registration"><form></form></div>' );
+
+		expect( payload.gate_has_newsletter_block ).toBe( 'no' );
+		expect( payload.gate_has_registration_block ).toBe( 'yes' );
+	} );
+} );

--- a/plugins/newspack-plugin/src/content-gate/gate-newsletter-flag.test.js
+++ b/plugins/newspack-plugin/src/content-gate/gate-newsletter-flag.test.js
@@ -78,6 +78,7 @@ describe( 'gate.js seen-event capability flags', () => {
 		mockSendEvent.mockReset();
 		document.querySelector( '.newspack-registration form' ).dispatchEvent( new Event( 'submit', { bubbles: true, cancelable: true } ) );
 		const submission = mockSendEvent.mock.calls.find( ( [ payload ] ) => payload?.action === 'form_submission' );
+		expect( submission ).toBeDefined();
 		expect( submission[ 0 ].action_type ).toBe( 'registration' );
 	} );
 

--- a/plugins/newspack-plugin/src/content-gate/gate.js
+++ b/plugins/newspack-plugin/src/content-gate/gate.js
@@ -124,6 +124,11 @@ function addFormInputs( gate ) {
 		...gate.querySelectorAll( '.newspack-registration form' ), // Registration block.
 		...gate.querySelectorAll( '.wp-block-newspack-blocks-checkout-button form' ), // Checkout button block.
 		...gate.querySelectorAll( '.wp-block-newspack-blocks-donate form' ), // Donate block.
+		// Newsletter Subscription Form block. With Reader Activation on, a signup
+		// here registers the reader too, and the newsletters handler copies this
+		// input into the registration metadata, so the reader_registered and
+		// newsletter_signup events carry the gate that produced them.
+		...gate.querySelectorAll( '.newspack-newsletters-subscribe form' ),
 	];
 	forms.forEach( form => {
 		if ( ! form.querySelector( 'input[name="gate_post_id"]' ) ) {
@@ -200,8 +205,7 @@ function getGateEventPayload( payload, gate ) {
 		// A Newsletter Subscription Form block registers the reader as well as
 		// subscribing them (when Reader Activation is on), so a gate built from it
 		// is a registration surface too. Insights on the hub reads this flag for
-		// both its registration- and newsletter-intent predicates; without it a
-		// newsletter-based gate looked like no surface at all.
+		// both its registration- and newsletter-intent definitions.
 		gateInfo.gate_has_newsletter_block = isVisible( gate.querySelector( '.newspack-newsletters-subscribe' ) ) ? 'yes' : 'no';
 		gateInfo.gate_has_checkout_button = isVisible( gate.querySelector( '.wp-block-newspack-blocks-checkout-button' ) ) ? 'yes' : 'no';
 		gateInfo.gate_has_registration_link = isVisible( gate.querySelector( 'a[href="#register_modal"]' ) ) ? 'yes' : 'no';
@@ -317,6 +321,10 @@ function handleFormSubmission( evt, gate ) {
 				}
 			}
 		}
+	}
+	// The newsletter block's form posts the email as `npe`.
+	if ( data.npe ) {
+		payload.action_type = 'newsletter_signup';
 	}
 	if ( data.newspack_checkout ) {
 		payload.action_type = 'checkout_button';

--- a/plugins/newspack-plugin/src/content-gate/gate.js
+++ b/plugins/newspack-plugin/src/content-gate/gate.js
@@ -197,6 +197,12 @@ function getGateEventPayload( payload, gate ) {
 	if ( gate ) {
 		gateInfo.gate_has_donation_block = isVisible( gate.querySelector( '.wp-block-newspack-blocks-donate' ) ) ? 'yes' : 'no';
 		gateInfo.gate_has_registration_block = isVisible( gate.querySelector( '.newspack-registration' ) ) ? 'yes' : 'no';
+		// A Newsletter Subscription Form block registers the reader as well as
+		// subscribing them (when Reader Activation is on), so a gate built from it
+		// is a registration surface too. Insights on the hub reads this flag for
+		// both its registration- and newsletter-intent predicates; without it a
+		// newsletter-based gate looked like no surface at all.
+		gateInfo.gate_has_newsletter_block = isVisible( gate.querySelector( '.newspack-newsletters-subscribe' ) ) ? 'yes' : 'no';
 		gateInfo.gate_has_checkout_button = isVisible( gate.querySelector( '.wp-block-newspack-blocks-checkout-button' ) ) ? 'yes' : 'no';
 		gateInfo.gate_has_registration_link = isVisible( gate.querySelector( 'a[href="#register_modal"]' ) ) ? 'yes' : 'no';
 		gateInfo.gate_has_signin_link = isVisible( gate.querySelector( 'a[href="#signin_modal"]' ) ) ? 'yes' : 'no';

--- a/plugins/newspack-plugin/src/content-gate/gate.js
+++ b/plugins/newspack-plugin/src/content-gate/gate.js
@@ -124,11 +124,7 @@ function addFormInputs( gate ) {
 		...gate.querySelectorAll( '.newspack-registration form' ), // Registration block.
 		...gate.querySelectorAll( '.wp-block-newspack-blocks-checkout-button form' ), // Checkout button block.
 		...gate.querySelectorAll( '.wp-block-newspack-blocks-donate form' ), // Donate block.
-		// Newsletter Subscription Form block. With Reader Activation on, a signup
-		// here registers the reader too, and the newsletters handler copies this
-		// input into the registration metadata, so the reader_registered and
-		// newsletter_signup events carry the gate that produced them.
-		...gate.querySelectorAll( '.newspack-newsletters-subscribe form' ),
+		...gate.querySelectorAll( '.newspack-newsletters-subscribe form' ), // Newsletter Subscription Form block (see getGateEventPayload).
 	];
 	forms.forEach( form => {
 		if ( ! form.querySelector( 'input[name="gate_post_id"]' ) ) {

--- a/plugins/newspack-plugin/src/content-gate/gate.js
+++ b/plugins/newspack-plugin/src/content-gate/gate.js
@@ -322,8 +322,9 @@ function handleFormSubmission( evt, gate ) {
 			}
 		}
 	}
-	// The newsletter block's form posts the email as `npe`.
-	if ( data.npe ) {
+	// Keyed on the block's container, not on a field: the auth modal and the
+	// Reader Registration block also post the email as `npe`.
+	if ( evt.target.closest( '.newspack-newsletters-subscribe' ) ) {
 		payload.action_type = 'newsletter_signup';
 	}
 	if ( data.newspack_checkout ) {

--- a/plugins/newspack-plugin/src/content-gate/gate.js
+++ b/plugins/newspack-plugin/src/content-gate/gate.js
@@ -322,9 +322,9 @@ function handleFormSubmission( evt, gate ) {
 			}
 		}
 	}
-	// Keyed on the block's container, not on a field: the auth modal and the
-	// Reader Registration block also post the email as `npe`.
-	if ( evt.target.closest( '.newspack-newsletters-subscribe' ) ) {
+	// Keyed on the block's own hidden field, like the siblings above: the auth
+	// modal and the Reader Registration block also post the email as `npe`.
+	if ( data.newspack_newsletters_subscribe ) {
 		payload.action_type = 'newsletter_signup';
 	}
 	if ( data.newspack_checkout ) {

--- a/plugins/newspack-plugin/src/content-gate/gate.js
+++ b/plugins/newspack-plugin/src/content-gate/gate.js
@@ -321,7 +321,7 @@ function handleFormSubmission( evt, gate ) {
 	// Keyed on the block's own hidden field, like the siblings above: the auth
 	// modal and the Reader Registration block also post the email as `npe`.
 	if ( data.newspack_newsletters_subscribe ) {
-		payload.action_type = 'newsletter_signup';
+		payload.action_type = 'newsletters_subscription'; // Same spelling as the prompt-side listener.
 	}
 	if ( data.newspack_checkout ) {
 		payload.action_type = 'checkout_button';

--- a/plugins/newspack-plugin/tests/unit-tests/data-events/class-memberships-gate-registration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/data-events/class-memberships-gate-registration.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Tests the Memberships data-events listener for registrations through a gate.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Data_Events\Memberships;
+
+/**
+ * A registration that carries a gate id produces a gate_interaction event.
+ * The producers of that metadata disagree on which key names the page the
+ * reader was on: the Reader Registration block and the auth modal set
+ * `referer`, the Newsletter Subscription Form block sets `current_page_url`.
+ * The listener has to read either without a notice.
+ *
+ * @group data-events
+ */
+class Newspack_Test_Data_Events_Memberships_Gate_Registration extends WP_UnitTestCase {
+
+	/**
+	 * Metadata from the newsletter block: gate id present, no `referer`.
+	 */
+	public function test_newsletter_block_registration_uses_current_page_url_as_referer() {
+		$data = Memberships::registration_submission(
+			'reader@example.test',
+			true,
+			123,
+			false,
+			[
+				'gate_post_id'        => 456,
+				'registration_method' => 'newsletters-subscription',
+				'current_page_url'    => 'https://example.test/gated-post/',
+			]
+		);
+
+		$this->assertSame( 'https://example.test/gated-post/', $data['referer'] );
+		$this->assertSame( 'registration', $data['action_type'] );
+	}
+
+	/**
+	 * Metadata from the registration block: `referer` wins when both are present.
+	 */
+	public function test_registration_block_referer_is_kept() {
+		$data = Memberships::registration_submission(
+			'reader@example.test',
+			true,
+			123,
+			false,
+			[
+				'gate_post_id'        => 456,
+				'registration_method' => 'registration-block',
+				'referer'             => 'https://example.test/from-referer/',
+				'current_page_url'    => 'https://example.test/from-page-url/',
+			]
+		);
+
+		$this->assertSame( 'https://example.test/from-referer/', $data['referer'] );
+	}
+
+	/**
+	 * No gate id, no event: the listener is only for registrations through a gate.
+	 */
+	public function test_registration_without_a_gate_produces_no_event() {
+		$this->assertNull(
+			Memberships::registration_submission( 'reader@example.test', true, 123, false, [ 'referer' => 'https://example.test/' ] )
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A content gate's `seen` event stamps a `gate_has_*` flag per block type it contains, and Insights reads those flags to decide whether an impression was a registration or newsletter surface. The **Newsletter Subscription Form** block had no flag, so a gate built from it (which registers the reader as well as subscribing them when Reader Activation is on) counted as no surface at all, and its registrations went unattributed in the Conversion Journey and Gates tabs.

- `gate.js` now emits `gate_has_newsletter_block` (`yes` / `no`) next to the existing block flags, and registers it as a GA4 custom dimension with the other gate flags, so it appears in GA4 UI reports as well as the BigQuery export.
- The content gate stamps its `gate_post_id` hidden input onto the newsletter block's form, as it already does for the auth modal, registration, checkout and donate forms, and labels that form's submission `newsletters_subscription` on the gate's `form_submission` event, the same spelling the prompt-side listener uses. The label is keyed on the block's own hidden field, like the sibling forms, since the auth modal and the Reader Registration block also post the email as `npe`.
- The newsletters handler copies `gate_post_id` into the registration metadata the same way it copies `newspack_popup_id`, so the `reader_registered` and `newsletter_signup` events name the gate that produced them. The response allowlist already let the key through.

Two things the gate id sets in motion server-side, handled in `Data_Events\Memberships`: the two `gate_interaction` listeners that fire on a registration carrying a gate id now run for newsletter-block signups for the first time, and they read the page from `referer`, a key the newsletters handler never sets (it sets `current_page_url`); the listener now accepts either, so those signups don't log an undefined-key notice on every submission. And the registration path now validates the posted gate id against the gate post types the way the order path already does, so a scripted POST can't attach an arbitrary integer to the per-gate attribution. The GA4 event still carries whatever integer the client posted.

One visible effect beyond the Conversion Journey fix: the Source Mix cards (registrations by gate / prompt / direct) start classifying newsletter-gate registrations as gate-sourced from the first update onward. Today they land in "direct".

The hub-side change that reads the flag, and that also recognises existing newsletter gates retroactively from session evidence, is the Automattic/newspack-manager-admin PR linked in the first comment. Either PR is safe to ship on its own.

### How to test the changes in this Pull Request:

1. Build a content gate layout that contains a Newsletter Subscription Form block and assign it to a gated post.
2. With GA4 debug view open (or `window.gtag` wrapped in the console), load the gated post as a logged-out reader and scroll the gate into view.
3. The `np_gate_interaction` event with `action: seen` carries `gate_has_newsletter_block: yes` and `gate_has_registration_block: no`.
4. Inspect the block's form. It contains a hidden `gate_post_id` input with the gate layout's post ID.
5. Sign up through the block with a new email. The `np_gate_interaction` event with `action: form_submission` carries `action_type: newsletters_subscription`, and the `np_reader_registered` event carries `gate_post_id`. The site's PHP error log shows no undefined-key notice from `class-memberships.php`.
6. Swap the block for a Registration block and repeat step 3. The flags invert.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? `gate-newsletter-flag.test.js` renders both gate shapes, asserts the `seen` payload, the hidden `gate_post_id` input on the newsletter form, the `newsletters_subscription` submission label, and that a registration-block submission carrying `npe` stays `registration`; mutation-checked (reverting each gate.js change turns its case red). A new data-events phpunit test pins the `referer` fallback (red with the old read, which raised an undefined-key notice). The newsletters handler's request-side read has no unit test (the form handler needs a live ESP provider); the response-side passthrough is covered by the existing `test_gate_post_id_survives`.
* [x] Have you successfully run tests with your changes locally? Plugin jest suite on `release`: 897 tests pass. Custom-dimensions phpunit group: 21 pass. Newsletters subscribe-block response tests: 14 pass. eslint and phpcs clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
