### PR TITLE
fix(checkout): scope the validation-only flag to the nonce-verified handler

### DIFF
--- a/plugins/newspack-blocks/includes/class-modal-checkout.php
+++ b/plugins/newspack-blocks/includes/class-modal-checkout.php
@@ -16,6 +16,15 @@ defined( 'ABSPATH' ) || exit;
  */
 final class Modal_Checkout {
 	/**
+	 * Whether the current request was accepted as validation-only by the nonce-verified
+	 * checkout handler. Kept request-scoped on purpose: the filters that consult it run on
+	 * every checkout request, so the request flag on its own is never enough.
+	 *
+	 * @var bool
+	 */
+	private static $is_validation_only_request = false;
+
+	/**
 	 * Checkout registration flag.
 	 *
 	 * @var string
@@ -337,6 +346,9 @@ final class Modal_Checkout {
 			wp_die();
 		}
 
+		// The validation-only flag is honored only here, once the nonce has been verified.
+		self::$is_validation_only_request = isset( $_POST['is_validation_only'] );
+
 		wc_nocache_headers();
 
 		if ( \WC()->cart->is_empty() ) {
@@ -357,7 +369,7 @@ final class Modal_Checkout {
 		$_REQUEST['woocommerce-process-checkout-nonce'] = wp_create_nonce( 'woocommerce-process_checkout' );
 
 		// If this is a validation-only request, set the flag that tells process_checkout() to only validate the order.
-		if ( isset( $_POST['is_validation_only'] ) ) {
+		if ( self::$is_validation_only_request ) {
 			$_POST['woocommerce_checkout_update_totals'] = '1';
 		}
 
@@ -2190,10 +2202,13 @@ final class Modal_Checkout {
 	/**
 	 * Is the current request only to validate billing field inputs on the first modal screen?
 	 *
+	 * True only after process_checkout_action() has verified the request's nonce and
+	 * accepted the flag; the request parameter is never read here directly.
+	 *
 	 * @return bool True if the request is for validation only.
 	 */
 	private static function is_validation_only() {
-		return boolval( filter_input( INPUT_POST, 'is_validation_only', FILTER_SANITIZE_NUMBER_INT ) );
+		return self::$is_validation_only_request;
 	}
 
 	/**

--- a/plugins/newspack-blocks/tests/test-modal-checkout.php
+++ b/plugins/newspack-blocks/tests/test-modal-checkout.php
@@ -99,6 +99,42 @@ if ( ! function_exists( 'WC' ) ) {
 				}
 
 				/**
+				 * Number of times the checkout double's process_checkout() ran.
+				 *
+				 * @var int
+				 */
+				public $process_checkout_calls = 0;
+				/**
+				 * Mimic WC()->checkout() with a double that records process_checkout() calls.
+				 *
+				 * @return object
+				 */
+				public function checkout() {
+					$container = $this;
+					return new class( $container ) {
+						/**
+						 * The container to record on.
+						 *
+						 * @var object
+						 */
+						private $container;
+						/**
+						 * Keep the container.
+						 *
+						 * @param object $container The WC() double.
+						 */
+						public function __construct( $container ) {
+							$this->container = $container;
+						}
+						/**
+						 * Record the call instead of processing a checkout.
+						 */
+						public function process_checkout() {
+							++$this->container->process_checkout_calls;
+						}
+					};
+				}
+				/**
 				 * Mimic WC()->payment_gateways() with no registered gateways.
 				 *
 				 * @return object
@@ -141,6 +177,36 @@ if ( ! class_exists( 'WC_Validation' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wc_nocache_headers' ) ) {
+	/**
+	 * Mock WooCommerce nocache headers as a no-op.
+	 */
+	function wc_nocache_headers() { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Mock WooCommerce global.
+	}
+}
+if ( ! function_exists( 'wc_get_cart_url' ) ) {
+	/**
+	 * Mock WooCommerce cart URL.
+	 *
+	 * @return string
+	 */
+	function wc_get_cart_url() { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Mock WooCommerce global.
+		return home_url( '/cart/' );
+	}
+}
+if ( ! function_exists( 'wc_maybe_define_constant' ) ) {
+	/**
+	 * Mock WooCommerce constant helper.
+	 *
+	 * @param string $name  Constant name.
+	 * @param mixed  $value Constant value.
+	 */
+	function wc_maybe_define_constant( $name, $value ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Mock WooCommerce global.
+		if ( ! defined( $name ) ) {
+			define( $name, $value );
+		}
+	}
+}
 if ( ! function_exists( 'wc_get_checkout_url' ) ) {
 	/**
 	 * Mock WooCommerce checkout URL helper.
@@ -310,6 +376,8 @@ class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 		remove_all_filters( 'woocommerce_cart_item_removed_message' );
 		remove_all_filters( 'newspack_blocks_donate_billing_fields_keys' );
 		unset( $_POST['billing_email'], $_POST['post_data'], $_POST['express_payment_type'], $_REQUEST['modal_checkout'], $_REQUEST['post_data'], $_SERVER['HTTP_REFERER'] );
+		unset( $_POST['is_validation_only'], $_POST['newspack_blocks_checkout_action'], $_POST['newspack_checkout_nonce'], $_POST['woocommerce_checkout_update_totals'], $_REQUEST['woocommerce-process-checkout-nonce'] );
+		$this->reset_validation_only_request();
 		parent::tear_down();
 	}
 
@@ -1303,6 +1371,106 @@ class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 		$this->assertSame(
 			'https://example.com/checkout/order-received/123/',
 			\Newspack_Blocks\Modal_Checkout::woocommerce_get_return_url( 'https://example.com/checkout/order-received/123/', $order )
+		);
+	}
+
+	/**
+	 * Helper: clear the request-scoped validation-only trust between tests.
+	 */
+	private function reset_validation_only_request() {
+		$property = new \ReflectionProperty( \Newspack_Blocks\Modal_Checkout::class, 'is_validation_only_request' );
+		$property->setAccessible( true );
+		$property->setValue( null, false );
+	}
+
+	/**
+	 * Helper: run the three filters that consult the validation-only state.
+	 *
+	 * @return array{needs_payment: bool, verify_captcha: bool, createaccount: int}
+	 */
+	private function checkout_filter_outcomes() {
+		$data = \Newspack_Blocks\Modal_Checkout::skip_account_creation(
+			[
+				'createaccount' => 1,
+				'billing_email' => 'nobody-' . wp_rand() . '@example.com',
+			]
+		);
+		return [
+			'needs_payment'  => \Newspack_Blocks\Modal_Checkout::cart_needs_payment( true ),
+			'verify_captcha' => \Newspack_Blocks\Modal_Checkout::recaptcha_verify_captcha( true, '', 'checkout' ),
+			'createaccount'  => $data['createaccount'],
+		];
+	}
+
+	public function test_validation_only_request_flags_alone_change_nothing() {
+		$_REQUEST['modal_checkout']  = '1';
+		$_POST['is_validation_only'] = '1';
+
+		$this->assertSame(
+			[
+				'needs_payment'  => true,
+				'verify_captcha' => true,
+				'createaccount'  => 1,
+			],
+			$this->checkout_filter_outcomes()
+		);
+	}
+
+	public function test_checkout_action_with_invalid_nonce_does_not_trust_validation_only() {
+		$_REQUEST['modal_checkout']               = '1';
+		$_POST['is_validation_only']              = '1';
+		$_POST['newspack_blocks_checkout_action'] = '1';
+		$_POST['newspack_checkout_nonce']         = 'not-a-nonce';
+
+		// wp_send_json_error() ends a non-AJAX request with a plain die; as AJAX it goes
+		// through the die handler this test case installs, which throws instead.
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		add_filter(
+			'wp_die_ajax_handler',
+			function () {
+				return [ $this, 'wp_die_handler' ];
+			}
+		);
+
+		try {
+			\Newspack_Blocks\Modal_Checkout::process_checkout_action();
+			$this->fail( 'An invalid nonce should stop the handler.' );
+		} catch ( \WPDieException $e ) {
+			// Expected: the handler ended the request before trusting the flag.
+		}
+
+		$this->assertTrue( \Newspack_Blocks\Modal_Checkout::cart_needs_payment( true ) );
+		$this->assertArrayNotHasKey( 'woocommerce_checkout_update_totals', $_POST );
+	}
+
+	public function test_checkout_action_with_valid_nonce_trusts_validation_only() {
+		$_REQUEST['modal_checkout']               = '1';
+		$_POST['is_validation_only']              = '1';
+		$_POST['newspack_blocks_checkout_action'] = '1';
+		$_POST['newspack_checkout_nonce']         = wp_create_nonce( 'newspack_modal_checkout_nonce' );
+
+		WC()->cart = new class() {
+			/**
+			 * The cart has items.
+			 *
+			 * @return bool
+			 */
+			public function is_empty() {
+				return false;
+			}
+		};
+
+		\Newspack_Blocks\Modal_Checkout::process_checkout_action();
+
+		$this->assertSame( 1, WC()->process_checkout_calls );
+		$this->assertSame( '1', $_POST['woocommerce_checkout_update_totals'] );
+		$this->assertSame(
+			[
+				'needs_payment'  => false,
+				'verify_captcha' => false,
+				'createaccount'  => 0,
+			],
+			$this->checkout_filter_outcomes()
 		);
 	}
 }

--- a/plugins/newspack-blocks/tests/test-modal-checkout.php
+++ b/plugins/newspack-blocks/tests/test-modal-checkout.php
@@ -1422,27 +1422,38 @@ class ModalCheckoutTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 		$_POST['newspack_blocks_checkout_action'] = '1';
 		$_POST['newspack_checkout_nonce']         = 'not-a-nonce';
 
-		// wp_send_json_error() ends a non-AJAX request with a plain die; as AJAX it goes
-		// through the die handler this test case installs, which throws instead.
-		add_filter( 'wp_doing_ajax', '__return_true' );
-		add_filter(
-			'wp_die_ajax_handler',
-			function () {
-				return [ $this, 'wp_die_handler' ];
-			}
-		);
+		// Outside AJAX, wp_send_json_error() calls the plain PHP die() and would halt the test
+		// runner; forcing AJAX routes it through wp_die(), which this handler turns into a
+		// catchable exception. Both filters are removed in the finally so they cannot leak
+		// wp_doing_ajax()==true or this handler into later tests.
+		$doing_ajax  = '__return_true';
+		$die_handler = function () {
+			return function () {
+				throw new \WPDieException( 'wp_die' );
+			};
+		};
+		add_filter( 'wp_doing_ajax', $doing_ajax );
+		add_filter( 'wp_die_ajax_handler', $die_handler );
 
 		try {
 			\Newspack_Blocks\Modal_Checkout::process_checkout_action();
 			$this->fail( 'An invalid nonce should stop the handler.' );
 		} catch ( \WPDieException $e ) {
 			// Expected: the handler ended the request before trusting the flag.
+		} finally {
+			remove_filter( 'wp_doing_ajax', $doing_ajax );
+			remove_filter( 'wp_die_ajax_handler', $die_handler );
 		}
 
 		$this->assertTrue( \Newspack_Blocks\Modal_Checkout::cart_needs_payment( true ) );
 		$this->assertArrayNotHasKey( 'woocommerce_checkout_update_totals', $_POST );
 	}
 
+	// Runs the handler to completion, which defines WOOCOMMERCE_CHECKOUT process-globally
+	// via wc_maybe_define_constant(). That define cannot be undone in tear_down(), so any
+	// later test that drives process_checkout_action() would hit the defined() early-return
+	// at class-modal-checkout.php and never reach process_checkout(). Keep this test last,
+	// or give a future full-flow test its own process.
 	public function test_checkout_action_with_valid_nonce_trusts_validation_only() {
 		$_REQUEST['modal_checkout']               = '1';
 		$_POST['is_validation_only']              = '1';


### PR DESCRIPTION
Modal checkout shows a first screen that checks the billing form before taking payment. This change makes the site treat a checkout as that validation step only when the request has been through modal checkout's own verification. Normal purchases and the genuine first-step validation behave as before.

## What changes

Modal checkout keeps a "validation only" state for the first billing screen. That state is now set in one place, the handler that verifies the request, and every payment-related decision that depends on it follows the verified state rather than the request on its own.

With this change:

* The first modal step still validates billing fields without creating an order.
* A normal checkout still completes and records a paid order.
* Captcha and account-creation behaviour are unchanged for real checkouts.

Closes NPPM-3226

## How to test

1. On a site running modal checkout with a purchasable product and a payment gateway, open the checkout modal and complete the first billing step. It validates and moves to the payment step without creating an order.
2. Finish the purchase. An order is created and recorded as paid with the chosen method.
3. Run the newspack-blocks PHP tests for modal checkout: `n test-php` in `plugins/newspack-blocks` (class `Test_Modal_Checkout`). They pass.

<details>
<summary><strong>Technical details</strong></summary>

`is_validation_only()` returns a request-scoped `private static $is_validation_only_request`, set after `wp_verify_nonce()` in `process_checkout_action()` — the handler that verifies the modal nonce. The three filter callbacks that consult it (`cart_needs_payment`, `recaptcha_verify_captcha`, `skip_account_creation`) are untouched and inherit the change through `is_validation_only()`, so the validation-only state and the check that acts on it share one source.

Verifying the nonce inside `is_validation_only()` was the other option and was rejected. Those filters run inside WooCommerce's own checkout handling, where the nonce field may legitimately be absent, and it would re-verify on every call. One decision point in the handler is easier to reason about.

Hook order keeps the genuine flow working. `process_checkout_action()` runs on `wp_loaded`; WooCommerce dispatches the checkout on `template_redirect`, which is later. WooCommerce's own `WC_Form_Handler::checkout_action` also runs on `wp_loaded`, at priority 20, and defines `WOOCOMMERCE_CHECKOUT`; the handler sets the validation-only flag only in the same branch that writes `woocommerce_checkout_update_totals`, below the early return that constant triggers, so the flag is never true without the write that makes it safe. The genuine first step carries the modal's action flag and nonce, so the handler runs and sets the state before any filter reads it.

Tests: `Test_Modal_Checkout` covers this at the filter level — one case drives the nonce-verified handler and asserts the flag is set and the three filters follow it; the others assert the filters stay inert, and the stored flag stays false, when a request carries the raw flags but never reached the handler. The unit suite cannot reproduce the original bug directly: the prior code read the flag through `filter_input( INPUT_POST, … )`, which sees the SAPI request body and returns NULL under the CLI SAPI whatever `$_POST` holds, so no in-process test can drive that path. The runtime repro on NPPM-3226 is the proof for that form; the unit tests guard the likely future regression, an accessor reading the raw request directly.

Verification, on an isolated environment: the genuine first-step validation behaves identically before and after, and a normal checkout completes to a paid order (Cash on Delivery).

This description follows the problem / What changes / How to test / Technical details shape (`Automattic/newspack-workspace#1057`), already used on several recent Newspack PRs.

Self-review: Copilot pass on open, a devkit review round to follow. Reviewed so far at the code level plus runtime verification of the payment flow.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

