### PR TITLE
chore(docker): report local environment type to WordPress

### DIFF
--- a/bin/env.sh
+++ b/bin/env.sh
@@ -489,6 +489,11 @@ MIGRATE
                 echo "Warning: could not add the memcached healthcheck to $compose_file (no extra_hosts anchor). Recreate the env to pick it up." >&2
             fi
         fi
+        # --- Migration: add WP_ENVIRONMENT_TYPE if missing (same reason as above) ---
+        if ! grep -q 'WP_ENVIRONMENT_TYPE=' "$compose_file"; then
+            awk '{ print } /^      - APACHE_RUN_USER=/ { print "      - WP_ENVIRONMENT_TYPE=local" }' "$compose_file" > "${compose_file}.tmp" && mv "${compose_file}.tmp" "$compose_file"
+            grep -q 'WP_ENVIRONMENT_TYPE=' "$compose_file" && echo "Migrated $env_name: added WP_ENVIRONMENT_TYPE=local" || echo "Warning: could not add WP_ENVIRONMENT_TYPE to $compose_file. Recreate the env to pick it up." >&2
+        fi
         # Re-read domain after potential migration.
         domain=$(domain_for_env "$compose_file")
         # Ensure loopback alias exists (macOS only — Linux routes all 127.x.x.x by default).

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -326,6 +326,7 @@ ${worktree_volumes}      - ./envs/${env_name}/html:/var/www/html
       - WP_CACHE_KEY_SALT=env_${env_name}_
       - WP_DOMAIN=${domain}
       - APACHE_RUN_USER=\${USE_CUSTOM_APACHE_USER:-www-data}
+      - WP_ENVIRONMENT_TYPE=local
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ## Probes memcached -- see docker-compose.yml for the rationale. Kept in step

--- a/docker-compose-82.yml
+++ b/docker-compose-82.yml
@@ -59,6 +59,7 @@ services:
       - HOST_PORT=${PORT_WORDPRESS:-80}
      # - COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME
       - APACHE_RUN_USER=${USE_CUSTOM_APACHE_USER:-www-data}
+      - WP_ENVIRONMENT_TYPE=local
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ## Probes memcached -- see docker-compose.yml for the rationale.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       - HOST_PORT=${PORT_WORDPRESS:-80}
       # - COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME
       - APACHE_RUN_USER=${USE_CUSTOM_APACHE_USER:-www-data}
+      - WP_ENVIRONMENT_TYPE=local
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ## Apache runs in the foreground, so it takes the container down with it when


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Sets `WP_ENVIRONMENT_TYPE=local` on the WordPress container, in both compose files and in the template the isolated envs use.

 `wp_get_environment_type()` reads that variable, so every site in the container will now report `local` instead of the `production` default, including sites set up before this change. A `WP_ENVIRONMENT_TYPE` constant in a site's wp-config still takes precedence.

The main site picks it up on the next `n start` or `n restart`. Existing isolated envs get the variable added to their compose file on the next `n env up`, the same way earlier template changes were migrated.

Some Newspack code checks the environment type. Automattic/newspack-manager#760 adds another case, as it stops PHP notices and deprecations from being logged, but only on production sites. Without this change, a local site reports `production` and loses those log entries too.

Closes [NEWS-3085](https://linear.app/a8c/issue/NEWS-3085/).

### How to test the changes in this Pull Request:

1. On `main`, run `n shell` and type `wp_get_environment_type()`. It prints `production`.
2. Check out this branch and run `n restart`.
3. Repeat step 1. It prints `local`.
4. Create an isolated env with `n env create` and `n env up`, then repeat step 1 from inside that env. It prints `local`.
5. Run `n env up` on an env created before this branch. It prints `Migrated <name>: added WP_ENVIRONMENT_TYPE=local`, and step 1 inside that env prints `local`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? n/a: container configuration.
* [x] Have you successfully run tests with your changes locally? Verified on the main site and WP-CLI after `n restart`.


