### PR TITLE
fix(reader-activation): no WP registration email without WooCommerce

### DIFF
--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
@@ -2638,13 +2638,19 @@ final class Reader_Activation {
 				}
 
 				/**
-				 * Create WooCommerce Customer if possible.
-				 * Email notification for WooCommerce is handled by the plugin.
+				 * Create a WooCommerce customer if possible. WooCommerce's "New account"
+				 * email never fires for readers (see disable_woocommerce_new_user_email()),
+				 * so registration sends nothing here. Newspack's verification, magic link,
+				 * or OTP emails reach the reader instead.
 				 */
 				$user_id = \wc_create_new_customer( $email, $user_data['user_login'], $user_data['user_pass'], $user_data );
 			} else {
+				/**
+				 * Deliberately no wp_new_user_notification(): readers are passwordless, and
+				 * the WooCommerce path above sends no account email, so this path must not
+				 * either (NPPD-2261).
+				 */
 				$user_id = \wp_insert_user( $user_data );
-				\wp_new_user_notification( $user_id, null, 'user' );
 			}
 			add_filter( 'woocommerce_new_customer_data', [ __CLASS__, 'canonize_user_data' ], 10, 1 );
 

--- a/plugins/newspack-plugin/tests/unit-tests/reader-activation.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-activation.php
@@ -134,6 +134,37 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A brand-new reader must not receive WordPress core's "set your password" email.
+	 *
+	 * Reproduces NPPD-2261: on sites without WooCommerce, register_reader() falls back
+	 * to wp_insert_user(), and that fallback also sent wp_new_user_notification(). A
+	 * WooCommerce site never sends an account-created email (Newspack removes
+	 * WooCommerce's trigger), so both paths must agree: only Newspack's own
+	 * verification, magic link, or OTP emails reach a reader.
+	 *
+	 * The plugin's test environment has no WooCommerce, so this exercises the fallback.
+	 */
+	public function test_register_new_reader_sends_no_wordpress_registration_email() {
+		$this->assertFalse( function_exists( 'wc_create_new_customer' ), 'Test precondition: the non-WooCommerce registration path must be the one under test.' );
+
+		$sent_emails   = 0;
+		$email_counter = function ( $args ) use ( &$sent_emails ) {
+			$sent_emails++;
+			return $args;
+		};
+		add_filter( 'wp_mail', $email_counter );
+
+		$user_id = Reader_Activation::register_reader( 'brand-new@test.com', 'Brand New Reader', true );
+
+		remove_filter( 'wp_mail', $email_counter );
+
+		$this->assertIsInt( $user_id );
+		$this->assertSame( 0, $sent_emails, 'Registering a new reader must not send the WordPress core registration email.' );
+
+		wp_delete_user( $user_id ); // Clean up.
+	}
+
+	/**
 	 * Test that verifying a reader register the proper meta.
 	 */
 	public function test_verify_reader_email() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

On sites where the WooCommerce plugin is not active (for example, reader revenue platform set to "Other"), every new reader received WordPress core's registration email, with a username and a "set your password" link. On WooCommerce sites the same signup sends no account email: Newspack removes WooCommerce's "New account" trigger, and readers only get Newspack's verification, magic link, or OTP emails.

The non-WooCommerce branch of reader registration called `wp_new_user_notification()` explicitly, written as though it replaced a WooCommerce email that the WooCommerce branch never sends. This removes that call so both paths send the same emails, and adds a regression test that registers a fresh reader and asserts nothing is sent.

Closes NPPD-2261.

### How to test the changes in this Pull Request:

1. On a site with Reader Activation enabled, deactivate the WooCommerce plugin (reader revenue platform "Other").
2. Register a new email address through the sign-in modal. The account is created and the reader is signed in.
3. Check the inbox (MailHog locally). No WordPress "Username: … To set your password" email arrives. Only Newspack's own emails do, such as the verification email when that setting is on.
4. Re-activate WooCommerce and register another new email address. Same result: no WordPress registration email.
5. Sign out and sign in again with the email from step 2. The magic link or one-time code email still arrives.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally? Full newspack-plugin PHPUnit suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
