### PR TITLE
chore(github): rewrite the PR template around problem, fix, and test

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,27 @@
-### All Submissions:
+<!-- Contributing guidelines: https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md -->
+<!-- Everything above the Technical details block is for the whole team, engineers and support alike. Each comment says what its section holds; replace it with the section. The headings suit a bugfix; a feature PR uses "The need" and "The change". -->
 
-* [ ] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
-* [ ] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
-* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
+## The problem
 
-### Changes proposed in this Pull Request:
+<!-- What did not work, or what was missing, in publisher terms: the feature, then what the reader or editor saw. Never why it broke. -->
 
-<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
+## The fix
+
+<!-- The solution in plain language, then a short "With this change:" list of what now works. No class names, file names, or format specifiers. -->
 
 Closes # .
 
-### How to test the changes in this Pull Request:
+## How to test
+
+<!-- Numbered steps anyone on the team can follow: one action per step, then the expected result. For a fix, reproduce on the base branch first, then verify on this one. A CLI command is fine where that is the honest check. -->
 
 1.
 2.
 3.
 
-### Other information:
+<details>
+<summary><strong>Technical details</strong></summary>
 
-* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-* [ ] Have you written new tests for your changes, as applicable?
-* [ ] Have you successfully run tests with your changes locally?
+<!-- Implementation, build commands, CLI reproduction and verification, the tests written and run, and notes for reviewers. End with one line on review: "Self-review: two rounds, clean. Copilot: one pass, three findings addressed." -->
+
+</details>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,15 @@
 <!-- Contributing guidelines: https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md -->
-<!-- Write everything above Technical details for the whole team, including engineers and support. Replace each comment below with the content it describes. For a feature PR, use "The need" and "The change" instead of "The problem" and "The fix". -->
+<!-- Write everything above Technical details for the whole team, including engineers and support. Replace each comment below with the content it describes, or delete it. For anything that is not a fix, use "The need" and "The change" instead of "The problem" and "The fix". -->
 
 ## The problem
 
-<!-- Describe what did not work or what was missing in publisher terms: name the feature, then explain what the reader or editor experienced. Save the root cause and implementation details for Technical details. -->
+<!-- Describe what did not work or what was missing, in the terms of whoever was affected: name the feature, then explain what the reader, editor, or teammate experienced. Save the root cause and implementation details for Technical details. -->
 
 ## The fix
 
 <!-- Explain the solution in plain language, then add a short "With this change:" list of what now works. Keep class names, file names, and other implementation details in Technical details. -->
 
-<!-- Keep the Linear issue reference here, or delete the line. -->
+<!-- Reference the Linear issue: Closes ABC-123 marks it done at merge, Ref ABC-123 links without closing. Delete the line if there is no issue. -->
 Closes # .
 
 ## How to test
@@ -23,6 +23,6 @@ Closes # .
 <details>
 <summary><strong>Technical details</strong></summary>
 
-<!-- Use Technical details for what a reviewer needs beyond the main description: implementation choices and reasoning, build or CLI commands, reproduction and verification details, tests written and run, and reviewer notes. End with a short review summary using the actual results, for example: Self-review: two rounds, clean. Copilot: one pass, three findings addressed. -->
+<!-- Use Technical details for what a reviewer needs beyond the main description: implementation choices and reasoning, build or CLI commands, reproduction and verification details, tests written and run, and reviewer notes. End with a short review summary using the actual results, for example: Self-review: two rounds, clean. Copilot: one pass, three findings addressed. Delete the block if there is nothing for it. -->
 
 </details>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 <!-- Explain the change in plain language, then add a short "With this change:" list of what now works or what someone can now do. Keep class names, file names, and other implementation details in Technical details. -->
 
 <!-- Reference the Linear issue: Closes ABC-123 marks it done at merge, Ref ABC-123 links without closing. Delete the line if there is no issue. -->
-Closes # .
+Closes ABC-123.
 
 ## How to test
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,18 @@
 <!-- Contributing guidelines: https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md -->
-<!-- Write everything above Technical details for the whole team, including engineers and support. Each comment below explains what belongs in its section; follow it, then delete the comment. For anything other than a fix, use "The need" and "The change" instead of "The problem" and "The fix". -->
+<!-- Write the opening paragraph and What changes for the whole team, including support. Each comment below explains what belongs in its section; follow it, then delete the comment. -->
 
-## The problem
+<!-- Open with a short paragraph on why this PR exists: the problem it fixes or what it makes possible, in the terms of whoever it affects. Save the root cause and implementation details for Technical details. -->
 
-<!-- Describe what did not work or what was missing, in the terms of whoever was affected: name the feature, then explain what the reader, editor, or teammate experienced. Save the root cause and implementation details for Technical details. -->
+## What changes
 
-## The fix
-
-<!-- Explain the solution in plain language, then add a short "With this change:" list of what now works. Keep class names, file names, and other implementation details in Technical details. -->
+<!-- Explain the change in plain language, then add a short "With this change:" list of what now works or what someone can now do. Keep class names, file names, and other implementation details in Technical details. -->
 
 <!-- Reference the Linear issue: Closes ABC-123 marks it done at merge, Ref ABC-123 links without closing. Delete the line if there is no issue. -->
 Closes # .
 
 ## How to test
 
-<!-- Write numbered test steps anyone on the team can follow. Give one action per step and the expected result. For a fix, reproduce the problem on the base branch first, then verify the fix on this branch. Use CLI commands when they are the clearest way to verify something. -->
+<!-- Write numbered test steps another engineer can follow without asking you. Give one action per step and the expected result. For a fix, reproduce the problem on the base branch first, then verify the fix on this branch. Use CLI commands when they are the clearest way to verify something. -->
 
 1.
 2.
@@ -23,6 +21,6 @@ Closes # .
 <details>
 <summary><strong>Technical details</strong></summary>
 
-<!-- Use Technical details for what a reviewer needs beyond the main description: implementation choices and reasoning, build or CLI commands, reproduction and verification details, tests written and run, and reviewer notes. End with a short review summary using the actual results, for example: Self-review: two rounds, clean. Copilot: one pass, three findings addressed. Delete the block if there is nothing for it. -->
+<!-- Use Technical details for what a reviewer needs beyond the main description: implementation choices and reasoning, build or CLI commands, reproduction and verification details, tests written and run, and reviewer notes. End with a short review summary: rounds, the models that reviewed, and any blockers fixed, for example: Self-review: two rounds (Fable 5.1, GPT-5.6 Sol), one blocker fixed. Delete the block if there is nothing for it. -->
 
 </details>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,20 @@
 <!-- Contributing guidelines: https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md -->
-<!-- Everything above the Technical details block is for the whole team, engineers and support alike. Each comment says what its section holds; replace it with the section. The headings suit a bugfix; a feature PR uses "The need" and "The change". -->
+<!-- Write everything above Technical details for the whole team, including engineers and support. Replace each comment below with the content it describes. For a feature PR, use "The need" and "The change" instead of "The problem" and "The fix". -->
 
 ## The problem
 
-<!-- What did not work, or what was missing, in publisher terms: the feature, then what the reader or editor saw. Never why it broke. -->
+<!-- Describe what did not work or what was missing in publisher terms: name the feature, then explain what the reader or editor experienced. Save the root cause and implementation details for Technical details. -->
 
 ## The fix
 
-<!-- The solution in plain language, then a short "With this change:" list of what now works. No class names, file names, or format specifiers. -->
+<!-- Explain the solution in plain language, then add a short "With this change:" list of what now works. Keep class names, file names, and other implementation details in Technical details. -->
 
+<!-- Keep the Linear issue reference here, or delete the line. -->
 Closes # .
 
 ## How to test
 
-<!-- Numbered steps anyone on the team can follow: one action per step, then the expected result. For a fix, reproduce on the base branch first, then verify on this one. A CLI command is fine where that is the honest check. -->
+<!-- Write numbered test steps anyone on the team can follow. Give one action per step and the expected result. For a fix, reproduce the problem on the base branch first, then verify the fix on this branch. Use CLI commands when they are the clearest way to verify something. -->
 
 1.
 2.
@@ -22,6 +23,6 @@ Closes # .
 <details>
 <summary><strong>Technical details</strong></summary>
 
-<!-- Implementation, build commands, CLI reproduction and verification, the tests written and run, and notes for reviewers. End with one line on review: "Self-review: two rounds, clean. Copilot: one pass, three findings addressed." -->
+<!-- Use Technical details for what a reviewer needs beyond the main description: implementation choices and reasoning, build or CLI commands, reproduction and verification details, tests written and run, and reviewer notes. End with a short review summary using the actual results, for example: Self-review: two rounds, clean. Copilot: one pass, three findings addressed. -->
 
 </details>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!-- Contributing guidelines: https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md -->
-<!-- Write everything above Technical details for the whole team, including engineers and support. Replace each comment below with the content it describes, or delete it. For anything that is not a fix, use "The need" and "The change" instead of "The problem" and "The fix". -->
+<!-- Write everything above Technical details for the whole team, including engineers and support. Each comment below explains what belongs in its section; follow it, then delete the comment. For anything other than a fix, use "The need" and "The change" instead of "The problem" and "The fix". -->
 
 ## The problem
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,7 @@ One repository, so a cross-plugin change is one branch and one PR. Before changi
 - **`hotfix/*` and `epic/*` branches don't release.** They remain valid branch names, but pushes to them no longer publish prerelease tags or builds; releases come only from `release` (stable) and `alpha`. To test a branch on a site, use the installable zip CI's `build-zips` job attaches to every commit.
 - **Never push or merge unless asked.**
 - **One Copilot pass per PR**, requested when the PR opens. After addressing its feedback do not re-request it; the next review should be a human's.
-- **PR bodies follow [the repository template](.github/PULL_REQUEST_TEMPLATE.md).** `gh pr create --body`/`--body-file` bypasses GitHub's automatic template application, so compose the body into the template's sections yourself, and replace each instruction comment with the section it describes.
+- **PR bodies follow [the repository template](.github/PULL_REQUEST_TEMPLATE.md).** `gh pr create --body`/`--body-file` bypasses GitHub's automatic template application, so compose the body into the template's sections yourself, and follow the template's instruction comments without including them.
 
 ## External tools
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,7 @@ One repository, so a cross-plugin change is one branch and one PR. Before changi
 - **`hotfix/*` and `epic/*` branches don't release.** They remain valid branch names, but pushes to them no longer publish prerelease tags or builds; releases come only from `release` (stable) and `alpha`. To test a branch on a site, use the installable zip CI's `build-zips` job attaches to every commit.
 - **Never push or merge unless asked.**
 - **One Copilot pass per PR**, requested when the PR opens. After addressing its feedback do not re-request it; the next review should be a human's.
-- **PR bodies follow [the repository template](.github/PULL_REQUEST_TEMPLATE.md).** `gh pr create --body`/`--body-file` bypasses GitHub's automatic template application, so compose the body into the template's sections yourself, and tick only the checklist items that are actually true.
+- **PR bodies follow [the repository template](.github/PULL_REQUEST_TEMPLATE.md).** `gh pr create --body`/`--body-file` bypasses GitHub's automatic template application, so compose the body into the template's sections yourself, and replace each instruction comment with the section it describes.
 
 ## External tools
 


### PR DESCRIPTION
The pull request template has not kept up with how we write and review PRs today. Descriptions are often drafted with agents and can become verbose, overly technical, or difficult to scan.

The template should make the main story clear to everyone reading the PR, while giving technical details and agent-specific notes their own place.

## What changes

The template now opens with a short paragraph explaining why the PR exists. A single What changes section describes the work in plain language, followed by a short list of what now works. Each test step includes its expected result.

A collapsible Technical details section at the end contains implementation notes, build and verification commands, test coverage, and anything mainly useful to engineers or agents. This keeps the information accessible without disrupting the main description.

Each section includes a short comment explaining what belongs there. Authors follow and delete these comments, so the guidance lives in the template itself and does not appear in the finished PR.

With this change:

* The six checkboxes are removed. Test coverage moves to the Technical details guidance, where it can be described instead of checked.
* The contributing-guidelines link from the first checkbox moves to a comment at the top of the template.
* One static heading, What changes, works for a fix, feature, or new idea; the opening paragraph explains why without a heading.
* The issue reference keeps its `Closes` keyword and appears at the end of What changes.
* The `AGENTS.md` guidance now tells agents to follow the template's comments without including them, instead of ticking checklist items.

Ref NPPD-2239.

## How to test

GitHub reads the template from `main`, so the form pre-fills with the new shape only after this merges. Until then:

1. Open `.github/PULL_REQUEST_TEMPLATE.md` on this branch in the GitHub file view. The page shows two headings, What changes and How to test, a `Closes` line, and a collapsed Technical details block. No comments appear.
2. Switch to the raw view. Two comments sit at the top of the file, one opens the body before What changes, one sits under each heading, one is above the `Closes` line, and one is inside the Technical details block.
3. Read this PR's description. It is the template filled in.
4. Open `AGENTS.md` on this branch and find the "Pull requests" list. The template bullet says to follow the template's instruction comments without including them, and no longer mentions checklists.

After merge:

5. Start a new pull request in the browser. The description box pre-fills with the new template, comments included.

<details>
<summary><strong>Technical details</strong></summary>

### What moved where

- "Changes proposed in this Pull Request" becomes a headingless opening paragraph and `## What changes`. The "With this change:" list is the outcome list #1016 and Automattic/newspack-elections#84 already use.
- "How to test the changes in this Pull Request" becomes `## How to test`, with the same `1. 2. 3.` scaffold.
- "Other information" and both checklists are removed. The coding-standards checkbox is covered by the pre-commit hook and CI, the remaining boxes carried nothing the description does not, and the duplicate-PR check is one Linear already covers.
- The issue line's placeholder is now `Closes ABC-123.`, matching the Linear form the comment above it teaches. The team's pr-create skill matches the new placeholder in its own update.
- Headings are `##`, matching the exemplar PRs. The previous file used `###`.

### Rendering

The `<details>` block keeps a blank line after `<summary>` and before `</details>`, which GitHub needs to render markdown inside it. An HTML comment inside the block renders as nothing, so an empty block collapses to its label.

### Not in this PR

The team's pr-create skill still fills the old sections, caps the body at 300 words, and bans notes about the review process. Those change in a separate PR, along with the skill's bundled fallback template. That fallback is what every repo without a template file of its own gets. The one workflow that reads PR bodies, `auto-merge.yml`, matches Dependabot bodies by regex and never this template; nothing else in `.github/workflows`, `.github/scripts`, or `bin/` reads a body by heading text.

This PR links its ticket with `Ref` rather than the template's `Closes`, because the pr-create skill and the other repositories follow in separate PRs and NPPD-2239 stays open until they land. `Ref` is Linear's non-closing keyword; `Closes` would mark the ticket done at merge.

### Tests and review

Docs-only change, so no tests to write or run. The pre-commit hook does not lint `.md` files.

Self-review: one round (Opus 5, Fable 5.1, GPT-5.6 Sol).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
