### PR TITLE
fix(story-budget): count images without rendering content on save

### DIFF
--- a/plugins/newspack-story-budget/includes/fields/class-fields.php
+++ b/plugins/newspack-story-budget/includes/fields/class-fields.php
@@ -569,8 +569,15 @@ class Fields {
 
 	/**
 	 * Get the image count of the post's content, not including the featured image.
-	 * Searches for all instances of <img> tags in the post content, which should
-	 * capture Image blocks as well as images embedded via other means such as galleries.
+	 *
+	 * Counts the <img> tags saved in the content (Image, Gallery, Cover and
+	 * Media & Text blocks, classic HTML) plus the images a classic [gallery]
+	 * shortcode lists. It deliberately does not run `the_content`: this runs
+	 * inside the save request, where that pipeline would execute every block,
+	 * shortcode and third-party filter with no global post set. A [gallery]
+	 * without ids rendered in that state falls back to post_parent 0 and loads
+	 * every unattached image on the site, which exhausts PHP memory on large
+	 * media libraries and makes the editor fail to save the post.
 	 *
 	 * @param int $post_id The post ID.
 	 *
@@ -584,8 +591,20 @@ class Fields {
 		if ( ! $story->is_valid() ) {
 			return 0;
 		}
-		$rendered_post_content = \apply_filters( 'the_content', \get_post_field( 'post_content', $post_id ) );
-		return substr_count( $rendered_post_content, '<img ' );
+		$content = \get_post_field( 'post_content', $post_id );
+		$count   = substr_count( $content, '<img ' );
+
+		if ( \has_shortcode( $content, 'gallery' ) && preg_match_all( '/' . \get_shortcode_regex( [ 'gallery' ] ) . '/s', $content, $matches, PREG_SET_ORDER ) ) {
+			foreach ( $matches as $shortcode ) {
+				// Pin the gallery to this post, as core's get_post_galleries() does, so it never queries parent 0.
+				$attrs = \shortcode_parse_atts( $shortcode[3] );
+				if ( ! is_array( $attrs ) || ! isset( $attrs['id'] ) ) {
+					$shortcode[3] .= ' id="' . (int) $post_id . '"';
+				}
+				$count += substr_count( \do_shortcode_tag( $shortcode ), '<img ' );
+			}
+		}
+		return $count;
 	}
 
 	/**

--- a/plugins/newspack-story-budget/tests/unit-tests/test-fields.php
+++ b/plugins/newspack-story-budget/tests/unit-tests/test-fields.php
@@ -190,6 +190,59 @@ class TestFields extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Characterization: image markup saved in the content keeps counting.
+	 */
+	public function test_image_count_counts_images_in_content_markup() {
+		$post_id = self::create_post(
+			[
+				'post_content' => '<!-- wp:image {"id":1} --><figure class="wp-block-image"><img src="https://example.com/a.jpg" alt="" class="wp-image-1"/></figure><!-- /wp:image --><p>Classic <img src="https://example.com/b.jpg" alt=""></p>',
+			]
+		);
+
+		$this->assertSame( 2, Fields::get_image_count( $post_id ), 'Counts the image tags saved in the content.' );
+	}
+
+	/**
+	 * A classic [gallery] shortcode without ids lists the post's own attachments.
+	 * A REST save has no global post; rendering the shortcode in that state falls
+	 * back to parent 0, which is every unattached image on the site.
+	 */
+	public function test_image_count_gallery_shortcode_counts_only_the_story_images() {
+		$post_id = self::create_post( [ 'post_content' => '<p>Photos below.</p>[gallery]' ] );
+		foreach ( [ $post_id, $post_id, 0, 0, 0 ] as $parent ) {
+			self::factory()->attachment->create(
+				[
+					'file'           => 'image.jpg',
+					'post_parent'    => $parent,
+					'post_mime_type' => 'image/jpeg',
+					'post_status'    => 'inherit',
+				]
+			);
+		}
+		unset( $GLOBALS['post'] );
+
+		$this->assertSame( 2, Fields::get_image_count( $post_id ), 'Counts the story\'s attached images, not the site\'s unattached media.' );
+	}
+
+	/**
+	 * Refreshing read-only fields on save must not run the front-end content pipeline.
+	 */
+	public function test_read_only_fields_do_not_render_the_content_on_save() {
+		$post_id = self::create_post( [ 'post_content' => '<p>Hello</p>[gallery]' ] );
+		$calls   = 0;
+		$spy     = function ( $content ) use ( &$calls ) {
+			$calls++;
+			return $content;
+		};
+
+		\add_filter( 'the_content', $spy );
+		Fields::update_read_only_fields( $post_id );
+		\remove_filter( 'the_content', $spy );
+
+		$this->assertSame( 0, $calls, 'Saving a story must not render the_content.' );
+	}
+
+	/**
 	 * Test a select dropdown field.
 	 */
 	public function test_field_with_options() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Saving a post that contains a classic `[gallery]` shortcode could fail with "Updating failed." and a PHP memory fatal, from both the editor's save and a budget or status change in the Story Budget sidebar. The read-only **Images** field recalculated on every save by running the full `the_content` pipeline. Inside a save request there is no global post, so a `[gallery]` without `ids` fell back to parent 0 and loaded every unattached image in the media library. On a site with a large library that exhausts the 512 MB memory limit; on a small one it silently counted the wrong images.

The count now reads the saved content: the `<img>` tags in the post markup, plus the images each classic gallery lists, with the gallery pinned to its post. Saving no longer runs blocks, shortcodes, or third-party content filters.

### How to test the changes in this Pull Request:

1. Upload three images to the Media Library without attaching them to any post.
2. Create a post and add a Shortcode block containing `[gallery]`.
3. Add an Image block, upload two new images through it, then delete that block. The images stay attached to the post. Publish.
4. Open Story Budget and add the post to a budget. The Images column reads 2, not 3 or 5.
5. In the post editor sidebar, change the story status and update the post. The update succeeds with no error notice.
6. Add an Image block with an existing image and update the post. The Images column reads 3.
7. Move the post to the trash. The action succeeds.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Scope note: images that other plugins inject into rendered content, or that dynamic blocks render at view time, no longer count toward Images. They were never part of the story's own content.
