### PR TITLE
Exclude Ultimate Addons for Gutenberg meta in content distribution

### DIFF
--- a/plugins/newspack-network/includes/class-content-distribution.php
+++ b/plugins/newspack-network/includes/class-content-distribution.php
@@ -409,6 +409,19 @@ class Content_Distribution {
 		];
 		$ignored_keys = array_merge( $ignored_keys, $distributor_meta );
 
+		// Always ignore Spectra (Ultimate Addons for Gutenberg) generated asset
+		// meta. These are local rendering artifacts the target regenerates on its
+		// own, and `_uag_page_assets` embeds a `uag_version` timestamp that the
+		// plugin rewrites on every asset regeneration, so leaving them in the
+		// payload triggers a redundant distribution each time they change.
+		$uagb_meta = [
+			'_uag_page_assets',
+			'_uag_css_file_name',
+			'_uag_custom_page_level_css',
+			'_uagb_previous_block_counts',
+		];
+		$ignored_keys = array_merge( $ignored_keys, $uagb_meta );
+
 		// Always ignore content distribution post meta.
 		return array_merge(
 			$ignored_keys,

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-content-distribution.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-content-distribution.php
@@ -98,4 +98,49 @@ class TestContentDistribution extends \WP_UnitTestCase {
 		// Assert that the post is still queued for full distribution.
 		$this->assertTrue( $queue[ $post_id ] );
 	}
+
+	/**
+	 * An ignored post meta write on a distributed post must not queue a
+	 * distribution, while an ordinary meta write must.
+	 *
+	 * This guards the `updated_post_meta` suppression in
+	 * handle_postmeta_update(): without it, every Spectra (UAGB) asset
+	 * regeneration would queue a redundant distribution, the reported
+	 * high-volume sync problem.
+	 */
+	public function test_ignored_meta_does_not_queue_distribution() {
+		$post_id = $this->factory->post->create();
+
+		// Mark the post as distributed to a network node.
+		update_post_meta( $post_id, Outgoing_Post::DISTRIBUTED_POST_META, [ 'https://node.test' ] );
+
+		// Clear the queue populated while marking the post distributed, so we
+		// measure only the writes under test.
+		$this->reset_distribution_queue();
+
+		// A Spectra asset-meta write must not queue a distribution.
+		update_post_meta( $post_id, '_uag_page_assets', 'version-2' );
+		$this->assertArrayNotHasKey(
+			$post_id,
+			Content_Distribution_Class::get_queued_distributions(),
+			'A Spectra asset-meta write should not queue a distribution.'
+		);
+
+		// A non-ignored meta write on the same post must queue a distribution.
+		update_post_meta( $post_id, 'some_meta_key', 'value' );
+		$this->assertArrayHasKey(
+			$post_id,
+			Content_Distribution_Class::get_queued_distributions(),
+			'A non-ignored meta write should queue a distribution.'
+		);
+	}
+
+	/**
+	 * Reset the static distribution queue so a test measures only its own writes.
+	 */
+	private function reset_distribution_queue() {
+		$property = new \ReflectionProperty( Content_Distribution_Class::class, 'queued_distributions' );
+		$property->setAccessible( true );
+		$property->setValue( null, [] );
+	}
 }

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -161,6 +161,32 @@ class TestIncomingPost extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Local-only meta on the target must survive an incoming sync whose payload
+	 * omits it, while ordinary meta absent from the payload is removed.
+	 *
+	 * This guards the ignored-key preservation in Incoming_Post::update_meta():
+	 * a target's own Spectra (UAGB) asset meta must not be deleted or overwritten
+	 * by a sync, since those keys are excluded from the distributed payload.
+	 */
+	public function test_insert_preserves_ignored_local_meta() {
+		// Insert the linked post for the first time.
+		$post_id = $this->incoming_post->insert();
+
+		// Simulate the target site's own Spectra assets plus an unrelated local
+		// meta, neither of which is present in the incoming payload.
+		update_post_meta( $post_id, '_uag_page_assets', 'local-assets' );
+		update_post_meta( $post_id, 'local_only_key', 'local-value' );
+
+		// Run an update sync. The sample payload contains neither key.
+		$updated = new Incoming_Post( $this->get_sample_payload() );
+		$this->assertSame( $post_id, $updated->insert() );
+
+		// The ignored Spectra meta is preserved; the ordinary local meta is removed.
+		$this->assertSame( 'local-assets', get_post_meta( $post_id, '_uag_page_assets', true ) );
+		$this->assertEmpty( get_post_meta( $post_id, 'local_only_key', true ) );
+	}
+
+	/**
 	 * Test insert post when unlinked.
 	 */
 	public function test_insert_post_when_unlinked() {

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-outgoing-post.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-outgoing-post.php
@@ -348,6 +348,42 @@ class TestOutgoingPost extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Ignored post meta keys must not appear in the distributed payload.
+	 *
+	 * Covers a representative key from each ignored group, including the Spectra
+	 * (Ultimate Addons for Gutenberg) asset meta whose `_uag_page_assets` value
+	 * carries a version timestamp the plugin rewrites on every asset
+	 * regeneration; leaving it in the payload triggers a redundant distribution
+	 * each time it changes.
+	 */
+	public function test_ignored_post_meta() {
+		$post = $this->outgoing_post->get_post();
+
+		$ignored_keys = [
+			'_edit_lock',                    // WordPress editor internal.
+			'_yoast_wpseo_primary_category', // Yoast SEO.
+			'dt_unlinked',                   // Distributor.
+			'_uag_page_assets',              // Spectra / UAGB (the churning one).
+			'_uag_css_file_name',            // Spectra / UAGB.
+			'_uag_custom_page_level_css',    // Spectra / UAGB.
+			'_uagb_previous_block_counts',   // Spectra / UAGB.
+		];
+		foreach ( $ignored_keys as $ignored_key ) {
+			update_post_meta( $post->ID, $ignored_key, 'ignored_value' );
+		}
+
+		// A non-ignored key to prove exclusion is selective, not wholesale.
+		update_post_meta( $post->ID, 'test_included_key', 'included_value' );
+
+		$payload = $this->outgoing_post->get_payload();
+
+		foreach ( $ignored_keys as $ignored_key ) {
+			$this->assertArrayNotHasKey( $ignored_key, $payload['post_data']['post_meta'] );
+		}
+		$this->assertArrayHasKey( 'test_included_key', $payload['post_data']['post_meta'] );
+	}
+
+	/**
 	 * Test ignored taxonomies.
 	 */
 	public function test_ignored_taxonomies() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**Note: This is a hotfix.**

Related to NEWS-3084

The docblock explains it well:

```
// Always ignore Spectra (Ultimate Addons for Gutenberg) generated asset
// meta. These are local rendering artifacts the target regenerates on its
// own, and `_uag_page_assets` embeds a `uag_version` timestamp that the
// plugin rewrites on every asset regeneration, so leaving them in the
// payload triggers a redundant distribution each time they change.
```

The plugin has a meta key that is constantly updating, triggering thousands of post distribution syncs a day and filling up the DB tables.

### How to test the changes in this Pull Request:

1. Run unit tests. I've added unit tests for the meta key exclusion functionality.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
