### PR TITLE
fix: migrate-team-products includes owner seat in group limit

### DIFF
--- a/plugins/newspack-plugin/includes/cli/class-teams-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-teams-migration.php
@@ -751,8 +751,10 @@ class Teams_Migration {
 	 *
 	 * Updates all published subscription products that have the "Team membership"
 	 * option enabled, setting their group subscription `enabled` meta to `yes` and
-	 * their `limit` meta to match the product's "Maximum member count". For variable
-	 * subscriptions, both the parent product and each subscription variation are
+	 * their `limit` meta to the owner-inclusive group limit — the product's "Maximum
+	 * member count", plus one for the owner's seat unless the "Owners must be members"
+	 * setting already reserves one (see map_product_max_members_to_group_limit()). For
+	 * variable subscriptions, both the parent product and each subscription variation are
 	 * updated so the setting is available at whichever level WooCommerce Subscriptions
 	 * resolves the product ID.
 	 *
@@ -822,6 +824,9 @@ class Teams_Migration {
 			}
 
 			$max_members = (int) $product->get_meta( '_wc_memberships_for_teams_max_member_count', true );
+			// Match migrate-teams: the group limit counts the owner, so add their seat
+			// unless "Owners must be members" already reserves one on the product.
+			$limit = self::map_product_max_members_to_group_limit( $max_members );
 
 			// Collect the IDs to update: always the parent; plus any
 			// subscription_variation children for variable subscriptions.
@@ -842,18 +847,18 @@ class Teams_Migration {
 						continue;
 					}
 					$p->update_meta_data( '_newspack_group_subscription_enabled', 'yes' );
-					$p->update_meta_data( '_newspack_group_subscription_limit', $max_members );
+					$p->update_meta_data( '_newspack_group_subscription_limit', $limit );
 					$p->save();
 				}
 			}
 
 			$variation_count = count( $ids_to_update ) - 1;
-			WP_CLI::success( sprintf( 'Product %d ("%s"): %s enabled=yes, limit=%s%s.', $product_id, $product->get_name(), $dry_run ? 'would set' : 'set', 0 === $max_members ? 'Unlimited' : $max_members, $variation_count > 0 ? sprintf( ' (+ %d variation(s))', $variation_count ) : '' ) );
+			WP_CLI::success( sprintf( 'Product %d ("%s"): %s enabled=yes, limit=%s%s.', $product_id, $product->get_name(), $dry_run ? 'would set' : 'set', 0 === $limit ? 'Unlimited' : $limit, $variation_count > 0 ? sprintf( ' (+ %d variation(s))', $variation_count ) : '' ) );
 
 			$summary[] = [
 				'product_id'   => $product_id,
 				'product_name' => $product->get_name(),
-				'limit'        => 0 === $max_members ? 'Unlimited' : $max_members,
+				'limit'        => 0 === $limit ? 'Unlimited' : $limit,
 				'variations'   => $variation_count,
 			];
 
@@ -2970,6 +2975,29 @@ class Teams_Migration {
 			return 0;
 		}
 		return max( $seat_count + ( $owner_is_team_member ? 0 : 1 ), 2 );
+	}
+
+	/**
+	 * Map a team product's "Maximum member count" to the owner-inclusive group limit.
+	 *
+	 * Access Control always counts the team owner as a group member, but WC Teams only
+	 * reserves a seat for the owner when the global "Owners must be members" setting is on
+	 * (or the buyer opts in per order via the `team_owner_takes_seat` order-item flag). So
+	 * unless the owner already occupies one of the product's seats, the group needs one more
+	 * seat than the product's member count — the same adjustment migrate-teams makes per team.
+	 *
+	 * A product carries no order, so per-order opt-ins are invisible here: on a site whose
+	 * global setting is off, a buyer who opts their owner into a seat yields a group limit one
+	 * larger than they strictly need. Over-provisioning by one seat is harmless; under-
+	 * provisioning (the bug this fixes) locks a paying member out of a seat.
+	 *
+	 * @param int $max_members The product's _wc_memberships_for_teams_max_member_count (0 = unlimited).
+	 *
+	 * @return int The owner-inclusive group limit (0 = unlimited).
+	 */
+	public static function map_product_max_members_to_group_limit( $max_members ) {
+		$owner_takes_seat = 'yes' === \get_option( 'wc_memberships_for_teams_owners_must_take_seat', 'no' );
+		return self::map_team_seats_to_group_limit( $max_members, $owner_takes_seat );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/cli/class-teams-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-teams-migration.php
@@ -2991,6 +2991,11 @@ class Teams_Migration {
 	 * larger than they strictly need. Over-provisioning by one seat is harmless; under-
 	 * provisioning (the bug this fixes) locks a paying member out of a seat.
 	 *
+	 * Note the mapping inherits map_team_seats_to_group_limit()'s 2-seat floor, so a
+	 * 1-member product never maps below a limit of 2 — including on an "Owners must be
+	 * members" site, where the owner occupies the single seat and the group strictly needs
+	 * only 1. That is one seat in the same safe over-provision direction as above.
+	 *
 	 * @param int $max_members The product's _wc_memberships_for_teams_max_member_count (0 = unlimited).
 	 *
 	 * @return int The owner-inclusive group limit (0 = unlimited).

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -559,6 +559,29 @@ class WC_Product {
 	public function get_meta( $key, $single = true ) {
 		return $this->meta[ $key ] ?? '';
 	}
+	/**
+	 * Stage a meta value in memory, as WC_Data::update_meta_data() does before a
+	 * save(). Kept minimal — no meta-id bookkeeping — because callers read the
+	 * value straight back with get_meta().
+	 *
+	 * @param string $key   Meta key.
+	 * @param mixed  $value Meta value.
+	 */
+	public function update_meta_data( $key, $value ) {
+		$this->meta[ $key ] = $value;
+	}
+	/**
+	 * Persist the product back into the mock store. The object is already held by
+	 * reference, so this only matters for a product built and saved without being
+	 * registered first; it mirrors WC_Product::save() returning the product ID.
+	 *
+	 * @return int The product ID.
+	 */
+	public function save() {
+		global $products_database;
+		$products_database[ $this->get_id() ] = $this;
+		return $this->get_id();
+	}
 }
 
 class WC_Cart {

--- a/plugins/newspack-plugin/tests/mocks/wp-cli-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wp-cli-mocks.php
@@ -174,4 +174,24 @@ namespace WP_CLI\Utils {
 			// No-op: the real helper trims caches to bound long-running CLI memory.
 		}
 	}
+
+	if ( ! function_exists( 'WP_CLI\Utils\make_progress_bar' ) ) {
+		/**
+		 * The real helper returns a cli\progress\Bar, or a silent no-op object when
+		 * output is not a TTY (as under PHPUnit). The mock always returns the no-op
+		 * shape so command code can call tick()/finish() without a terminal.
+		 *
+		 * @param string $message  Progress message (unused).
+		 * @param int    $count    Total ticks (unused).
+		 * @param int    $interval Redraw interval in ms (unused).
+		 *
+		 * @return object A tick()/finish() no-op stand-in.
+		 */
+		function make_progress_bar( $message, $count, $interval = 100 ) {
+			return new class() {
+				public function tick( $incr = 1, $msg = '' ) {}
+				public function finish() {}
+			};
+		}
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/cli/class-test-migrate-team-products.php
+++ b/plugins/newspack-plugin/tests/unit-tests/cli/class-test-migrate-team-products.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Tests for the `wp newspack migrate-team-products` CLI command (NPPD-2153).
+ *
+ * The unit test in the group-subscription suite covers the pure limit mapping
+ * (`map_product_max_members_to_group_limit()`); this suite covers the wiring the
+ * regression actually lived in — that the command persists the owner-inclusive
+ * *mapped* limit to `_newspack_group_subscription_limit`, not the raw product
+ * member count.
+ *
+ * @package Newspack\Tests
+ * @group teams-migration
+ */
+
+use Newspack\CLI\Teams_Migration;
+
+/**
+ * Test the migrate-team-products command end-to-end against mock products.
+ *
+ * @group teams-migration
+ */
+class Test_Migrate_Team_Products extends WP_UnitTestCase {
+
+	/**
+	 * Product post IDs to clean up.
+	 *
+	 * @var int[]
+	 */
+	private $product_ids = [];
+
+	/**
+	 * Load the WooCommerce and WP-CLI mocks the command depends on.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		require_once dirname( __DIR__, 2 ) . '/mocks/wc-mocks.php';
+		require_once dirname( __DIR__, 2 ) . '/mocks/wp-cli-mocks.php';
+	}
+
+	/**
+	 * Reset the mock product store, the recorded CLI output, and the team option.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $products_database;
+		$products_database = [];
+		WP_CLI::reset();
+		delete_option( 'wc_memberships_for_teams_owners_must_take_seat' );
+	}
+
+	/**
+	 * Tear down fixtures.
+	 */
+	public function tear_down() {
+		global $products_database;
+		$products_database = [];
+		foreach ( $this->product_ids as $id ) {
+			wp_delete_post( $id, true );
+		}
+		$this->product_ids = [];
+		delete_option( 'wc_memberships_for_teams_owners_must_take_seat' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a published team product: a real `product` post so the command's
+	 * get_posts() meta_query finds it, plus a matching mock WC_Product carrying the
+	 * team member-count meta so wc_get_product() can read and write it.
+	 *
+	 * @param int $max_members The product's team "Maximum member count".
+	 * @return int The product ID.
+	 */
+	private function create_team_product( int $max_members ): int {
+		$product_id = wp_insert_post(
+			[
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+				'post_title'  => 'Team subscription',
+			]
+		);
+		$this->assertNotWPError( $product_id, 'Fixture product creation should succeed.' );
+		update_post_meta( $product_id, '_wc_memberships_for_teams_has_team_membership', 'yes' );
+		$this->product_ids[] = $product_id;
+
+		global $products_database;
+		$products_database[ $product_id ] = new WC_Product(
+			[
+				'id'   => $product_id,
+				'name' => 'Team subscription',
+				'type' => 'subscription',
+				'meta' => [ '_wc_memberships_for_teams_max_member_count' => $max_members ],
+			]
+		);
+		return $product_id;
+	}
+
+	/**
+	 * A live run must persist the owner-inclusive mapped limit (owner + members),
+	 * not the raw product member count. This is the regression the fix exists to
+	 * prevent: writing the raw count leaves the next buyer's owner occupying a seat
+	 * the publisher paid for. Reverting the command to write `$max_members` again
+	 * fails this test, where the mapping unit test would still pass.
+	 */
+	public function test_live_run_persists_owner_inclusive_limit() {
+		$product_id = $this->create_team_product( 5 );
+
+		( new Teams_Migration() )->migrate_team_products( [], [ 'live' => true ] );
+
+		global $products_database;
+		$product = $products_database[ $product_id ];
+		$this->assertSame( 'yes', $product->get_meta( '_newspack_group_subscription_enabled' ), 'The command must enable group subscriptions on the product.' );
+		$this->assertSame( 6, $product->get_meta( '_newspack_group_subscription_limit' ), 'A 5-member product must persist a limit of 6 (owner + 5), not the raw 5.' );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-teams-migration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-teams-migration.php
@@ -257,6 +257,33 @@ class Test_Teams_Migration extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The product command must set the same owner-inclusive limit migrate-teams does:
+	 * a product's "Maximum member count" gains a seat for the owner unless the global
+	 * "Owners must be members" setting already reserves one. 0 (unlimited) is untouched.
+	 */
+	public function test_map_product_max_members_to_group_limit_accounts_for_owner_seat() {
+		// Default (option unset) behaves as "no": WC Teams does not count the owner, so
+		// Access Control adds a seat — a "5 members" product becomes a 6-seat group.
+		delete_option( 'wc_memberships_for_teams_owners_must_take_seat' );
+		$this->assertSame( 6, Teams_Migration::map_product_max_members_to_group_limit( 5 ), 'Owner uncounted by default → 5-member product needs 6 group seats.' );
+
+		// Explicit "no" matches the default.
+		update_option( 'wc_memberships_for_teams_owners_must_take_seat', 'no' );
+		$this->assertSame( 6, Teams_Migration::map_product_max_members_to_group_limit( 5 ) );
+
+		// "yes": the owner already occupies one of the product's seats, so no seat is added.
+		update_option( 'wc_memberships_for_teams_owners_must_take_seat', 'yes' );
+		$this->assertSame( 5, Teams_Migration::map_product_max_members_to_group_limit( 5 ) );
+
+		// 0 = unlimited passes through unchanged, regardless of the setting.
+		$this->assertSame( 0, Teams_Migration::map_product_max_members_to_group_limit( 0 ) );
+		update_option( 'wc_memberships_for_teams_owners_must_take_seat', 'no' );
+		$this->assertSame( 0, Teams_Migration::map_product_max_members_to_group_limit( 0 ) );
+
+		delete_option( 'wc_memberships_for_teams_owners_must_take_seat' );
+	}
+
+	/**
 	 * The add_group_member() helper skips editors/admins — they are not readers and
 	 * already have full access, so they should not be recorded as group members.
 	 */


### PR DESCRIPTION
## What & why

`migrate-team-products` copied each team product's **Maximum member count**
(`_wc_memberships_for_teams_max_member_count`) straight into the group subscription
limit (`_newspack_group_subscription_limit`). But Access Control always counts the
team **owner** as a group member, so a "Business Subscription – 5 Team Members"
product became a 5-seat group. Once the owner takes one of those seats, only four
other people can be added — the next buyer of that product comes up one short, with
nothing to explain it.

`migrate-teams` already handles this per team (adds the owner's seat via
`map_team_seats_to_group_limit()`). This makes the product command consistent.

Found during an Access Control migration. Existing teams were unaffected (the
subscription-level limit wins over the product's), so this only reached future
buyers of the product.

## The fix

New helper `map_product_max_members_to_group_limit()` routes the product's max member
count through the same owner-inclusive mapping, adding the owner's seat **unless** the
global **Owners must be members** setting
(`wc_memberships_for_teams_owners_must_take_seat`, default `no`) already reserves one:

- setting `no`/unset → owner is not counted on the product → group limit = max + 1
- setting `yes` → owner already occupies a product seat → group limit = max
- `0` (unlimited) passes through unchanged

This mirrors WC Teams' own purchase-time rule (`Orders.php`: the owner takes a seat
when the option is `yes` **or** the buyer opts in per order).

### Known limitation (accepted)

A product carries no order, so the per-order `team_owner_takes_seat` opt-in is invisible
here. On an owners-optional (`no`) site, a buyer who opts their owner into a seat gets a
group limit one larger than strictly needed. Over-provisioning by one seat is harmless;
the bug this replaces under-provisioned and locked a paying member out.

## Testing

- New unit test `test_map_product_max_members_to_group_limit_accounts_for_owner_seat`
  covers the `no`/`yes`/unset and unlimited cases.
- Whole `WooCommerce_Subscriptions_Integration` group: `OK (420 tests, 1306 assertions)`.
- Red-first proof: mutating the helper to the pre-fix behavior fails exactly this test
  (`5 is identical to 6`) and nothing else; restoring returns the group to green.
- PHPCS (WordPress-Extra + WordPress-Docs + VIP-Go) clean on both files.

Ticket: NPPD-2153

🤖 Generated with [Claude Code](https://claude.com/claude-code)

