### PR TITLE
fix(memberships-audit): honour gifting state and membership end dates

### DIFF
--- a/plugins/newspack-plugin/includes/cli/class-memberships-audit.php
+++ b/plugins/newspack-plugin/includes/cli/class-memberships-audit.php
@@ -1126,6 +1126,9 @@ class Memberships_Audit {
 	/**
 	 * The Subscriptions Gifting recipient of a subscription.
 	 *
+	 * Public so the meta-reading rules can be tested directly; nothing outside
+	 * this command should need it.
+	 *
 	 * Read off the subscription's own meta rather than through `WCS_Gifting`, so
 	 * a site carrying gifting data without the integration still reports the gift
 	 * instead of a subscription that merely looks bought by the wrong person.
@@ -1138,12 +1141,17 @@ class Memberships_Audit {
 	 *
 	 * @return int|null Recipient user ID, or null when not a gifted subscription.
 	 */
-	private static function get_wcsg_recipient_id( $subscription ) {
+	public static function get_wcsg_recipient_id( $subscription ) {
 		if ( ! method_exists( $subscription, 'get_meta' ) ) {
 			return null;
 		}
 		$recipient_id = $subscription->get_meta( '_recipient_user' );
-		return is_numeric( $recipient_id ) ? (int) $recipient_id : null;
+
+		// `! empty()` before the numeric test, matching is_gifted_subscription():
+		// a subscription that was never gifted can still carry the meta as '' or
+		// '0', and 0 is not a user. Reading it as a recipient would turn a
+		// subscription the member owns into a gift they gave away.
+		return ( ! empty( $recipient_id ) && is_numeric( $recipient_id ) ) ? (int) $recipient_id : null;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/cli/class-memberships-audit.php
+++ b/plugins/newspack-plugin/includes/cli/class-memberships-audit.php
@@ -219,6 +219,7 @@ class Memberships_Audit {
 		self::CLASS_ORDER_ONLY_UNPAID,
 		self::CLASS_SUBSCRIPTION_MISSING,
 		self::CLASS_GIFT_WCSG_INERT,
+		self::CLASS_OUTSIDE_ACTIVE_PERIOD,
 	];
 
 	/**
@@ -262,6 +263,13 @@ class Memberships_Audit {
 	];
 
 	/**
+	 * Whether the Subscriptions Gifting integration is running, once resolved.
+	 *
+	 * @var bool|null
+	 */
+	private static $gifting_integration_active = null;
+
+	/**
 	 * Audit how active memberships are backed, and flag the ones whose access
 	 * Access Control cannot reproduce.
 	 *
@@ -297,7 +305,7 @@ class Memberships_Audit {
 	 * : Comma-delimited membership plan IDs to audit — the plans whose content the new gates cover. Omit the flag to audit every published plan (a plan in any other status is audited only when named here); passing it with no ID is an error.
 	 *
 	 * [--only=<classes>]
-	 * : Comma-delimited classes to report member-by-member: gift, order-only, order-only-unpaid, subscription-missing, gift-wcsg-inert. Omit the flag for the default gift + order-only report; passing it with no class is an error. Counts for every class are printed regardless — on STDERR in the machine-readable formats.
+	 * : Comma-delimited classes to report member-by-member: gift, order-only, order-only-unpaid, subscription-missing, gift-wcsg-inert, outside-active-period. Omit the flag for the default gift + order-only report; passing it with no class is an error. Counts for every class are printed regardless — on STDERR in the machine-readable formats.
 	 *
 	 * [--sleep=<seconds>]
 	 * : Seconds to pause between batches of memberships, to keep a full-table walk from monopolising the database on a live site. Pass 0 to run flat out.
@@ -552,6 +560,13 @@ class Memberships_Audit {
 			)
 		);
 		WP_CLI::line( 'These readers lose access at the flip. `member_own_access_subscriptions` is evidence, not a verdict: a subscription there only preserves access if the gates accept its product.' );
+		// gift-wcsg-inert is the one reported class a $0 subscription is the wrong
+		// answer for, so the standing advice has to step aside when it is on screen
+		// — an operator following both lines would double-grant every one of them.
+		if ( in_array( self::CLASS_GIFT_WCSG_INERT, $only_classes, true ) ) {
+			WP_CLI::line( 'Next: the gift-wcsg-inert rows are fixed by restoring the gifting integration, not by granting access. Re-run with --only naming the other classes for the list that `migrate-manual-members` takes.' );
+			return;
+		}
 		WP_CLI::line( 'Next: confirm buyer-vs-recipient intent with the publisher, then re-run with --format=ids for the signed-off list and grant those readers $0 subscriptions with `wp newspack migrate-manual-members --product-id=<id> --user-ids-file=<path>`. That command dry-runs and writes nothing until --live is added.' );
 	}
 
@@ -751,7 +766,10 @@ class Memberships_Audit {
 	 *                                                 retry scheduled. Grants access through the runtime's
 	 *                                                 payment-recovery grace, so it decides gift vs
 	 *                                                 gift-inactive for the on-hold shape.
-	 *     @type int|null    $wcsg_recipient_id        Subscriptions Gifting recipient, null when not a gifted subscription.
+	 *     @type int|null    $wcsg_recipient_id        Subscriptions Gifting recipient, null when there is no recipient
+	 *                                                 account (including a gift addressed only to an email).
+	 *     @type bool        $wcsg_gifted              Whether the subscription is a gift at all, which is true for an
+	 *                                                 email-only gift whose recipient has no account yet.
 	 *     @type bool        $gifting_integration_active Whether the gifting integration is running, which decides
 	 *                                                 whether a gifted subscription resolves to its recipient.
 	 *     @type bool        $outside_active_period    Whether the membership's own start/end window has it inactive
@@ -769,19 +787,21 @@ class Memberships_Audit {
 	public static function classify( array $facts ) {
 		$holder_id = (int) ( $facts['holder_id'] ?? 0 );
 
-		// Before anything about the backing record: a membership outside its own
-		// start/end window grants nothing under Memberships either, whatever its
-		// stored status says. Classifying it by its subscription would report a
+		// Teams first: the Teams integration stamps the team's subscription (owned
+		// by the team owner) onto every seat's membership, so without this every
+		// seat on a team would read as a gift. It stays ahead of the active-period
+		// check so the seat count this reports is the one migrate-teams reconciles
+		// against, whatever state an individual seat is in.
+		if ( ! empty( $facts['team_id'] ) ) {
+			return self::CLASS_TEAM_BACKED;
+		}
+
+		// Then, before anything about the backing record: a membership outside its
+		// own start/end window grants nothing under Memberships either, whatever
+		// its stored status says. Classifying it by its subscription would report a
 		// reader losing access who does not have any.
 		if ( ! empty( $facts['outside_active_period'] ) ) {
 			return self::CLASS_OUTSIDE_ACTIVE_PERIOD;
-		}
-
-		// Teams first: the Teams integration stamps the team's subscription (owned
-		// by the team owner) onto every seat's membership, so without this every
-		// seat on a team would read as a gift.
-		if ( ! empty( $facts['team_id'] ) ) {
-			return self::CLASS_TEAM_BACKED;
 		}
 
 		if ( ! empty( $facts['subscription_id'] ) ) {
@@ -795,13 +815,18 @@ class Memberships_Audit {
 				// status BEFORE the gifting rule, so a dead gift carries over nothing
 				// and the holder is losing access like any other lapsed member.
 				// Both gifting branches below turn on whether the integration is
-				// actually running. The recipient meta is durable and the code that
-				// reads it is not, so the same row means opposite things depending on
-				// the runtime: with the integration the gift resolves to the recipient,
-				// without it nothing moves and the buyer keeps the access.
+				// running — see CLASS_GIFT_WCSG_INERT for why the same row means
+				// opposite things either side of it. A holder who is also the
+				// subscription's customer is excluded: they own the access outright,
+				// so no runtime can move it away from them.
 				$gifting_active    = ! empty( $facts['gifting_integration_active'] );
 				$wcsg_recipient_id = $facts['wcsg_recipient_id'] ?? null;
-				$is_gift_to_holder = $grants_access && $holder_id && null !== $wcsg_recipient_id && (int) $wcsg_recipient_id === $holder_id;
+				// A known recipient is itself proof of a gift, so the two facts cannot
+				// contradict each other: wcsg_gifted only ever adds the email-only gift,
+				// whose recipient has no account to name.
+				$is_gift           = ! empty( $facts['wcsg_gifted'] ) || null !== $wcsg_recipient_id;
+				$is_gift_to_holder = $grants_access && $holder_id && (int) $customer_id !== $holder_id
+					&& null !== $wcsg_recipient_id && (int) $wcsg_recipient_id === $holder_id;
 				if ( $is_gift_to_holder ) {
 					return $gifting_active ? self::CLASS_GIFT_WCSG : self::CLASS_GIFT_WCSG_INERT;
 				}
@@ -821,7 +846,12 @@ class Memberships_Audit {
 				// access at the flip — with no row anywhere to catch it, since
 				// member-owned is only ever an aggregate count. The sibling teams
 				// migration makes the same check for the same reason.
-				if ( $gifting_active && $grants_access && $holder_id && null !== $wcsg_recipient_id && (int) $wcsg_recipient_id !== $holder_id ) {
+				// Keyed on "is a gift", not "has a resolved recipient": a gift bought
+				// before its recipient has an account carries only the recipient's
+				// email, so the runtime resolves it to nobody and withholds it from the
+				// buyer too. The holder loses access either way, and reading only the
+				// resolved recipient would file that as access they keep.
+				if ( $gifting_active && $grants_access && $holder_id && $is_gift && (int) $wcsg_recipient_id !== $holder_id ) {
 					return self::CLASS_GIFT;
 				}
 
@@ -1045,16 +1075,12 @@ class Memberships_Audit {
 
 		$facts = [
 			'holder_id'                        => $holder_id,
-			'outside_active_period'            => self::is_outside_active_period(
-				(string) \get_post_meta( $membership_id, '_start_date', true ),
-				(string) \get_post_meta( $membership_id, '_end_date', true )
-			),
+			'outside_active_period'            => self::is_outside_active_period( $membership_id ),
 			// The same predicate the runtime uses in
 			// WooCommerce_Connection::get_active_subscriptions_for_user(), so the
 			// audit and the access it is predicting cannot disagree about whether a
-			// gift resolves. Read per membership rather than per subscription: it is
-			// a property of the runtime, not of any one row.
-			'gifting_integration_active'       => class_exists( 'WCS_Gifting' ),
+			// gift resolves.
+			'gifting_integration_active'       => self::gifting_integration_active(),
 			'team_id'                          => (int) \get_post_meta( $membership_id, '_team_id', true ),
 			'subscription_id'                  => $subscription_id,
 			'subscription_customer_id'         => null,
@@ -1064,6 +1090,7 @@ class Memberships_Audit {
 			// runtime's payment-recovery grace turns exactly this shape into access.
 			'subscription_in_payment_recovery' => false,
 			'wcsg_recipient_id'                => null,
+			'wcsg_gifted'                      => false,
 			'order_id'                         => $order_id,
 			'order_customer_id'                => null,
 			'order_status'                     => '',
@@ -1080,6 +1107,7 @@ class Memberships_Audit {
 				$facts['subscription_in_payment_recovery'] = class_exists( 'Newspack\WooCommerce_Connection' )
 					&& \Newspack\WooCommerce_Connection::is_subscription_in_payment_recovery( $subscription );
 				$facts['wcsg_recipient_id']        = self::get_wcsg_recipient_id( $subscription );
+				$facts['wcsg_gifted']              = self::is_wcsg_gifted( $subscription );
 				$facts['products']                 = self::get_product_ids( $subscription );
 				if ( ! $facts['subscription_customer_id'] && method_exists( $subscription, 'get_billing_email' ) ) {
 					// Guest purchase: the billing address is the only identity the
@@ -1132,19 +1160,17 @@ class Memberships_Audit {
 	 * Read off the subscription's own meta rather than through `WCS_Gifting`, so
 	 * a site carrying gifting data without the integration still reports the gift
 	 * instead of a subscription that merely looks bought by the wrong person.
-	 * This is what `WCS_Gifting::get_recipient_user()` reads, and a non-empty
-	 * numeric value is what `is_gifted_subscription()` tests. Whether the
-	 * integration is running is a separate fact, because it decides who the gift
-	 * resolves to.
+	 * This is what `WCS_Gifting::get_recipient_user()` reads. It is only half of
+	 * what `is_gifted_subscription()` tests, so it answers "who is the recipient",
+	 * not "is this a gift" — see is_wcsg_gifted(). Whether the integration is
+	 * running is a separate fact again, because it decides who the gift resolves
+	 * to.
 	 *
 	 * @param \WC_Subscription $subscription The subscription.
 	 *
 	 * @return int|null Recipient user ID, or null when not a gifted subscription.
 	 */
 	public static function get_wcsg_recipient_id( $subscription ) {
-		if ( ! method_exists( $subscription, 'get_meta' ) ) {
-			return null;
-		}
 		$recipient_id = $subscription->get_meta( '_recipient_user' );
 
 		// `! empty()` before the numeric test, matching is_gifted_subscription():
@@ -1155,18 +1181,82 @@ class Memberships_Audit {
 	}
 
 	/**
+	 * Whether the Subscriptions Gifting integration is running.
+	 *
+	 * Resolved once: it is a property of the runtime, and on a site without the
+	 * class every call re-enters the autoloaders — a filesystem probe per row on a
+	 * walk that is deliberately paced to stay off the database.
+	 *
+	 * @return bool
+	 */
+	private static function gifting_integration_active() {
+		if ( null === self::$gifting_integration_active ) {
+			self::$gifting_integration_active = class_exists( 'WCS_Gifting' );
+		}
+		return self::$gifting_integration_active;
+	}
+
+	/**
+	 * Whether a subscription is a gift, by the same test the gifting code uses.
+	 *
+	 * `WCS_Gifting::is_gifted_subscription()` accepts either a recipient account
+	 * or a recipient email, and the email is what a gift carries between checkout
+	 * and the recipient's account being created. Keyed on the account alone, such
+	 * a gift reads as an ordinary purchase.
+	 *
+	 * @param \WC_Subscription $subscription The subscription.
+	 *
+	 * @return bool
+	 */
+	public static function is_wcsg_gifted( $subscription ) {
+		return null !== self::get_wcsg_recipient_id( $subscription )
+			|| ! empty( $subscription->get_meta( '_recipient_user_email_address' ) );
+	}
+
+	/**
 	 * Whether a membership's own start/end window has it inactive.
 	 *
-	 * Mirrors `WC_Memberships_User_Membership::is_in_active_period()`: both dates
-	 * are UTC strings, and an empty one means unbounded rather than epoch — so an
-	 * open-ended membership must read as inside the window, not outside it.
+	 * Asks Memberships rather than reading `_end_date`, because for a
+	 * subscription-tied membership that meta is not the end date in force:
+	 * `WC_Memberships_Integration_Subscriptions_User_Membership::get_end_date()`
+	 * replaces it with the linked subscription's end date, and the parent shifts
+	 * it by any recorded pause. Those are exactly the memberships this command
+	 * walks, so reading the meta would file live members as expired — and this
+	 * class is tested first in classify(), so such a row would leave the report
+	 * entirely. `is_in_active_period()` writes nothing, unlike the sibling
+	 * `is_active()`, which expires a lapsed membership as a side effect.
+	 *
+	 * @param int $membership_id Membership post ID.
+	 *
+	 * @return bool
+	 */
+	public static function is_outside_active_period( $membership_id ) {
+		if ( function_exists( 'wc_memberships_get_user_membership' ) ) {
+			$membership = \wc_memberships_get_user_membership( $membership_id );
+			if ( $membership && method_exists( $membership, 'is_in_active_period' ) ) {
+				return ! $membership->is_in_active_period();
+			}
+		}
+		return self::is_outside_meta_active_period(
+			(string) \get_post_meta( $membership_id, '_start_date', true ),
+			(string) \get_post_meta( $membership_id, '_end_date', true )
+		);
+	}
+
+	/**
+	 * The same window read straight off the membership's meta.
+	 *
+	 * The fallback for when Memberships cannot be asked. Both dates are UTC
+	 * strings, and an empty one means unbounded rather than epoch — reading an
+	 * empty end date as a boundary would expire every open-ended membership on
+	 * the site.
 	 *
 	 * @param string $start_date Membership `_start_date` meta, '' when unset.
 	 * @param string $end_date   Membership `_end_date` meta, '' when unset.
 	 *
 	 * @return bool
 	 */
-	public static function is_outside_active_period( $start_date, $end_date ) {
+	public static function is_outside_meta_active_period( $start_date, $end_date ) {
 		$now   = time();
 		$start = $start_date ? strtotime( $start_date . ' UTC' ) : false;
 		$end   = $end_date ? strtotime( $end_date . ' UTC' ) : false;

--- a/plugins/newspack-plugin/includes/cli/class-memberships-audit.php
+++ b/plugins/newspack-plugin/includes/cli/class-memberships-audit.php
@@ -131,6 +131,25 @@ class Memberships_Audit {
 	const CLASS_GIFT_WCSG = 'gift-wcsg';
 
 	/**
+	 * Gifting data with no gifting code behind it. The integration moved from a
+	 * standalone plugin into WooCommerce Subscriptions core, so a site can carry
+	 * `_recipient_user` meta that nothing resolves: access stays with the buyer
+	 * and the recipient is dark. Held apart from `gift` because the remedy is
+	 * restoring the integration, not granting $0 subscriptions — those would
+	 * double-grant the moment it comes back.
+	 */
+	const CLASS_GIFT_WCSG_INERT = 'gift-wcsg-inert';
+
+	/**
+	 * Status says active, but the membership's own start/end window says
+	 * otherwise. Memberships expires lazily — `is_active()` calls
+	 * `expire_membership()` the next time anything asks — so a row nobody has
+	 * asked about since its end date still reads active while granting nothing.
+	 * There is no access here to carry over, and no reader to remediate.
+	 */
+	const CLASS_OUTSIDE_ACTIVE_PERIOD = 'outside-active-period';
+
+	/**
 	 * Backed only by a paid one-off order — no subscription at all, so there is
 	 * nothing recurring for an Access Control `subscription` rule to key on.
 	 */
@@ -199,6 +218,7 @@ class Memberships_Audit {
 		self::CLASS_ORDER_ONLY,
 		self::CLASS_ORDER_ONLY_UNPAID,
 		self::CLASS_SUBSCRIPTION_MISSING,
+		self::CLASS_GIFT_WCSG_INERT,
 	];
 
 	/**
@@ -213,10 +233,12 @@ class Memberships_Audit {
 		self::CLASS_ORDER_ONLY_UNPAID,
 		self::CLASS_SUBSCRIPTION_MISSING,
 		self::CLASS_GIFT_WCSG,
+		self::CLASS_GIFT_WCSG_INERT,
 		self::CLASS_GIFT_INACTIVE,
 		self::CLASS_MEMBER_OWNED_INACTIVE,
 		self::CLASS_TEAM_BACKED,
 		self::CLASS_NO_PURCHASE_RECORD,
+		self::CLASS_OUTSIDE_ACTIVE_PERIOD,
 	];
 
 	/**
@@ -231,10 +253,12 @@ class Memberships_Audit {
 		self::CLASS_ORDER_ONLY_UNPAID     => 'backed by an unpaid/refunded order, no subscription',
 		self::CLASS_SUBSCRIPTION_MISSING  => 'linked subscription no longer exists',
 		self::CLASS_GIFT_WCSG             => 'gifted via Subscriptions Gifting — recipient keeps access',
+		self::CLASS_GIFT_WCSG_INERT       => 'gifted, but the gifting integration is not active — access sits with the buyer',
 		self::CLASS_GIFT_INACTIVE         => 'subscription owned by someone else, grants no access (lapsed/on-hold)',
 		self::CLASS_MEMBER_OWNED_INACTIVE => 'member owns the subscription, grants no access (lapsed/on-hold)',
 		self::CLASS_TEAM_BACKED           => 'team seat — handled by migrate-teams',
 		self::CLASS_NO_PURCHASE_RECORD    => 'no purchase record (comp/legacy)',
+		self::CLASS_OUTSIDE_ACTIVE_PERIOD => 'status is active but the membership is outside its own start/end window',
 	];
 
 	/**
@@ -253,6 +277,9 @@ class Memberships_Audit {
 	 *   and the buyer gains access they never had.
 	 * - **order-only**: the membership is backed by a paid one-off order with no
 	 *   subscription behind it.
+	 * - **gift-wcsg-inert**: the subscription carries Subscriptions Gifting data
+	 *   that nothing on the site resolves, so access stays with the buyer. Fixed
+	 *   by restoring the gifting integration, not by granting access.
 	 *
 	 * Every other membership is counted under a named class, so the per-plan
 	 * summary reconciles against the plan's member count rather than leaving a
@@ -270,7 +297,7 @@ class Memberships_Audit {
 	 * : Comma-delimited membership plan IDs to audit — the plans whose content the new gates cover. Omit the flag to audit every published plan (a plan in any other status is audited only when named here); passing it with no ID is an error.
 	 *
 	 * [--only=<classes>]
-	 * : Comma-delimited classes to report member-by-member: gift, order-only, order-only-unpaid, subscription-missing. Omit the flag for the default gift + order-only report; passing it with no class is an error. Counts for every class are printed regardless — on STDERR in the machine-readable formats.
+	 * : Comma-delimited classes to report member-by-member: gift, order-only, order-only-unpaid, subscription-missing, gift-wcsg-inert. Omit the flag for the default gift + order-only report; passing it with no class is an error. Counts for every class are printed regardless — on STDERR in the machine-readable formats.
 	 *
 	 * [--sleep=<seconds>]
 	 * : Seconds to pause between batches of memberships, to keep a full-table walk from monopolising the database on a live site. Pass 0 to run flat out.
@@ -457,6 +484,18 @@ class Memberships_Audit {
 		// "no gift memberships found" would read as a clean bill of health.
 		if ( 0 === $audited_plans ) {
 			WP_CLI::error( 'None of the given plan IDs are membership plans — nothing was audited.' );
+		}
+
+		// The one cohort whose fix is not a subscription. Granting these readers
+		// access papers over a missing integration, and double-grants them when it
+		// returns, so say so even when the class was not reported member-by-member.
+		if ( $total_counts[ self::CLASS_GIFT_WCSG_INERT ] > 0 ) {
+			WP_CLI::warning(
+				sprintf(
+					'%d membership(s) are gifts whose recipient cannot be resolved: the subscriptions carry Subscriptions Gifting data, but the gifting integration is not running on this site. Access sits with the buyer until it is restored. Restore the integration rather than granting these readers subscriptions.',
+					$total_counts[ self::CLASS_GIFT_WCSG_INERT ]
+				)
+			);
 		}
 
 		$flagged_user_ids = self::flagged_user_ids( $rows );
@@ -713,6 +752,10 @@ class Memberships_Audit {
 	 *                                                 payment-recovery grace, so it decides gift vs
 	 *                                                 gift-inactive for the on-hold shape.
 	 *     @type int|null    $wcsg_recipient_id        Subscriptions Gifting recipient, null when not a gifted subscription.
+	 *     @type bool        $gifting_integration_active Whether the gifting integration is running, which decides
+	 *                                                 whether a gifted subscription resolves to its recipient.
+	 *     @type bool        $outside_active_period    Whether the membership's own start/end window has it inactive
+	 *                                                 regardless of its stored status.
 	 *     @type int         $order_id                 Linked order ID, 0 if unlinked.
 	 *     @type int|null    $order_customer_id        Order customer, null if it could not be loaded.
 	 *     @type string      $order_status             Order status, '' when no order loaded.
@@ -725,6 +768,14 @@ class Memberships_Audit {
 	 */
 	public static function classify( array $facts ) {
 		$holder_id = (int) ( $facts['holder_id'] ?? 0 );
+
+		// Before anything about the backing record: a membership outside its own
+		// start/end window grants nothing under Memberships either, whatever its
+		// stored status says. Classifying it by its subscription would report a
+		// reader losing access who does not have any.
+		if ( ! empty( $facts['outside_active_period'] ) ) {
+			return self::CLASS_OUTSIDE_ACTIVE_PERIOD;
+		}
 
 		// Teams first: the Teams integration stamps the team's subscription (owned
 		// by the team owner) onto every seat's membership, so without this every
@@ -743,9 +794,16 @@ class Memberships_Audit {
 				// Only while it still grants access, though: the runtime checks the
 				// status BEFORE the gifting rule, so a dead gift carries over nothing
 				// and the holder is losing access like any other lapsed member.
+				// Both gifting branches below turn on whether the integration is
+				// actually running. The recipient meta is durable and the code that
+				// reads it is not, so the same row means opposite things depending on
+				// the runtime: with the integration the gift resolves to the recipient,
+				// without it nothing moves and the buyer keeps the access.
+				$gifting_active    = ! empty( $facts['gifting_integration_active'] );
 				$wcsg_recipient_id = $facts['wcsg_recipient_id'] ?? null;
-				if ( $grants_access && $holder_id && null !== $wcsg_recipient_id && (int) $wcsg_recipient_id === $holder_id ) {
-					return self::CLASS_GIFT_WCSG;
+				$is_gift_to_holder = $grants_access && $holder_id && null !== $wcsg_recipient_id && (int) $wcsg_recipient_id === $holder_id;
+				if ( $is_gift_to_holder ) {
+					return $gifting_active ? self::CLASS_GIFT_WCSG : self::CLASS_GIFT_WCSG_INERT;
 				}
 
 				if ( ! $holder_id || (int) $customer_id !== $holder_id ) {
@@ -763,7 +821,7 @@ class Memberships_Audit {
 				// access at the flip — with no row anywhere to catch it, since
 				// member-owned is only ever an aggregate count. The sibling teams
 				// migration makes the same check for the same reason.
-				if ( $grants_access && $holder_id && null !== $wcsg_recipient_id && (int) $wcsg_recipient_id !== $holder_id ) {
+				if ( $gifting_active && $grants_access && $holder_id && null !== $wcsg_recipient_id && (int) $wcsg_recipient_id !== $holder_id ) {
 					return self::CLASS_GIFT;
 				}
 
@@ -987,6 +1045,16 @@ class Memberships_Audit {
 
 		$facts = [
 			'holder_id'                        => $holder_id,
+			'outside_active_period'            => self::is_outside_active_period(
+				(string) \get_post_meta( $membership_id, '_start_date', true ),
+				(string) \get_post_meta( $membership_id, '_end_date', true )
+			),
+			// The same predicate the runtime uses in
+			// WooCommerce_Connection::get_active_subscriptions_for_user(), so the
+			// audit and the access it is predicting cannot disagree about whether a
+			// gift resolves. Read per membership rather than per subscription: it is
+			// a property of the runtime, not of any one row.
+			'gifting_integration_active'       => class_exists( 'WCS_Gifting' ),
 			'team_id'                          => (int) \get_post_meta( $membership_id, '_team_id', true ),
 			'subscription_id'                  => $subscription_id,
 			'subscription_customer_id'         => null,
@@ -1056,18 +1124,49 @@ class Memberships_Audit {
 	}
 
 	/**
-	 * The WooCommerce Subscriptions Gifting recipient of a subscription, when
-	 * that plugin is active and the subscription is a gift.
+	 * The Subscriptions Gifting recipient of a subscription.
+	 *
+	 * Read off the subscription's own meta rather than through `WCS_Gifting`, so
+	 * a site carrying gifting data without the integration still reports the gift
+	 * instead of a subscription that merely looks bought by the wrong person.
+	 * This is what `WCS_Gifting::get_recipient_user()` reads, and a non-empty
+	 * numeric value is what `is_gifted_subscription()` tests. Whether the
+	 * integration is running is a separate fact, because it decides who the gift
+	 * resolves to.
 	 *
 	 * @param \WC_Subscription $subscription The subscription.
 	 *
 	 * @return int|null Recipient user ID, or null when not a gifted subscription.
 	 */
 	private static function get_wcsg_recipient_id( $subscription ) {
-		if ( ! class_exists( 'WCS_Gifting' ) || ! \WCS_Gifting::is_gifted_subscription( $subscription ) ) {
+		if ( ! method_exists( $subscription, 'get_meta' ) ) {
 			return null;
 		}
-		return (int) \WCS_Gifting::get_recipient_user( $subscription );
+		$recipient_id = $subscription->get_meta( '_recipient_user' );
+		return is_numeric( $recipient_id ) ? (int) $recipient_id : null;
+	}
+
+	/**
+	 * Whether a membership's own start/end window has it inactive.
+	 *
+	 * Mirrors `WC_Memberships_User_Membership::is_in_active_period()`: both dates
+	 * are UTC strings, and an empty one means unbounded rather than epoch — so an
+	 * open-ended membership must read as inside the window, not outside it.
+	 *
+	 * @param string $start_date Membership `_start_date` meta, '' when unset.
+	 * @param string $end_date   Membership `_end_date` meta, '' when unset.
+	 *
+	 * @return bool
+	 */
+	public static function is_outside_active_period( $start_date, $end_date ) {
+		$now   = time();
+		$start = $start_date ? strtotime( $start_date . ' UTC' ) : false;
+		$end   = $end_date ? strtotime( $end_date . ' UTC' ) : false;
+
+		if ( $start && $start > $now ) {
+			return true;
+		}
+		return (bool) ( $end && $end < $now );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/cli/class-test-memberships-audit.php
+++ b/plugins/newspack-plugin/tests/unit-tests/cli/class-test-memberships-audit.php
@@ -39,6 +39,7 @@ class Test_Memberships_Audit extends WP_UnitTestCase {
 				// Off by default: only a test about the payment-recovery grace sets it.
 				'subscription_in_payment_recovery' => false,
 				'wcsg_recipient_id'                => null,
+				'wcsg_gifted'                      => false,
 				// On by default: the gifting integration ships inside WooCommerce
 				// Subscriptions, so its absence is the exception a test opts into.
 				'gifting_integration_active'       => true,
@@ -1045,30 +1046,30 @@ class Test_Memberships_Audit extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The window Memberships itself enforces, in `is_in_active_period()`: dates
-	 * are stored as UTC strings, and an empty one means unbounded rather than
-	 * "epoch". Reading an empty end date as a boundary would expire every
+	 * The meta-reading fallback, used when Memberships cannot be asked directly.
+	 * Dates are stored as UTC strings, and an empty one means unbounded rather
+	 * than "epoch": reading an empty end date as a boundary would expire every
 	 * open-ended membership on the site.
 	 */
-	public function test_active_period_window_matches_memberships() {
+	public function test_meta_active_period_window_treats_empty_dates_as_unbounded() {
 		$this->assertFalse(
-			Memberships_Audit::is_outside_active_period( '', '' ),
+			Memberships_Audit::is_outside_meta_active_period( '', '' ),
 			'No dates at all is an unbounded membership.'
 		);
 		$this->assertFalse(
-			Memberships_Audit::is_outside_active_period( '2020-01-01 00:00:00', '' ),
+			Memberships_Audit::is_outside_meta_active_period( '2020-01-01 00:00:00', '' ),
 			'A start in the past with no end is unbounded.'
 		);
 		$this->assertTrue(
-			Memberships_Audit::is_outside_active_period( '2020-01-01 00:00:00', '2020-06-01 00:00:00' ),
+			Memberships_Audit::is_outside_meta_active_period( '2020-01-01 00:00:00', '2020-06-01 00:00:00' ),
 			'An end date in the past closes the window.'
 		);
 		$this->assertTrue(
-			Memberships_Audit::is_outside_active_period( gmdate( 'Y-m-d H:i:s', time() + DAY_IN_SECONDS ), '' ),
+			Memberships_Audit::is_outside_meta_active_period( gmdate( 'Y-m-d H:i:s', time() + DAY_IN_SECONDS ), '' ),
 			'A start date in the future has not opened the window yet.'
 		);
 		$this->assertFalse(
-			Memberships_Audit::is_outside_active_period( '2020-01-01 00:00:00', gmdate( 'Y-m-d H:i:s', time() + DAY_IN_SECONDS ) ),
+			Memberships_Audit::is_outside_meta_active_period( '2020-01-01 00:00:00', gmdate( 'Y-m-d H:i:s', time() + DAY_IN_SECONDS ) ),
 			'Between the two dates is inside the window.'
 		);
 	}
@@ -1104,14 +1105,35 @@ class Test_Memberships_Audit extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Gift detection has to accept either signal, because Subscriptions Gifting
+	 * does: a gift bought for someone without an account carries their email and
+	 * no recipient ID until the account is created.
+	 */
+	public function test_gift_detection_accepts_either_recipient_signal() {
+		$this->assertTrue(
+			Memberships_Audit::is_wcsg_gifted( $this->subscription_with_recipient_meta( '', 'recipient@example.com' ) ),
+			'A recipient email alone marks the subscription as a gift.'
+		);
+		$this->assertTrue(
+			Memberships_Audit::is_wcsg_gifted( $this->subscription_with_recipient_meta( '501' ) ),
+			'A recipient ID alone marks the subscription as a gift.'
+		);
+		$this->assertFalse(
+			Memberships_Audit::is_wcsg_gifted( $this->subscription_with_recipient_meta( '' ) ),
+			'Neither signal means the subscription was never gifted.'
+		);
+	}
+
+	/**
 	 * A stand-in for a subscription carrying a given `_recipient_user` value.
 	 *
-	 * @param mixed $value The recipient meta value.
+	 * @param mixed  $value The recipient meta value.
+	 * @param string $email The recipient email meta value, for an email-only gift.
 	 *
 	 * @return object Something with the `get_meta()` the reader calls.
 	 */
-	private function subscription_with_recipient_meta( $value ) {
-		return new class( $value ) {
+	private function subscription_with_recipient_meta( $value, $email = '' ) {
+		return new class( $value, $email ) {
 			/**
 			 * The subscription's `_recipient_user` meta value.
 			 *
@@ -1120,12 +1142,21 @@ class Test_Memberships_Audit extends WP_UnitTestCase {
 			private $recipient;
 
 			/**
+			 * The subscription's `_recipient_user_email_address` meta value.
+			 *
+			 * @var string
+			 */
+			private $email;
+
+			/**
 			 * Constructor.
 			 *
-			 * @param mixed $recipient The recipient meta value.
+			 * @param mixed  $recipient The recipient meta value.
+			 * @param string $email     The recipient email meta value.
 			 */
-			public function __construct( $recipient ) {
+			public function __construct( $recipient, $email ) {
 				$this->recipient = $recipient;
+				$this->email     = $email;
 			}
 
 			/**
@@ -1136,8 +1167,99 @@ class Test_Memberships_Audit extends WP_UnitTestCase {
 			 * @return mixed
 			 */
 			public function get_meta( $key ) {
-				return '_recipient_user' === $key ? $this->recipient : '';
+				if ( '_recipient_user' === $key ) {
+					return $this->recipient;
+				}
+				return '_recipient_user_email_address' === $key ? $this->email : '';
 			}
 		};
+	}
+	/**
+	 * A gift exists from checkout, but its recipient account may not. Subscriptions
+	 * Gifting accepts a recipient email as well as a recipient ID, and the runtime
+	 * resolves an email-only gift to nobody — withholding access from the buyer
+	 * without granting it to anyone. Read as "not a gift", the holder is filed as
+	 * keeping access they are about to lose, in the aggregate-only member-owned
+	 * class that produces no row to catch it.
+	 */
+	public function test_gift_addressed_only_to_an_email_is_still_a_gift() {
+		$this->assertSame(
+			Memberships_Audit::CLASS_GIFT,
+			Memberships_Audit::classify(
+				$this->facts(
+					[
+						'subscription_id'          => 90210,
+						'subscription_customer_id' => 501,
+						'subscription_status'      => 'active',
+						'wcsg_recipient_id'        => null,
+						'wcsg_gifted'              => true,
+					]
+				)
+			)
+		);
+	}
+
+	/**
+	 * The `--only` synopsis is the only one of the class lists no other test
+	 * guards, and WP-CLI reads it from the docblock, so it cannot interpolate the
+	 * constant. It is also what tells an operator a class exists at all: a class
+	 * that is selectable but unlisted is one nobody knows to ask for.
+	 */
+	public function test_every_selectable_class_is_named_in_the_only_synopsis() {
+		$audit_command = new \ReflectionMethod( Memberships_Audit::class, 'audit_membership_subscriptions' );
+		$synopsis      = $audit_command->getDocComment();
+
+		foreach ( Memberships_Audit::SELECTABLE_CLASSES as $class ) {
+			$this->assertStringContainsString(
+				$class,
+				$synopsis,
+				sprintf( 'The --only synopsis names the "%s" class.', $class )
+			);
+		}
+	}
+
+	/**
+	 * A holder who is also the subscription's customer owns their access outright,
+	 * so no runtime moves it. A recipient meta naming that same user — a gift
+	 * re-homed to its recipient — must not read as a gift they are about to lose,
+	 * which would put a covered reader in the remediation cohort.
+	 */
+	public function test_holder_who_owns_the_subscription_is_covered_even_when_named_as_recipient() {
+		$this->assertSame(
+			Memberships_Audit::CLASS_MEMBER_OWNED,
+			Memberships_Audit::classify(
+				$this->facts(
+					[
+						'subscription_id'            => 90210,
+						'subscription_customer_id'   => 501,
+						'subscription_status'        => 'active',
+						'wcsg_recipient_id'          => 501,
+						'wcsg_gifted'                => true,
+						'gifting_integration_active' => false,
+					]
+				)
+			)
+		);
+	}
+
+	/**
+	 * A team seat is migrate-teams' to handle whatever state it is in, so the
+	 * count this command reports against that cohort has to stay the count
+	 * migrate-teams reconciles — the active-period check must not quietly take
+	 * rows out of it.
+	 */
+	public function test_team_seat_outside_its_active_period_is_still_team_backed() {
+		$this->assertSame(
+			Memberships_Audit::CLASS_TEAM_BACKED,
+			Memberships_Audit::classify(
+				$this->facts(
+					[
+						'team_id'               => 77,
+						'subscription_id'       => 90210,
+						'outside_active_period' => true,
+					]
+				)
+			)
+		);
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/cli/class-test-memberships-audit.php
+++ b/plugins/newspack-plugin/tests/unit-tests/cli/class-test-memberships-audit.php
@@ -1072,4 +1072,44 @@ class Test_Memberships_Audit extends WP_UnitTestCase {
 			'Between the two dates is inside the window.'
 		);
 	}
+
+	/**
+	 * `_recipient_user` is not always a user. Subscriptions Gifting treats an
+	 * empty or `'0'` value as "not a gift" (`is_gifted_subscription()` guards with
+	 * `! empty()`), and a subscription that was never gifted can carry one. Read
+	 * as a recipient of 0, it turns a subscription the member owns into a gift
+	 * they supposedly gave away, and the member is reported as losing access they
+	 * actually keep.
+	 */
+	public function test_non_user_recipient_meta_is_not_a_gift() {
+		$subscription_with_meta = function( $value ) {
+			return new class( $value ) {
+				/**
+				 * @var mixed
+				 */
+				private $value;
+
+				public function __construct( $value ) {
+					$this->value = $value;
+				}
+
+				public function get_meta( $key ) {
+					return '_recipient_user' === $key ? $this->value : '';
+				}
+			};
+		};
+
+		foreach ( [ '', '0', 0, 'not-a-user' ] as $value ) {
+			$this->assertNull(
+				Memberships_Audit::get_wcsg_recipient_id( $subscription_with_meta( $value ) ),
+				sprintf( 'A recipient meta of "%s" is not a gift recipient.', var_export( $value, true ) )
+			);
+		}
+
+		$this->assertSame(
+			501,
+			Memberships_Audit::get_wcsg_recipient_id( $subscription_with_meta( '501' ) ),
+			'A real user ID is read as the recipient.'
+		);
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/cli/class-test-memberships-audit.php
+++ b/plugins/newspack-plugin/tests/unit-tests/cli/class-test-memberships-audit.php
@@ -1082,34 +1082,62 @@ class Test_Memberships_Audit extends WP_UnitTestCase {
 	 * actually keep.
 	 */
 	public function test_non_user_recipient_meta_is_not_a_gift() {
-		$subscription_with_meta = function( $value ) {
-			return new class( $value ) {
-				/**
-				 * @var mixed
-				 */
-				private $value;
+		$cases = [
+			'an empty string'     => '',
+			'the string zero'     => '0',
+			'integer zero'        => 0,
+			'a non-numeric value' => 'not-a-user',
+		];
 
-				public function __construct( $value ) {
-					$this->value = $value;
-				}
-
-				public function get_meta( $key ) {
-					return '_recipient_user' === $key ? $this->value : '';
-				}
-			};
-		};
-
-		foreach ( [ '', '0', 0, 'not-a-user' ] as $value ) {
+		foreach ( $cases as $label => $value ) {
 			$this->assertNull(
-				Memberships_Audit::get_wcsg_recipient_id( $subscription_with_meta( $value ) ),
-				sprintf( 'A recipient meta of "%s" is not a gift recipient.', var_export( $value, true ) )
+				Memberships_Audit::get_wcsg_recipient_id( $this->subscription_with_recipient_meta( $value ) ),
+				sprintf( 'Recipient meta of %s is not a gift recipient.', $label )
 			);
 		}
 
 		$this->assertSame(
 			501,
-			Memberships_Audit::get_wcsg_recipient_id( $subscription_with_meta( '501' ) ),
+			Memberships_Audit::get_wcsg_recipient_id( $this->subscription_with_recipient_meta( '501' ) ),
 			'A real user ID is read as the recipient.'
 		);
+	}
+
+	/**
+	 * A stand-in for a subscription carrying a given `_recipient_user` value.
+	 *
+	 * @param mixed $value The recipient meta value.
+	 *
+	 * @return object Something with the `get_meta()` the reader calls.
+	 */
+	private function subscription_with_recipient_meta( $value ) {
+		return new class( $value ) {
+			/**
+			 * The subscription's `_recipient_user` meta value.
+			 *
+			 * @var mixed
+			 */
+			private $recipient;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param mixed $recipient The recipient meta value.
+			 */
+			public function __construct( $recipient ) {
+				$this->recipient = $recipient;
+			}
+
+			/**
+			 * Read a meta value off the subscription.
+			 *
+			 * @param string $key Meta key.
+			 *
+			 * @return mixed
+			 */
+			public function get_meta( $key ) {
+				return '_recipient_user' === $key ? $this->recipient : '';
+			}
+		};
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/cli/class-test-memberships-audit.php
+++ b/plugins/newspack-plugin/tests/unit-tests/cli/class-test-memberships-audit.php
@@ -39,6 +39,10 @@ class Test_Memberships_Audit extends WP_UnitTestCase {
 				// Off by default: only a test about the payment-recovery grace sets it.
 				'subscription_in_payment_recovery' => false,
 				'wcsg_recipient_id'                => null,
+				// On by default: the gifting integration ships inside WooCommerce
+				// Subscriptions, so its absence is the exception a test opts into.
+				'gifting_integration_active'       => true,
+				'outside_active_period'            => false,
 				'order_id'                         => 0,
 				'order_customer_id'                => null,
 				'order_status'                     => '',
@@ -964,6 +968,108 @@ class Test_Memberships_Audit extends WP_UnitTestCase {
 				Memberships_Audit::VALUE_FLAGS
 			),
 			'A sibling command\'s flag is not one this command accepts, so it must not be reported against it.'
+		);
+	}
+
+	/**
+	 * Gifting data outlives the code that reads it: the integration moved from a
+	 * standalone plugin into WooCommerce Subscriptions core, so a site can carry
+	 * `_recipient_user` meta while nothing resolves it. Access then sits with the
+	 * buyer, and the recipient is dark — but the remedy is restoring the
+	 * integration, not granting the recipient a $0 subscription, which would
+	 * double-grant the moment the integration comes back. Reporting this as a
+	 * plain gift sends the operator to the wrong command.
+	 */
+	public function test_gift_without_the_gifting_integration_is_its_own_class() {
+		$this->assertSame(
+			Memberships_Audit::CLASS_GIFT_WCSG_INERT,
+			Memberships_Audit::classify(
+				$this->facts(
+					[
+						'subscription_id'            => 90210,
+						'subscription_customer_id'   => 500,
+						'subscription_status'        => 'active',
+						'wcsg_recipient_id'          => 501,
+						'gifting_integration_active' => false,
+					]
+				)
+			)
+		);
+	}
+
+	/**
+	 * The mirror case, and the reason the gifting classification cannot be read
+	 * off the meta alone. When the holder bought the gift, an active integration
+	 * moves their access to the recipient and the holder is losing it; with no
+	 * integration nothing moves, so the holder keeps the access they already had
+	 * and there is nothing to preserve.
+	 */
+	public function test_gift_bought_by_the_holder_stays_covered_without_the_integration() {
+		$this->assertSame(
+			Memberships_Audit::CLASS_MEMBER_OWNED,
+			Memberships_Audit::classify(
+				$this->facts(
+					[
+						'subscription_id'            => 90210,
+						'subscription_customer_id'   => 501,
+						'subscription_status'        => 'active',
+						'wcsg_recipient_id'          => 777,
+						'gifting_integration_active' => false,
+					]
+				)
+			)
+		);
+	}
+
+	/**
+	 * A membership can sit at `wcm-active` past its own end date, because
+	 * Memberships expires it lazily — `WC_Memberships_User_Membership::is_active()`
+	 * calls `expire_membership()` the next time anything asks. Nothing asked here,
+	 * so the row still reads active while the member has no access under
+	 * Memberships either. Counting it as a loss invents a reader to remediate.
+	 */
+	public function test_membership_outside_its_active_period_is_not_a_live_member() {
+		$this->assertSame(
+			Memberships_Audit::CLASS_OUTSIDE_ACTIVE_PERIOD,
+			Memberships_Audit::classify(
+				$this->facts(
+					[
+						'subscription_id'          => 90210,
+						'subscription_customer_id' => 500,
+						'subscription_status'      => 'active',
+						'outside_active_period'    => true,
+					]
+				)
+			)
+		);
+	}
+
+	/**
+	 * The window Memberships itself enforces, in `is_in_active_period()`: dates
+	 * are stored as UTC strings, and an empty one means unbounded rather than
+	 * "epoch". Reading an empty end date as a boundary would expire every
+	 * open-ended membership on the site.
+	 */
+	public function test_active_period_window_matches_memberships() {
+		$this->assertFalse(
+			Memberships_Audit::is_outside_active_period( '', '' ),
+			'No dates at all is an unbounded membership.'
+		);
+		$this->assertFalse(
+			Memberships_Audit::is_outside_active_period( '2020-01-01 00:00:00', '' ),
+			'A start in the past with no end is unbounded.'
+		);
+		$this->assertTrue(
+			Memberships_Audit::is_outside_active_period( '2020-01-01 00:00:00', '2020-06-01 00:00:00' ),
+			'An end date in the past closes the window.'
+		);
+		$this->assertTrue(
+			Memberships_Audit::is_outside_active_period( gmdate( 'Y-m-d H:i:s', time() + DAY_IN_SECONDS ), '' ),
+			'A start date in the future has not opened the window yet.'
+		);
+		$this->assertFalse(
+			Memberships_Audit::is_outside_active_period( '2020-01-01 00:00:00', gmdate( 'Y-m-d H:i:s', time() + DAY_IN_SECONDS ) ),
+			'Between the two dates is inside the window.'
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`audit-membership-subscriptions` predicts which readers lose access at an Access Control flip. Two of its inputs were read in ways that disagree with the runtime it predicts, so the report pointed the operator at the wrong remedy.

Gifting: a gifted subscription resolves to its recipient only while the gifting integration is running, and that integration moved from a standalone plugin into WooCommerce Subscriptions core. A site can carry `_recipient_user` meta with nothing to resolve it, leaving access with the buyer. Those now report as `gift-wcsg-inert`, with a warning, since the fix is restoring the integration rather than granting $0 subscriptions, which would double-grant once it returns. Gift detection also accepts a recipient email, matching `is_gifted_subscription()`: a gift bought before its recipient has an account carries only that.

Active period: a membership can sit at `wcm-active` past its own end date, because Memberships expires lazily. Those now report as `outside-active-period` instead of as readers losing access. The window comes from `is_in_active_period()` rather than `_end_date` meta, because for a subscription-tied membership the linked subscription's end date supersedes that meta and a pause shifts it.

Reported via NPPD-2072.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Go to `plugins/newspack-plugin`.
3. Run `n test-php --filter Test_Memberships_Audit`. All 56 tests pass.
4. Open a site with WooCommerce Memberships and WooCommerce Subscriptions active.
5. Set a membership to the `wcm-active` status.
6. Give that membership an `_end_date` meta value in the past.
7. Link the membership to an active subscription that another user owns.
8. Run `wp newspack audit-membership-subscriptions --plan-ids=<plan id>`.
9. The membership reports as `outside-active-period`. Before this change it reported as `gift`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

CLI only: no publisher-facing surface changes, and the command remains read-only.

Verified end to end against seeded Memberships and Subscriptions data in an isolated environment — a membership that reported as `gift` now reports as `outside-active-period`. That run predates the final round of review fixes; the delegation to `is_in_active_period()` added in the last commit is covered by unit tests and CI rather than by a repeated end-to-end run.

Each behaviour is mutation-tested: reverting any one of them individually fails a test.
